### PR TITLE
Add initialListSize to ContactsView

### DIFF
--- a/views/contacts.js
+++ b/views/contacts.js
@@ -41,6 +41,7 @@ export default class ContactView extends React.Component {
     return (
       <View style={styles.container}>
         <ListView
+          initialListSize={3}
           renderRow={this._renderRow.bind(this)}
           dataSource={this.state.dataSource}
         />


### PR DESCRIPTION
> Closes #321

I think that setting this to 3 should tell RN to start by rendering 3 rows, rather than 0.

I believe that, without this prop, RN starts at 0 rows, and continues to render them until the `scrollRenderAheadDistance` prop is reached. For some reason, sometimes it never goes beyond 0 rows. Therefore, I think that starting it at 3 should kick-start that process.