### PR TITLE
Fix blank ordering on init of the Edit Home view

### DIFF
--- a/flux/index.js
+++ b/flux/index.js
@@ -6,7 +6,7 @@ import {AsyncStorage} from 'react-native'
 import {allViews} from '../views/views'
 
 export const SAVE_HOMESCREEN_ORDER = 'SAVE_HOMESCREEN_ORDER'
-let defaultViewOrder = allViews.map(v > v.view)
+let defaultViewOrder = allViews.map(v => v.view)
 
 export const loadHomescreenOrder = async () => {
   let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || defaultViewOrder

--- a/flux/index.js
+++ b/flux/index.js
@@ -3,11 +3,14 @@ import createLogger from 'redux-logger'
 import reduxPromise from 'redux-promise'
 import reduxThunk from 'redux-thunk'
 import {AsyncStorage} from 'react-native'
+import fromPairs from 'lodash/fromPairs'
+import {allViews} from '../views/views'
 
 export const SAVE_HOMESCREEN_ORDER = 'SAVE_HOMESCREEN_ORDER'
+const objViews = fromPairs(allViews.map(v => ([v.view, v])))
 
 export const loadHomescreenOrder = async () => {
-  let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || []
+  let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || Object.keys(objViews)
   return saveHomescreenOrder(savedOrder)
 }
 

--- a/flux/index.js
+++ b/flux/index.js
@@ -3,14 +3,13 @@ import createLogger from 'redux-logger'
 import reduxPromise from 'redux-promise'
 import reduxThunk from 'redux-thunk'
 import {AsyncStorage} from 'react-native'
-import fromPairs from 'lodash/fromPairs'
 import {allViews} from '../views/views'
 
 export const SAVE_HOMESCREEN_ORDER = 'SAVE_HOMESCREEN_ORDER'
-const objViews = fromPairs(allViews.map(v => ([v.view, v])))
+let defaultViewOrder = allViews.map(v > v.view)
 
 export const loadHomescreenOrder = async () => {
-  let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || Object.keys(objViews)
+  let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || defaultViewOrder
   return saveHomescreenOrder(savedOrder)
 }
 


### PR DESCRIPTION
* The order passed in would remain forever blank if we did not initialize it first.
* This was changed by accident during the redux/flux additions.
* Adding back a default order in place of a blank one solves this.