### PR TITLE
add a <Toolbar /> component

### DIFF
--- a/views/components/toolbar/index.js
+++ b/views/components/toolbar/index.js
@@ -1,0 +1,3 @@
+// @flow
+export {Toolbar} from './toolbar'
+export {ToolbarButton} from './toolbar-button'

--- a/views/components/toolbar/toolbar-button.js
+++ b/views/components/toolbar/toolbar-button.js
@@ -1,0 +1,74 @@
+// @flow
+import React from 'react'
+import {StyleSheet, View, Text, Platform} from 'react-native'
+import Icon from 'react-native-vector-icons/Ionicons'
+import * as c from '../../components/colors'
+
+const buttonStyles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginRight: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 0,
+    marginVertical: 8,
+    borderWidth: 1,
+    borderRadius: 2,
+  },
+  activeButton: {
+    backgroundColor: c.mandarin,
+    borderColor: c.mandarin,
+  },
+  inactiveButton: {
+    borderColor: c.iosDisabledText,
+  },
+  activeText: {
+    color: c.white,
+  },
+  inactiveText: {
+    color: c.iosDisabledText,
+  },
+  textWithIcon: {
+    paddingRight: 8,
+  },
+})
+
+type ButtonPropsType = {
+  iconName?: string,
+  title: string,
+  isActive: boolean,
+};
+
+export function ToolbarButton({title, iconName, isActive}: ButtonPropsType) {
+  let icon
+  if (!iconName) {
+    icon = null
+  } else if (Platform.OS === 'ios') {
+    icon = isActive ? iconName : iconName + '-outline'
+  } else if (Platform.OS === 'android') {
+    icon = iconName
+  }
+
+  let activeButtonStyle = isActive
+    ? buttonStyles.activeButton
+    : buttonStyles.inactiveButton
+  let activeContentStyle = isActive
+    ? buttonStyles.activeText
+    : buttonStyles.inactiveText
+
+  let textWithIconStyle = icon ? buttonStyles.textWithIcon : null
+  let activeTextStyle = {
+    fontWeight: isActive && Platform.OS === 'android' ? 'bold' : 'normal',
+  }
+
+  return (
+    <View style={[buttonStyles.button, activeButtonStyle]}>
+      <Text style={[activeContentStyle, textWithIconStyle, activeTextStyle]}>
+        {title}
+      </Text>
+      {icon
+        ? <Icon size={18} name={icon} style={activeContentStyle} />
+        : null}
+    </View>
+  )
+}

--- a/views/components/toolbar/toolbar.js
+++ b/views/components/toolbar/toolbar.js
@@ -1,0 +1,42 @@
+// @flow
+import React from 'react'
+import {StyleSheet, View, Platform, TouchableOpacity, TouchableNativeFeedback} from 'react-native'
+const Touchable = Platform.OS === 'ios' ? TouchableOpacity : TouchableNativeFeedback
+const touchableBg = Platform.OS === 'ios' ? null : Touchable.SelectableBackgroundBorderless()
+
+const toolbarStyles = StyleSheet.create({
+  shadow: {
+    ...Platform.select({
+      ios: {
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: '#ebebeb',
+      },
+      android: {
+        elevation: 4,
+      },
+    }),
+  },
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'white',
+    justifyContent: 'center',
+  },
+})
+
+type ToolbarPropsType = {
+  children?: any,
+  onPress: () => any,
+};
+
+export function Toolbar({children, onPress}: ToolbarPropsType) {
+  return (
+    <View style={[toolbarStyles.shadow, toolbarStyles.container]}>
+      <Touchable onPress={onPress} style={{flex: 1}} background={touchableBg}>
+        <View style={{flexDirection: 'row'}}>
+          {children}
+        </View>
+      </Touchable>
+    </View>
+  )
+}


### PR DESCRIPTION
Toolbar is a simple component that renders a "toolbar".

The current implementation is intended for use solely in the Menus view,
where the Filters notice needs a home.

This component should be abstracted as needed when we need to use it
somewhere else.