### PR TITLE
Update rn-sortable-list to v0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-onesignal": "1.2.3",
     "react-native-parallax-view": "2.0.6",
     "react-native-refreshable-listview": "1.3.0",
-    "react-native-sortable-list": "github:drewvolz/react-native-sortable-list#92762db0e2e5d38a5262aea53cfb71073adedf1d",
+    "react-native-sortable-list": "github:drewvolz/react-native-sortable-list#d8c4f40738e10cdb423bd5e1ea091da769cae3d4",
     "react-native-tab-view": "0.0.40",
     "react-native-tableview-simple": "0.13.0",
     "react-native-vector-icons": "3.0.0",


### PR DESCRIPTION
Our patched rn-sortable-list released 0.0.4

* Fix onPanResponderTerminationRequest, remove useless _cancelLongPress call
* Make autoscroll more accurate