### PR TITLE
Shrink the size of the home screen buttons

### DIFF
--- a/views/home.js
+++ b/views/home.js
@@ -88,7 +88,7 @@ export default connect(mapStateToProps)(HomePage)
 
 
 let cellMargin = 10
-let cellSidePadding = 10
+let cellSidePadding = 8
 let cellEdgePadding = 4
 let cellWidth = (Viewport.width / 2) - (cellMargin * 1.5)
 


### PR DESCRIPTION
Removes two pixels of padding from the buttons so 5s users can see icons below, now that we have included Student Orgs.

Screenshots:

Before | After
---|---
 ![original](https://cloud.githubusercontent.com/assets/5240843/21579008/fd856252-cf65-11e6-97c7-0c1ee29ed2a0.png) |  ![shrunken](https://cloud.githubusercontent.com/assets/5240843/21579009/fd9227ee-cf65-11e6-8e8e-61b9c8f66f79.png)