### PR TITLE
Added image check for posts not containing images

### DIFF
--- a/views/oleville/index.js
+++ b/views/oleville/index.js
@@ -80,11 +80,9 @@ export default class OlevilleView extends React.Component {
       if (responseJson.media_details.sizes.medium.source_url) {
         // if there is a featured image, use that url
         return responseJson.media_details.sizes.medium.source_url
-      } else {
-        // otherwise default to the oleville logo
-        return 'http://oleville.com/wp-content/uploads/2015/12/Oleville-Logo.png'
       }
     }
+    return 'http://oleville.com/wp-content/uploads/2015/12/Oleville-Logo.png'
   }
 
   fetchData = async () => {


### PR DESCRIPTION
Closes #237. This checks to see if an image id exists from the `article.featured_media` prop. If it does not, we return the default image.
