### PR TITLE
Speed up android builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ cache:
     - /usr/local/Cellar/.git
 
 install:
+  - echo "Now testing $TEST_TYPE on $TRAVIS_OS_NAME"
+  - echo "Using android emulator $EMULATOR"
+  - echo "Travis branch is $TRAVIS_BRANCH"
+  - echo "Travis branch is in pull request $TRAVIS_PULL+REQUEST"
+
   # work around android build failing - https://github.com/travis-ci/travis-ci/issues/6307
   - if [[ "$TEST_TYPE" = android ]]; then rvm get head; fi
   ### basic setup stuff
@@ -33,7 +38,7 @@ install:
 
   ### do js-only setup stuff
   # prepare for jest
-  - if [[ "$TEST_TYPE" = js ]]; then rm -rf "${TMPDIR}/jest_preprocess_cache"; fi
+  - if [[ "$TEST_TYPE" = js ]]; then rm -rf "$TMPDIR/jest_preprocess_cache"; fi
 
   ### do ios-only setup stuff
   - if [[ "$TEST_TYPE" = ios ]]; then brew install xctool; fi
@@ -77,14 +82,14 @@ script:
   - touch keys.js
 
   # JS-only tests - type checking and specs
-  - if [[ "$TEST_TYPE" = js ]]; then npm run lint; fi
+  - if [[ "$TEST_TYPE" == "js" ]]; then npm run lint; fi
   # unfortunately, flow does not yet seem willing to run properly on travis.
   # we'll just run it locally for now.
   # - if [[ "$TEST_TYPE" = js ]]; then npm run flow; fi
-  - if [[ "$TEST_TYPE" = js ]]; then npm run test:js; fi
+  - if [[ "$TEST_TYPE" == "js" ]]; then npm run test:js; fi
 
   # iOS-only tests - building and specs
-  - if [[ "$TEST_TYPE" = ios ]]; then npm run test:ios; fi
+  - if [[ "$TEST_TYPE" == "ios" ]]; then npm run test:ios; fi
 
   # android-only tests - building and specs
   - if [[ "$TEST_TYPE" = android ]]; then npm run build:android:macos; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,91 @@
-language: objective-c
-# We're using 7.2 currently, as xctool has issues with 7.3.
-# This also means that we're testing against iOS 9.2.
-osx_image: xcode7.2
+language: generic
+
+my-caches:
+  node: &my-node-cache
+    directories:
+      # cache node_modules b/c they take a long time to install
+      - ./node_modules
+  android-before: &my-android-before_cache
+    - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+  android: &my-android-cache
+    directories:
+      # cache node_modules b/c they take a long time to install
+      - ./node_modules
+      # cache .gradle for both gradle and gradle's cache
+      - $HOME/.gradle/caches/
+      - $HOME/.gradle/wrapper/
+  ios: &my-ios-cache
+    directories:
+      # cache node_modules b/c they take a long time to install
+      - ./node_modules
+      # cache homebrew's git repo?
+      - /usr/local/Cellar/.git
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+      env: TEST_TYPE=js
+      language: node_js
+      node_js: '6'
+      cache: *my-node-cache
+
+    - os: linux
+      sudo: false
+      env: TEST_TYPE=android
+      jdk: oraclejdk8
+      language: android
+      android:
+        components:
+          # Some components come pre-installed:
+          # docs.travis-ci.com/user/languages/android#Pre-installed-components
+          # However, that seems to leave us with errors in the build
+          - tools
+          - platform-tools
+          - build-tools-23.0.1
+          - android-23
+          - extra-android-m2repository
+          - extra-google-m2repository
+          - extra-android-support
+      cache: *my-android-cache
+      before_cache: *my-android-before_cache
+
+    # This is all ready to go; we just need to want it :-)
+    # - os: linux
+    #   distro: trusty
+    #   sudo: true
+    #   env: TEST_TYPE=android EMULATOR=yes
+    #   jdk: oraclejdk8
+    #   language: android
+    #   android:
+    #     components:
+    #       # Some components come pre-installed:
+    #       # docs.travis-ci.com/user/languages/android#Pre-installed-components
+    #       # However, that seems to leave us with errors in the build
+    #       - tools
+    #       - platform-tools
+    #       - build-tools-23.0.1
+    #       - android-23
+    #       - extra-android-m2repository
+    #       - extra-google-m2repository
+    #       - extra-android-support
+    #       - sys-img-armeabi-v7a-google_apis-23
+    #   cache: *my-android-cache
+    #   before_cache: *my-android-before_cache
+
+    - os: osx
+      # We're using 7.2 currently, as xctool has issues with 7.3.
+      # This also means that we're testing against iOS 9.2.
+      osx_image: xcode7.2
+      language: objective-c
+      env: TEST_TYPE=ios
+      cache: *my-ios-cache
 
 # As seen in http://stackoverflow.com/a/31882307/2347774
 # Prevent travis from building twice for PRs
 branches:
   only:
     - master
-
-cache:
-  directories:
-    # cache node_modules b/c they take a long time to install
-    - node_modules
-    # cache .gradle for both gradle and gradle's cache
-    - ~/.gradle
-    # cache homebrew's git repo?
-    - /usr/local/Cellar/.git
 
 install:
   - echo "Now testing $TEST_TYPE on $TRAVIS_OS_NAME"
@@ -25,10 +94,9 @@ install:
   - echo "Travis branch is in pull request $TRAVIS_PULL+REQUEST"
 
   # work around android build failing - https://github.com/travis-ci/travis-ci/issues/6307
-  - if [[ "$TEST_TYPE" = android ]]; then rvm get head; fi
-  ### basic setup stuff
-  - brew update
+  # - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TEST_TYPE" == "android" ]]; then rvm get head; fi
   # force node 6
+  - nvm install 6
   - nvm use 6
   # turn off fancy npm stuff
   - npm config set spin=false
@@ -41,35 +109,26 @@ install:
   - if [[ "$TEST_TYPE" = js ]]; then rm -rf "$TMPDIR/jest_preprocess_cache"; fi
 
   ### do ios-only setup stuff
-  - if [[ "$TEST_TYPE" = ios ]]; then brew install xctool; fi
-
-  ### do android-only setup stuff
-  # install gradle
-  - if [[ "$TEST_TYPE" = android ]]; then brew install gradle; fi
-  # install android tools
   - |
-    if [[ "$TEST_TYPE" = android ]]; then
-      set -ve
-      brew install android-sdk
-
-      echo y | android update sdk --no-ui --all --filter tools > /dev/null
-      echo y | android update sdk --no-ui --all --filter platform-tools > /dev/null
-      echo y | android update sdk --no-ui --all --filter build-tools-23.0.1 > /dev/null
-      echo y | android update sdk --no-ui --all --filter android-23 > /dev/null
-      echo y | android update sdk --no-ui --all --filter extra-android-m2repository > /dev/null
-      echo y | android update sdk --no-ui --all --filter extra-google-m2repository > /dev/null
-      echo y | android update sdk --no-ui --all --filter extra-android-support > /dev/null
-
-      export ANDROID_HOME=/usr/local/opt/android-sdk
+    if [[ "$TRAVIS_OS_NAME" == "osx" && "$TEST_TYPE" == "ios" ]]; then
+      brew update
+      brew install xctool;
     fi
 
 
-# we can run three builds in parallel!
-env:
-  matrix:
-    - TEST_TYPE=js
-    - TEST_TYPE=ios
-    - TEST_TYPE=android
+before_script:
+  # Emulator Management: Create, Start and Wait
+  - |
+    if [[ "$TEST_TYPE" == "android" && "$EMULATOR" == "yes" ]]; then
+      EmuName="react-native"
+      df -h
+      mkdir -p "$HOME/.android/avd/$EmuName.avd/"
+      echo no | android create avd --force -n $EmuName -t android-23 --abi google_apis/armeabi-v7a
+      emulator -avd $EmuName -no-audio -no-window &
+      android-wait-for-emulator
+      adb shell input keyevent 82 &
+    fi
+
 
 script:
   # These sections will grow over time.

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ script:
   - if [[ "$TEST_TYPE" == "ios" ]]; then npm run test:ios; fi
 
   # android-only tests - building and specs
-  - if [[ "$TEST_TYPE" = android ]]; then npm run build:android:macos; fi
+  - if [[ "$TEST_TYPE" == "android" ]]; then npm run build:android:unix; fi
 
 # ping slack with status
 notifications:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -126,6 +126,12 @@ android {
             }
         }
     }
+    android {
+        dexOptions {
+            // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
+            preDexLibraries = preDexEnabled && !travisBuild
+        }
+    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,6 +12,12 @@ buildscript {
     }
 }
 
+ext {
+    travisBuild = System.getenv("TRAVIS") == "true"
+    // allows for -Dpre-dex=false to be set
+    preDexEnabled = "true".equals(System.getProperty("pre-dex", "true"))
+}
+
 allprojects {
     repositories {
         mavenLocal()

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "bundle:ios": "react-native bundle --entry-file index.ios.js --dev true --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --assets-dest ./ios",
     "bundle:android": "react-native bundle --entry-file index.android.js --dev true --platform android --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/",
     "build:ios": "xctool -configuration Release -project ios/AllAboutOlaf.xcodeproj -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2'",
-    "build:android:macos": "cd android && ./gradlew assembleRelease --info --console=plain",
+    "build:android:unix": "cd android && ./gradlew assembleRelease --info --console=plain",
     "build:android:win": "cd android && .\\gradlew assembleRelease --info --console=plain",
     "test": "npm run flow && npm run test:js",
     "test:js": "echo 'Not yet implemented! Figure out jest.'",


### PR DESCRIPTION
I enabled a more … selective build matrix on Travis.
- JS builds only need JS tooling, so we use Travis' docker-based containers for fast boot. this trims the runtime for js-tests from around 3-4 minutes to about 45-50 seconds.
- Android builds have a dedicated `android` environment that we can take advantage of. use it. this drops the time from ~20 minutes to ~9 minutes.
- I added the tooling to support running an android emulator on the new builds. however, it takes about 20 minutes to run the android tests on this system because of the emulator. when we decide to build more tests for the emulator, this will be useful.
- OS X / iOS builds still use the same image.

None of this affected Appveyor, whose builds are currently averaging 7 minutes (windows, android-only).

Oh, and the linux image-based builds also start up faster 😉. They usually run about a minute ahead of the OS X-based images.

---
### Before ([build 138](https://travis-ci.org/StoDevX/AAO-React-Native/builds/152887135))
- **JS:** 1 min, 59 sec
- **iOS:** 8 min, 56 sec
- **Android:** 20 min, 25 sec
- **Total:** 31 min, 20 sec
### After ([build 163](https://travis-ci.org/StoDevX/AAO-React-Native/builds/152953913))
- **JS:** 0 min, 48 sec
- **iOS:** 10 min, 44 sec
- **Android:** 9 min, 5 sec
- **Total:** 20 min, 37 sec
