### PR TITLE
Use HTTPS to load the KSTO radio page

### DIFF
--- a/views/streaming/radio.js
+++ b/views/streaming/radio.js
@@ -13,7 +13,7 @@ import {
 
 // let kstoDownload = 'itms://itunes.apple.com/us/app/ksto/id953916647'
 
-const url = 'http://pages.stolaf.edu/ksto/listen/'
+const url = 'https://pages.stolaf.edu/ksto/listen/'
 
 export default function KSTOView() {
   return (


### PR DESCRIPTION
This should fix it not loading.

Closes #156.
