### PR TITLE
Small tweaks

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,7 +89,7 @@ const styles = StyleSheet.create({
     backgroundColor: Platform.OS === 'ios' ? c.iosLightBackground : c.androidLightBackground,
   },
   navigationBar: {
-    backgroundColor: c.olevilleGold,
+    backgroundColor: c.tint,
     ...navbarShadows,
   },
   backButton: {

--- a/app.js
+++ b/app.js
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
     color: 'white',
     fontFamily: Platform.OS === 'ios' ? 'System' : 'sans-serif-light',
     fontSize: Platform.OS === 'ios' ? 17 : 20,
-    fontWeight: Platform.OS === 'ios' ? 'bold' : '500',
+    fontWeight: Platform.OS === 'ios' ? '600' : '500',
     marginVertical: Platform.OS === 'ios' ? 12 : 14,
   },
   rightButton: {

--- a/app.js
+++ b/app.js
@@ -89,7 +89,7 @@ const styles = StyleSheet.create({
     backgroundColor: Platform.OS === 'ios' ? c.iosLightBackground : c.androidLightBackground,
   },
   navigationBar: {
-    backgroundColor: c.tint,
+    backgroundColor: c.olevilleGold,
     ...navbarShadows,
   },
   backButton: {


### PR DESCRIPTION
This PR is made up of two changes:
- reduce font weight of ios navbar
- darken app tint color

We have been using a heavier font weight (`700`, or `bold`) in our navbar since … well, since always. That's because my brain said that 600 == bold, not 700, but iOS uses 600 for navbars, not 700.

And secondly, the app's tint color is too light IMHO. This changes it to the same color used for tinting the app in other places, most noticeably the iOS tab bars. This makes it much easier to read the titlebar, especially when night shift is enabled, IMO.

![diff-1](https://cloud.githubusercontent.com/assets/464441/20943951/38784a9e-bbc7-11e6-93d3-ca4956cf24ad.gif)

| Before | After |
|:---:|:---:|
![before](https://cloud.githubusercontent.com/assets/464441/20943949/377813f4-bbc7-11e6-9fa3-e3cd901ef3ea.png) | ![after](https://cloud.githubusercontent.com/assets/464441/20943950/37869a96-bbc7-11e6-81f7-f4f96a8ace36.png)

---

Comment period: until someone from Olaf comments.