### PR TITLE
change how config vars are loaded

### DIFF
--- a/.env.sample.js
+++ b/.env.sample.js
@@ -1,0 +1,3 @@
+// Make a copy of this file as '.env.js'
+// Fill in the variables as appropriate
+export const GOOGLE_CALENDAR_API_KEY = 'key goes here'

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ android/keystores/debug.keystore
 
 # KEYS
 keys.js
+.env.js

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,5 @@
+// By explicity naming the things we expect to find in .env.js,
+// we make it easier to know what's available.
+export {
+  GOOGLE_CALENDAR_API_KEY,
+} from '../.env.js'

--- a/views/calendar/calendar.js
+++ b/views/calendar/calendar.js
@@ -12,7 +12,7 @@ import {
 } from 'react-native'
 
 import EventView from './event'
-import * as k from '../../keys'
+import { GOOGLE_CALENDAR_API_KEY } from '../../lib/config'
 
 export default class CalendarView extends React.Component {
   constructor(props) {
@@ -39,9 +39,9 @@ export default class CalendarView extends React.Component {
     var offsetString = "-" + offset + ":00Z";
     nowString.replace('Z', offsetString);
     if(this.props.events == 'master') {
-      this.getMasterEvents(k.calendarKey, nowString);
+      this.getMasterEvents(GOOGLE_CALENDAR_API_KEY, nowString);
     } else {
-      this.getOlevilleEvents(k.calendarKey, nowString);
+      this.getOlevilleEvents(GOOGLE_CALENDAR_API_KEY, nowString);
     }
   }
 


### PR DESCRIPTION
Really, this PR is more about a filename change than anything else.

I centralized config loading in `/lib/config.js` - it's up to that file to figure out how to import config stuff. That way, we can experiment with alternative approaches without changing the callsites.

I took `keys.js` and changed it to `.env.js`. I also created a sample `.env.sample.js`, for reference purposes. I left `keys.js` in the .gitignore, so that we wouldn't accidentally commit an existing one.

``` js
// Make a copy of this file as '.env.js'
// Fill in the variables as appropriate
export const GOOGLE_CALENDAR_API_KEY = 'key goes here'
```

The main change is in the names of the keys, so you can't quite just rename `keys.js` to `.env.js`.

---

I experimented with `react-native-config`, but it's a bit wonky. Also it's completely broken for Android currently. Yeah. Fun.

---

Closes #29
