### PR TITLE
Fix post-midnight times

### DIFF
--- a/views/building-hours/get-building-hours.js
+++ b/views/building-hours/get-building-hours.js
@@ -10,7 +10,7 @@ type HourPairType = {open: momentT, close: momentT};
 
 export function parseBuildingHours(hours: BuildingHoursType, now: momentT): HourPairType {
   let dayOfYear = now.dayOfYear()
-  let [startTimeString, closeTimeString, options={nextDay: false}] = hours
+  let [startTimeString, closeTimeString] = hours
 
   let open = moment.tz(startTimeString, TIME_FORMAT, true, CENTRAL_TZ)
   open.dayOfYear(dayOfYear)
@@ -18,7 +18,7 @@ export function parseBuildingHours(hours: BuildingHoursType, now: momentT): Hour
   let close = moment.tz(closeTimeString, TIME_FORMAT, true, CENTRAL_TZ)
   close.dayOfYear(dayOfYear)
 
-  if (options && options.nextDay) {
+  if (close.isBefore(open)) {
     close.add(1, 'day')
   }
 

--- a/views/building-hours/get-building-hours.js
+++ b/views/building-hours/get-building-hours.js
@@ -8,9 +8,17 @@ import type momentT from 'moment'
 
 type HourPairType = {open: momentT, close: momentT};
 
+function isBefore3am(now: momentT): boolean {
+  return now.hour() < 2
+}
+
 export function parseBuildingHours(hours: BuildingHoursType, now: momentT): HourPairType {
   let dayOfYear = now.dayOfYear()
   let [startTimeString, closeTimeString] = hours
+
+  if (isBefore3am(now)) {
+    dayOfYear -= 1
+  }
 
   let open = moment.tz(startTimeString, TIME_FORMAT, true, CENTRAL_TZ)
   open.dayOfYear(dayOfYear)


### PR DESCRIPTION
> Sorry about this bring blank at first.

This PR fixes a bug with building hours.

The current implementation always uses the current day as the base for finding the open status, but when a building is open onto the next day, that starts to all apart.

Namely, when someone opens the Building Hours view after Midnight on Friday night (which is technically Saturday Morning), it will switch to evaluating the hours on Saturday. Which results in (for example) the Pause being closed, because it's checking (saturday: open 10:30am, close Sunday 2am) instead of (friday: open 10:30am, close Saturday 2am).

This PR introduces the assumption that no buildings will be open past 3am.

With that assumption, though, if it is currently before 3am, we subtract a day from the evaluation, allowing the logic to work correctly.

I will rebase this PR to be smaller after #338 is dealt with.