### PR TITLE
Fixed NSAppTransportSecurity exceptions for BonApp

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -70,6 +70,31 @@
           <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
           <true/>
         </dict>
+        <key>stolaf.cafebonappetit.com</key>
+        <dict>
+          <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+        </dict>
+        <key>template.cafebonappetit.com</key>
+        <dict>
+          <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+        </dict>
+        <key>bamco.com</key>
+        <dict>
+          <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+        </dict>
+        <key>hub.cafebonappetit.com</key>
+        <dict>
+          <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+        </dict>
+        <key>legacy.cafebonappetit.com</key>
+        <dict>
+          <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+          <true/>
+        </dict>
       </dict>
     </dict>
     <key>UIAppFonts</key>

--- a/views/menus/stav.js
+++ b/views/menus/stav.js
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
   },
 })
 
-const URL = 'https://stolaf.cafebonappetit.com/cafe/stav-hall#Lunch'
+const URL = 'http://stolaf.cafebonappetit.com/cafe/stav-hall#Lunch'
 // const DEFAULT_URL = 'http://legacy.cafebonappetit.com/print-menu/cafe/261/menu/112732/days/today/pgbrks/0/'
 
 export default class StavMenuView extends React.Component {


### PR DESCRIPTION
- Fixed the non-secure urls that cafebonappetit uses
- Added the non-https url to the menu so that it loads
