### PR TITLE
Make Travis work with Cocoapods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ script:
   - if [[ "$TEST_TYPE" == "js" ]]; then npm run test:js; fi
 
   # iOS-only tests - building and specs
-  - if [[ "$TEST_TYPE" == "ios" ]]; then npm run test:ios; fi
+  - if [[ "$TEST_TYPE" == "ios" ]]; then npm run build:ios; fi
 
   # android-only tests - building and specs
   - if [[ "$TEST_TYPE" == "android" ]]; then npm run build:android:unix; fi

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "flow": "flow",
     "bundle:ios": "react-native bundle --entry-file index.ios.js --dev true --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --assets-dest ./ios",
     "bundle:android": "react-native bundle --entry-file index.android.js --dev true --platform android --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/",
-    "build:ios": "xctool -configuration Release -project ios/AllAboutOlaf.xcodeproj -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2'",
+    "build:ios": "xctool -configuration Release -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2'",
     "build:android:unix": "cd android && ./gradlew assembleRelease --info --console=plain",
     "build:android:win": "cd android && .\\gradlew assembleRelease --info --console=plain",
     "test": "npm run flow && npm run test:js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:android:win": "cd android && .\\gradlew assembleRelease --info --console=plain",
     "test": "npm run flow && npm run test:js",
     "test:js": "echo 'Not yet implemented! Figure out jest.'",
-    "test:ios": "xctool -configuration Release -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2' test",
+    "test:ios": "xcodebuild -configuration Release -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2' test",
     "test:android": "echo 'Not yet implemented! See http://facebook.github.io/react-native/docs/signed-apk-android.html#testing-the-release-build-of-your-app'",
     "release": "npm run release:ios && npm run release:android",
     "release:ios": "echo 'Not yet implemented!'",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:android:win": "cd android && .\\gradlew assembleRelease --info --console=plain",
     "test": "npm run flow && npm run test:js",
     "test:js": "echo 'Not yet implemented! Figure out jest.'",
-    "test:ios": "xctool -configuration Release -project ios/AllAboutOlaf.xcodeproj -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2' test",
+    "test:ios": "xctool -configuration Release -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2' test",
     "test:android": "echo 'Not yet implemented! See http://facebook.github.io/react-native/docs/signed-apk-android.html#testing-the-release-build-of-your-app'",
     "release": "npm run release:ios && npm run release:android",
     "release:ios": "echo 'Not yet implemented!'",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:android:win": "cd android && .\\gradlew assembleRelease --info --console=plain",
     "test": "npm run flow && npm run test:js",
     "test:js": "echo 'Not yet implemented! Figure out jest.'",
-    "test:ios": "xcodebuild -configuration Release -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2' test",
+    "test:ios": "xctool -configuration Release -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2' test",
     "test:android": "echo 'Not yet implemented! See http://facebook.github.io/react-native/docs/signed-apk-android.html#testing-the-release-build-of-your-app'",
     "release": "npm run release:ios && npm run release:android",
     "release:ios": "echo 'Not yet implemented!'",


### PR DESCRIPTION
Part of #161.

Travis needs to be updated to work with the cocoapods from iOS notifications.
- [x] Use the `xcworkspace` file.
- [x] ???
- [x] Build successfully
- Profit
