### PR TITLE
Moves button check to global scope

### DIFF
--- a/app.js
+++ b/app.js
@@ -146,8 +146,9 @@ const styles = StyleSheet.create({
   },
 })
 
+let settingsButtonActive = false
+
 function openSettings(route, navigator) {
-  let settingsButtonActive = false
   return () => {
     if (settingsButtonActive) {
       return


### PR DESCRIPTION
This got shuffled around in a reorganization of files a bit ago, and belongs in the global scope in order to retain its value.