### PR TITLE
Enable Bitrise for faster OS X builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,0 +1,47 @@
+---
+# Any edits to this file must be copied into the online editor at
+# https://www.bitrise.io/app/bc51be6a59ccbc35/workflow/editor
+# and saved there.
+format_version: 1.3.0
+default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+trigger_map:
+- push_branch: master
+  workflow: primary
+- push_branch: bitrise
+  workflow: primary
+- pull_request_source_branch: "*"
+  workflow: primary
+workflows:
+  primary:
+    steps:
+    - activate-ssh-key@3.1.1:
+        run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+    - git-clone@3.4.1: {}
+    - script@1.1.3:
+        title: initial setup
+        inputs:
+        - content: |-
+            #!/bin/bash -ex
+
+            npm config set spin=false
+            npm config set progress=false
+
+            # make the env variable file available
+            touch .env.js
+            touch keys.js
+    - certificate-and-profile-installer@1.8.1: {}
+    - npm@0.1.1:
+        title: npm install
+        inputs:
+        - command: install
+    - npm@0.1.1:
+        title: 'build:ios'
+        inputs:
+        - command: run build:ios
+    - deploy-to-bitrise-io@1.2.5: {}
+app:
+  envs:
+  - opts: {is_expand: false}
+    BITRISE_PROJECT_PATH: ios/AllAboutOlaf.xcworkspace
+  - opts: {is_expand: false}
+    BITRISE_SCHEME: AllAboutOlaf

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "flow": "flow",
     "bundle:ios": "react-native bundle --entry-file index.ios.js --dev true --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --assets-dest ./ios",
     "bundle:android": "react-native bundle --entry-file index.android.js --dev true --platform android --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/",
-    "build:ios": "xctool -configuration Release -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2'",
+    "build:ios": "xcodebuild -configuration Release -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -sdk iphonesimulator -destination platform='iOS Simulator,name=iPhone 5s,OS=9.2' | xcpretty",
     "build:android:unix": "cd android && ./gradlew assembleRelease --info --console=plain",
     "build:android:win": "cd android && .\\gradlew assembleRelease --info --console=plain",
     "test": "npm run flow && npm run test:js",


### PR DESCRIPTION
> Bitrise is a bit different from Appveyor and TravisCI, as it doesn't use the committed config file. Instead, you can import and export a config using their web interface. 
>
> I would like to keep this as the canonical version, and copy it into their system whenever it changes.

Bitrise finishes the build in roughly 5 minutes, and has almost no startup time, unlike Travis. I intend to disable Travis' OS X builds for now, leaving it with just JS and Android/unix build duties.

Eventually, I want to start writing tests for Xcode to run against different versions of iOS, to make sure things work – things like "tapping on this button opens this screen". When that happens, I will probably re-enable Travis, since it makes it so much easier to start multiple builds at once.