### PR TITLE
<FilterView/> component

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,7 @@ import HomeView from './views/home'
 import MapView from './views/map'
 import StreamingView from './views/streaming'
 import {MenusView} from './views/menus'
+import {FilterView} from './views/components/filter'
 import NewsView from './views/news'
 import NewsItemView from './views/news/news-item'
 import SISView from './views/sis'
@@ -49,6 +50,7 @@ function renderScene(route, navigator) {
   switch (route.id) {
     case 'HomeView': return <HomeView {...props} />
     case 'MenusView': return <MenusView {...props} />
+    case 'FilterView': return <FilterView {...props} />
     case 'DirectoryView': return <DirectoryView {...props} />
     case 'CalendarView': return <CalendarView {...props} />
     case 'ContactsView': return <ContactsView {...props} />

--- a/views/components/filter/__tests__/apply-and-list-filter.test.js
+++ b/views/components/filter/__tests__/apply-and-list-filter.test.js
@@ -1,0 +1,15 @@
+/* eslint-env jest */
+// @flow
+import {applyAndListFilter} from '../apply-filters'
+
+it("should return `true` if the item's value is a superset of the needle", () => {
+  expect(applyAndListFilter(['1'], ['1', '2'])).toBeTruthy()
+})
+
+it("should return `false` if the item's value is a subset of the needle", () => {
+  expect(applyAndListFilter(['1', '2', '3'], ['1'])).toBeFalsy()
+})
+
+it('should convert objects into an array of values to act as the value', () => {
+  expect(applyAndListFilter(['1', '2'], {key: '1', alt: '2'})).toBeTruthy()
+})

--- a/views/components/filter/__tests__/apply-filter.test.js
+++ b/views/components/filter/__tests__/apply-filter.test.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+// @flow
+import {applyFilter} from '../apply-filters'
+
+it('should return `true` if the fitler is disabled', () => {
+  let filter = {
+    type: 'list',
+    key: 'key',
+    enabled: false,
+    spec: {label: 'label', options: ['1', '2', '3'], selected: [], mode: 'OR'},
+    apply: {key: 'categories'},
+  }
+  expect(applyFilter(filter, {categories: []})).toBeTruthy()
+})

--- a/views/components/filter/__tests__/apply-or-list-filter.test.js
+++ b/views/components/filter/__tests__/apply-or-list-filter.test.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+// @flow
+import {applyOrListFilter} from '../apply-filters'
+
+it("should return `true` if the item's value contains the needle", () => {
+  expect(applyOrListFilter(['1', '2', '3'], '1')).toBeTruthy()
+})
+
+it("should return `false` if the item's value does not contain the needle", () => {
+  expect(applyOrListFilter(['1', '2', '3'], ['-1'])).toBeFalsy()
+})

--- a/views/components/filter/__tests__/apply-toggle-filter.test.js
+++ b/views/components/filter/__tests__/apply-toggle-filter.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+// @flow
+import {applyToggleFilter} from '../apply-filters'
+
+it('should return `true` if the item has a truthy value', () => {
+  let filter = {
+    type: 'toggle',
+    key: 'key',
+    enabled: true,
+    spec: {label: 'label'},
+    apply: {key: 'i-am-a-key'},
+  }
+  let item = {'i-am-a-key': true}
+  expect(applyToggleFilter(filter, item)).toBeTruthy()
+})
+
+it('should return `false` if the item has a falsy value', () => {
+  let filter = {
+    type: 'toggle',
+    key: 'key',
+    enabled: true,
+    spec: {label: 'label'},
+    apply: {key: 'i-am-a-key'},
+  }
+  let item = {'i-am-a-key': false}
+  expect(applyToggleFilter(filter, item)).toBeFalsy()
+})
+
+it('should ignore the `enabled` status of the filter', () => {
+  let filter = {
+    type: 'toggle',
+    key: 'key',
+    enabled: false,
+    spec: {label: 'label'},
+    apply: {key: 'i-am-a-key'},
+  }
+  let itemTrue = {'i-am-a-key': true}
+  let itemFalse = {'i-am-a-key': false}
+  expect(applyToggleFilter(filter, itemTrue)).toBeTruthy()
+  expect(applyToggleFilter(filter, itemFalse)).toBeFalsy()
+})

--- a/views/components/filter/apply-filters.js
+++ b/views/components/filter/apply-filters.js
@@ -1,0 +1,73 @@
+// @flow
+import type {FilterType, ToggleType, ListType} from './types'
+import values from 'lodash/values'
+import difference from 'lodash/difference'
+import isPlainObject from 'lodash/isPlainObject'
+
+export function applyFiltersToItem(filters: FilterType[], item: any): boolean {
+  // Given a list of filters, return the result of running all of those
+  // filters over the item
+  return filters.every(f => applyFilter(f, item))
+}
+
+export function applyFilter(filter: FilterType, item: any): boolean {
+  // if the filter is disabled, we don't want to filter at all, so we return
+  // `true` for every item
+  if (!filter.enabled) {
+    return true
+  }
+
+  // otherwise, we apply the appropriate filter to the item
+  switch (filter.type) {
+    case 'toggle':
+      return applyToggleFilter(filter, item)
+    case 'list':
+      return applyListFilter(filter, item)
+    default:
+      return true
+  }
+}
+
+export function applyToggleFilter(filter: ToggleType, item: any): boolean {
+  // Dereference the value-to-check
+  const itemValue = item[filter.apply.key]
+  return Boolean(itemValue)
+}
+
+export function applyListFilter(filter: ListType, item: any): boolean {
+  // Dereference the value-to-check
+  const itemValue = item[filter.apply.key]
+  // Extract the list of "selected" items
+  const filterValue = filter.spec.selected
+
+  switch (filter.spec.mode) {
+    case 'OR':
+      return applyOrListFilter(filterValue, itemValue)
+    case 'AND':
+      return applyAndListFilter(filterValue, itemValue)
+    default:
+      return true
+  }
+}
+
+export function applyOrListFilter<T>(filterValue: T[], itemValue: T): boolean {
+  // An item passes, if its value is in the filter's selected items array
+  return filterValue.includes(itemValue)
+}
+
+export function applyAndListFilter<T>(filterValue: T[], itemValue: T[]|{[key: string]: T}): boolean {
+  // In case the value is an object, instead of an array, convert it to an array
+  if (isPlainObject(itemValue)) {
+    itemValue = values(itemValue)
+  }
+
+  // If there are no items, it cannot contain the item we're filtering by.
+  if (!itemValue.length) {
+    return false
+  }
+
+  // Check that the number of different items between the two lists is 0, to
+  // ensure that all of the restrictions we're seeking are present.
+  const differentItems = difference(filterValue, itemValue)
+  return differentItems.length === 0
+}

--- a/views/components/filter/filter-view.js
+++ b/views/components/filter/filter-view.js
@@ -1,0 +1,45 @@
+// @flow
+import React from 'react'
+import {ScrollView} from 'react-native'
+import type {FilterType} from './types'
+import {FilterSection} from './section'
+import {TableView} from 'react-native-tableview-simple'
+import {connect} from 'react-redux'
+import get from 'lodash/get'
+
+type PropsType = {
+  pathToFilters: string[],
+  filters: FilterType[],
+  onChange: (x: FilterType[]) => any,
+};
+
+export function FilterViewComponent(props: PropsType) {
+  const onFilterChanged = (filter: FilterType) => {
+    // replace the changed filter in the array, maintaining position
+    let result = props.filters.map(f => f.key !== filter.key ? f : filter)
+    props.onChange(result)
+  }
+
+  const contents = props.filters.map(filter =>
+    <FilterSection
+      key={filter.key}
+      filter={filter}
+      onChange={onFilterChanged}
+    />)
+
+  return (
+    <ScrollView style={{flex: 1}}>
+      <TableView>
+        {contents}
+      </TableView>
+    </ScrollView>
+  )
+}
+
+const mapStateToProps = (state, actualProps) => {
+  return {
+    filters: get(state, actualProps.pathToFilters, []),
+  }
+}
+
+export const FilterView = connect(mapStateToProps)(FilterViewComponent)

--- a/views/components/filter/index.js
+++ b/views/components/filter/index.js
@@ -1,0 +1,3 @@
+// @flow
+export {FilterView} from './filter-view'
+export type {FilterType} from './types'

--- a/views/components/filter/index.js
+++ b/views/components/filter/index.js
@@ -1,3 +1,4 @@
 // @flow
 export {FilterView} from './filter-view'
 export type {FilterType} from './types'
+export {applyFiltersToItem} from './apply-filters'

--- a/views/components/filter/section-list.js
+++ b/views/components/filter/section-list.js
@@ -1,0 +1,82 @@
+// @flow
+import React from 'react'
+import type {ListType} from './types'
+import {Section, Cell} from 'react-native-tableview-simple'
+import includes from 'lodash/includes'
+import without from 'lodash/without'
+import concat from 'lodash/concat'
+
+type PropsType = {
+  filter: ListType,
+  onChange: (filter: ListType) => any,
+};
+
+export function ListSection({filter, onChange}: PropsType) {
+  const {spec} = filter
+  const {title='', options, selected, mode} = spec
+  const {caption=`Show items with ${mode === 'AND' ? 'all' : 'any'} of these options.`} = spec
+
+  function buttonPushed(tappedValue: string) {
+    let result
+
+    if (includes(selected, tappedValue)) {
+      // if the user has tapped an item, and it's already in the list of
+      // things they've tapped, we want to _remove_ it from that list.
+      result = without(selected, tappedValue)
+    } else {
+      // otherwise, we need to add it to the list
+      result = concat(selected, tappedValue)
+    }
+
+    onChange({
+      ...filter,
+      enabled: result.length !== options.length,
+      spec: {...spec, selected: result},
+    })
+  }
+
+  function showAll() {
+    let result
+
+    if (selected.length === options.length) {
+      // when all items are selected: uncheck them all
+      result = []
+    } else {
+      // when one or more items are not checked: check them all
+      result = options
+    }
+
+    onChange({
+      ...filter,
+      enabled: result.length !== options.length,
+      spec: {...spec, selected: result},
+    })
+  }
+
+  let buttons = options.map(val =>
+    <Cell
+      key={val}
+      onPress={() => buttonPushed(val)}
+      accessory={includes(selected, val) ? 'Checkmark' : null}
+      title={val}
+    />
+  )
+
+  if (mode === 'OR') {
+    const showAllButton = (
+      <Cell
+        key='__show_all'
+        title='Show All'
+        onPress={showAll}
+        accessory={selected.length === options.length ? 'Checkmark' : null}
+      />
+    )
+    buttons = [showAllButton].concat(buttons)
+  }
+
+  return (
+    <Section header={title.toUpperCase()} footer={caption}>
+      {buttons}
+    </Section>
+  )
+}

--- a/views/components/filter/section-toggle.js
+++ b/views/components/filter/section-toggle.js
@@ -1,0 +1,23 @@
+// @flow
+import React from 'react'
+import type {ToggleType} from './types'
+import {Text, Switch} from 'react-native'
+import {Section, CustomCell} from 'react-native-tableview-simple'
+
+type PropsType = {
+  filter: ToggleType,
+  onChange: (filterSpec: ToggleType) => any,
+};
+
+export function SingleToggleSection({filter, onChange}: PropsType) {
+  const {spec, enabled} = filter
+  const {title='', caption, label} = spec
+  return (
+    <Section header={title.toUpperCase()} footer={caption}>
+      <CustomCell>
+        <Text style={{flex: 1, fontSize: 16}}>{label}</Text>
+        <Switch value={enabled} onValueChange={val => onChange({...filter, enabled: val})} />
+      </CustomCell>
+    </Section>
+  )
+}

--- a/views/components/filter/section.js
+++ b/views/components/filter/section.js
@@ -1,0 +1,26 @@
+// @flow
+import React from 'react'
+import type {FilterType} from './types'
+import {SingleToggleSection} from './section-toggle'
+import {ListSection} from './section-list'
+
+type FilterSectionPropsType = {
+  filter: FilterType,
+  onChange: (filter: FilterType) => any,
+};
+
+export function FilterSection({filter, onChange}: FilterSectionPropsType) {
+  if (filter.type === 'toggle') {
+    return <SingleToggleSection filter={filter} onChange={onChange} />
+  }
+
+  if (filter.type === 'list') {
+    if (!filter.spec.options.length) {
+      return null
+    }
+
+    return <ListSection filter={filter} onChange={onChange} />
+  }
+
+  return null
+}

--- a/views/components/filter/types.js
+++ b/views/components/filter/types.js
@@ -1,0 +1,40 @@
+// @flow
+export type ToggleSpecType = {
+  label: string,
+  title?: string,
+  caption?: string,
+};
+
+export type ListSpecType = {
+  title?: string,
+  caption?: string,
+  options: string[],
+  selected: string[],
+  mode: 'AND'|'OR',
+};
+
+export type ToggleFilterFunctionType = {
+  key: string,
+};
+
+export type ListFilterFunctionType = {
+  key: string,
+};
+
+export type ToggleType = {
+  type: 'toggle',
+  key: string,
+  enabled: boolean,
+  spec: ToggleSpecType,
+  apply: ToggleFilterFunctionType,
+};
+
+export type ListType = {
+  type: 'list',
+  key: string,
+  enabled: boolean,
+  spec: ListSpecType,
+  apply: ListFilterFunctionType,
+};
+
+export type FilterType = ToggleType | ListType;


### PR DESCRIPTION
> Part of the `fancy-menus` series

Ever wanted to filter a list? Say, only show calendar events in a certain category, or courses from a given department, or student orgs in categories X or Y, or menu items in the Pizza line that are vegetarian?

Well, you're in luck!

This PR adds a concept, a component, and a function: the concept of "filter specs", a component to render said specs, and a function to apply them to an array of data items.

## Specs
A filter spec!

This PR includes two types of filter spec: `toggle` and `list`. A filter spec looks something like this: `{type, key, enabled, spec, apply}`. 

- `type` is either `toggle` or `list`
- `key` must be unique within any collection of filters
- `enabled` is `true` if the filter is enabled and should be applied to the items, or `false` if it should not
- `spec` is a little blob for specifying how to render the filter to the UI
- `apply` is really simple: `{key}`, where `key` is the key where the value to filter _on_ resides in the data to be filtered (e.g., `"categories"` if you're sorting a list of `{categories: [A, B, C]}` objects.)

More information in `filter/types.js`.

## Component
This is where the bits in the `spec` key come in: `title`, and `caption` apply to both types of filter; Toggle filters have a `label`, and List filters have `options` and `selected`.

- `title` is the title, above a UITableView section, or the little, like, section titles on the Android settings app.
- `caption` is rendered below the section.
- `label` is the label shown to the left of the toggle switch.
- `options` are the entire list of options to show; `selected` is a list of items from `options` that are checked.

`<FilterView/>` itself is hooked up to the filters by a redux store, so you have to tell it where to find them.

```jsx
<FilterView
  // a path to the filters stored in Redux somewhere
  pathToFilters={['menus', 'stav']}
  // you need to do something with the changes
  onChange={filters => doSomething()}
/>
```

In React parlance, FilterView is a "controlled component" – it will only ever render what it is given, and it does not maintain any state itself.

## Function
Given a list of filters, and an item, it checks the item against each filter. If they all pass, it returns true; otherwise, it returns false. You can use it in an `Array#filter` callback, such as `items.filter(item => applyFilterToItem(filters, item))`

Oh, and there are two types of List filter: AND and OR. OR filters will pass an item if _any_ of the selected values are present: given options `[1, 2, 3]`, an item just needs to have `{val: 1}` to pass. AND filters must have _all_ of the selected items to pass: given `[vegan, seafood]`, you'd need something like `{dietary: [vegan, seafood]}` to pass — a mere `{dietary: [vegan]}` option wouldn't succeed.

---

That started out strong… ok. I don't have time to make the entire description make sense, so there you go. Make filters, apply them to items, yadda ya.

<img src=https://cloud.githubusercontent.com/assets/464441/21583832/a1a75984-d057-11e6-8999-34d2b781a9cf.png width=320>
