### PR TITLE
Allow home view to reorder

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ import SISLoginView from './views/settings/login'
 import CreditsView from './views/settings/credits'
 import PrivacyView from './views/settings/privacy'
 import LegalView from './views/settings/legal'
+import EditHomeView from './views/editHome'
 
 import NoRoute from './views/components/no-route'
 
@@ -62,6 +63,7 @@ function renderScene(route, navigator) {
     case 'CreditsView': return <CreditsView {...props} />
     case 'PrivacyView': return <PrivacyView {...props} />
     case 'LegalView': return <LegalView {...props} />
+    case 'EditHomeView': return <EditHomeView {...props} />
     default: return <NoRoute {...props} />
   }
 }
@@ -117,11 +119,22 @@ const styles = StyleSheet.create({
     paddingVertical: Platform.OS === 'ios' ? 10 : 16,
     paddingHorizontal: Platform.OS === 'ios' ? 18 : 16,
   },
+  editHomeButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: Platform.OS === 'ios' ? 18 : 16,
+  },
+  editHomeText: {
+    fontSize: 17,
+    color: 'white',
+    paddingVertical: Platform.OS === 'ios' ? 10 : 16,
+  },
   backButtonClose: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingVertical: Platform.OS === 'ios' ? 18 : 16,
-    paddingHorizontal: Platform.OS === 'ios' ? 10 : 16,
+    paddingVertical: Platform.OS === 'ios' ? 10 : 16,
+    paddingHorizontal: Platform.OS === 'ios' ? 18 : 16,
   },
   backButtonCloseText: {
     fontSize: 17,
@@ -146,8 +159,30 @@ const styles = StyleSheet.create({
   },
 })
 
-let settingsButtonActive = false
+let editHomeButtonActive = false
+function openEditHome(route, navigator) {
+  return () => {
+    if (editHomeButtonActive) {
+      return
+    }
 
+    function closeEditHome(route, navigator) {
+      editHomeButtonActive = false
+      navigator.pop()
+    }
+
+    editHomeButtonActive = true
+    navigator.push({
+      id: 'EditHomeView',
+      title: 'Edit Home',
+      index: route.index + 1,
+      sceneConfig: Navigator.SceneConfigs.FloatFromBottom,
+      onDismiss: closeEditHome,
+    })
+  }
+}
+
+let settingsButtonActive = false
 function openSettings(route, navigator) {
   return () => {
     if (settingsButtonActive) {
@@ -224,6 +259,16 @@ function RightButton(route, navigator) {
         onPress={() => route.onDismiss(route, navigator)}
       >
         <Text style={styles.backButtonCloseText}>Close</Text>
+      </TouchableOpacity>
+    )
+  }
+  if (route.id === 'HomeView') {
+    return (
+      <TouchableOpacity
+        style={[styles.editHomeButton]}
+        onPress={openEditHome(route, navigator)}
+      >
+        <Text style={[styles.editHomeText]}>Edit</Text>
       </TouchableOpacity>
     )
   }

--- a/app.js
+++ b/app.js
@@ -12,6 +12,8 @@ import {
   Text,
   Platform,
 } from 'react-native'
+import {Provider} from 'react-redux'
+import {store} from './flux'
 
 import CalendarView from './views/calendar'
 import ContactsView from './views/contacts'
@@ -286,7 +288,7 @@ function Title(route) {
   )
 }
 
-export default class App extends React.Component {
+class App extends React.Component {
   componentDidMount() {
     BackAndroid.addEventListener('hardwareBackPress', this.registerAndroidBackButton)
   }
@@ -333,4 +335,12 @@ export default class App extends React.Component {
       />
     )
   }
+}
+
+export default () => {
+  return (
+    <Provider store={store}>
+      <App />
+    </Provider>
+  )
 }

--- a/flux/index.js
+++ b/flux/index.js
@@ -1,0 +1,49 @@
+import {createStore, applyMiddleware} from 'redux'
+import createLogger from 'redux-logger'
+import reduxPromise from 'redux-promise'
+import reduxThunk from 'redux-thunk'
+import {AsyncStorage} from 'react-native'
+
+export const SAVE_HOMESCREEN_ORDER = 'SAVE_HOMESCREEN_ORDER'
+
+export const loadHomescreenOrder = async () => {
+  let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || []
+  return saveHomescreenOrder(savedOrder)
+}
+
+export const saveHomescreenOrder = order => {
+  AsyncStorage.setItem('homescreen:view-order', JSON.stringify(order))
+  return {type: SAVE_HOMESCREEN_ORDER, payload: order}
+}
+
+const initialHomescreenState = {
+  order: [],
+}
+function homescreen(state=initialHomescreenState, action) {
+  let {type, payload} = action
+  switch (type) {
+    case SAVE_HOMESCREEN_ORDER: {
+      return {...state, order: payload}
+    }
+    default:
+      return state
+  }
+}
+
+export function aao(state={}, action) {
+  return {
+    homescreen: homescreen(state.homescreen, action),
+  }
+}
+
+const logger = createLogger()
+export const store = createStore(
+  aao,
+  applyMiddleware(
+    reduxPromise,
+    reduxThunk,
+    logger
+  )
+)
+
+store.dispatch(loadHomescreenOrder())

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-native-onesignal": "1.2.3",
     "react-native-parallax-view": "2.0.6",
     "react-native-refreshable-listview": "1.3.0",
+    "react-native-sortable-list": "0.0.2",
     "react-native-tab-view": "0.0.40",
     "react-native-tableview-simple": "0.13.0",
     "react-native-vector-icons": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-onesignal": "1.2.3",
     "react-native-parallax-view": "2.0.6",
     "react-native-refreshable-listview": "1.3.0",
-    "react-native-sortable-list": "github:drewvolz/react-native-sortable-list#7af082be70b11086ab3a1dbc64620b975407a5e4",
+    "react-native-sortable-list": "github:drewvolz/react-native-sortable-list#a46c78161e0a1a8d3a45f2fef69d98af3e911b6d",
     "react-native-tab-view": "0.0.40",
     "react-native-tableview-simple": "0.13.0",
     "react-native-vector-icons": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,11 @@
     "react-native-tab-view": "0.0.40",
     "react-native-tableview-simple": "0.13.0",
     "react-native-vector-icons": "3.0.0",
+    "react-redux": "4.4.6",
     "redux": "3.6.0",
+    "redux-logger": "2.7.4",
+    "redux-promise": "0.5.3",
+    "redux-thunk": "2.1.0",
     "stream": "0.0.2",
     "timers": "0.1.1",
     "xml2js": "0.4.17"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-onesignal": "1.2.3",
     "react-native-parallax-view": "2.0.6",
     "react-native-refreshable-listview": "1.3.0",
-    "react-native-sortable-list": "0.0.2",
+    "react-native-sortable-list": "github:drewvolz/react-native-sortable-list#7af082be70b11086ab3a1dbc64620b975407a5e4",
     "react-native-tab-view": "0.0.40",
     "react-native-tableview-simple": "0.13.0",
     "react-native-vector-icons": "3.0.0",

--- a/views/editHome.js
+++ b/views/editHome.js
@@ -45,6 +45,8 @@ class Row extends React.Component {
     style: {
       shadowRadius: new Animated.Value(2),
       transform: [{scale: new Animated.Value(1)}],
+      opacity: new Animated.Value(1.0),
+      elevation: new Animated.Value(2),
     },
   }
 
@@ -76,6 +78,16 @@ class Row extends React.Component {
         easing: Easing.out(Easing.quad),
         toValue: 10,
       }),
+      Animated.timing(style.opacity, {
+        duration: 100,
+        easing: Easing.out(Easing.quad),
+        toValue: 0.65,
+      }),
+      Animated.timing(style.elevation, {
+        duration: 100,
+        easing: Easing.out(Easing.quad),
+        toValue: 4,
+      }),
     ]).start()
   }
 
@@ -88,6 +100,16 @@ class Row extends React.Component {
         toValue: 1,
       }),
       Animated.timing(style.shadowRadius, {
+        duration: 100,
+        easing: Easing.out(Easing.quad),
+        toValue: 2,
+      }),
+      Animated.timing(style.opacity, {
+        duration: 100,
+        easing: Easing.out(Easing.quad),
+        toValue: 1.0,
+      }),
+      Animated.timing(style.elevation, {
         duration: 100,
         easing: Easing.out(Easing.quad),
         toValue: 2,
@@ -157,6 +179,7 @@ let styles = StyleSheet.create({
     shadowOpacity: 1,
     shadowOffset: {height: 2, width: 2},
     shadowRadius: 2,
+    opacity: 1.0,
     elevation: 2,
   },
   rectangleButtonIcon: {

--- a/views/editHome.js
+++ b/views/editHome.js
@@ -139,7 +139,7 @@ function EditHomeView(props: {
       contentContainerStyle={styles.contentContainer}
       data={objViews}
       order={props.order}
-      onChangeOrder={(order: {[key: string]: ViewType}) => props.onSaveOrder(order)}
+      onChangeOrder={(order: ViewType[]) => props.onSaveOrder(order)}
       renderRow={({data, active}: {data: ViewType, active: boolean}) =>
         <Row data={data} active={active} />}
     />

--- a/views/editHome.js
+++ b/views/editHome.js
@@ -13,7 +13,6 @@ import {
   Navigator,
   StyleSheet,
   Text,
-  View,
 } from 'react-native'
 
 import * as c from './components/colors'

--- a/views/editHome.js
+++ b/views/editHome.js
@@ -131,12 +131,8 @@ export default class EditHomeView extends React.Component {
 
   loadData = async () => {
     this.setState({loaded: false})
-
     let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order'))
-
-    // check to see if we have a modified view order or not
     savedOrder = savedOrder || Object.keys(objViews)
-
     this.setState({loaded: true, order: savedOrder})
   }
 
@@ -177,7 +173,6 @@ let styles = StyleSheet.create({
     marginHorizontal: 15,
     paddingVertical: 12,
     borderRadius: 4,
-
     shadowColor: 'rgba(0,0,0,0.2)',
     shadowOpacity: 1,
     shadowOffset: {height: 2, width: 2},
@@ -186,13 +181,11 @@ let styles = StyleSheet.create({
   },
   rectangleButtonIcon: {
     marginRight: 20,
-    // borderRadius: 20,
     color: c.white,
     paddingLeft: 10,
     paddingRight: 10,
   },
   listButtonIcon: {
-    // borderRadius: 20,
     color: c.black,
     paddingLeft: 10,
     paddingRight: 10,

--- a/views/editHome.js
+++ b/views/editHome.js
@@ -22,8 +22,8 @@ import EntypoIcon from 'react-native-vector-icons/Entypo'
 import IonIcon from 'react-native-vector-icons/Ionicons'
 import SortableList from 'react-native-sortable-list'
 
-import type {ViewType} from './home'
-import {allViews} from './home'
+import type {ViewType} from './views'
+import {allViews} from './views'
 import LoadingView from './components/loading'
 //import AsyncStorageHOC from './components/asyncStorageHOC'
 

--- a/views/editHome.js
+++ b/views/editHome.js
@@ -163,7 +163,6 @@ export default class EditHomeView extends React.Component {
 
 let styles = StyleSheet.create({
   contentContainer: {
-    flex: 1,
     width: window.width,
     backgroundColor: c.iosLightBackground,
     paddingTop: 10,

--- a/views/editHome.js
+++ b/views/editHome.js
@@ -25,8 +25,6 @@ import SortableList from 'react-native-sortable-list'
 
 import type {ViewType} from './views'
 import {allViews} from './views'
-import LoadingView from './components/loading'
-//import AsyncStorageHOC from './components/asyncStorageHOC'
 
 const window = Dimensions.get('window')
 const objViews = fromPairs(allViews.map(v => ([v.view, v])))

--- a/views/editHome.js
+++ b/views/editHome.js
@@ -1,0 +1,207 @@
+// @flow
+/**
+ * All About Olaf
+ * Edit Home page
+ */
+
+import React, { Component } from 'react'
+import {
+  Animated,
+  AsyncStorage,
+  Dimensions,
+  Easing,
+  Navigator,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native'
+
+import * as c from './components/colors'
+import fromPairs from 'lodash/fromPairs'
+
+import EntypoIcon from 'react-native-vector-icons/Entypo'
+import IonIcon from 'react-native-vector-icons/Ionicons'
+import SortableList from 'react-native-sortable-list'
+
+import type {ViewType} from './home'
+import {allViews} from './home'
+import LoadingView from './components/loading'
+//import AsyncStorageHOC from './components/asyncStorageHOC'
+
+const window = Dimensions.get('window')
+
+let objViews = fromPairs(allViews.map(v => ([v.view, v])))
+
+const ReorderIcon = () =>
+  <IonIcon name='ios-reorder' size={32} style={styles.listButtonIcon} />
+
+const MenuIcon = ({icon, tint}: {icon: string, tint: string}) =>
+  <EntypoIcon name={icon} size={32} style={[styles.rectangleButtonIcon, {color: tint}]} />
+
+class Row extends Component {
+  static propTypes = {
+    active: React.PropTypes.bool,
+    data: React.PropTypes.object.isRequired,
+  }
+
+  state = {
+    style: {
+      shadowRadius: new Animated.Value(2),
+      transform: [{scale: new Animated.Value(1)}],
+    },
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.active !== nextProps.active) {
+      if (nextProps.active) {
+        this.startActivationAnimation()
+      } else {
+        this.startDeactivationAnimation()
+      }
+    }
+  }
+
+  props: {
+    data: ViewType,
+    active: boolean,
+  };
+
+  startActivationAnimation = () => {
+    const {style} = this.state
+    Animated.parallel([
+      Animated.timing(style.transform[0].scale, {
+        duration: 100,
+        easing: Easing.out(Easing.quad),
+        toValue: 1.05,
+      }),
+      Animated.timing(style.shadowRadius, {
+        duration: 100,
+        easing: Easing.out(Easing.quad),
+        toValue: 10,
+      }),
+    ]).start()
+  }
+
+  startDeactivationAnimation = () => {
+    const {style} = this.state
+    Animated.parallel([
+      Animated.timing(style.transform[0].scale, {
+        duration: 100,
+        easing: Easing.out(Easing.quad),
+        toValue: 1,
+      }),
+      Animated.timing(style.shadowRadius, {
+        duration: 100,
+        easing: Easing.out(Easing.quad),
+        toValue: 2,
+      }),
+    ]).start()
+  }
+
+  render() {
+    return (
+      <Animated.View style={[styles.row, this.state.style]}>
+        <MenuIcon icon={this.props.data.icon} tint={this.props.data.tint} />
+        <Text style={[styles.text, {color: this.props.data.tint}]}>
+          {this.props.data.title}
+        </Text>
+        <ReorderIcon />
+      </Animated.View>
+    )
+  }
+}
+
+export default class EditHomeView extends React.Component {
+  static propTypes = {
+    navigator: React.PropTypes.instanceOf(Navigator),
+    route: React.PropTypes.object,
+  }
+
+  state = {
+    loaded: false,
+    order: Object.keys(objViews),
+  }
+
+  componentWillMount() {
+    this.loadData()
+  }
+
+  renderRow({data, active}: {data: ViewType, active: boolean}) {
+    return <Row data={data} active={active} />
+  }
+
+  loadData = async () => {
+    this.setState({loaded: false})
+
+    let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order'))
+
+    // check to see if we have a modified view order or not
+    savedOrder = savedOrder || Object.keys(objViews)
+
+    this.setState({loaded: true, order: savedOrder})
+  }
+
+  onOrderChange = (order: {[key: string]: ViewType}) => {
+    AsyncStorage.setItem('homescreen:view-order', JSON.stringify(Object.values(order)))
+  }
+
+  render() {
+    if (!this.state.loaded) {
+      return <LoadingView />
+    }
+
+    return (
+      <SortableList
+        contentContainerStyle={styles.contentContainer}
+        data={objViews}
+        order={this.state.order}
+        onChangeOrder={this.onOrderChange}
+        renderRow={this.renderRow}
+      />
+    )
+  }
+}
+
+let styles = StyleSheet.create({
+  contentContainer: {
+    flex: 1,
+    width: window.width,
+    backgroundColor: c.iosLightBackground,
+    paddingTop: 10,
+    paddingBottom: 20,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'white',
+    width: window.width - 15 * 2,
+    marginVertical: 5,
+    marginHorizontal: 15,
+    paddingVertical: 12,
+    borderRadius: 4,
+
+    shadowColor: 'rgba(0,0,0,0.2)',
+    shadowOpacity: 1,
+    shadowOffset: {height: 2, width: 2},
+    shadowRadius: 2,
+    elevation: 2,
+  },
+  rectangleButtonIcon: {
+    marginRight: 20,
+    // borderRadius: 20,
+    color: c.white,
+    paddingLeft: 10,
+    paddingRight: 10,
+  },
+  listButtonIcon: {
+    // borderRadius: 20,
+    color: c.black,
+    paddingLeft: 10,
+    paddingRight: 10,
+  },
+  text: {
+    flex: 1,
+    fontSize: 18,
+    color: c.white,
+  },
+})

--- a/views/home.js
+++ b/views/home.js
@@ -19,6 +19,7 @@ import {
   TouchableNativeFeedback,
 } from 'react-native'
 
+import { connect } from 'react-redux'
 import Icon from 'react-native-vector-icons/Entypo'
 import * as c from './components/colors'
 import sortBy from 'lodash/sortBy'
@@ -50,7 +51,7 @@ function HomeScreenButton({view, onPress}: {view: ViewType, onPress: () => any})
   )
 }
 
-function HomePage({navigator, route, order, views}: {order: string[], views: ViewType[]} & TopLevelViewPropsType) {
+function HomePage({navigator, route, order, views=allViews}: {order: string[], views: ViewType[]} & TopLevelViewPropsType) {
   const sortedViews = sortBy(views, view => order.indexOf(view.view))
 
   return (
@@ -80,49 +81,12 @@ function HomePage({navigator, route, order, views}: {order: string[], views: Vie
   )
 }
 
-export default class HomePageScene extends React.Component {
-  static propTypes = {
-    navigator: React.PropTypes.instanceOf(Navigator),
-    route: React.PropTypes.object,
+function mapStateToProps(state) {
+  return {
+    order: state.homescreen.order,
   }
-
-  state = {
-    order: [],
   }
-
-  componentWillMount() {
-    this.loadData()
-  }
-
-  componentWillReceiveProps() {
-    this.loadData()
-  }
-
-  loadData = async () => {
-    let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order'))
-
-    // check to see if we have a modified view order or not
-    savedOrder = savedOrder || []
-
-    this.setState({order: savedOrder})
-  }
-
-  render() {
-    return (
-      <HomePage
-        route={this.props.route}
-        navigator={this.props.navigator}
-        order={this.state.order}
-        views={allViews}
-      />
-    )
-  }
-}
-
-HomePageScene.propTypes = {
-  navigator: React.PropTypes.instanceOf(Navigator),
-  route: React.PropTypes.object.isRequired,
-}
+export default connect(mapStateToProps)(HomePage)
 
 
 let cellMargin = 10

--- a/views/home.js
+++ b/views/home.js
@@ -5,6 +5,7 @@
  */
 
 import React from 'react'
+import type {Element} from 'react'
 import {
   Navigator,
   ScrollView,
@@ -12,17 +13,23 @@ import {
   Text,
   TouchableOpacity,
   StatusBar,
+  View,
   Platform,
+  AsyncStorage,
+  TouchableNativeFeedback,
 } from 'react-native'
 
 import Icon from 'react-native-vector-icons/Entypo'
 import * as c from './components/colors'
+import sortBy from 'lodash/sortBy'
+import type {TopLevelViewPropsType} from './types'
+//import AsyncStorageHOC from './components/asyncStorageHOC'
 
 const Dimensions = require('Dimensions')
 let Viewport = Dimensions.get('window')
 
-type ViewType = {view: string, title: string, icon: string, tint: string};
-const views: ViewType[] = [
+export type ViewType = {view: string, title: string, icon: string, tint: string};
+export const allViews: ViewType[] = [
   {view: 'MenusView', title: 'Menus', icon: 'bowl', tint: c.emerald},
   {view: 'SISView', title: 'SIS', icon: 'fingerprint', tint: c.goldenrod},
   {view: 'BuildingHoursView', title: 'Building Hours', icon: 'clock', tint: c.wave},
@@ -37,25 +44,42 @@ const views: ViewType[] = [
   {view: 'OlevilleView', title: 'Oleville', icon: 'mouse-pointer', tint: c.grapefruit},
 ]
 
+const Touchable = ({children, onPress}: {onPress: () => any, children?: Element<any>}) => {
+  return Platform.OS === 'ios'
+    ? <TouchableOpacity onPress={onPress} activeOpacity={0.65}>{children}</TouchableOpacity>
+    : <TouchableNativeFeedback onPress={onPress}>{children}</TouchableNativeFeedback>
+}
 
-type ScenePropsType = {navigator: typeof Navigator, route: Object};
-export default function HomePageScene({navigator, route}: ScenePropsType) {
+function HomeScreenButton({view, onPress}: {view: ViewType, onPress: () => any}) {
+  return (
+    <Touchable onPress={onPress}>
+      <View style={[styles.rectangle, {backgroundColor: view.tint}]}>
+        <Icon name={view.icon} size={32} style={styles.rectangleButtonIcon} />
+        <Text style={styles.rectangleButtonText}>
+          {view.title}
+        </Text>
+      </View>
+    </Touchable>
+  )
+}
+
+function HomePage({navigator, route, order, views}: {order: string[], views: ViewType[]} & TopLevelViewPropsType) {
+  const sortedViews = sortBy(views, view => order.indexOf(view.view))
+
   return (
     <ScrollView
-      overflow={'hidden'}
+      overflow='hidden'
       alwaysBounceHorizontal={false}
       showsHorizontalScrollIndicator={false}
       showsVerticalScrollIndicator={false}
       style={styles.scrollView}
-      //contentContainerStyle={Platform.OS === 'android' ? styles.rows : styles.cells}
       contentContainerStyle={styles.cells}
     >
-      <StatusBar
-        barStyle='light-content'
-        backgroundColor={c.gold}
-      />
-      {views.map(view =>
-        <TouchableOpacity
+      <StatusBar barStyle='light-content' backgroundColor={c.gold} />
+
+      {sortedViews.map(view =>
+        <HomeScreenButton
+          view={view}
           key={view.view}
           onPress={() => navigator.push({
             id: view.view,
@@ -63,23 +87,49 @@ export default function HomePageScene({navigator, route}: ScenePropsType) {
             title: view.title,
             sceneConfig: Navigator.SceneConfigs.PushFromRight,
           })}
-          activeOpacity={0.5}
-          //style={[Platform.OS === 'ios' ? styles.rectangle : styles.row, Platform.OS === 'ios' ? {backgroundColor: view.tint} : null]}
-          style={[styles.rectangle, {backgroundColor: view.tint}]}
-        >
-          {/*<Icon name={view.icon} size={Platform.OS === 'ios' ? 32 : 28} style={[Platform.OS === 'ios' ? styles.rectangleButtonIcon : styles.listIcon, Platform.OS === 'android' ? {color: view.tint} : null]} />*/}
-          <Icon name={view.icon} size={32} style={styles.rectangleButtonIcon} />
-
-          <Text
-            style={styles.rectangleButtonText}
-            autoAdjustsFontSize={true}
-          >
-            {view.title}
-          </Text>
-        </TouchableOpacity>)
+        />)
       }
     </ScrollView>
   )
+}
+
+export default class HomePageScene extends React.Component {
+  static propTypes = {
+    navigator: React.PropTypes.instanceOf(Navigator),
+    route: React.PropTypes.object,
+  }
+
+  state = {
+    order: [],
+  }
+
+  componentWillMount() {
+    this.loadData()
+  }
+
+  componentWillReceiveProps() {
+    this.loadData()
+  }
+
+  loadData = async () => {
+    let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order'))
+
+    // check to see if we have a modified view order or not
+    savedOrder = savedOrder || []
+
+    this.setState({order: savedOrder})
+  }
+
+  render() {
+    return (
+      <HomePage
+        route={this.props.route}
+        navigator={this.props.navigator}
+        order={this.state.order}
+        views={allViews}
+      />
+    )
+  }
 }
 
 HomePageScene.propTypes = {

--- a/views/home.js
+++ b/views/home.js
@@ -15,7 +15,6 @@ import {
   StatusBar,
   View,
   Platform,
-  AsyncStorage,
   TouchableNativeFeedback,
 } from 'react-native'
 
@@ -24,7 +23,6 @@ import Icon from 'react-native-vector-icons/Entypo'
 import * as c from './components/colors'
 import sortBy from 'lodash/sortBy'
 import type {TopLevelViewPropsType} from './types'
-//import AsyncStorageHOC from './components/asyncStorageHOC'
 
 const Dimensions = require('Dimensions')
 let Viewport = Dimensions.get('window')
@@ -85,7 +83,7 @@ function mapStateToProps(state) {
   return {
     order: state.homescreen.order,
   }
-  }
+}
 export default connect(mapStateToProps)(HomePage)
 
 

--- a/views/home.js
+++ b/views/home.js
@@ -28,21 +28,8 @@ import type {TopLevelViewPropsType} from './types'
 const Dimensions = require('Dimensions')
 let Viewport = Dimensions.get('window')
 
-export type ViewType = {view: string, title: string, icon: string, tint: string};
-export const allViews: ViewType[] = [
-  {view: 'MenusView', title: 'Menus', icon: 'bowl', tint: c.emerald},
-  {view: 'SISView', title: 'SIS', icon: 'fingerprint', tint: c.goldenrod},
-  {view: 'BuildingHoursView', title: 'Building Hours', icon: 'clock', tint: c.wave},
-  {view: 'CalendarView', title: 'Calendar', icon: 'calendar', tint: c.coolPurple},
-  {view: 'DirectoryView', title: 'Directory', icon: 'v-card', tint: c.indianRed},
-  {view: 'StreamingView', title: 'Streaming Media', icon: 'video', tint: c.denim},
-  {view: 'NewsView', title: 'News', icon: 'news', tint: c.eggplant},
-  {view: 'MapView', title: 'Campus Map', icon: 'map', tint: c.coffee},
-  {view: 'ContactsView', title: 'Important Contacts', icon: 'phone', tint: c.crimson},
-  {view: 'TransportationView', title: 'Transportation', icon: 'address', tint: c.cardTable},
-  {view: 'DictionaryView', title: 'Campus Dictionary', icon: 'open-book', tint: c.olive},
-  {view: 'OlevilleView', title: 'Oleville', icon: 'mouse-pointer', tint: c.grapefruit},
-]
+import type {ViewType} from './views'
+import {allViews} from './views'
 
 const Touchable = ({children, onPress}: {onPress: () => any, children?: Element<any>}) => {
   return Platform.OS === 'ios'

--- a/views/types.js
+++ b/views/types.js
@@ -4,7 +4,9 @@ import {Navigator} from 'react-native'
 
 export type TopLevelViewPropsType = {
   navigator: typeof Navigator,
-  route: Object,
+  route: {
+    index: number,
+  },
 };
 
 export const TopLevelViewPropTypes = {

--- a/views/views.js
+++ b/views/views.js
@@ -1,0 +1,17 @@
+import * as c from './components/colors'
+
+export type ViewType = {view: string, title: string, icon: string, tint: string, gradient?: [string, string]};
+export const allViews: ViewType[] = [
+  {view: 'MenusView', title: 'Menus', icon: 'bowl', tint: c.emerald, gradient: c.grassToLime},
+  {view: 'SISView', title: 'SIS', icon: 'fingerprint', tint: c.goldenrod, gradient: c.yellowToGoldDark},
+  {view: 'BuildingHoursView', title: 'Building Hours', icon: 'clock', tint: c.wave, gradient: c.lightBlueToBlueDark},
+  {view: 'CalendarView', title: 'Calendar', icon: 'calendar', tint: c.coolPurple, gradient: c.magentaToPurple},
+  {view: 'DirectoryView', title: 'Directory', icon: 'v-card', tint: c.indianRed, gradient: c.redToPurple},
+  {view: 'StreamingView', title: 'Streaming Media', icon: 'video', tint: c.denim, gradient: c.lightBlueToBlueLight},
+  {view: 'NewsView', title: 'News', icon: 'news', tint: c.eggplant, gradient: c.purpleToIndigo},
+  {view: 'MapView', title: 'Campus Map', icon: 'map', tint: c.coffee, gradient: c.navyToNavy},
+  {view: 'ContactsView', title: 'Important Contacts', icon: 'phone', tint: c.crimson, gradient: c.orangeToRed},
+  {view: 'TransportationView', title: 'Transportation', icon: 'address', tint: c.cardTable, gradient: c.grayToDarkGray},
+  {view: 'DictionaryView', title: 'Campus Dictionary', icon: 'open-book', tint: c.olive, gradient: c.yellowToGoldLight},
+  {view: 'OlevilleView', title: 'Oleville', icon: 'mouse-pointer', tint: c.grapefruit, gradient: c.pinkToHotpink},
+]


### PR DESCRIPTION
* Adds a view to reorder list of main views on home view
* Saves order to async storage to use back on the home view
* Reorders home view with any changes made
* Adds @hawkrives' WIP async storage higher-order component

- [x] Works on Android
- [x] Works on iOS

<img width="385" alt="opening-in" src="https://cloud.githubusercontent.com/assets/5240843/20651302/c5e82e3a-b4b0-11e6-8e01-5f0e25d6c3c3.gif">