### PR TITLE
Oleville fix

### DIFF
--- a/views/oleville/index.js
+++ b/views/oleville/index.js
@@ -21,6 +21,7 @@ import LoadingView from '../components/loading'
 import * as c from '../components/colors'
 import { getText, parseHtml } from '../../lib/html'
 import get from 'lodash/get'
+import zipWith from 'lodash/zipWith'
 
 const URL = 'http://oleville.com/wp-json/wp/v2/posts?per_page=5'
 const defaultOlevilleImageUrl = 'http://oleville.com/wp-content/uploads/2015/12/Oleville-Logo.png'
@@ -90,14 +91,14 @@ export default class OlevilleView extends React.Component {
 
   fetchData = async () => {
     try {
-      let response = await fetch(URL)
-      let articles = await response.json()
+      let articles = await fetchJson(URL)
 
       // get all the image urls
       let imageUrls = await Promise.all(articles.map(article => this.getImageUrl(article.featured_media)))
+
       // and embed them in the article responses
-      articles.forEach((article, i) => {
-        article._featuredImageUrl = imageUrls[i]
+      articles = zipWith(articles, imageUrls, (article, imageUrl) => {
+        return {...article, _featuredImageUrl: imageUrl}
       })
 
       // then we have the _featuredImageUrl key to just get the url

--- a/views/oleville/index.js
+++ b/views/oleville/index.js
@@ -23,6 +23,8 @@ import { getText, parseHtml } from '../../lib/html'
 
 const URL = 'http://oleville.com/wp-json/wp/v2/posts?per_page=5'
 
+const fetchJson = url => fetch(url).then(r => r.json())
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,

--- a/views/oleville/index.js
+++ b/views/oleville/index.js
@@ -20,8 +20,10 @@ import delay from 'delay'
 import LoadingView from '../components/loading'
 import * as c from '../components/colors'
 import { getText, parseHtml } from '../../lib/html'
+import get from 'lodash/get'
 
 const URL = 'http://oleville.com/wp-json/wp/v2/posts?per_page=5'
+const defaultOlevilleImageUrl = 'http://oleville.com/wp-content/uploads/2015/12/Oleville-Logo.png'
 
 const fetchJson = url => fetch(url).then(r => r.json())
 
@@ -74,17 +76,16 @@ export default class OlevilleView extends React.Component {
   }
 
   async getImageUrl(id: number) {
-    if (id) {
-      let response = await fetch(`http://oleville.com/wp-json/wp/v2/media/${id}`)
-      let responseJson = await response.json()
-      this.setState({loaded: true})
-
-      if (responseJson.media_details.sizes.medium.source_url) {
-        // if there is a featured image, use that url
-        return responseJson.media_details.sizes.medium.source_url
+    try {
+      if (id) {
+        let responseJson = await fetchJson(`http://oleville.com/wp-json/wp/v2/media/${id}`)
+        let url = get(responseJson, 'media_details.sizes.medium.source_url')
+        return url || defaultOlevilleImageUrl
       }
+    } catch (err) {
+      console.warn(err)
     }
-    return 'http://oleville.com/wp-content/uploads/2015/12/Oleville-Logo.png'
+    return defaultOlevilleImageUrl
   }
 
   fetchData = async () => {

--- a/views/oleville/index.js
+++ b/views/oleville/index.js
@@ -28,8 +28,8 @@ const fetchJson = url => fetch(url).then(r => r.json())
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginLeft: 5,
-    marginRight: 5,
+    paddingLeft: 5,
+    paddingRight: 5,
     backgroundColor: c.olevilleBackground,
   },
   imageStyle: {


### PR DESCRIPTION
Oleville is currently returning a 403 for 
http://oleville.com/wp-json/wp/v2/media/8263. (from http://oleville.com/blog/jingle-ball-rock/)

```json
{
  "code": "rest_forbidden",
  "message": "You don't have permission to do this.",
  "data": {
    "status": 403
  }
}
```

This breaks the getImageUrl function, which wasn't wrapped in a try/catch block.

This wraps it in the try/catch block, and fixes some other things around the Oleville view.