### PR TITLE
Fix the iOS navbar shadow

### DIFF
--- a/app.js
+++ b/app.js
@@ -82,8 +82,10 @@ const styles = StyleSheet.create({
     // flexDirection: 'row',
     // justifyContent: 'center',
     // alignItems: 'center',
-    borderBottomColor: '#b2b2b2',
-    borderBottomWidth: 1,
+    shadowOffset: { width: 0, height: StyleSheet.hairlineWidth },
+    shadowColor: 'rgb(100, 100, 100)',
+    shadowOpacity: 0.5,
+    shadowRadius: StyleSheet.hairlineWidth,
   },
   backButton: {
     flexDirection: 'row',


### PR DESCRIPTION
It was close before, but not quite there. (Next up, Android's drop shadow 😜.)
## At Rest
###### Before

<img width="376" alt="screen shot 2016-09-05 at 9 44 04 pm" src="https://cloud.githubusercontent.com/assets/464441/18248482/6c3d1fa0-73b3-11e6-9f48-89a563be48b0.png">
###### After

<img width="377" alt="screen shot 2016-09-05 at 9 43 46 pm" src="https://cloud.githubusercontent.com/assets/464441/18248479/6aed2b7c-73b3-11e6-8018-5bc76a21c684.png">
## Scrolled slightly
###### Before

<img width="376" alt="screen shot 2016-09-05 at 9 44 29 pm" src="https://cloud.githubusercontent.com/assets/464441/18248335/7b37c3d0-73b2-11e6-971e-049ed83f077f.png">
###### After

<img width="376" alt="screen shot 2016-09-05 at 9 44 20 pm" src="https://cloud.githubusercontent.com/assets/464441/18248334/7b13e8c0-73b2-11e6-9869-3edbe94d5636.png">
