### PR TITLE
Enable flow on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,9 +141,7 @@ script:
 
   # JS-only tests - type checking and specs
   - if [[ "$TEST_TYPE" == "js" ]]; then npm run lint; fi
-  # unfortunately, flow does not yet seem willing to run properly on travis.
-  # we'll just run it locally for now.
-  # - if [[ "$TEST_TYPE" = js ]]; then npm run flow; fi
+  - if [[ "$TEST_TYPE" == "js" ]]; then npm run flow; fi
   - if [[ "$TEST_TYPE" == "js" ]]; then npm run test:js:coverage; fi
 
   # iOS-only tests - building and specs


### PR DESCRIPTION
Flow, in addition to catching type problems, also catches missing function calls.

It is how I noticed the missing definitions in #335.

This makes it part of the Travis flow.