### PR TITLE
Edit building hours stuff

### DIFF
--- a/views/building-hours/all-building-hours.js
+++ b/views/building-hours/all-building-hours.js
@@ -1,35 +1,30 @@
-import React from 'react'
-import {
-  Text,
-} from 'react-native'
+// @flow
+import map from 'lodash/map'
+import type momentT from 'moment'
+import type {BuildingInfoType, DayOfWeekType} from './types'
+import {parseBuildingHours} from './get-building-hours'
 
-import moment from 'moment-timezone'
-const CENTRAL_TZ = 'America/Winnipeg'
+const dayToDayMap: {[key: DayOfWeekType]: string} = {
+  'Mon': 'Monday',
+  'Tue': 'Tuesday',
+  'Wed': 'Wednesday',
+  'Thu': 'Thursday',
+  'Fri': 'Friday',
+  'Sat': 'Saturday',
+  'Sun': 'Sunday',
+}
 
-export function allBuildingHours(info, style) {
-  let dayTimes = []
-  let current = moment().tz(CENTRAL_TZ)
+export function allBuildingHours(info: BuildingInfoType, now: momentT) {
+  return map(info.times.hours, (hourSet, day) => {
+    let times = parseBuildingHours(hourSet, now)
 
-  for (let i = 0; i < 7; i++) {
-    let hoursString = ''
-    let day = current.format('dddd')
-    let d = current.format('ddd')
-
-    current.add(1, 'days')
-
-    let timesArray = info.times.hours[d]
-
-    if (timesArray) {
-      let open = moment(timesArray[0], 'H:mm').tz(CENTRAL_TZ).format('h:mm a')
-      let close = moment(timesArray[1], 'H:mm').tz(CENTRAL_TZ).format('h:mm a')
-      hoursString = open + ' - ' + close
+    let hoursString
+    if (times) {
+      hoursString = `${times.open.format('h:mm a')} – ${times.close.format('h:mm a')}`
     } else {
       hoursString = 'Closed'
     }
 
-    let dayString = day + ': ' + hoursString
-    dayTimes.push(<Text key={d} style={style}>{dayString}</Text>)
-  }
-
-  return dayTimes
+    return `${dayToDayMap[day]}: ${hoursString}`
+  })
 }

--- a/views/building-hours/all-building-hours.js
+++ b/views/building-hours/all-building-hours.js
@@ -4,27 +4,25 @@ import type momentT from 'moment'
 import type {BuildingInfoType, DayOfWeekType} from './types'
 import {parseBuildingHours} from './get-building-hours'
 
-const dayToDayMap: {[key: DayOfWeekType]: string} = {
-  'Mon': 'Monday',
-  'Tue': 'Tuesday',
-  'Wed': 'Wednesday',
-  'Thu': 'Thursday',
-  'Fri': 'Friday',
-  'Sat': 'Saturday',
-  'Sun': 'Sunday',
-}
+const dayToDayMap: Map<DayOfWeekType, string> = new Map([
+  ['Mon', 'Monday'],
+  ['Tue', 'Tuesday'],
+  ['Wed', 'Wednesday'],
+  ['Thu', 'Thursday'],
+  ['Fri', 'Friday'],
+  ['Sat', 'Saturday'],
+  ['Sun', 'Sunday'],
+])
+const dayToDayMapArray = Array.from(dayToDayMap.entries())
 
 export function allBuildingHours(info: BuildingInfoType, now: momentT) {
-  return map(info.times.hours, (hourSet, day) => {
-    let times = parseBuildingHours(hourSet, now)
-
-    let hoursString
-    if (times) {
-      hoursString = `${times.open.format('h:mm a')} – ${times.close.format('h:mm a')}`
-    } else {
-      hoursString = 'Closed'
+  return map(dayToDayMapArray, ([shortDay, longDay]) => {
+    let hourSet = info.times.hours[shortDay]
+    if (!hourSet) {
+      return `${longDay}: Closed`
     }
 
-    return `${dayToDayMap[day]}: ${hoursString}`
+    let {open, close} = parseBuildingHours(hourSet, now)
+    return `${longDay}: ${open.format('h:mm a')} – ${close.format('h:mm a')}`
   })
 }

--- a/views/building-hours/building.js
+++ b/views/building-hours/building.js
@@ -13,19 +13,19 @@ import {
  StyleSheet,
 } from 'react-native'
 
-import * as c from '../components/colors'
+import type momentT from 'moment'
 import type {BuildingInfoType} from './types'
+import * as c from '../components/colors'
 import {isBuildingOpen} from './is-building-open'
 import {formatBuildingHours} from './format-building-hours'
 import CollapsibleBlock from '../components/collapsibleBlock'
 import {allBuildingHours} from './all-building-hours.js'
 
-
-
 type PropsType = {
   info: BuildingInfoType,
   image: number,
   name: string,
+  now: momentT,
 };
 
 let styles = StyleSheet.create({
@@ -67,17 +67,18 @@ let styles = StyleSheet.create({
 })
 
 
-export default function BuildingView({info, image, name}: PropsType) {
-
+export function BuildingView({info, image, name, now}: PropsType) {
   let borderColors = {
     'Open': '#CEFFCE',
     'Almost Closed': '#FFFC96',
     'Closed': '#F7C8C8',
   }
 
-  let openStatus = isBuildingOpen(info)
-  let hours = formatBuildingHours(info)
-  let allHours = allBuildingHours(info, styles.hoursText)
+  const openStatus = isBuildingOpen(info, now)
+  const hours = formatBuildingHours(info, now)
+  const allHours = allBuildingHours(info, now)
+  const allHoursAsElements = allHours.map((time, i) =>
+    <Text key={i} style={styles.hoursText}>{time}</Text>)
 
   return (
     <CollapsibleBlock style={styles} collapsedStyle={{backgroundColor: borderColors[openStatus]}}>
@@ -95,7 +96,7 @@ export default function BuildingView({info, image, name}: PropsType) {
 
       <View style={[styles.contents, {width: Dimensions.get('window').width}]}>
         <Text style={styles.hoursText}>Daily Hours</Text>
-        {allHours}
+        {allHoursAsElements}
       </View>
     </CollapsibleBlock>
   )
@@ -105,4 +106,5 @@ BuildingView.propTypes = {
   image: React.PropTypes.number.isRequired,
   info: React.PropTypes.object.isRequired,
   name: React.PropTypes.string.isRequired,
+  now: React.PropTypes.object.isRequired,
 }

--- a/views/building-hours/building.js
+++ b/views/building-hours/building.js
@@ -32,8 +32,8 @@ let styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    borderLeftWidth: 5,
-    borderRightWidth: 5,
+    borderLeftWidth: 10,
+    borderRightWidth: 10,
     marginTop: 10,
     height: 100,
   },
@@ -86,7 +86,8 @@ export function BuildingView({info, image, name, now}: PropsType) {
         <Image
           source={image}
           style={{width: undefined, height: 100}}
-          resizeMode='cover'>
+          resizeMode='cover'
+        >
           <View style={styles.inner}>
             <Text style={styles.name}>{name}</Text>
             <Text style={styles.status}>{hours}</Text>

--- a/views/building-hours/format-building-hours.js
+++ b/views/building-hours/format-building-hours.js
@@ -4,15 +4,16 @@ const RESULT_FORMAT = 'h:mma'
 import {isBuildingOpen} from './is-building-open'
 import {getBuildingHours} from './get-building-hours'
 import type {BuildingInfoType} from './types'
+import type momentT from 'moment'
 
-export function formatBuildingHours(hoursInfo: BuildingInfoType): string {
-  let hours = getBuildingHours(hoursInfo)
+export function formatBuildingHours(hoursInfo: BuildingInfoType, now: momentT): string {
+  let hours = getBuildingHours(hoursInfo, now)
   if (!hours) {
     return 'Closed today'
   }
 
   let {open, close} = hours
-  let isOpen = isBuildingOpen(hoursInfo)
+  let isOpen = isBuildingOpen(hoursInfo, now)
 
   let openString = open.format(RESULT_FORMAT)
   let closeString = close.format(RESULT_FORMAT)

--- a/views/building-hours/get-building-hours.js
+++ b/views/building-hours/get-building-hours.js
@@ -6,9 +6,9 @@ const TIME_FORMAT = 'H:mm'
 import type {BuildingInfoType, BuildingHoursType} from './types'
 import type momentT from 'moment'
 
-type ReturnType = false|{open: momentT, close: momentT};
+type HourPairType = {open: momentT, close: momentT};
 
-export function parseBuildingHours(hours: BuildingHoursType, now: momentT) {
+export function parseBuildingHours(hours: BuildingHoursType, now: momentT): HourPairType {
   let dayOfYear = now.dayOfYear()
   let [startTimeString, closeTimeString, options={nextDay: false}] = hours
 
@@ -25,7 +25,7 @@ export function parseBuildingHours(hours: BuildingHoursType, now: momentT) {
   return {open, close}
 }
 
-export function getBuildingHours(hoursInfo: BuildingInfoType, now: momentT): ReturnType {
+export function getBuildingHours(hoursInfo: BuildingInfoType, now: momentT): false|HourPairType {
   let dayOfWeek = now.format('ddd')
   let times = hoursInfo.times.hours[dayOfWeek]
 

--- a/views/building-hours/get-building-hours.js
+++ b/views/building-hours/get-building-hours.js
@@ -3,19 +3,14 @@ import moment from 'moment-timezone'
 const CENTRAL_TZ = 'America/Winnipeg'
 const TIME_FORMAT = 'H:mm'
 
-import type {BuildingInfoType} from './types'
+import type {BuildingInfoType, BuildingHoursType} from './types'
+import type momentT from 'moment'
 
-export function getBuildingHours(hoursInfo: BuildingInfoType): false|{open: typeof moment, close: typeof moment, current: typeof moment} {
-  let dayOfWeek = moment.tz(CENTRAL_TZ).format('ddd')
-  let times = hoursInfo.times.hours[dayOfWeek]
-  if (!times) {
-    return false
-  }
+type ReturnType = false|{open: momentT, close: momentT};
 
-  let current = moment.tz(CENTRAL_TZ)
-  let dayOfYear = current.dayOfYear()
-
-  let [startTimeString, closeTimeString, options={nextDay: false}] = times
+export function parseBuildingHours(hours: BuildingHoursType, now: momentT) {
+  let dayOfYear = now.dayOfYear()
+  let [startTimeString, closeTimeString, options={nextDay: false}] = hours
 
   let open = moment.tz(startTimeString, TIME_FORMAT, true, CENTRAL_TZ)
   open.dayOfYear(dayOfYear)
@@ -27,5 +22,16 @@ export function getBuildingHours(hoursInfo: BuildingInfoType): false|{open: type
     close.add(1, 'day')
   }
 
-  return {open, close, current}
+  return {open, close}
+}
+
+export function getBuildingHours(hoursInfo: BuildingInfoType, now: momentT): ReturnType {
+  let dayOfWeek = now.format('ddd')
+  let times = hoursInfo.times.hours[dayOfWeek]
+
+  if (!times) {
+    return false
+  }
+
+  return parseBuildingHours(times, now)
 }

--- a/views/building-hours/index.js
+++ b/views/building-hours/index.js
@@ -38,6 +38,8 @@ const buildingImages = {
   'tomson': require('../../data/images/buildinghours/w1440/tomson.jpg'),
 }
 
+import moment from 'moment-timezone'
+const CENTRAL_TZ = 'America/Winnipeg'
 
 export default class BuildingHoursView extends React.Component {
   state = {
@@ -45,7 +47,7 @@ export default class BuildingHoursView extends React.Component {
       rowHasChanged: (r1: BuildingInfoType, r2: BuildingInfoType) => r1.name !== r2.name,
     }).cloneWithRows(hoursData),
     intervalId: 0,
-    now: Date.now(),
+    now: moment.tz(CENTRAL_TZ),
     refreshing: false,
   }
 
@@ -60,7 +62,7 @@ export default class BuildingHoursView extends React.Component {
   }
 
   updateTime = () => {
-    this.setState({now: Date.now()})
+    this.setState({now: moment.tz(CENTRAL_TZ)})
   }
 
   _renderRow = (data: BuildingInfoType) => {
@@ -69,6 +71,7 @@ export default class BuildingHoursView extends React.Component {
         name={data.name}
         info={data}
         image={buildingImages[data.image]}
+        now={this.state.now}
       />
     )
   }
@@ -76,8 +79,7 @@ export default class BuildingHoursView extends React.Component {
   refresh = async () => {
     this.setState({refreshing: true})
     await delay(500)
-    this.setState({now: Date.now()})
-    this.setState({refreshing: false})
+    this.setState({now: moment.tz(CENTRAL_TZ), refreshing: false})
   }
 
   // Render a given scene

--- a/views/building-hours/index.js
+++ b/views/building-hours/index.js
@@ -11,6 +11,7 @@ import {BuildingView} from './building'
 import delay from 'delay'
 import type {BuildingInfoType} from './types'
 import hoursData from '../../data/building-hours.json'
+(hoursData: BuildingInfoType[])
 
 const buildingImages = {
   'alumni-hall': require('../../data/images/buildinghours/w1440/alumni-hall.jpg'),

--- a/views/building-hours/index.js
+++ b/views/building-hours/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 import {ListView, RefreshControl} from 'react-native'
-import BuildingView from './building'
+import {BuildingView} from './building'
 
 import delay from 'delay'
 import type {BuildingInfoType} from './types'

--- a/views/building-hours/is-building-open.js
+++ b/views/building-hours/is-building-open.js
@@ -12,7 +12,7 @@ export function isBuildingOpen(hoursInfo: BuildingInfoType, now: momentT): Build
   let {open, close} = hours
 
   if (now.isBetween(open, close)) {
-    if (now.clone().add(30, 'min').isAfter(close)) {
+    if (now.clone().add(30, 'minutes').isAfter(close)) {
       return 'Almost Closed'
     }
     return 'Open'

--- a/views/building-hours/is-building-open.js
+++ b/views/building-hours/is-building-open.js
@@ -1,18 +1,18 @@
 // @flow
 import {getBuildingHours} from './get-building-hours'
-
+import type momentT from 'moment'
 import type {BuildingStatusType, BuildingInfoType} from './types'
 
-export function isBuildingOpen(hoursInfo: BuildingInfoType): BuildingStatusType {
-  let hours = getBuildingHours(hoursInfo)
+export function isBuildingOpen(hoursInfo: BuildingInfoType, now: momentT): BuildingStatusType {
+  let hours = getBuildingHours(hoursInfo, now)
   if (!hours) {
     return 'Closed'
   }
 
-  let {open, close, current} = hours
+  let {open, close} = hours
 
-  if (current.isBetween(open, close)) {
-    if (current.clone().add(30, 'min').isAfter(close)) {
+  if (now.isBetween(open, close)) {
+    if (now.clone().add(30, 'min').isAfter(close)) {
       return 'Almost Closed'
     }
     return 'Open'

--- a/views/building-hours/types.js
+++ b/views/building-hours/types.js
@@ -7,7 +7,7 @@ export type BuildingInfoType = {
   image: string,
   times: {
     hours: {
-      [key: DayOfWeekType]: BuildingHoursType,
+      [key: string|DayOfWeekType]: BuildingHoursType,
     },
   },
 };

--- a/views/building-hours/types.js
+++ b/views/building-hours/types.js
@@ -1,12 +1,13 @@
 // @flow
 export type BuildingStatusType = 'Open'|'Closed'|'Almost Closed';
 export type DayOfWeekType = 'Mon'|'Tue'|'Wed'|'Thu'|'Fri'|'Sat'|'Sun';
+export type BuildingHoursType = [string, string, ?{nextDay: boolean}];
 export type BuildingInfoType = {
   name: string,
   image: string,
   times: {
     hours: {
-      [key: DayOfWeekType]: [string, string, ?{nextDay: boolean}],
+      [key: DayOfWeekType]: BuildingHoursType,
     },
   },
 };


### PR DESCRIPTION
> Closes #337 

This is a pretty big refactoring of the building hours time tooling stuff. It cleans up more than just #337, but it fixes that as part of the cleanups.

- I removed the `<Text>` generation from `allBuildingHours()`
- I added `now` as a prop and argument to everything that needs the "current" time, so there's one spot to define the current moment. This eliminates the edge-case of one moment being in one hour or day, and the next function using a moment from the next hour or day.
- I made a new function `parseBuildingHours`, which takes over the actual logic of checking if a building is open or closed. I reworked the other functions to use it, as appropriate.

I think that's everything. I'll edit this comment once I see the diff again.