### PR TITLE
Activity indicator on loading views

### DIFF
--- a/views/components/loading.js
+++ b/views/components/loading.js
@@ -4,6 +4,6 @@ import {NoticeView} from './notice'
 
 export default function LoadingView({text='Loading…'}: {text?: string}) {
   return (
-    <NoticeView text={text} />
+    <NoticeView text={text} spinner={true} />
   )
 }

--- a/views/components/notice.js
+++ b/views/components/notice.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {StyleSheet, Text, View} from 'react-native'
+import {ActivityIndicator, StyleSheet, Text, View} from 'react-native'
 
 const styles = StyleSheet.create({
   container: {
@@ -12,14 +12,21 @@ const styles = StyleSheet.create({
   text: {
     textAlign: 'center',
   },
+  spinner: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 8,
+  },
 })
 
 export function NoticeView({text, style}: {text: string, style?: any}) {
+  let spinner = text === 'Loading…' ? <ActivityIndicator style={styles.spinner} /> : null
   return (
     <View style={[styles.container, style]}>
       <Text style={styles.text}>
         {text}
       </Text>
+      {spinner}
     </View>
   )
 }

--- a/views/components/notice.js
+++ b/views/components/notice.js
@@ -19,14 +19,14 @@ const styles = StyleSheet.create({
   },
 })
 
-export function NoticeView({text, style}: {text: string, style?: any}) {
-  let spinner = text === 'Loading…' ? <ActivityIndicator style={styles.spinner} /> : null
+export function NoticeView({text, style, spinner}: {text: string, style?: any, spinner?: boolean}) {
+  let activityIndicator = spinner ? <ActivityIndicator style={styles.spinner} /> : null
   return (
     <View style={[styles.container, style]}>
       <Text style={styles.text}>
         {text}
       </Text>
-      {spinner}
+      {activityIndicator}
     </View>
   )
 }

--- a/views/components/notice.js
+++ b/views/components/notice.js
@@ -23,10 +23,10 @@ export function NoticeView({text, style, spinner}: {text: string, style?: any, s
   let activityIndicator = spinner ? <ActivityIndicator style={styles.spinner} /> : null
   return (
     <View style={[styles.container, style]}>
+      {activityIndicator}
       <Text style={styles.text}>
         {text}
       </Text>
-      {activityIndicator}
     </View>
   )
 }


### PR DESCRIPTION
This handless the case where the loading view has the text "Loading…". It adds a spinner below the text.

It tries to handle the case where the loading message is anything else e.g. the menus custom messages. Although those can be "loading" messages, it would be confusing to display a "closed" message and the spinner at the same time. That could be handled in the future by importing those messages? I dunno. Suggestions?

Screenshots:

Before | After
---|---
 ![before](https://cloud.githubusercontent.com/assets/5240843/21579076/82921360-cf6a-11e6-931e-08ea611b0a34.png) |  ![after](https://cloud.githubusercontent.com/assets/5240843/21579075/829167da-cf6a-11e6-8864-cd2b09e4ae0f.gif)