### PR TITLE
Fix the `fastlane register` command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       xcode-install (~> 2.0.0)
       xcodeproj (>= 0.20, < 2.0.0)
       xcpretty (>= 0.2.4, < 1.0.0)
+    fastlane-plugin-get_unprovisioned_devices_from_hockey (0.1.1)
+      json
     fastlane-plugin-increment_version_code (0.3.1)
     fastlane-plugin-latest_hockeyapp_version_number (1.0.0)
       hockeyapp
@@ -287,6 +289,7 @@ PLATFORMS
 
 DEPENDENCIES
   fastlane
+  fastlane-plugin-get_unprovisioned_devices_from_hockey
   fastlane-plugin-increment_version_code
   fastlane-plugin-latest_hockeyapp_version_number
   xcodeproj

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,3 +4,4 @@
 
 gem 'fastlane-plugin-increment_version_code'
 gem 'fastlane-plugin-latest_hockeyapp_version_number'
+gem 'fastlane-plugin-get_unprovisioned_devices_from_hockey'


### PR DESCRIPTION
It's a command I made and hadn't tested; I forgot to include the plugin properly.

It works, btw. Automatic addition of testers from hockeyapp into the profile.