### PR TITLE
Thumbnails on news stories

### DIFF
--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -23,8 +23,9 @@ const entities = new AllHtmlEntities()
 
 type NewsRowPropsType = {
   story: StoryType,
-  onPress: (t: string, s: StoryType) => any,
+  onPress: (title: string, story: StoryType) => any,
 };
+
 class NewsRow extends React.Component {
   state = {
     thumbnailUrl: null,
@@ -46,7 +47,7 @@ class NewsRow extends React.Component {
       const url = this.findImage(props.story['content:encoded'][0])
       // if we didn't find a valid URL, return null
       if (!url) {
-        resolve(null)
+        return null
       }
 
       // Image.getSize is a callback-based API

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -45,12 +45,12 @@ export default class NewsContainer extends React.Component {
     let re = '<img.*?src="([^"]*)"[^>]*>(?:</img>)?'
     let imageMatch = content.match(re)
 
-    if (imageMatch !== null && imageMatch !== undefined) {
+    if (imageMatch) {
       let src = imageMatch[1]
       return <Image source={{uri: src}} style={styles.image} />
     }
 
-    return false
+    return null
   }
 
   fetchData = async () => {

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -42,12 +42,14 @@ export default class NewsContainer extends React.Component {
   };
 
   findImage = (content: string) => {
-    let re = '<img.*?src="([^"]*)"[^>]*>(?:</img>)?'
-    let imageMatch = content.match(re)
+    let reUrl = /^https?:\/\/[^\s/$.?#].[^\s]*$/
+    let reImg = /<img.*src=["'](.*?)["'].*?>/g
+    let images = content.match(reImg)
 
-    if (imageMatch) {
-      let src = imageMatch[1]
-      return <Image source={{uri: src}} style={styles.image} />
+    if (images) {
+      let imageUrls = images.map(tag => reImg.exec(tag))
+      let validUrls = imageUrls[0].filter(url => reUrl.test(url))[0]
+      return <Image source={{uri: validUrls}} style={styles.image} />
     }
 
     return null

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -2,118 +2,19 @@
 import React from 'react'
 import {
   StyleSheet,
-  Image,
   ListView,
   Platform,
   RefreshControl,
 } from 'react-native'
-import {fastGetTrimmedText} from '../../lib/html'
 import delay from 'delay'
 import {parseXml} from './parse-feed'
 import type {StoryType} from './types'
 import LoadingView from '../components/loading'
-import {Row, Column} from '../components/layout'
-import {ListRow, ListSeparator, Detail, Title} from '../components/list'
+import {ListSeparator} from '../components/list'
 import {NoticeView} from '../components/notice'
+import {NewsRow} from './news-row'
 import type {TopLevelViewPropsType} from '../types'
 import {tracker} from '../../analytics'
-import {AllHtmlEntities} from 'html-entities'
-
-const entities = new AllHtmlEntities()
-
-type NewsRowPropsType = {
-  story: StoryType,
-  onPress: (title: string, story: StoryType) => any,
-};
-
-class NewsRow extends React.Component {
-  state = {
-    thumbnailUrl: null,
-  }
-
-  componentWillMount() {
-    this.makeThumbnail(this.props)
-  }
-
-  componentWillReceiveProps(nextProps: NewsRowPropsType) {
-    this.makeThumbnail(nextProps)
-  }
-
-  props: NewsRowPropsType;
-
-  makeThumbnail = async (props: NewsRowPropsType) => {
-    const thumbnailUrl = await new Promise(resolve => {
-      // grab the URL
-      const url = this.findImage(props.story['content:encoded'][0])
-      // if we didn't find a valid URL, return null
-      if (!url) {
-        resolve(null)
-        return
-      }
-
-      // Image.getSize is a callback-based API
-      Image.getSize(url,
-        (width, height) => {
-          // so if it's successful, we "resolve" the promise
-          // – aka we return a value
-          if (width >= 50 && height >= 50) {
-            // if the image is big enough, we return the url
-            resolve(url)
-          }
-          // otherwise, we return `null`
-          resolve(null)
-        },
-        // if getSize fails, we also resolve with `null`
-        () => resolve(null))
-    })
-
-    if (!thumbnailUrl) {
-      return
-    }
-
-    this.setState({thumbnailUrl})
-  }
-
-  findImage = (content: string) => {
-    let reUrl = /^https?:\/\/[^\s/$.?#].[^\s]*$/
-    let reImg = /<img.*src=["'](.*?)["'].*?>/
-    let imageMatch = reImg.exec(content)
-
-    if (!imageMatch) {
-      return null
-    }
-
-    let imageUrl = imageMatch[1]
-    if (!reUrl.test(imageUrl)) {
-      return null
-    }
-
-    return imageUrl
-  }
-
-  render() {
-    let title = entities.decode(this.props.story.title[0])
-    let snippet = entities.decode(fastGetTrimmedText(this.props.story.description[0]))
-    let image = this.state.thumbnailUrl
-      ? <Image source={{uri: this.state.thumbnailUrl}} style={styles.image} />
-      : null
-
-    return (
-      <ListRow
-        onPress={() => this.props.onPress(title, this.props.story)}
-        arrowPosition='top'
-      >
-        <Row justifyContent='space-between'>
-          <Column>
-            <Title lines={1}>{title}</Title>
-            <Detail lines={2}>{snippet}</Detail>
-          </Column>
-          {image}
-        </Row>
-      </ListRow>
-    )
-  }
-}
 
 export default class NewsContainer extends React.Component {
   state = {
@@ -220,12 +121,5 @@ export default class NewsContainer extends React.Component {
 const styles = StyleSheet.create({
   listContainer: {
     backgroundColor: '#ffffff',
-  },
-  image: {
-    height: 50,
-    width: 50,
-    marginTop: 3,
-    marginLeft: 6,
-    marginRight: 6,
   },
 })

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -55,7 +55,13 @@ export default class NewsContainer extends React.Component {
       return null
     }
 
-    return <Image source={{uri: imageUrl}} style={styles.image} />
+    let icon = <Image source={{uri: imageUrl}} style={styles.image} />
+
+    Image.getSize(imageUrl, (width, height) => {
+      icon = (width >= 50 && height >= 50) ? icon : null
+    })
+
+    return icon
   }
 
   fetchData = async () => {

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -47,7 +47,8 @@ class NewsRow extends React.Component {
       const url = this.findImage(props.story['content:encoded'][0])
       // if we didn't find a valid URL, return null
       if (!url) {
-        return null
+        resolve(null)
+        return
       }
 
       // Image.getSize is a callback-based API

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -21,6 +21,10 @@ import {AllHtmlEntities} from 'html-entities'
 
 const entities = new AllHtmlEntities()
 
+type NewsRowPropsType = {
+  story: StoryType,
+  onPress: (t: string, s: StoryType) => any,
+};
 class NewsRow extends React.Component {
   state = {
     thumbnailUrl: null,
@@ -30,16 +34,13 @@ class NewsRow extends React.Component {
     this.makeThumbnail(this.props)
   }
 
-  componentWillRecieveProps(nextProps) {
+  componentWillReceiveProps(nextProps: NewsRowPropsType) {
     this.makeThumbnail(nextProps)
   }
 
-  props: {
-    story: StoryType,
-    onPress: (title: string, story: StoryType) => any,
-  };
+  props: NewsRowPropsType;
 
-  makeThumbnail = async props => {
+  makeThumbnail = async (props: NewsRowPropsType) => {
     const thumbnailUrl = await new Promise(resolve => {
       // grab the URL
       const url = this.findImage(props.story['content:encoded'][0])

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -43,16 +43,19 @@ export default class NewsContainer extends React.Component {
 
   findImage = (content: string) => {
     let reUrl = /^https?:\/\/[^\s/$.?#].[^\s]*$/
-    let reImg = /<img.*src=["'](.*?)["'].*?>/g
-    let images = content.match(reImg)
+    let reImg = /<img.*src=["'](.*?)["'].*?>/
+    let imageMatch = reImg.exec(content)
 
-    if (images) {
-      let imageUrls = images.map(tag => reImg.exec(tag))
-      let validUrls = imageUrls[0].filter(url => reUrl.test(url))[0]
-      return <Image source={{uri: validUrls}} style={styles.image} />
+    if (!imageMatch) {
+      return null
     }
 
-    return null
+    let imageUrl = imageMatch[1]
+    if (!reUrl.test(imageUrl)) {
+      return null
+    }
+
+    return <Image source={{uri: imageUrl}} style={styles.image} />
   }
 
   fetchData = async () => {

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import {
   StyleSheet,
+  Image,
   ListView,
   Platform,
   RefreshControl,
@@ -11,7 +12,7 @@ import delay from 'delay'
 import {parseXml} from './parse-feed'
 import type {StoryType} from './types'
 import LoadingView from '../components/loading'
-import {Column} from '../components/layout'
+import {Row, Column} from '../components/layout'
 import {ListRow, ListSeparator, Detail, Title} from '../components/list'
 import {NoticeView} from '../components/notice'
 import type {TopLevelViewPropsType} from '../types'
@@ -39,6 +40,18 @@ export default class NewsContainer extends React.Component {
     url: string,
     mode: 'rss'|'wp-json',
   };
+
+  findImage = (content: string) => {
+    let re = '<img.*?src="([^"]*)"[^>]*>(?:</img>)?'
+    let imageMatch = content.match(re)
+
+    if (imageMatch !== null && imageMatch !== undefined) {
+      let src = imageMatch[1]
+      return <Image source={{uri: src}} style={styles.image} />
+    }
+
+    return false
+  }
 
   fetchData = async () => {
     try {
@@ -75,15 +88,19 @@ export default class NewsContainer extends React.Component {
   renderRow = (story: StoryType) => {
     let title = entities.decode(story.title[0])
     let snippet = entities.decode(fastGetTrimmedText(story.description[0]))
+    let image = this.findImage(story['content:encoded'][0])
     return (
       <ListRow
         onPress={() => this.onPressNews(title, story)}
         arrowPosition='top'
       >
-        <Column>
-          <Title lines={1}>{title}</Title>
-          <Detail lines={2}>{snippet}</Detail>
-        </Column>
+        <Row justifyContent='space-between'>
+          <Column>
+            <Title lines={1}>{title}</Title>
+            <Detail lines={2}>{snippet}</Detail>
+          </Column>
+          {image}
+        </Row>
       </ListRow>
     )
   }
@@ -137,5 +154,12 @@ export default class NewsContainer extends React.Component {
 const styles = StyleSheet.create({
   listContainer: {
     backgroundColor: '#ffffff',
+  },
+  image: {
+    height: 50,
+    width: 50,
+    marginTop: 3,
+    marginLeft: 6,
+    marginRight: 6,
   },
 })

--- a/views/news/news-row.js
+++ b/views/news/news-row.js
@@ -1,0 +1,110 @@
+// @flow
+import React from 'react'
+import {Image, StyleSheet} from 'react-native'
+import {fastGetTrimmedText} from '../../lib/html'
+import type {StoryType} from './types'
+import {Row, Column} from '../components/layout'
+import {ListRow, Detail, Title} from '../components/list'
+import {AllHtmlEntities} from 'html-entities'
+
+const entities = new AllHtmlEntities()
+
+type NewsRowPropsType = {
+  story: StoryType,
+  onPress: (title: string, story: StoryType) => any,
+};
+
+export class NewsRow extends React.Component {
+  state = {
+    thumbnailUrl: null,
+  }
+
+  componentWillMount() {
+    this.makeThumbnail(this.props)
+  }
+
+  componentWillReceiveProps(nextProps: NewsRowPropsType) {
+    this.makeThumbnail(nextProps)
+  }
+
+  props: NewsRowPropsType;
+
+  makeThumbnail = async (props: NewsRowPropsType) => {
+    const thumbnailUrl = await new Promise(resolve => {
+      // grab the URL
+      const url = this.findImage(props.story['content:encoded'][0])
+      // if we didn't find a valid URL, return null
+      if (!url) {
+        resolve(null)
+        return
+      }
+
+      // Image.getSize is a callback-based API
+      Image.getSize(url,
+        (width, height) => {
+          // so if it's successful, we "resolve" the promise
+          // – aka we return a value
+          if (width >= 50 && height >= 50) {
+            // if the image is big enough, we return the url
+            resolve(url)
+          }
+          // otherwise, we return `null`
+          resolve(null)
+        },
+        // if getSize fails, we also resolve with `null`
+        () => resolve(null))
+    })
+
+    if (!thumbnailUrl) {
+      return
+    }
+
+    this.setState({thumbnailUrl})
+  }
+
+  findImage = (content: string) => {
+    let reUrl = /^https?:\/\/[^\s/$.?#].[^\s]*$/
+    let reImg = /<img.*src=["'](.*?)["'].*?>/
+    let imageMatch = reImg.exec(content)
+
+    if (!imageMatch) {
+      return null
+    }
+
+    let imageUrl = imageMatch[1]
+    if (!reUrl.test(imageUrl)) {
+      return null
+    }
+
+    return imageUrl
+  }
+
+  render() {
+    let title = entities.decode(this.props.story.title[0])
+    let snippet = entities.decode(fastGetTrimmedText(this.props.story.description[0]))
+    let image = this.state.thumbnailUrl
+      ? <Image source={{uri: this.state.thumbnailUrl}} style={styles.image} />
+      : null
+
+    return (
+      <ListRow
+        onPress={() => this.props.onPress(title, this.props.story)}
+        arrowPosition='top'
+      >
+        <Row justifyContent='space-between'>
+          <Column>
+            <Title lines={1}>{title}</Title>
+            <Detail lines={2}>{snippet}</Detail>
+          </Column>
+          {image}
+        </Row>
+      </ListRow>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  listContainer: {
+    backgroundColor: '#ffffff',
+  },
+})

--- a/views/news/news-row.js
+++ b/views/news/news-row.js
@@ -32,7 +32,7 @@ export class NewsRow extends React.Component {
   makeThumbnail = async (props: NewsRowPropsType) => {
     const thumbnailUrl = await new Promise(resolve => {
       // grab the URL
-      const url = this.findImage(props.story['content:encoded'][0])
+      const url = this.findImage((props.story['content:encoded'] || props.story['description'])[0])
       // if we didn't find a valid URL, return null
       if (!url) {
         resolve(null)
@@ -92,7 +92,7 @@ export class NewsRow extends React.Component {
         arrowPosition='top'
       >
         <Row justifyContent='space-between'>
-          <Column>
+          <Column flex={1}>
             <Title lines={1}>{title}</Title>
             <Detail lines={2}>{snippet}</Detail>
           </Column>
@@ -104,7 +104,11 @@ export class NewsRow extends React.Component {
 }
 
 const styles = StyleSheet.create({
-  listContainer: {
-    backgroundColor: '#ffffff',
+  image: {
+    height: 50,
+    width: 50,
+    marginTop: 3,
+    marginLeft: 6,
+    marginRight: 6,
   },
 })


### PR DESCRIPTION
This adds 50x50 thumbnails to stories with images embedded into their content. It seeks out the first image within the story content and uses it as the image's source. Stories without images will display as they did previously.

Screenshots:

Before | After
---|---
![no-thumbs](https://cloud.githubusercontent.com/assets/5240843/21582540/244b59b2-d02b-11e6-8013-8a2cc0cd7ea7.png) |  ![thumbs](https://cloud.githubusercontent.com/assets/5240843/21575623/91aee2cc-cee0-11e6-95a6-25d972d44e8d.png)