### PR TITLE
Show version in Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AllAboutOlaf",
-  "version": "0.0.1",
+  "version": "2.0.0-beta.1",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/views/settings/index.js
+++ b/views/settings/index.js
@@ -24,6 +24,8 @@ import {
     TableView,
 } from 'react-native-tableview-simple'
 
+import {version} from '../../package.json'
+
 import NavigatorScreen from '../components/navigator-screen'
 import Icon from 'react-native-vector-icons/Entypo'
 import Communications from 'react-native-communications'
@@ -230,7 +232,7 @@ export default class SettingsView extends React.Component {
       <Section header='ODDS & ENDS'>
         <Cell cellStyle='RightDetail'
           title='Version'
-          detail='<get me from info.plist>'
+          detail={version}
         />
 
         <Cell cellStyle='Basic'


### PR DESCRIPTION
This uses the `package.json` file as the authoritative version. We will need to ensure that this is continued by whatever packaging system we use to build the final apps.
