### PR TITLE
Faster transit updates

### DIFF
--- a/data/bus-times.json
+++ b/data/bus-times.json
@@ -1,6 +1,6 @@
 [
   {
-    "line": "Express",
+    "line": "Express Bus",
     "schedules": [
       {
         "days": ["mo", "tu", "we", "th", "fr", "sa"],
@@ -31,7 +31,7 @@
     ]
   },
   {
-    "line": "Red",
+    "line": "Red Line",
     "schedules": [
       {
         "days": ["su", "mo", "tu", "we", "th", "fr", "sa"],
@@ -58,7 +58,7 @@
     ]
   },
   {
-    "line": "Blue",
+    "line": "Blue Line",
     "schedules": [
       {
         "days": ["su", "mo", "tu", "we", "th", "fr", "sa"],

--- a/views/transportation/bus/bus-line-title.js
+++ b/views/transportation/bus/bus-line-title.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react'
+import {View, StyleSheet, Text} from 'react-native'
+
+let styles = StyleSheet.create({
+  busLineTitle: {
+    paddingTop: 5,
+    paddingBottom: 5,
+    paddingLeft: 15,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: '#c8c7cc',
+  },
+  busLineTitleText: {
+    color: 'rgb(113, 113, 118)',
+  },
+})
+
+export function BusLineTitle({title}: {title: string}) {
+  return (
+    <View style={styles.busLineTitle}>
+      <Text style={styles.busLineTitleText}>
+        {title.toUpperCase()}
+      </Text>
+    </View>
+  )
+}

--- a/views/transportation/bus/bus-line-title.js
+++ b/views/transportation/bus/bus-line-title.js
@@ -1,25 +1,28 @@
 // @flow
 import React from 'react'
-import {View, StyleSheet, Text} from 'react-native'
+import {Platform, View, StyleSheet, Text} from 'react-native'
 
 let styles = StyleSheet.create({
   busLineTitle: {
-    paddingTop: 5,
-    paddingBottom: 5,
+    paddingVertical: Platform.OS === 'ios' ? 5 : 15,
     paddingLeft: 15,
-    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: Platform.OS === 'ios' ? StyleSheet.hairlineWidth : 0,
     borderColor: '#c8c7cc',
   },
   busLineTitleText: {
     color: 'rgb(113, 113, 118)',
+    fontWeight: Platform.OS === 'ios' ? 'normal' : 'bold',
   },
 })
 
-export function BusLineTitle({title}: {title: string}) {
+export function BusLineTitle({title, androidColor}: {title: string, androidColor: string}) {
+  title = Platform.OS === 'ios'
+    ? title.toUpperCase()
+    : title
   return (
     <View style={styles.busLineTitle}>
-      <Text style={styles.busLineTitleText}>
-        {title.toUpperCase()}
+      <Text style={[styles.busLineTitleText, Platform.OS === 'ios' ? null : {color: androidColor}]}>
+        {title}
       </Text>
     </View>
   )

--- a/views/transportation/bus/bus-line.js
+++ b/views/transportation/bus/bus-line.js
@@ -1,8 +1,8 @@
 // @flow
 
 import React from 'react'
-import {View, StyleSheet, Text} from 'react-native'
-import type {BusLineType, BusTimeListType, BusScheduleType} from './types'
+import {View, StyleSheet} from 'react-native'
+import type {BusLineType} from './types'
 import getScheduleForNow from './get-schedule-for-now'
 import getSetOfStopsForNow from './get-set-of-stops-for-now'
 import zip from 'lodash/zip'
@@ -10,6 +10,9 @@ import head from 'lodash/head'
 import last from 'lodash/last'
 import moment from 'moment-timezone'
 import * as c from '../../components/colors'
+
+import {BusLineTitle} from './bus-line-title'
+import {BusStopRow} from './bus-stop-row'
 
 const TIME_FORMAT = 'h:mma'
 const TIMEZONE = 'America/Winnipeg'
@@ -20,193 +23,12 @@ let styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderColor: '#c8c7cc',
   },
-  busLineTitle: {
-    paddingTop: 5,
-    paddingBottom: 5,
-    paddingLeft: 15,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderColor: '#c8c7cc',
-  },
-  busLineTitleText: {
-    color: 'rgb(113, 113, 118)',
-  },
   listContainer: {
     backgroundColor: '#ffffff',
     flex: 1,
     flexDirection: 'column',
   },
-  busWillSkipStopTitle: {
-    color: c.iosDisabledText,
-  },
-  busWillSkipStopDetail: {},
-  busWillSkipStopDot: {
-    backgroundColor: 'transparent',
-    borderColor: 'transparent',
-  },
-  row: {
-    flexDirection: 'row',
-  },
-  rowDetail: {
-    flex: 1,
-    marginLeft: 0,
-    paddingRight: 10,
-    paddingTop: 8,
-    paddingBottom: 8,
-    flexDirection: 'column',
-  },
-  notLastRowContainer: {
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#c8c7cc',
-  },
-  passedStopDetail: {
-
-  },
-  itemTitle: {
-    color: c.black,
-    paddingLeft: 0,
-    paddingRight: 0,
-    paddingBottom: 3,
-    fontSize: 16,
-    textAlign: 'left',
-  },
-  itemDetail: {
-    color: c.iosDisabledText,
-    paddingLeft: 0,
-    paddingRight: 0,
-    fontSize: 13,
-    textAlign: 'left',
-  },
-  barContainer: {
-    paddingRight: 5,
-    width: 45,
-    flexDirection: 'column',
-    alignItems: 'center',
-  },
-  bar: {
-    flex: 1,
-    width: 5,
-  },
-  dot: {
-    height: 15,
-    width: 15,
-    marginTop: -20,
-    marginBottom: -20,
-    borderRadius: 20,
-    zIndex: 1,
-  },
-  passedStop: {
-    height: 12,
-    width: 12,
-  },
-  beforeStop: {
-    borderWidth: 3,
-    backgroundColor: 'white',
-    height: 18,
-    width: 18,
-  },
-  atStop: {
-    height: 20,
-    width: 20,
-    borderColor: 'white',
-    borderWidth: 3,
-    backgroundColor: 'white',
-  },
-  atStopTitle: {
-    fontWeight: 'bold',
-  },
-  passedStopTitle: {
-    color: c.iosDisabledText,
-  },
 })
-
-function BusLineTitle({title}: {title: string}) {
-  return (
-    <View style={styles.busLineTitle}>
-      <Text style={styles.busLineTitleText}>
-        {title.toUpperCase()}
-      </Text>
-    </View>
-  )
-}
-
-function BusStopRow({
-  index,
-  time,
-  now,
-  barColor,
-  currentStopColor,
-  isLastRow,
-  place,
-  times,
-}: {
-  index: number,
-  time: typeof moment,
-  now: typeof moment,
-  barColor: string,
-  currentStopColor: string,
-  isLastRow: boolean,
-  place: string,
-  times: BusTimeListType[]
-}) {
-  const afterStop = time && now.isAfter(time, 'minute')
-  const atStop = time && now.isSame(time, 'minute')
-  const beforeStop = !afterStop && !atStop && time !== false
-  const skippingStop = time === false
-
-  // To draw the bar, we draw a chunk of the bar, then we draw the dot, then
-  // we draw the last chunk of the bar.
-  const busLineProgressBar = (
-    <View style={styles.barContainer}>
-      <View style={[styles.bar, {backgroundColor: barColor}]} />
-      <View
-        style={[
-          styles.dot,
-          afterStop && [styles.passedStop, {borderColor: barColor, backgroundColor: barColor}],
-          beforeStop && [styles.beforeStop, {borderColor: barColor}],
-          atStop && [styles.atStop, {borderColor: currentStopColor}],
-          skippingStop && styles.busWillSkipStopDot,
-        ]}
-      />
-      <View style={[styles.bar, {backgroundColor: barColor}]} />
-    </View>
-  )
-
-  // The bus line information is the stop name, and the times.
-  const busLineInformation = (
-    <View style={[
-      styles.rowDetail,
-      !isLastRow && styles.notLastRowContainer,
-    ]}>
-      <Text style={[
-        styles.itemTitle,
-        skippingStop && styles.busWillSkipStopTitle,
-        afterStop && styles.passedStopTitle,
-        atStop && styles.atStopTitle,
-      ]}>
-        {place}
-      </Text>
-      <Text
-        style={[
-          styles.itemDetail,
-          skippingStop && styles.busWillSkipStopDetail,
-        ]}
-        numberOfLines={1}
-      >
-        {times
-          .map(timeSet => timeSet[index])
-          .map(time => time === false ? 'None' : time.format(TIME_FORMAT))
-          .join(' • ')}
-      </Text>
-    </View>
-  )
-
-  return (
-    <View style={styles.row}>
-      {busLineProgressBar}
-      {busLineInformation}
-    </View>
-  )
-}
 
 export default function BusLineView({
   line,
@@ -215,14 +37,14 @@ export default function BusLineView({
 }: {
   line: BusLineType,
   style: Object|number,
-  now: typeof moment,
+  now: moment,
 }) {
   let schedule = getScheduleForNow(line.schedules, now)
   if (!schedule) {
     return null
   }
 
-  schedule.times = schedule.times.map(timeset => {
+  let scheduledMoments = schedule.times.map(timeset => {
     return timeset.map(time =>
       time === false
         ? false
@@ -231,10 +53,10 @@ export default function BusLineView({
           .dayOfYear(now.dayOfYear()))
   })
 
-  let times = getSetOfStopsForNow(schedule, now)
-  let timesIndex = schedule.times.indexOf(times)
+  let moments = getSetOfStopsForNow(scheduledMoments, now)
+  let timesIndex = scheduledMoments.indexOf(moments)
 
-  let pairs: [[string], [typeof moment]] = zip(schedule.stops, times)
+  let pairs: [[string, typeof moment]] = zip(schedule.stops, moments)
 
   let barColor = c.salmon
   if (line.line === 'Blue') {
@@ -250,12 +72,12 @@ export default function BusLineView({
     currentStopColor = c.hollyGreen
   }
 
-  let isLastBus = timesIndex === schedule.times.length - 1
+  let isLastBus = timesIndex === scheduledMoments.length - 1
 
   let lineTitle = line.line
-  if (timesIndex === 0 && now.isBefore(head(times))) {
-    lineTitle += ` — Starting ${head(times).format('h:mma')}`
-  } else if (now.isAfter(last(times))) {
+  if (timesIndex === 0 && now.isBefore(head(moments))) {
+    lineTitle += ` — Starting ${head(moments).format('h:mma')}`
+  } else if (now.isAfter(last(moments))) {
     lineTitle += ' — Over for Today'
   } else if (isLastBus) {
     lineTitle += ' — Last Bus'
@@ -267,16 +89,16 @@ export default function BusLineView({
     <View style={[styles.container, style]}>
       <BusLineTitle title={lineTitle} />
       <View style={[styles.listContainer]}>
-        {pairs.map(([place, time], i) =>
+        {pairs.map(([place, moment], i) =>
           <BusStopRow
             key={i}
             index={i}
 
             place={place}
-            times={schedule.times.slice(timesIndex)}
+            times={scheduledMoments.slice(timesIndex)}
 
             now={now}
-            time={time}
+            time={moment}
             isLastRow={i === pairs.length - 1}
 
             barColor={barColor}

--- a/views/transportation/bus/bus-line.js
+++ b/views/transportation/bus/bus-line.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import {View, StyleSheet} from 'react-native'
-import type {BusLineType} from './types'
+import type {BusLineType, FancyBusTimeListType} from './types'
 import getScheduleForNow from './get-schedule-for-now'
 import getSetOfStopsForNow from './get-set-of-stops-for-now'
 import zip from 'lodash/zip'
@@ -36,15 +36,15 @@ export default function BusLineView({
   now,
 }: {
   line: BusLineType,
-  style: Object|number,
-  now: moment,
+  style: Object|number|Array<Object|number>,
+  now: typeof moment,
 }) {
   let schedule = getScheduleForNow(line.schedules, now)
   if (!schedule) {
     return null
   }
 
-  let scheduledMoments = schedule.times.map(timeset => {
+  let scheduledMoments: FancyBusTimeListType[] = schedule.times.map(timeset => {
     return timeset.map(time =>
       time === false
         ? false
@@ -53,7 +53,7 @@ export default function BusLineView({
           .dayOfYear(now.dayOfYear()))
   })
 
-  let moments = getSetOfStopsForNow(scheduledMoments, now)
+  let moments: FancyBusTimeListType = getSetOfStopsForNow(scheduledMoments, now)
   let timesIndex = scheduledMoments.indexOf(moments)
 
   let pairs: [[string, typeof moment]] = zip(schedule.stops, moments)

--- a/views/transportation/bus/bus-line.js
+++ b/views/transportation/bus/bus-line.js
@@ -41,16 +41,16 @@ export default function BusLineView({
   now: typeof moment,
 }) {
   let barColor = c.salmon
-  if (line.line === 'Blue') {
+  if (line.line === 'Blue Line') {
     barColor = c.steelBlue
-  } else if (line.line === 'Express') {
+  } else if (line.line === 'Express Bus') {
     barColor = c.moneyGreen
   }
 
   let currentStopColor = c.brickRed
-  if (line.line === 'Blue') {
+  if (line.line === 'Blue Line') {
     currentStopColor = c.midnightBlue
-  } else if (line.line === 'Express') {
+  } else if (line.line === 'Express Line') {
     currentStopColor = c.hollyGreen
   }
 

--- a/views/transportation/bus/bus-line.js
+++ b/views/transportation/bus/bus-line.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {View, StyleSheet} from 'react-native'
+import {View, Text, StyleSheet} from 'react-native'
 import type {BusLineType, FancyBusTimeListType} from './types'
 import getScheduleForNow from './get-schedule-for-now'
 import getSetOfStopsForNow from './get-set-of-stops-for-now'
@@ -41,7 +41,14 @@ export default function BusLineView({
 }) {
   let schedule = getScheduleForNow(line.schedules, now)
   if (!schedule) {
-    return null
+    return (
+      <View style={[styles.container, style]}>
+        <BusLineTitle title={line.line} />
+        <View>
+          <Text>This line is not running today.</Text>
+        </View>
+      </View>
+    )
   }
 
   let scheduledMoments: FancyBusTimeListType[] = schedule.times.map(timeset => {

--- a/views/transportation/bus/bus-stop-row.js
+++ b/views/transportation/bus/bus-stop-row.js
@@ -1,0 +1,173 @@
+// @flow
+
+import React from 'react'
+import {View, StyleSheet, Text} from 'react-native'
+import type {FancyBusTimeListType} from './types'
+import type moment from 'moment'
+import * as c from '../../components/colors'
+
+const TIME_FORMAT = 'h:mma'
+
+let styles = StyleSheet.create({
+  busWillSkipStopTitle: {
+    color: c.iosDisabledText,
+  },
+  busWillSkipStopDetail: {},
+  busWillSkipStopDot: {
+    backgroundColor: 'transparent',
+    borderColor: 'transparent',
+  },
+  row: {
+    flexDirection: 'row',
+  },
+  rowDetail: {
+    flex: 1,
+    marginLeft: 0,
+    paddingRight: 10,
+    paddingTop: 8,
+    paddingBottom: 8,
+    flexDirection: 'column',
+  },
+  notLastRowContainer: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#c8c7cc',
+  },
+  passedStopDetail: {
+
+  },
+  itemTitle: {
+    color: c.black,
+    paddingLeft: 0,
+    paddingRight: 0,
+    paddingBottom: 3,
+    fontSize: 16,
+    textAlign: 'left',
+  },
+  itemDetail: {
+    color: c.iosDisabledText,
+    paddingLeft: 0,
+    paddingRight: 0,
+    fontSize: 13,
+    textAlign: 'left',
+  },
+  barContainer: {
+    paddingRight: 5,
+    width: 45,
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  bar: {
+    flex: 1,
+    width: 5,
+  },
+  dot: {
+    height: 15,
+    width: 15,
+    marginTop: -20,
+    marginBottom: -20,
+    borderRadius: 20,
+    zIndex: 1,
+  },
+  passedStop: {
+    height: 12,
+    width: 12,
+  },
+  beforeStop: {
+    borderWidth: 3,
+    backgroundColor: 'white',
+    height: 18,
+    width: 18,
+  },
+  atStop: {
+    height: 20,
+    width: 20,
+    borderColor: 'white',
+    borderWidth: 3,
+    backgroundColor: 'white',
+  },
+  atStopTitle: {
+    fontWeight: 'bold',
+  },
+  passedStopTitle: {
+    color: c.iosDisabledText,
+  },
+})
+
+export function BusStopRow({
+  index,
+  time,
+  now,
+  barColor,
+  currentStopColor,
+  isLastRow,
+  place,
+  times,
+}: {
+  index: number,
+  time: moment,
+  now: moment,
+  barColor: string,
+  currentStopColor: string,
+  isLastRow: boolean,
+  place: string,
+  times: FancyBusTimeListType[]
+}) {
+  const afterStop = time && now.isAfter(time, 'minute')
+  const atStop = time && now.isSame(time, 'minute')
+  const beforeStop = !afterStop && !atStop && time !== false
+  const skippingStop = time === false
+
+  // To draw the bar, we draw a chunk of the bar, then we draw the dot, then
+  // we draw the last chunk of the bar.
+  const busLineProgressBar = (
+    <View style={styles.barContainer}>
+      <View style={[styles.bar, {backgroundColor: barColor}]} />
+      <View
+        style={[
+          styles.dot,
+          afterStop && [styles.passedStop, {borderColor: barColor, backgroundColor: barColor}],
+          beforeStop && [styles.beforeStop, {borderColor: barColor}],
+          atStop && [styles.atStop, {borderColor: currentStopColor}],
+          skippingStop && styles.busWillSkipStopDot,
+        ]}
+      />
+      <View style={[styles.bar, {backgroundColor: barColor}]} />
+    </View>
+  )
+
+  // The bus line information is the stop name, and the times.
+  const busLineInformation = (
+    <View style={[
+      styles.rowDetail,
+      !isLastRow && styles.notLastRowContainer,
+    ]}>
+      <Text style={[
+        styles.itemTitle,
+        skippingStop && styles.busWillSkipStopTitle,
+        afterStop && styles.passedStopTitle,
+        atStop && styles.atStopTitle,
+      ]}>
+        {place}
+      </Text>
+      <Text
+        style={[
+          styles.itemDetail,
+          skippingStop && styles.busWillSkipStopDetail,
+        ]}
+        numberOfLines={1}
+      >
+        {times
+          .map(timeSet => timeSet[index])
+          .map(time => time === false ? 'None' : time.format(TIME_FORMAT))
+          .join(' • ')}
+      </Text>
+    </View>
+  )
+
+  return (
+    <View style={styles.row}>
+      {busLineProgressBar}
+      {busLineInformation}
+    </View>
+  )
+}

--- a/views/transportation/bus/bus-stop-row.js
+++ b/views/transportation/bus/bus-stop-row.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {View, StyleSheet, Text} from 'react-native'
+import {Platform, View, StyleSheet, Text} from 'react-native'
 import type {FancyBusTimeListType} from './types'
 import type moment from 'moment'
 import * as c from '../../components/colors'
@@ -24,13 +24,12 @@ let styles = StyleSheet.create({
     flex: 1,
     marginLeft: 0,
     paddingRight: 10,
-    paddingTop: 8,
-    paddingBottom: 8,
+    paddingVertical: Platform.OS === 'ios' ? 8 : 15,
     flexDirection: 'column',
   },
   notLastRowContainer: {
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: '#c8c7cc',
+    borderBottomWidth: Platform.OS === 'ios' ? StyleSheet.hairlineWidth : 1,
+    borderBottomColor: Platform.OS === 'ios' ? '#c8c7cc' : '#e0e0e0',
   },
   passedStopDetail: {
 
@@ -40,7 +39,7 @@ let styles = StyleSheet.create({
     paddingLeft: 0,
     paddingRight: 0,
     paddingBottom: 3,
-    fontSize: 16,
+    fontSize: Platform.OS === 'ios' ? 16 : 17,
     textAlign: 'left',
   },
   itemDetail: {

--- a/views/transportation/bus/get-set-of-stops-for-now.js
+++ b/views/transportation/bus/get-set-of-stops-for-now.js
@@ -1,31 +1,31 @@
 // @flow
-import type {BusScheduleType} from './types'
-import moment from 'moment-timezone'
+import type {FancyBusTimeListType} from './types'
+import type moment from 'moment'
 import head from 'lodash/head'
 import last from 'lodash/last'
 import find from 'lodash/find'
 
 export default function getSetOfStopsForNow(
-  schedule: BusScheduleType,
-  now: typeof moment
-): (typeof moment)[] {
-  let times: string[]|void = find(schedule.times, times => {
-    const startTime = head(times)
-    const endTime = last(times)
+  scheduledMoments: FancyBusTimeListType[],
+  now: moment
+): FancyBusTimeListType {
+  let moments: ?Array<moment|false> = find(scheduledMoments, moments => {
+    const startTime = head(moments)
+    const endTime = last(moments)
     // Momentjs inclusivity: A [ indicates inclusion of a value. A ( indicates
     // exclusion. If the inclusivity parameter is used, both indicators must
     // be passed.
     return now.isBetween(startTime, endTime, null, '[]')
   })
 
-  if (times) {
-    return times
+  if (moments) {
+    return moments
   }
 
-  let firstBus = head(head(schedule.times))
+  let firstBus = head(head(scheduledMoments))
   if (now.isSameOrBefore(firstBus, 'minute')) {
-    return head(schedule.times)
+    return head(scheduledMoments)
   }
 
-  return last(schedule.times)
+  return last(scheduledMoments)
 }

--- a/views/transportation/bus/index.js
+++ b/views/transportation/bus/index.js
@@ -22,7 +22,7 @@ export default class BusView extends React.Component {
 
   state = {
     intervalId: 0,
-    now: Date.now(),
+    now: moment.tz(TIMEZONE),
   }
 
   componentWillMount() {
@@ -41,13 +41,12 @@ export default class BusView extends React.Component {
   }
 
   updateTime = () => {
-    this.setState({now: Date.now()})
+    this.setState({now: moment.tz(TIMEZONE)})
   }
 
   render() {
     // const now = moment.tz('6:53am', 'h:mma', true, TIMEZONE)
     // now.dayOfYear(moment.tz(TIMEZONE).dayOfYear())
-    const now = moment.tz(TIMEZONE)
     const busLines = this.props.busLines
     const activeBusLine = busLines.find(({line}) => line === this.props.line)
 
@@ -68,7 +67,7 @@ export default class BusView extends React.Component {
             marginBottom: Platform.OS === 'ios' ? 0 : 8,
           }}
           line={activeBusLine}
-          now={now}
+          now={this.state.now}
         />
       </ScrollView>
     )

--- a/views/transportation/bus/index.js
+++ b/views/transportation/bus/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {Platform, ScrollView} from 'react-native'
+import {Platform, ScrollView, View, Text} from 'react-native'
 import type {BusLineType} from './types'
 import BusLineView from './bus-line'
 import moment from 'moment-timezone'
@@ -13,6 +13,7 @@ const TIMEZONE = 'America/Winnipeg'
 export default class BusView extends React.Component {
   static propTypes = {
     busLines: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+    line: React.PropTypes.string.isRequired,
   }
 
   static defaultProps = {
@@ -36,6 +37,7 @@ export default class BusView extends React.Component {
 
   props: {
     busLines: BusLineType[],
+    line: string,
   }
 
   updateTime = () => {
@@ -47,21 +49,27 @@ export default class BusView extends React.Component {
     // now.dayOfYear(moment.tz(TIMEZONE).dayOfYear())
     const now = moment.tz(TIMEZONE)
     const busLines = this.props.busLines
+    const activeBusLine = busLines.find(({line}) => line === this.props.line)
+
+    if (!activeBusLine) {
+      return (
+        <View>
+          <Text>The line "{this.props.line}" was not found among {busLines.map(({line}) => line).join(', ')}</Text>
+        </View>
+      )
+    }
 
     return (
       <ScrollView>
-        {busLines.map((busLine: BusLineType, i) =>
-          <BusLineView
-            key={busLine.line}
-            style={{
-              marginTop: Platform.OS === 'ios' ? 15 : 0,
-              marginBottom: Platform.OS === 'ios'
-                ? i < busLines.length - 1 ? 15 : 5
-                : 8,
-            }}
-            line={busLine}
-            now={now}
-          />)}
+        <BusLineView
+          key={activeBusLine.line}
+          style={{
+            marginTop: Platform.OS === 'ios' ? 15 : 0,
+            marginBottom: Platform.OS === 'ios' ? 0 : 8,
+          }}
+          line={activeBusLine}
+          now={now}
+        />
       </ScrollView>
     )
   }

--- a/views/transportation/bus/index.js
+++ b/views/transportation/bus/index.js
@@ -1,15 +1,18 @@
 // @flow
 import React from 'react'
 import {Platform, ScrollView} from 'react-native'
-import defaultBusLines from '../../../data/bus-times.json'
 import type {BusLineType} from './types'
 import BusLineView from './bus-line'
 import moment from 'moment-timezone'
+
+import defaultBusLines from '../../../data/bus-times.json'
+(defaultBusLines: BusLineType[])
+
 const TIMEZONE = 'America/Winnipeg'
 
 export default class BusView extends React.Component {
   static propTypes = {
-    busLines: React.PropTypes.arrayOf(React.PropTypes.object),
+    busLines: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
   }
 
   static defaultProps = {
@@ -32,7 +35,7 @@ export default class BusView extends React.Component {
   }
 
   props: {
-    busLines: BusLineType[]
+    busLines: BusLineType[],
   }
 
   updateTime = () => {

--- a/views/transportation/bus/index.js
+++ b/views/transportation/bus/index.js
@@ -1,13 +1,21 @@
 // @flow
 import React from 'react'
 import {ScrollView} from 'react-native'
-import busInfo from '../../../data/bus-times.json'
+import defaultBusLines from '../../../data/bus-times.json'
 import type {BusLineType} from './types'
 import BusLineView from './bus-line'
 import moment from 'moment-timezone'
 const TIMEZONE = 'America/Winnipeg'
 
 export default class BusView extends React.Component {
+  static propTypes = {
+    busLines: React.PropTypes.arrayOf(React.PropTypes.object),
+  }
+
+  static defaultProps = {
+    busLines: defaultBusLines,
+  }
+
   state = {
     intervalId: 0,
     now: Date.now(),
@@ -16,11 +24,15 @@ export default class BusView extends React.Component {
   componentWillMount() {
     // This updates the screen every second, so that the "next bus" times are
     // updated without needing to leave and come back.
-    this.setState({intervalId: setInterval(this.updateTime, 1000)})
+    this.setState({intervalId: setInterval(this.updateTime, 5000)})
   }
 
   componentWillUnmount() {
     clearTimeout(this.state.intervalId)
+  }
+
+  props: {
+    busLines: BusLineType[]
   }
 
   updateTime = () => {
@@ -31,13 +43,14 @@ export default class BusView extends React.Component {
     // const now = moment.tz('6:53am', 'h:mma', true, TIMEZONE)
     // now.dayOfYear(moment.tz(TIMEZONE).dayOfYear())
     const now = moment.tz(TIMEZONE)
+    const busLines = this.props.busLines
 
     return (
       <ScrollView>
-        {busInfo.map((busLine: BusLineType, i) =>
+        {busLines.map((busLine: BusLineType, i) =>
           <BusLineView
             key={busLine.line}
-            style={{marginBottom: i < busInfo.length - 1 ? 5 : 15}}
+            style={{marginBottom: i < busLines.length - 1 ? 5 : 15}}
             line={busLine}
             now={now}
           />)}

--- a/views/transportation/bus/index.js
+++ b/views/transportation/bus/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {ScrollView} from 'react-native'
+import {Platform, ScrollView} from 'react-native'
 import defaultBusLines from '../../../data/bus-times.json'
 import type {BusLineType} from './types'
 import BusLineView from './bus-line'
@@ -50,7 +50,12 @@ export default class BusView extends React.Component {
         {busLines.map((busLine: BusLineType, i) =>
           <BusLineView
             key={busLine.line}
-            style={{marginBottom: i < busLines.length - 1 ? 5 : 15}}
+            style={{
+              marginTop: Platform.OS === 'ios' ? 15 : 0,
+              marginBottom: Platform.OS === 'ios'
+                ? i < busLines.length - 1 ? 15 : 5
+                : 8,
+            }}
             line={busLine}
             now={now}
           />)}

--- a/views/transportation/bus/types.js
+++ b/views/transportation/bus/types.js
@@ -1,4 +1,5 @@
 // @flow
+import type moment from 'moment'
 type DayOfWeekType = 'su'|'mo'|'tu'|'we'|'th'|'fr'|'sa';
 
 export type BusLineType = {
@@ -10,7 +11,7 @@ export type BusScheduleType = {
   days: DayOfWeekType[],
   stops: BusStopType[],
   coordinates?: [number, number][],
-  times: BusTimeListType[],
+  times: PlainBusTimeListType[],
 };
 
 export type BusStopType = string | {
@@ -18,4 +19,5 @@ export type BusStopType = string | {
   latlong: [number, number],
 };
 
-export type BusTimeListType = (string|false)[];
+export type PlainBusTimeListType = Array<string|false>;
+export type FancyBusTimeListType = Array<moment|false>;

--- a/views/transportation/tabs.js
+++ b/views/transportation/tabs.js
@@ -6,24 +6,24 @@ import BusView from './bus'
 export default [
   {
     id: 'express',
-    title: 'Express',
+    title: 'Express Bus',
     rnVectorIcon: {iconName: 'bus'},
     component: BusView,
-    props: {line: 'Express'},
+    props: {line: 'Express Bus'},
   },
   {
     id: 'red',
     title: 'Red Line',
     rnVectorIcon: {iconName: 'car'},
     component: BusView,
-    props: {line: 'Red'},
+    props: {line: 'Red Line'},
   },
   {
     id: 'blue',
     title: 'Blue Line',
     rnVectorIcon: {iconName: 'train'},
     component: BusView,
-    props: {line: 'Blue'},
+    props: {line: 'Blue Line'},
   },
   {
     id: 'otherModes',

--- a/views/transportation/tabs.js
+++ b/views/transportation/tabs.js
@@ -5,10 +5,25 @@ import BusView from './bus'
 
 export default [
   {
-    id: 'bus',
-    title: 'Bus',
+    id: 'express',
+    title: 'Express',
     rnVectorIcon: {iconName: 'bus'},
     component: BusView,
+    props: {line: 'Express'},
+  },
+  {
+    id: 'red',
+    title: 'Red Line',
+    rnVectorIcon: {iconName: 'car'},
+    component: BusView,
+    props: {line: 'Red'},
+  },
+  {
+    id: 'blue',
+    title: 'Blue Line',
+    rnVectorIcon: {iconName: 'train'},
+    component: BusView,
+    props: {line: 'Blue'},
   },
   {
     id: 'otherModes',

--- a/views/transportation/tabs.js
+++ b/views/transportation/tabs.js
@@ -14,14 +14,14 @@ export default [
   {
     id: 'red',
     title: 'Red Line',
-    rnVectorIcon: {iconName: 'car'},
+    rnVectorIcon: {iconName: 'bus'},
     component: BusView,
     props: {line: 'Red Line'},
   },
   {
     id: 'blue',
     title: 'Blue Line',
-    rnVectorIcon: {iconName: 'train'},
+    rnVectorIcon: {iconName: 'bus'},
     component: BusView,
     props: {line: 'Blue Line'},
   },


### PR DESCRIPTION
This PR does two things:

- It slows down the update frequency of the Bus views, since they were lagging (open the Transit view, then slowly perform the swipe back gesture on iOS; you will see the animation judder about every second, as the view updates)
- It splits the bus lines into three tabs, one per line
  - ~~I think I'm still using my silly icons for the different tabs. I can change that, if anyone cares.~~ Not any longer

---

There are two important architectural changes in this PR:

One is that I've started applying Flow types to the imported data.

```js
import defaultBusLines from '../../../data/bus-times.json'
(defaultBusLines: BusLineType[])
```

Because we're just importing from a JSON file, Flow has no idea what we're bringing in. So, I apply a [Flow typecast](https://flowtype.org/docs/builtins.html#note-about-typecast-syntax) to the imported variable. This allows Flow to properly propagate that type information to the rest of the program. (Side note: we're getting really close to being able to turn Flow on in the CIs. One more RN version and we should be good!!!)

The second change is that in these root components, which deal with the imported data, I've begun passing the data in as a `prop`. This is to allow us to more easily test the components with mock data later, because we can override the default with custom data easily.

This is accomplished by taking advantage of the "defaultProps" special value, which sets a default value for a prop if no value is given (think of a default argument value in c++).

```js
import defaultBusLines from '../../../data/bus-times.json'
(defaultBusLines: BusLineType[])

export class BusView extends React.Component {
  // First, we sketch out the type for the runtime propTypes check
  static propTypes = {
    busLines: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
  }

  // Then, we set the `static` defaultProps key.
  // The `static` keyword sets the value on the class, instead of a particular instance
  static defaultProps = {
    busLines: defaultBusLines,
  }

  // Then, we specify the flow types to allow us earlier and stronger typechecks
  // Make sure that `propTypes` and `props` check for the same keys;
  // `eslint` will help with a lot of making sure you do this right. (It will complain if
  // you try to access a prop or state value that you haven't declared before.)
  props: {
    busLines: BusLineType[],
  }

  // Finally, you just use it like any other prop, because that's all it is!
  render() {
     return this.props.busLines.map(busLine => busLine.line)
  }
}
```