### PR TITLE
Bump patched rn-sortable-list hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-onesignal": "1.2.3",
     "react-native-parallax-view": "2.0.6",
     "react-native-refreshable-listview": "1.3.0",
-    "react-native-sortable-list": "github:drewvolz/react-native-sortable-list#6e00a2c6ad639d5397fc370136ca3972f6690c59",
+    "react-native-sortable-list": "github:drewvolz/react-native-sortable-list#92762db0e2e5d38a5262aea53cfb71073adedf1d",
     "react-native-tab-view": "0.0.40",
     "react-native-tableview-simple": "0.13.0",
     "react-native-vector-icons": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-onesignal": "1.2.3",
     "react-native-parallax-view": "2.0.6",
     "react-native-refreshable-listview": "1.3.0",
-    "react-native-sortable-list": "github:drewvolz/react-native-sortable-list#b19dbc7e8de53a0996e5e068a20d25fbe0e2b57e",
+    "react-native-sortable-list": "github:drewvolz/react-native-sortable-list#6e00a2c6ad639d5397fc370136ca3972f6690c59",
     "react-native-tab-view": "0.0.40",
     "react-native-tableview-simple": "0.13.0",
     "react-native-vector-icons": "3.0.0",


### PR DESCRIPTION
* We are still patching this package until `zindex` support is fixed for android.
* `react-native-sortable-list` updated to include a fix for `AutoScroll` not scrolling on devices when moving items around the list.