### PR TITLE
Fixed maps URL

### DIFF
--- a/data/map.json
+++ b/data/map.json
@@ -1,4 +1,4 @@
 {
-	"url": "https://www.myatlascms.com/map/index.php?id=294#!ct/14990,14877,15145,15789,14884,14882,14874,14889,15142?ce/14889",
+	"url": "https://www.myatlascms.com/map/index.php?id=294",
 	"description": "Known as “The Hill”, St. Olaf College’s picturesque 300-acre (120 ha) campus is home to 17 academic and administrative buildings, 29 student residences and 10 athletic facilities. St. Olaf is a residential college; 96 percent of St. Olaf students reside in one of the 11 residence halls and 18 academic and special interest group houses. Adjacent to campus are 325 acres (132 ha) of restored wetlands, woodlands, and native tall grass prairie owned and maintained by St. Olaf, and a utility-grade wind turbine that supplies up to one-third of the college’s daily electrical needs."
 }


### PR DESCRIPTION
St. Olaf updates their selected list of buildings through their hosted online map from Concept3D/CampusBird. We are loading a URL that has changed, and most likely caused the map to break. By changing the URL to request our map id number of 294 without additional parameters, the rest of the URL populates and the map is once again usable.

Closes #322