### PR TITLE
Shrink iOS build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
 branches:
   only:
     - master
-    - travis
+    - /^travis/
 
 install:
   - echo "Now testing $TEST_TYPE on $TRAVIS_OS_NAME"

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,13 +110,6 @@ install:
   # prepare for jest
   - if [[ "$TEST_TYPE" = js ]]; then rm -rf "$TMPDIR/jest_preprocess_cache"; fi
 
-  ### do ios-only setup stuff
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" && "$TEST_TYPE" == "ios" ]]; then
-      brew update
-      brew install xctool;
-    fi
-
 
 before_script:
   # Emulator Management: Create, Start and Wait


### PR DESCRIPTION
Drops about a minute by not installing xctool – it's already installed on the Travis images. iOS now builds in about ~8 minutes.
