### PR TITLE
Add some eslint rules  for managing whitespace

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -29,6 +29,7 @@ rules:
   consistent-this: [warn, self]
   curly: [error, multi-line]
   default-case: error
+  eol-last: [error, always]
   guard-for-in: error
   indent: [error, 2, {SwitchCase: 1, MemberExpression: 1}]
   key-spacing: ['error', {beforeColon: false, afterColon: true}]

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -51,6 +51,7 @@ rules:
   no-redeclare: ['error', {builtinGlobals: true}]
   no-restricted-syntax: [error, WithStatement]
   no-self-assign: warn
+  no-trailing-spaces: error
   no-undef-init: 'off'
   no-underscore-dangle: 'off'
   no-unmodified-loop-condition: error

--- a/views/building-hours/all-building-hours.js
+++ b/views/building-hours/all-building-hours.js
@@ -14,9 +14,8 @@ export function allBuildingHours(info, style) {
     let hoursString = ''
     let day = current.format('dddd')
     let d = current.format('ddd')
-    
+
     current.add(1, 'days')
-    
 
     let timesArray = info.times.hours[d]
 


### PR DESCRIPTION
This enables two eslint rules: 

- `no-trailing-spaces` requires that there be no whitespace characters at the end of a line
- `eol-last` requires that the file end in a newline

`eol-last`, in particular, makes git diffs cleaner because without a newline at the end of the file, the diff will always show it as changed.