### PR TITLE
Add "Ongoing" section to the calendars

### DIFF
--- a/views/calendar/calendar.js
+++ b/views/calendar/calendar.js
@@ -86,8 +86,9 @@ export default class CalendarView extends React.Component {
         event.endTime = moment(event.end.date || event.end.dateTime)
       })
       data.forEach(event => {
-        if (event.startTime < Date.now())
+        if (event.startTime < Date.now()) {
           event.startTime = moment()
+        }
       })
       let grouped = groupBy(data, event => event.startTime.format('ddd  MMM Do'))
       this.setState({events: this.state.events.cloneWithRowsAndSections(grouped)})

--- a/views/calendar/calendar.js
+++ b/views/calendar/calendar.js
@@ -85,6 +85,10 @@ export default class CalendarView extends React.Component {
         event.startTime = moment(event.start.date || event.start.dateTime)
         event.endTime = moment(event.end.date || event.end.dateTime)
       })
+      data.forEach(event => {
+        if (event.startTime < Date.now())
+          event.startTime = moment()
+      })
       let grouped = groupBy(data, event => event.startTime.format('ddd  MMM Do'))
       this.setState({events: this.state.events.cloneWithRowsAndSections(grouped)})
     } else if (data && !data.length) {

--- a/views/calendar/calendar.js
+++ b/views/calendar/calendar.js
@@ -40,8 +40,8 @@ export default class CalendarView extends React.Component {
 
   state = {
     events: new ListView.DataSource({
-      rowHasChanged: this.rowHasChanged,
-      sectionHeaderHasChanged: this.sectionHeaderHasChanged,
+      rowHasChanged: (r1: GoogleCalendarEventType, r2: GoogleCalendarEventType) => r1.summary !== r2.summary,
+      sectionHeaderHasChanged: (h1: number, h2: number) => h1 !== h2,
     }),
     loaded: false,
     refreshing: true,
@@ -51,14 +51,6 @@ export default class CalendarView extends React.Component {
 
   componentWillMount() {
     this.refresh()
-  }
-
-  rowHasChanged(r1: GoogleCalendarEventType, r2: GoogleCalendarEventType) {
-    return r1.summary !== r2.summary
-  }
-
-  sectionHeaderHasChanged(h1: number, h2: number) {
-    return h1 !== h2
   }
 
   buildCalendarUrl(calendarId: string) {


### PR DESCRIPTION
I changed something on the calendar. The old calendar had multi-day events listed at their start day, rather than today. This makes the St. Olaf Master Calendar view look silly, since it seems like it's stuck in the past. These changes set the start time of anything in the past to the current time. Since the API will never send us anything that has already ended, we're not going to show past events. As a side effect, any event that is happening now will display the current time and the end time, which I considered changing but kinda liked, since it emphasizes the currency of the event. If there are objections, I'd be willing to compromise.