### PR TITLE
Remove jest-react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       "{lib,views}/**/*.{js,jsx}",
       "!**/node_modules/**"
     ],
-    "preset": "jest-react-native"
+    "preset": "react-native"
   },
   "dependencies": {
     "buffer": "5.0.1",
@@ -80,7 +80,6 @@
     "eslint-plugin-react": "6.7.1",
     "flow-bin": "0.33.0",
     "jest": "17.0.2",
-    "jest-react-native": "17.0.2",
     "react-test-renderer": "15.4.1"
   }
 }


### PR DESCRIPTION
`jest-react-native` was fully merged into `react-native` as of 0.38.