### PR TITLE
Switch to trusty builds for android dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ matrix:
       cache: *my-node-cache
 
     - os: linux
-      sudo: false
+      sudo: true
+      distro: trusty
       env: TEST_TYPE=android
       jdk: oraclejdk8
       language: android
@@ -86,6 +87,7 @@ matrix:
 branches:
   only:
     - master
+    - travis
 
 install:
   - echo "Now testing $TEST_TYPE on $TRAVIS_OS_NAME"


### PR DESCRIPTION
I think this will speed things up again.

Yup. Android build is down to ~6 minutes, meaning that we only need to wait about 10 minutes for build status, which should save us around 2 minutes per PR.
