### PR TITLE
remove automaticallyAdjustContentInsets

### DIFF
--- a/views/directory.js
+++ b/views/directory.js
@@ -57,7 +57,6 @@ export default class DirectoryView extends React.Component {
     return (
       <View style={styles.container}>
         <WebView
-          automaticallyAdjustContentInsets={false}
           style={styles.webView}
           source={webViewSource}
           javaScriptEnabled={true}

--- a/views/home.js
+++ b/views/home.js
@@ -42,7 +42,6 @@ type ScenePropsType = {navigator: typeof Navigator, route: Object};
 export default function HomePageScene({navigator, route}: ScenePropsType) {
   return (
     <ScrollView
-      automaticallyAdjustContentInsets={false}
       overflow={'hidden'}
       alwaysBounceHorizontal={false}
       showsHorizontalScrollIndicator={false}

--- a/views/settings/login.js
+++ b/views/settings/login.js
@@ -101,7 +101,6 @@ export default class SISLoginView extends React.Component {
 
     return (
       <WebView
-        automaticallyAdjustContentInsets={false}
         source={{uri: LOGIN_URL}}
         javaScriptEnabled={true}
         onNavigationStateChange={this.onNavigationStateChange}

--- a/views/streaming/webcams.js
+++ b/views/streaming/webcams.js
@@ -48,7 +48,7 @@ const videoAsThumbnail = url => `
 
 export default function WebcamsView() {
   return (
-    <ScrollView style={styles.container} contentInset={{bottom: 49}} automaticallyAdjustContentInsets={false}>
+    <ScrollView style={styles.container}>
       {webcamInfo.map(webcam =>
         <View style={styles.row} key={webcam.name}>
           <View style={styles.webCamTitleBox}>

--- a/views/transportation/bus/index.js
+++ b/views/transportation/bus/index.js
@@ -33,10 +33,7 @@ export default class BusView extends React.Component {
     const now = moment.tz(TIMEZONE)
 
     return (
-      <ScrollView
-        contentInset={{bottom: 49}}
-        automaticallyAdjustContentInsets={false}
-      >
+      <ScrollView>
         {busInfo.map((busLine: BusLineType, i) =>
           <BusLineView
             key={busLine.line}

--- a/views/transportation/otherModes.js
+++ b/views/transportation/otherModes.js
@@ -79,8 +79,6 @@ export default class OtherModesView extends React.Component {
   render() {
     return (
       <ListView
-        contentInset={{bottom: Platform.OS === 'ios' ? 49 : 0}}
-        automaticallyAdjustContentInsets={false}
         contentContainerStyle={styles.container}
         dataSource={this.state.dataSource}
         renderRow={this._renderRow.bind(this)}


### PR DESCRIPTION
The `automaticallyAdjustContentInsets` prop is supposed to be all you need to allow the ScrollViews to sit above a tab bar, but on RN`@0.29` it was broken, so we removed it.

It is now fixed, so we can allow it to work its magic once again.