### PR TITLE
Group events on this day by the "Today" heading

### DIFF
--- a/views/calendar/calendar.js
+++ b/views/calendar/calendar.js
@@ -89,9 +89,14 @@ export default class CalendarView extends React.Component {
         event.isOngoing = event.startTime.isBefore(now, 'day')
       })
       let grouped = groupBy(data, event => {
-        return event.isOngoing
-          ? 'Ongoing'  // default to "now" in CST
-          : event.startTime.format('ddd  MMM Do')  // google returns events in CST
+        if (event.isOngoing) {
+          return 'Ongoing'
+        }
+        let isToday = event.startTime.isSame(now, 'day')
+        if (isToday) {
+          return 'Today'
+        }
+        return event.startTime.format('ddd  MMM Do')  // google returns events in CST
       })
       this.setState({events: this.state.events.cloneWithRowsAndSections(grouped)})
     } else if (data && !data.length) {


### PR DESCRIPTION
This makes it easier to see what events are happening "Today" instead of explicitly listing dates, which requires thinking about what day today is. Thanks to @hawkrives for help on understanding how grouping works in the calendar.

**Before**
<img width="487" alt="screen shot 2016-11-24 at 11 31 29 am" src="https://cloud.githubusercontent.com/assets/5240843/20607903/8d416462-b239-11e6-8c6b-b5343d3285c5.png">
**After**
<img width="487" alt="screen shot 2016-11-24 at 11 31 21 am" src="https://cloud.githubusercontent.com/assets/5240843/20607902/8d209534-b239-11e6-9b75-ce869c566ef1.png">
