### PR TITLE
Add CI Integration – Travis and Appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,76 @@
+language: objective-c
+# We're using 7.2 currently, as xctool has issues with 7.3.
+# This also means that we're testing against iOS 9.2.
+osx_image: xcode7.2
+
+install:
+  ### basic setup stuff
+  - brew update
+  # force node 6
+  - nvm use 6
+  # turn off fancy npm stuff
+  - npm config set spin=false
+  - npm config set progress=false
+  # install node deps
+  - travis_wait npm install
+
+  ### do js-only setup stuff
+  # install flow
+  - if [[ "$TEST_TYPE" = js ]]; then brew install flow; fi
+  # prepare for jest
+  - if [[ "$TEST_TYPE" = js ]]; then rm -rf "${TMPDIR}/jest_preprocess_cache"; fi
+
+  ### do ios-only setup stuff
+  - if [[ "$TEST_TYPE" = ios ]]; then brew install xctool; fi
+
+  ### do android-only setup stuff
+  # install gradle
+  - if [[ "$TEST_TYPE" = android ]]; then brew install gradle; fi
+  # install android tools
+  - |
+    if [[ "$TEST_TYPE" = android ]]; then
+      set -ve
+      brew install android-sdk
+
+      echo y | android update sdk --no-ui --all --filter tools
+      echo y | android update sdk --no-ui --all --filter platform-tools
+      echo y | android update sdk --no-ui --all --filter build-tools-23.0.1
+      echo y | android update sdk --no-ui --all --filter android-23
+      echo y | android update sdk --no-ui --all --filter extra-android-m2repository
+      echo y | android update sdk --no-ui --all --filter extra-google-m2repository
+      echo y | android update sdk --no-ui --all --filter extra-android-support
+
+      export ANDROID_HOME=/usr/local/opt/android-sdk
+    fi
+
+
+# we can run three builds in parallel!
+env:
+  matrix:
+    - TEST_TYPE=js
+    - TEST_TYPE=ios
+    - TEST_TYPE=android
+
+script:
+  # These sections will grow over time.
+  # Each line is collapsed nicely in the travis output, which is why they're
+  # grouped in this fashion.
+
+  # travis apps don't have any env vars at the moment.
+  # I'm not comfortable having them written to disk there.
+  - touch .env.js
+
+  # JS-only tests - type checking and specs
+  - if [[ "$TEST_TYPE" = js ]]; then npm run flow; fi
+  - if [[ "$TEST_TYPE" = js ]]; then npm run test:js; fi
+
+  # iOS-only tests - building and specs
+  - if [[ "$TEST_TYPE" = ios ]]; then npm run test:ios; fi
+
+  # android-only tests - building and specs
+  - if [[ "$TEST_TYPE" = android ]]; then npm run build:android:macos; fi
+
+# ping slack with status
+notifications:
+  slack:
+    secure: fmOwJp9Xj5dJanJsdUcoJwCpHzoGEmP32zfUF+EfvHmNNkkiCiPGuXa2vt829655rjopfjm1sILfagEYr1CcnjI4fa6zIY6fQkWgii0Acy+vIEB3GZ1h46Uj8vLYOjOBC6tgNqGZvfFhtfo67hmhfRxXpP1jY6Ta0eAtxjqQ/cgGI3vUXstI3HN9eLsTa8Ejf8YiIkfV6dAPZkxDdbiQuO5+4ZbZdPYEke/QC4a/a14l4IzPntusS/8ebD5mYDavkW1+gtjZmYrqMn9aWSh+R0L1KwkqoQq5USjDw6gg4/H9L8OEj/tnCwyUQ9jyyvSLvCMTjAPGWzVvvtQKHULPuCUoH6dLAAn6HeyAPpj5rJbyVgb6voj3jfHvcOGIO2o81l4g/4JKxzN9m2tCeR8I83aPboIMUT2d1F7trfFZLWzxPUroTIWVhEoa3mRneKcQU4IY2+cATFLQnrG+iu7G3q3mNXt3figRXP76fgmdAIvdeBvN1jdmY4148DhXZVkk/Fkddd8BEJ2l/5qHlCGEKKYhM5q//+GdFOnnAiFzjbPIKixF4c1B6itEfrWo+slu3IFsd7Wsc7pb5yaW9dHaiQwlhrk5mYH0getws8fmufT1BY/Qg9pp9XJxLDos9cd24QNF3ACpKxvB9k48M4Ez0Pe5khruq+0YK04rHO+xJVw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
   # travis apps don't have any env vars at the moment.
   # I'm not comfortable having them written to disk there.
   - touch .env.js
+  - touch keys.js
 
   # JS-only tests - type checking and specs
   - if [[ "$TEST_TYPE" = js ]]; then npm run flow; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: objective-c
 osx_image: xcode7.2
 
 install:
+  # work around android build failing - https://github.com/travis-ci/travis-ci/issues/6307
+  - rvm get head
   ### basic setup stuff
   - brew update
   # force node 6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ test_script:
   - npm test
   # prepare env
   - touch .env.js
+  - touch keys.js
 
 build_script: 'npm run build:android:win'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,46 @@
+clone_folder: c:\projects\all-about-olaf
+
+# the basic outline for this install process is from
+# github.com/googlesamples/android-ndk/blob/master/appveyor.yml
+install:
+  # prepare android-sdk
+  - cd \
+  - appveyor DownloadFile "http://dl.google.com/android/android-sdk_r24.4.1-windows.zip"
+  - 7z x "android-sdk_r24.4.1-windows.zip" > nul
+  - cd c:\projects\all-about-olaf
+  # install android-sdk
+  - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter android-23
+  - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter platform-tools
+  - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter tools
+  - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter build-tools-23.0.1
+  - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter extra-google-m2repository
+  - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter extra-android-m2repository
+  - echo y | C:\android-sdk-windows\tools\android.bat update sdk --no-ui --all --filter extra-android-support
+  # install node and npm packages
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+environment:
+  nodejs_version: '6'
+  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  ANDROID_HOME: C:\android-sdk-windows
+  matrix:
+    # - TEST_TYPE: js
+    - TEST_TYPE: android
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+  # prepare env
+  - touch .env.js
+
+build_script: 'npm run build:android:win'
+
+notifications:
+  - provider: Slack
+    incoming_webhook:
+      secure: FAKVymf5kPEMsOf2Brk5VWIeylmsG6oCXBBURcN3S2RTSKGvLV/qEiN1m2HWU+OxGlnMZcBR7UjB2hsOw6S/Ri81KDzgpuTWcYH9FOobXWU=

--- a/package.json
+++ b/package.json
@@ -3,12 +3,25 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "start": "react-native start",
     "ios": "react-native run-ios",
     "rn": "react-native",
     "lint": "eslint app.js *.index.js lib/ views/",
-    "launch-android-emulator": "emulator -avd 'react-native'",
-    "android": "react-native run-android"
+    "android": "react-native run-android",
+    "android-emulator": "emulator -avd 'react-native'",
+    "flow": "echo 'Not yet implemented.'",
+    "bundle:ios": "react-native bundle --entry-file index.ios.js --dev true --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --assets-dest ./ios",
+    "bundle:android": "react-native bundle --entry-file index.android.js --dev true --platform android --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/",
+    "build:ios": "xctool -configuration Release -project ios/AllAboutOlaf.xcodeproj -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2'",
+    "build:android:macos": "cd android && ./gradlew assembleRelease --info --console=plain",
+    "build:android:win": "cd android && .\\gradlew assembleRelease --info --console=plain",
+    "test": "npm run flow && npm run test:js",
+    "test:js": "echo 'Not yet implemented! Figure out jest.'",
+    "test:ios": "xctool -configuration Release -project ios/AllAboutOlaf.xcodeproj -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2' test",
+    "test:android": "echo 'Not yet implemented! See http://facebook.github.io/react-native/docs/signed-apk-android.html#testing-the-release-build-of-your-app'",
+    "release": "npm run release:ios && npm run release:android",
+    "release:ios": "echo 'Not yet implemented!'",
+    "release:android": "echo 'Not yet implemented!'"
   },
   "dependencies": {
     "buffer": "^4.9.0",


### PR DESCRIPTION
This is made up of three main changes: new npm scripts and two config files.

I added a bunch of `npm run` scripts to do various things:
- added `flow` – will eventually run flow on the code
- added `bundle:{ios,android}` – just bundles the code for ios/android
- added `build:{ios,android:{macos,win}}` – builds the app binary
- added `test:js` - will run jest tests, when we have them
- added `test` - runs the `flow` and `test:js` commands
- added `test:ios` - runs the default ios native xctests
- added placeholders for `test:android` and `release:*` scripts

There is one config file each for TravisCI and Appveyor. Travis can handle Linux- and macOS-based builds, and Appveyor specializes in Windows machines. Both are free for open-source projects.

The nicest thing about having these config files is that you can use them to get set up locally, too – moreso with the Travis one than Appveyor, unfortunately, but they still give you a list of commands that you can run.

Additionally, they can check that the executables can build for each push to master and every PR we get.

I eventually want to add `eslint`, `flow`, and `jest` tests to the Javascript builds, to automate those tests as well.
