### PR TITLE
Oauth stuff

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,7 +135,6 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-cookies')
     compile project(':react-native-vector-icons')
     compile project(':react-native-keychain')
     compile project(':react-native-android-tablayout')

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,6 +135,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-cookies')
     compile project(':react-native-vector-icons')
     compile project(':react-native-keychain')
     compile project(':react-native-android-tablayout')

--- a/android/app/src/main/java/com/allaboutolaf/MainActivity.java
+++ b/android/app/src/main/java/com/allaboutolaf/MainActivity.java
@@ -1,7 +1,6 @@
 package com.allaboutolaf;
 
 import com.facebook.react.ReactActivity;
-import com.psykar.cookiemanager.CookieManagerPackage;
 
 public class MainActivity extends ReactActivity {
 

--- a/android/app/src/main/java/com/allaboutolaf/MainActivity.java
+++ b/android/app/src/main/java/com/allaboutolaf/MainActivity.java
@@ -1,6 +1,7 @@
 package com.allaboutolaf;
 
 import com.facebook.react.ReactActivity;
+import com.psykar.cookiemanager.CookieManagerPackage;
 
 public class MainActivity extends ReactActivity {
 

--- a/android/app/src/main/java/com/allaboutolaf/MainApplication.java
+++ b/android/app/src/main/java/com/allaboutolaf/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
+import com.psykar.cookiemanager.CookieManagerPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.oblador.keychain.KeychainPackage;
 import com.xebia.reactnative.TabLayoutPackage;
@@ -28,6 +29,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
         new MainReactPackage(),
+            new CookieManagerPackage(),
         new VectorIconsPackage(),
         new KeychainPackage(),
         new TabLayoutPackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,8 +1,6 @@
 rootProject.name = 'All About Olaf'
 
 include ':app'
-include ':react-native-cookies'
-project(':react-native-cookies').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-cookies/android')
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
 include ':react-native-keychain'

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,6 +1,8 @@
 rootProject.name = 'All About Olaf'
 
 include ':app'
+include ':react-native-cookies'
+project(':react-native-cookies').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-cookies/android')
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
 include ':react-native-keychain'

--- a/app.js
+++ b/app.js
@@ -11,7 +11,6 @@ import {
   TouchableOpacity,
   Text,
   Platform,
-  View,
 } from 'react-native'
 
 import AboutView from './views/about'
@@ -31,6 +30,7 @@ import TransportationView from './views/transportation'
 import OlevilleView from './views/oleville'
 import OlevilleNewsStoryView from './views/oleville/latestView'
 import SettingsView from './views/settings'
+import SISLoginView from './views/settings/login'
 import CreditsView from './views/settings/credits'
 import PrivacyView from './views/settings/privacy'
 import LegalView from './views/settings/legal'
@@ -58,6 +58,7 @@ function renderScene(route, navigator) {
     case 'OlevilleView': return <OlevilleView {...props} />
     case 'OlevilleNewsStoryView': return <OlevilleNewsStoryView {...props} />
     case 'SettingsView': return <SettingsView {...props} />
+    case 'SISLoginView': return <SISLoginView {...props} />
     case 'CreditsView': return <CreditsView {...props} />
     case 'PrivacyView': return <PrivacyView {...props} />
     case 'LegalView': return <LegalView {...props} />
@@ -209,13 +210,19 @@ function Title(route) {
 
 export default class App extends React.Component {
   componentDidMount() {
-    BackAndroid.addEventListener('hardwareBackPress', () => {
-      if (this._navigator && this._navigator.getCurrentRoutes().length > 1) {
-        this._navigator.pop()
-        return true
-      }
-      return false
-    })
+    BackAndroid.addEventListener('hardwareBackPress', this.registerAndroidBackButton)
+  }
+
+  componentWillUnmount() {
+    BackAndroid.removeEventListener('hardwareBackPress', this.registerAndroidBackButton)
+  }
+
+  registerAndroidBackButton = () => {
+    if (this._navigator && this._navigator.getCurrentRoutes().length > 1) {
+      this._navigator.pop()
+      return true
+    }
+    return false
   }
 
   render() {

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -36,6 +35,7 @@
 		F0739B3A70BA995B58032C19 /* libPods-AllAboutOlaf.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B997F61616AEE0B6BF79DB54 /* libPods-AllAboutOlaf.a */; };
 		F5A92AB96CCC44F5A4944718 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 25889372CF4341B19A8A69C5 /* FontAwesome.ttf */; };
 		FEE667253C1C4F4F891D5B1F /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1A27CF9941A9482697F215C6 /* MaterialIcons.ttf */; };
+		EB9A4881A1464154B6F35611 /* libRNCookieManagerIOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2104D1F24B874E7EB194665B /* libRNCookieManagerIOS.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -196,6 +196,8 @@
 		B997F61616AEE0B6BF79DB54 /* libPods-AllAboutOlaf.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AllAboutOlaf.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF2508C73D024BE2B226091B /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
 		E6FBE71A05CC43E2B4885180 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
+		939088A4207C45ED9DF78B04 /* RNCookieManagerIOS.xcodeproj */ = {isa = PBXFileReference; name = "RNCookieManagerIOS.xcodeproj"; path = "../node_modules/react-native-cookies/RNCookieManagerIOS.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		2104D1F24B874E7EB194665B /* libRNCookieManagerIOS.a */ = {isa = PBXFileReference; name = "libRNCookieManagerIOS.a"; path = "libRNCookieManagerIOS.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -226,6 +228,7 @@
 				9B1AE705D4204424A71EE737 /* libRNKeychain.a in Frameworks */,
 				9304AFEA1BEF4D77A9BE9E47 /* libRNVectorIcons.a in Frameworks */,
 				F0739B3A70BA995B58032C19 /* libPods-AllAboutOlaf.a in Frameworks */,
+				EB9A4881A1464154B6F35611 /* libRNCookieManagerIOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -400,6 +403,7 @@
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				A91038679F834707B769D282 /* RNKeychain.xcodeproj */,
 				71D5CCADA66D45008D9A38F2 /* RNVectorIcons.xcodeproj */,
+				939088A4207C45ED9DF78B04 /* RNCookieManagerIOS.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -893,7 +897,10 @@
 				INFOPLIST_FILE = AllAboutOlafTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -909,7 +916,10 @@
 				INFOPLIST_FILE = AllAboutOlafTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/All About Olaf.app/All About Olaf";
@@ -931,6 +941,7 @@
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/**",
+					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -957,6 +968,7 @@
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/**",
+					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1011,6 +1023,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -1053,6 +1066,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -35,7 +36,6 @@
 		F0739B3A70BA995B58032C19 /* libPods-AllAboutOlaf.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B997F61616AEE0B6BF79DB54 /* libPods-AllAboutOlaf.a */; };
 		F5A92AB96CCC44F5A4944718 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 25889372CF4341B19A8A69C5 /* FontAwesome.ttf */; };
 		FEE667253C1C4F4F891D5B1F /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1A27CF9941A9482697F215C6 /* MaterialIcons.ttf */; };
-		EB9A4881A1464154B6F35611 /* libRNCookieManagerIOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2104D1F24B874E7EB194665B /* libRNCookieManagerIOS.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -196,8 +196,6 @@
 		B997F61616AEE0B6BF79DB54 /* libPods-AllAboutOlaf.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AllAboutOlaf.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF2508C73D024BE2B226091B /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
 		E6FBE71A05CC43E2B4885180 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
-		939088A4207C45ED9DF78B04 /* RNCookieManagerIOS.xcodeproj */ = {isa = PBXFileReference; name = "RNCookieManagerIOS.xcodeproj"; path = "../node_modules/react-native-cookies/RNCookieManagerIOS.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		2104D1F24B874E7EB194665B /* libRNCookieManagerIOS.a */ = {isa = PBXFileReference; name = "libRNCookieManagerIOS.a"; path = "libRNCookieManagerIOS.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -228,7 +226,6 @@
 				9B1AE705D4204424A71EE737 /* libRNKeychain.a in Frameworks */,
 				9304AFEA1BEF4D77A9BE9E47 /* libRNVectorIcons.a in Frameworks */,
 				F0739B3A70BA995B58032C19 /* libPods-AllAboutOlaf.a in Frameworks */,
-				EB9A4881A1464154B6F35611 /* libRNCookieManagerIOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -403,7 +400,6 @@
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				A91038679F834707B769D282 /* RNKeychain.xcodeproj */,
 				71D5CCADA66D45008D9A38F2 /* RNVectorIcons.xcodeproj */,
-				939088A4207C45ED9DF78B04 /* RNCookieManagerIOS.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -897,10 +893,7 @@
 				INFOPLIST_FILE = AllAboutOlafTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -916,10 +909,7 @@
 				INFOPLIST_FILE = AllAboutOlafTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/All About Olaf.app/All About Olaf";
@@ -941,7 +931,6 @@
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/**",
-					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -968,7 +957,6 @@
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/**",
-					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1023,7 +1011,6 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
-					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -1066,7 +1053,6 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
-					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -36,6 +35,7 @@
 		F0739B3A70BA995B58032C19 /* libPods-AllAboutOlaf.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B997F61616AEE0B6BF79DB54 /* libPods-AllAboutOlaf.a */; };
 		F5A92AB96CCC44F5A4944718 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 25889372CF4341B19A8A69C5 /* FontAwesome.ttf */; };
 		FEE667253C1C4F4F891D5B1F /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1A27CF9941A9482697F215C6 /* MaterialIcons.ttf */; };
+		1F8239F6A983407CB8C0A1F7 /* libRNCookieManagerIOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 124A9486664047EEAF7CBCDF /* libRNCookieManagerIOS.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -196,6 +196,8 @@
 		B997F61616AEE0B6BF79DB54 /* libPods-AllAboutOlaf.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AllAboutOlaf.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF2508C73D024BE2B226091B /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
 		E6FBE71A05CC43E2B4885180 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
+		10892B9A230345CC9EC09E61 /* RNCookieManagerIOS.xcodeproj */ = {isa = PBXFileReference; name = "RNCookieManagerIOS.xcodeproj"; path = "../node_modules/react-native-cookies/RNCookieManagerIOS.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		124A9486664047EEAF7CBCDF /* libRNCookieManagerIOS.a */ = {isa = PBXFileReference; name = "libRNCookieManagerIOS.a"; path = "libRNCookieManagerIOS.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -226,6 +228,7 @@
 				9B1AE705D4204424A71EE737 /* libRNKeychain.a in Frameworks */,
 				9304AFEA1BEF4D77A9BE9E47 /* libRNVectorIcons.a in Frameworks */,
 				F0739B3A70BA995B58032C19 /* libPods-AllAboutOlaf.a in Frameworks */,
+				1F8239F6A983407CB8C0A1F7 /* libRNCookieManagerIOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -400,6 +403,7 @@
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				A91038679F834707B769D282 /* RNKeychain.xcodeproj */,
 				71D5CCADA66D45008D9A38F2 /* RNVectorIcons.xcodeproj */,
+				10892B9A230345CC9EC09E61 /* RNCookieManagerIOS.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -893,7 +897,10 @@
 				INFOPLIST_FILE = AllAboutOlafTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -909,7 +916,10 @@
 				INFOPLIST_FILE = AllAboutOlafTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/All About Olaf.app/All About Olaf";
@@ -931,6 +941,7 @@
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/**",
+					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -957,6 +968,7 @@
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/**",
+					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1011,6 +1023,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -1053,6 +1066,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/lib/courses.js
+++ b/lib/courses.js
@@ -3,6 +3,7 @@ import {
     api,
     loadLoginCredentials,
     sisLogin,
+    isLoggedIn,
 } from '../lib/login'
 import { AsyncStorage, NetInfo } from 'react-native'
 
@@ -118,8 +119,9 @@ async function getTermListFromStorage(): Promise<number[]> {
 }
 
 async function getTermListFromServer(): Promise<number[]> {
-  let {username, password} = await loadLoginCredentials()
-  let {result} = await sisLogin(username, password)
+  // let {username, password} = await loadLoginCredentials()
+  // let {result} = await sisLogin(username, password)
+  let result = await isLoggedIn()
   if (!result) {
     return []
   }
@@ -136,6 +138,7 @@ async function getTermListFromServer(): Promise<number[]> {
   } else if (stunum.choices) {
     throw new Error('multiple student numbers!')
   }
+
   let terms = cssSelect('[name=searchyearterm]', dom)[0]
     .children
     .filter(node => node.type === 'tag' && node.name === 'option')

--- a/lib/courses.js
+++ b/lib/courses.js
@@ -1,9 +1,7 @@
 // @flow
 import {
-    api,
-    loadLoginCredentials,
-    sisLogin,
-    isLoggedIn,
+  api,
+  isLoggedIn,
 } from '../lib/login'
 import { AsyncStorage, NetInfo } from 'react-native'
 

--- a/lib/financials.js
+++ b/lib/financials.js
@@ -1,9 +1,8 @@
 // @flow
 import {
-    api,
-    loadLoginCredentials,
-    sisLogin,
-    isLoggedIn,
+  api,
+  loadLoginCredentials,
+  isLoggedIn,
 } from '../lib/login'
 import { AsyncStorage, NetInfo } from 'react-native'
 
@@ -87,6 +86,7 @@ async function getFinancialDataFromServer(): Promise<FinancialDataShapeType> {
 }
 
 
+// TODO: come up with a better story around auth for olecard
 export default async function getWeeklyMealsRemaining() {
   let {username, password} = await loadLoginCredentials()
   let form = buildFormData({

--- a/lib/financials.js
+++ b/lib/financials.js
@@ -3,6 +3,7 @@ import {
     api,
     loadLoginCredentials,
     sisLogin,
+    isLoggedIn,
 } from '../lib/login'
 import { AsyncStorage, NetInfo } from 'react-native'
 
@@ -52,8 +53,9 @@ async function getSisFinancialsPage() {
 }
 
 async function getFinancialDataFromServer(): Promise<FinancialDataShapeType> {
-  let {username, password} = await loadLoginCredentials()
-  let {result} = await sisLogin(username, password)
+  // let {username, password} = await loadLoginCredentials()
+  // let {result} = await sisLogin(username, password)
+  let result = await isLoggedIn()
   if (!result) {
     return {flex: null, ole: null, print: null}
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-native-calendar": "0.6.4",
     "react-native-collapsible": "0.7.0",
     "react-native-communications": "2.1.0",
+    "react-native-cookies": "1.0.2",
     "react-native-keychain": "0.3.2",
     "react-native-onesignal": "1.2.0",
     "react-native-refreshable-listview": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "react-native-calendar": "0.6.4",
     "react-native-collapsible": "0.7.0",
     "react-native-communications": "2.1.0",
-    "react-native-cookies": "1.0.2",
     "react-native-keychain": "0.3.2",
     "react-native-onesignal": "1.2.0",
     "react-native-refreshable-listview": "1.3.0",

--- a/views/settings/index.js
+++ b/views/settings/index.js
@@ -59,6 +59,9 @@ export default class SettingsView extends React.Component {
     this.props.navigator.push({
       id: 'SISLoginView',
       index: this.props.route.index + 1,
+      props: {
+        onLoginComplete: status => this.setState({success: status}),
+      },
     })
   }
 

--- a/views/settings/index.js
+++ b/views/settings/index.js
@@ -26,9 +26,7 @@ import {version} from '../../package.json'
 
 import Communications from 'react-native-communications'
 import * as c from '../components/colors'
-import {
-  loadLoginCredentials,
-} from '../../lib/login'
+import CookieManager from 'react-native-cookies'
 
 
 export default class SettingsView extends React.Component {
@@ -38,8 +36,7 @@ export default class SettingsView extends React.Component {
   }
 
   state = {
-    username: '',
-    password: '',
+    loggedIn: false,
     success: false,
     loading: false,
     attempted: false,
@@ -49,17 +46,10 @@ export default class SettingsView extends React.Component {
     this.loadData()
   }
 
-  _usernameInput: any;
-  _passwordInput: any;
-
   loadData = async () => {
-    let [creds, status] = await Promise.all([
-      loadLoginCredentials(),
+    let [status] = await Promise.all([
       AsyncStorage.getItem('credentials:valid').then(val => JSON.parse(val)),
     ])
-    if (creds) {
-      this.setState({username: creds.username, password: creds.password})
-    }
     if (status) {
       this.setState({success: true})
     }
@@ -73,19 +63,17 @@ export default class SettingsView extends React.Component {
   }
 
   logOut = async () => {
-    // this.props.navigator.push({
-    //   id: 'SISLoginView',
-    //   index: this.props.route.index + 1,
-    // })
-  }
-
-  focusUsername = () => {
-    console.log(this._usernameInput)
-    this._usernameInput.focus()
-  }
-
-  focusPassword = () => {
-    this._passwordInput.focus()
+    this.setState({loading: true})
+    CookieManager.clearAll((err, res) => {
+      if (err) {
+        console.log(err)
+      }
+      console.log(res)
+      this.setState({
+        success: false,
+        loading: false,
+      })
+    })
   }
 
   onPressLegalButton() {
@@ -110,9 +98,6 @@ export default class SettingsView extends React.Component {
   }
 
   render() {
-    let username = this.state.username
-    let password = this.state.password
-
     let loggedIn = this.state.success
     let loading = this.state.loading
 

--- a/views/settings/index.js
+++ b/views/settings/index.js
@@ -65,11 +65,18 @@ export default class SettingsView extends React.Component {
     }
   }
 
-  logIn = async () => {
+  logIn = () => {
     this.props.navigator.push({
       id: 'SISLoginView',
       index: this.props.route.index + 1,
     })
+  }
+
+  logOut = async () => {
+    // this.props.navigator.push({
+    //   id: 'SISLoginView',
+    //   index: this.props.route.index + 1,
+    // })
   }
 
   focusUsername = () => {
@@ -109,7 +116,7 @@ export default class SettingsView extends React.Component {
     let loggedIn = this.state.success
     let loading = this.state.loading
 
-    let disabled = loading || (!username || !password)
+    let disabled = loading
 
     let loginTextStyle = disabled
       ? styles.loginButtonTextDisabled

--- a/views/settings/index.js
+++ b/views/settings/index.js
@@ -8,12 +8,10 @@ import React from 'react'
 import {
   StyleSheet,
   Text,
-  TextInput,
   ScrollView,
   Platform,
   AsyncStorage,
   Navigator,
-  Alert,
   View,
 } from 'react-native'
 
@@ -28,19 +26,15 @@ import {version} from '../../package.json'
 
 import Communications from 'react-native-communications'
 import * as c from '../components/colors'
-import LegalView from './legal'
-import CreditsView from './credits'
-import PrivacyView from './privacy'
 import {
   loadLoginCredentials,
-  clearLoginCredentials,
-  performLogin,
 } from '../../lib/login'
 
 
 export default class SettingsView extends React.Component {
   static propTypes = {
     navigator: React.PropTypes.instanceOf(Navigator),
+    route: React.PropTypes.object,
   }
 
   state = {
@@ -72,19 +66,10 @@ export default class SettingsView extends React.Component {
   }
 
   logIn = async () => {
-    this.setState({loading: true})
-    let {username, password} = this.state
-    let {result} = await performLogin(username, password)
-    if (!result) {
-      Alert.alert('Error signing in', 'The username or password is incorrect.')
-    }
-    this.setState({loading: false, attempted: true, success: result})
-  }
-
-  logOut = async () => {
-    this.setState({username: '', password: '', success: false, attempted: false})
-    clearLoginCredentials()
-    AsyncStorage.removeItem('credentials:valid')
+    this.props.navigator.push({
+      id: 'SISLoginView',
+      index: this.props.route.index + 1,
+    })
   }
 
   focusUsername = () => {
@@ -99,27 +84,21 @@ export default class SettingsView extends React.Component {
   onPressLegalButton() {
     this.props.navigator.push({
       id: 'LegalView',
-      component: <LegalView
-        navigator={this.props.navigator}
-      />,
+      index: this.props.route.index + 1,
     })
   }
 
   onPressCreditsButton() {
     this.props.navigator.push({
       id: 'CreditsView',
-      component: <CreditsView
-        navigator={this.props.navigator}
-      />,
+      index: this.props.route.index + 1,
     })
   }
 
   onPressPrivacyButton() {
     this.props.navigator.push({
       id: 'PrivacyView',
-      component: <PrivacyView
-        navigator={this.props.navigator}
-      />,
+      index: this.props.route.index + 1,
     })
   }
 
@@ -137,49 +116,6 @@ export default class SettingsView extends React.Component {
       : loading
         ? styles.loginButtonTextLoading
         : styles.loginButtonTextActive
-
-    let usernameCell = (
-      <CustomCell contentContainerStyle={styles.loginCell}>
-        <Text onPress={this.focusUsername} style={styles.label}>Username</Text>
-
-        <TextInput
-          ref={ref => this._usernameInput = ref}
-          cellStyle='Basic'
-          autoCorrect={false}
-          autoCapitalize='none'
-          style={styles.customTextInput}
-          placeholderTextColor='#C7C7CC'
-          disabled={disabled}
-          placeholder='username'
-          value={username}
-          returnKeyType='next'
-          onChangeText={text => this.setState({username: text})}
-          onSubmitEditing={this.focusPassword}
-        />
-      </CustomCell>
-    )
-
-    let passwordCell = (
-      <CustomCell contentContainerStyle={styles.loginCell}>
-        <Text onPress={this.focusPassword} style={styles.label}>Password</Text>
-
-        <TextInput
-          ref={ref => this._passwordInput = ref}
-          cellStyle='Basic'
-          autoCorrect={false}
-          autoCapitalize='none'
-          style={styles.customTextInput}
-          placeholderTextColor='#C7C7CC'
-          disabled={disabled}
-          secureTextEntry={true}
-          placeholder='password'
-          value={password}
-          returnKeyType='done'
-          onChangeText={text => this.setState({password: text})}
-          onSubmitEditing={loggedIn ? () => {} : this.logIn}
-        />
-      </CustomCell>
-    )
 
     let actionCell = (
       <CustomCell
@@ -199,11 +135,6 @@ export default class SettingsView extends React.Component {
 
     let accountSection = (
       <View>
-        <Section header='ST. OLAF ACCOUNT'>
-          {usernameCell}
-          {passwordCell}
-        </Section>
-
         <Section>
           {actionCell}
         </Section>

--- a/views/settings/index.js
+++ b/views/settings/index.js
@@ -77,6 +77,7 @@ export default class SettingsView extends React.Component {
         loading: false,
       })
     })
+    await AsyncStorage.setItem('credentials:valid', JSON.stringify(false))
   }
 
   onPressLegalButton() {

--- a/views/settings/login.js
+++ b/views/settings/login.js
@@ -1,0 +1,87 @@
+/**
+ * All About Olaf
+ * Index view
+ */
+
+import React from 'react'
+import {
+  WebView,
+  View,
+  Text,
+} from 'react-native'
+
+
+import CookieManager from 'react-native-cookies'
+import LoadingView from '../components/loading'
+
+const HOME_URL = 'https://www.stolaf.edu/sis/index.cfm'
+const LOGIN_URL = 'https://www.stolaf.edu/sis/landing-page.cfm'
+
+
+export default class SISLoginView extends React.Component {
+  state = {
+    loggedIn: false,
+    cookieLoaded: false,
+  }
+
+  loadCookie = () => {
+    CookieManager.get(HOME_URL, cookie => {
+      let isAuthenticated
+      // If it differs, change `cookie.remember_me` to whatever the name for your persistent cookie is!!!
+      if (cookie && cookie.indexOf('remember_me') != -1) {
+        isAuthenticated = true
+      } else {
+        isAuthenticated = false
+      }
+
+      this.setState({
+        loggedIn: isAuthenticated,
+        loadedCookie: true,
+      })
+    })
+  }
+
+  logout () {
+    CookieManager.clearAll((err, res) => {
+      if (err) {
+        console.log(err)
+      }
+      console.log(res)
+    })
+
+    this.setState({
+      loggedIn: false,
+    })
+  }
+
+  onNavigationStateChange = navState => {
+    // If we get redirected back to the HOME_URL we know that we are logged in. If your backend does something different than this
+    // change this line.
+    if (navState.url == HOME_URL) {
+      this.setState({
+        loggedIn: true,
+      })
+    }
+  }
+
+  render() {
+    // If we have completed loading the cookie choose to show Login WebView or the LoggedIn component, else just show an empty View.
+    if (!this.state.loadedCookie) {
+      return <LoadingView />
+    }
+    if (this.state.loggedIn) {
+      return <View><Text>Logged in!</Text></View>
+    }
+
+    return (
+      <WebView
+        automaticallyAdjustContentInsets={false}
+        source={{uri: LOGIN_URL}}
+        javaScriptEnabled={true}
+        onNavigationStateChange={this.onNavigationStateChange}
+        startInLoadingState={true}
+        scalesPageToFit={true}
+      />
+    )
+  }
+}

--- a/views/settings/login.js
+++ b/views/settings/login.js
@@ -9,19 +9,24 @@ import {
   View,
   Text,
 } from 'react-native'
-
+import startsWith from 'lodash/startsWith'
 
 import CookieManager from 'react-native-cookies'
 import LoadingView from '../components/loading'
 
 const HOME_URL = 'https://www.stolaf.edu/sis/index.cfm'
-const LOGIN_URL = 'https://www.stolaf.edu/sis/landing-page.cfm'
+const LOGIN_URL = 'https://www.stolaf.edu/sis/login.cfm'
+const AUTH_REJECTED_URL = 'https://www.stolaf.edu/sis/login.cfm?error=access_denied#'
 
 
 export default class SISLoginView extends React.Component {
   state = {
     loggedIn: false,
     cookieLoaded: false,
+  }
+
+  componentWillMount() {
+    this.loadCookie()
   }
 
   loadCookie = () => {
@@ -57,10 +62,12 @@ export default class SISLoginView extends React.Component {
   onNavigationStateChange = navState => {
     // If we get redirected back to the HOME_URL we know that we are logged in. If your backend does something different than this
     // change this line.
-    if (navState.url == HOME_URL) {
+    if (startsWith(navState.url, HOME_URL)) {
       this.setState({
         loggedIn: true,
       })
+    } else if (startsWith(navState.url, AUTH_REJECTED_URL)) {
+      this.navigator.pop()
     }
   }
 

--- a/views/settings/login.js
+++ b/views/settings/login.js
@@ -9,6 +9,7 @@ import {
   View,
   Text,
   AsyncStorage,
+  Navigator,
 } from 'react-native'
 import startsWith from 'lodash/startsWith'
 
@@ -23,6 +24,7 @@ const AUTH_REJECTED_URL = 'https://www.stolaf.edu/sis/login.cfm?error=access_den
 
 export default class SISLoginView extends React.Component {
   static propTypes = {
+    navigator: React.PropTypes.instanceOf(Navigator),
     onLoginComplete: React.PropTypes.func,
   };
 

--- a/views/settings/login.js
+++ b/views/settings/login.js
@@ -8,6 +8,7 @@ import {
   WebView,
   View,
   Text,
+  AsyncStorage,
 } from 'react-native'
 import startsWith from 'lodash/startsWith'
 
@@ -63,6 +64,7 @@ export default class SISLoginView extends React.Component {
     // If we get redirected back to the HOME_URL we know that we are logged in. If your backend does something different than this
     // change this line.
     if (startsWith(navState.url, HOME_URL)) {
+      AsyncStorage.setItem('credentials:valid', JSON.stringify(true))
       this.setState({
         loggedIn: true,
       })

--- a/views/settings/login.js
+++ b/views/settings/login.js
@@ -15,16 +15,21 @@ import startsWith from 'lodash/startsWith'
 import CookieManager from 'react-native-cookies'
 import LoadingView from '../components/loading'
 
+const COOKIE_NAME = 'JSESSIONID'
 const HOME_URL = 'https://www.stolaf.edu/sis/index.cfm'
 const LOGIN_URL = 'https://www.stolaf.edu/sis/login.cfm'
 const AUTH_REJECTED_URL = 'https://www.stolaf.edu/sis/login.cfm?error=access_denied#'
 
 
 export default class SISLoginView extends React.Component {
+  static propTypes = {
+    onLoginComplete: React.PropTypes.func,
+  };
+
   state = {
     loggedIn: false,
     cookieLoaded: false,
-  }
+  };
 
   componentWillMount() {
     this.loadCookie()
@@ -33,8 +38,8 @@ export default class SISLoginView extends React.Component {
   loadCookie = () => {
     CookieManager.get(HOME_URL, cookie => {
       let isAuthenticated
-      // If it differs, change `cookie.remember_me` to whatever the name for your persistent cookie is!!!
-      if (cookie && cookie.indexOf('remember_me') != -1) {
+
+      if (cookie && cookie.indexOf(COOKIE_NAME) != -1) {
         isAuthenticated = true
       } else {
         isAuthenticated = false
@@ -44,6 +49,7 @@ export default class SISLoginView extends React.Component {
         loggedIn: isAuthenticated,
         loadedCookie: true,
       })
+      this.props.onLoginComplete(isAuthenticated)
     })
   }
 
@@ -68,8 +74,13 @@ export default class SISLoginView extends React.Component {
       this.setState({
         loggedIn: true,
       })
+      // TODO: figure out a way to do this that doesn't involve reaching
+      // into the parent? But this migth be the good way. Think about it.
+      this.props.onLoginComplete(true)
+      this.props.navigator.pop()
     } else if (startsWith(navState.url, AUTH_REJECTED_URL)) {
-      this.navigator.pop()
+      this.props.onLoginComplete(false)
+      this.props.navigator.pop()
     }
   }
 


### PR DESCRIPTION
I can't do any more tonight. This is what I've got so far, but _both_ simulators are fighting me. iOS says it can't find CFBundleIdentifier, and Android is throwing an invariant of "please link the damned library with `rnpm link`" (paraphrased).

But this might work? It's a copy of https://github.com/ryanmcdermott/react-native-login/tree/master/ReactNativeLogin, and if I understand correctly, the cookies are cached by the underlying network layer, not the webview, so once we get a login _here_ it should just work for the other `fetch` requests. (see https://github.com/facebook/react-native/issues/1274#issuecomment-102221311)

One of you is going to have to take this on, I'm afraid.
