### PR TITLE
Titles for Settings pages

### DIFF
--- a/views/settings/index.js
+++ b/views/settings/index.js
@@ -83,6 +83,7 @@ export default class SettingsView extends React.Component {
   onPressLegalButton() {
     this.props.navigator.push({
       id: 'LegalView',
+      title: 'Legal',
       index: this.props.route.index + 1,
     })
   }
@@ -90,6 +91,7 @@ export default class SettingsView extends React.Component {
   onPressCreditsButton() {
     this.props.navigator.push({
       id: 'CreditsView',
+      title: 'Credits',
       index: this.props.route.index + 1,
     })
   }
@@ -97,6 +99,7 @@ export default class SettingsView extends React.Component {
   onPressPrivacyButton() {
     this.props.navigator.push({
       id: 'PrivacyView',
+      title: 'Privacy Policy',
       index: this.props.route.index + 1,
     })
   }


### PR DESCRIPTION
The `title` prop was missing from our call to `this.props.navigator.push`. These titles were by default set to blank, but now they are populated.