### PR TITLE
Moar calendar tweaks

### DIFF
--- a/views/calendar/event.js
+++ b/views/calendar/event.js
@@ -55,7 +55,7 @@ let styles = StyleSheet.create({
 })
 
 // PROPS: eventTitle, location, startTime, endTime
-export default function EventView(props: {eventTitle: string, location: string, startTime?: Object, endTime?: Object, style?: any}) {
+export default function EventView(props: {eventTitle: string, location: string, startTime?: Object, endTime?: Object, style?: any, isOngoing: bool}) {
   let title = getText(parseHtml(props.eventTitle))
 
   let eventLength = moment.duration(props.endTime.diff(props.startTime)).asHours()
@@ -65,6 +65,11 @@ export default function EventView(props: {eventTitle: string, location: string, 
   let times = null
   if (allDay) {
     times = <Text style={[styles.timeText, styles.startTime]}>all-day</Text>
+  } else if (props.isOngoing) {
+    times = [
+      <Text key={0} style={[styles.timeText, styles.startTime]}>{props.startTime.format('MMM. D')}</Text>,
+      <Text key={1} style={[styles.timeText, styles.endTime]}>{props.endTime.format('MMM. D')}</Text>,
+    ]
   } else if (multiDay) {
     times = [
       <Text key={0} style={[styles.timeText, styles.startTime]}>{props.startTime.format('h:mma')}</Text>,


### PR DESCRIPTION
(Sorry @elijahverdoorn. I merged your PR before I noticed the new commits.)

This PR edits the calendar view some more.

It groups times into "Ongoing" if the event started before today (`startTime.isBefore(now, 'day')`), and hides the time from ongoing events.

<img width="487" alt="screen shot 2016-11-09 at 10 50 05 am" src="https://cloud.githubusercontent.com/assets/464441/20146674/7c31dcea-a66a-11e6-9d3f-88ac9e5bb460.png">

<img width="487" alt="screen shot 2016-11-09 at 10 47 17 am" src="https://cloud.githubusercontent.com/assets/464441/20146676/7e1c9e28-a66a-11e6-835e-5f6fe2c81452.png">