### PR TITLE
Removing unused react-tween-state dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "react-native-refreshable-listview": "1.3.0",
     "react-native-tableview-simple": "0.12.0",
     "react-native-vector-icons": "2.1.0",
-    "react-tween-state": "0.1.5",
     "redux": "3.6.0",
     "stream": "0.0.2",
     "timers": "0.1.1",


### PR DESCRIPTION
@hawkrives suggested that this be removed, we do not use it yet depend upon it. I added this one way back when to try and get SIS numbers to animate. Never did anything with it.
