### PR TITLE
Fix new home additions

### DIFF
--- a/flux/__tests__/update-view-order.test.js
+++ b/flux/__tests__/update-view-order.test.js
@@ -1,0 +1,66 @@
+/* eslint-env jest */
+import {updateViewOrder} from '../index'
+
+test('it should return the current order if no screens have changed', () => {
+  let savedOrder = ['a', 'b', 'c']
+  let defaultOrder = savedOrder
+  let actual = updateViewOrder(savedOrder, defaultOrder)
+  let expected = savedOrder
+  expect(actual).toEqual(expected)
+})
+
+test('it should return the current order if no screens have changed, even if sorted differently', () => {
+  let savedOrder = ['c', 'b', 'a']
+  let defaultOrder = ['a', 'b', 'c']
+  let actual = updateViewOrder(savedOrder, defaultOrder)
+  let expected = savedOrder
+  expect(actual).toEqual(expected)
+})
+
+test('it should return the current order if no screens have changed, even if not sorted alphabetically', () => {
+  let savedOrder = ['a', 'b', 'c']
+  let defaultOrder = ['c', 'b', 'a']
+  let actual = updateViewOrder(savedOrder, defaultOrder)
+  let expected = savedOrder
+  expect(actual).toEqual(expected)
+})
+
+test('it should return the default order if no current order is given', () => {
+  let savedOrder = null
+  let defaultOrder = ['a', 'b', 'c']
+  let actual = updateViewOrder(savedOrder, defaultOrder)
+  let expected = defaultOrder
+  expect(actual).toEqual(expected)
+})
+
+test('it should add new values from the default list', () => {
+  let savedOrder = ['b']
+  let defaultOrder = ['a', 'b', 'c']
+  let actual = updateViewOrder(savedOrder, defaultOrder)
+  let expected = ['b', 'a', 'c']
+  expect(actual).toEqual(expected)
+})
+
+test('it should remove values from the given list when not present in the default list', () => {
+  let savedOrder = ['d', 'b']
+  let defaultOrder = ['a', 'b', 'c']
+  let actual = updateViewOrder(savedOrder, defaultOrder)
+  let expected = ['b', 'a', 'c']
+  expect(actual).toEqual(expected)
+})
+
+test('it should maintain the order of the given items when adding values', () => {
+  let savedOrder = ['b']
+  let defaultOrder = ['a', 'b', 'c']
+  let actual = updateViewOrder(savedOrder, defaultOrder)
+  let expected = ['b', 'a', 'c']
+  expect(actual).toEqual(expected)
+})
+
+test('it should maintain the order of the given items when removing values', () => {
+  let savedOrder = ['d', 'b', 'a']
+  let defaultOrder = ['a', 'b', 'c']
+  let actual = updateViewOrder(savedOrder, defaultOrder)
+  let expected = ['b', 'a', 'c']
+  expect(actual).toEqual(expected)
+})

--- a/flux/index.js
+++ b/flux/index.js
@@ -4,16 +4,24 @@ import reduxPromise from 'redux-promise'
 import reduxThunk from 'redux-thunk'
 import {AsyncStorage} from 'react-native'
 import {allViews} from '../views/views'
+import difference from 'lodash/difference'
 
 export const SAVE_HOMESCREEN_ORDER = 'SAVE_HOMESCREEN_ORDER'
 let defaultViewOrder = allViews.map(v => v.view)
 
 export const loadHomescreenOrder = async () => {
-  let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || defaultViewOrder
-  let shouldSaveNewView = savedOrder.length != defaultViewOrder.length
-  let homeOrder = shouldSaveNewView === true ? defaultViewOrder : savedOrder
+  // get the saved list from asyncstorage
+  // or, if the result is null, use the default order.
+  let order = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || defaultViewOrder
+  // In case new screens have been added, get a list of the new screens
+  let newAdditions = difference(order, defaultViewOrder)
+  // add the new screens to the list
+  order = order.concat(newAdditions)
+  // check for removed screens
+  let removedScreens = difference(defaultViewOrder, order)
+  order = difference(order, removedScreens)
 
-  return saveHomescreenOrder(homeOrder)
+  return saveHomescreenOrder(order)
 }
 
 export const saveHomescreenOrder = order => {

--- a/flux/index.js
+++ b/flux/index.js
@@ -3,11 +3,10 @@ import createLogger from 'redux-logger'
 import reduxPromise from 'redux-promise'
 import reduxThunk from 'redux-thunk'
 import {AsyncStorage} from 'react-native'
-import {allViews} from '../views/views'
+import {allViewNames as defaultViewOrder} from '../views/views'
 import difference from 'lodash/difference'
 
 export const SAVE_HOMESCREEN_ORDER = 'SAVE_HOMESCREEN_ORDER'
-let defaultViewOrder = allViews.map(v => v.view)
 
 export const loadHomescreenOrder = async () => {
   // get the saved list from asyncstorage

--- a/flux/index.js
+++ b/flux/index.js
@@ -10,7 +10,10 @@ let defaultViewOrder = allViews.map(v => v.view)
 
 export const loadHomescreenOrder = async () => {
   let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || defaultViewOrder
-  return saveHomescreenOrder(savedOrder)
+  let shouldSaveNewView = savedOrder.length != defaultViewOrder.length
+  let homeOrder = shouldSaveNewView === true ? defaultViewOrder : savedOrder
+
+  return saveHomescreenOrder(homeOrder)
 }
 
 export const saveHomescreenOrder = order => {

--- a/flux/index.js
+++ b/flux/index.js
@@ -8,18 +8,34 @@ import difference from 'lodash/difference'
 
 export const SAVE_HOMESCREEN_ORDER = 'SAVE_HOMESCREEN_ORDER'
 
-export const loadHomescreenOrder = async () => {
-  // get the saved list from asyncstorage
-  // or, if the result is null, use the default order.
-  let order = JSON.parse(await AsyncStorage.getItem('homescreen:view-order')) || defaultViewOrder
-  // In case new screens have been added, get a list of the new screens
-  let newAdditions = difference(order, defaultViewOrder)
-  // add the new screens to the list
-  order = order.concat(newAdditions)
-  // check for removed screens
-  let removedScreens = difference(defaultViewOrder, order)
-  order = difference(order, removedScreens)
+export const updateViewOrder = (currentOrder, defaultOrder=defaultViewOrder) => {
+  currentOrder = currentOrder || []
 
+  // lodash/difference: Creates an array of array values _not included_ in the
+  // other given arrays.
+
+  // In case new screens have been added, get a list of the new screens
+  let addedScreens = difference(defaultOrder, currentOrder)
+  // check for removed screens
+  let removedScreens = difference(currentOrder, defaultOrder)
+
+  // add the new screens to the list
+  currentOrder = currentOrder.concat(addedScreens)
+
+  // now we remove the screens that were removed
+  currentOrder = difference(currentOrder, removedScreens)
+
+  return currentOrder
+}
+
+export const loadHomescreenOrder = async () => {
+  // get the saved list from AsyncStorage
+  let savedOrder = JSON.parse(await AsyncStorage.getItem('homescreen:view-order'))
+
+  // update the order, in case new views have been added/removed
+  let order = updateViewOrder(savedOrder, defaultViewOrder)
+
+  // return an action to save it to AsyncStorage
   return saveHomescreenOrder(order)
 }
 

--- a/views/views.js
+++ b/views/views.js
@@ -15,3 +15,5 @@ export const allViews: ViewType[] = [
   {view: 'DictionaryView', title: 'Campus Dictionary', icon: 'open-book', tint: c.olive, gradient: c.yellowToGoldLight},
   {view: 'OlevilleView', title: 'Oleville', icon: 'mouse-pointer', tint: c.grapefruit, gradient: c.pinkToHotpink},
 ]
+
+export const allViewNames = allViews.map(v => v.view)


### PR DESCRIPTION
The home screen became editable as of a few PRs ago! You can reorder the views to your liking, or to your friend's disliking!

So what happens when we add a new view to the home screen? It doesn't show in the list of views you can reorder. Oh no... how do we fix this? Well, we could check if we have a differing amount of views between what we _know_ is your preferred order, and the list of views we know are displaying by default.

That seems to work pretty well! We can now get away with safely adding or removing views from the home screen without any issues. This is good news, because we want the user to be able to reorder all of the views, not just some of them.

This was a combo effort by @hawkrives and myself. We even have tests to prove it works (thank you hawken).

tl;dr: adding/removing views did not work with the edit stuff, and this fixes that.