### PR TITLE
Removing unused react-native-calendar dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "react-native-android-tablayout": "0.3.0",
     "react-native-animatable": "0.6.1",
     "react-native-button": "1.7.0",
-    "react-native-calendar": "0.6.4",
     "react-native-collapsible": "0.7.0",
     "react-native-communications": "2.1.0",
     "react-native-cookies": "1.0.2",


### PR DESCRIPTION
@hawkrives suggested that this be removed, we do not use it yet depend upon it.
