### PR TITLE
𝕱𝖆𝖓𝖈𝖞𝕸𝖊𝖓𝖚𝖘 ③ (point-something) — 𝚌𝚕𝚎𝚊𝚗𝚞𝚙𝚜

### DIFF
--- a/views/components/notice.js
+++ b/views/components/notice.js
@@ -18,7 +18,7 @@ export function NoticeView({text, style}: {text: string, style?: any}) {
   return (
     <View style={[styles.container, style]}>
       <Text style={styles.text}>
-        {text}
+        {text || 'Notice!'}
       </Text>
     </View>
   )

--- a/views/menus/components/fancy-menu.js
+++ b/views/menus/components/fancy-menu.js
@@ -7,9 +7,8 @@ import type {MenuItemType, MasterCorIconMapType, StationMenuType} from '../types
 import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
 import fromPairs from 'lodash/fromPairs'
-import mapValues from 'lodash/mapValues'
+import filter from 'lodash/filter'
 import {MenuListView} from './menu'
-import {trimStationName, trimItemLabel} from '../lib/trim-names'
 
 type FancyMenuPropsType = TopLevelViewPropsType & {
   now: momentT,
@@ -28,25 +27,21 @@ export class FancyMenu extends React.Component {
   props: FancyMenuPropsType;
 
   render() {
-    let {foodItems, stationMenus} = this.props
+    const {foodItems, stationMenus} = this.props
 
-    let stationNotes = fromPairs(stationMenus.map(m => [m.label, m.note]))
+    const stationNotes = fromPairs(stationMenus.map(m => [m.label, m.note]))
+    const stationsSort = stationMenus.map(m => m.label)
 
-    // get all the food
-    let allMenuItems = foodItems.map(item => ({
-      ...item,  // we want to edit the item, not replace it
-      station: trimStationName(item.station),  // <b>@station names</b> are a mess
-      label: trimItemLabel(item.label),  // clean up the titles
-    }))
-
-    // apply the selected filters, then group them for the ListView, then sort
-    // each list of menu items
-    let grouped = groupBy(allMenuItems, item => item.station)
-    let sorted = mapValues(grouped, items => sortBy(items, item => item.id))
+    // only show items that the menu lists today
+    const filtered = filter(foodItems, item => stationsSort.includes(item.station))
+    // sort the remaining items by station
+    const sortedByStation = sortBy(filtered, item => stationsSort.indexOf(item.station))
+    // group them for the ListView
+    const grouped = groupBy(sortedByStation, item => item.station)
 
     return (
       <View style={{flex: 1}}>
-        <MenuListView data={sorted} stationNotes={stationNotes} badgeSpecials />
+        <MenuListView data={grouped} stationNotes={stationNotes} badgeSpecials />
       </View>
     )
   }

--- a/views/menus/components/menu.js
+++ b/views/menus/components/menu.js
@@ -6,7 +6,6 @@ import {FoodItemRow} from './food-item-row'
 import DietaryFilters from '../../../data/dietary-filters'
 import * as c from '../../components/colors'
 import {Separator} from '../../components/separator'
-import {toLaxTitleCase} from 'titlecase'
 import type {MenuItemType, ProcessedMenuPropsType} from '../types'
 
 const rightSideSpacing = 10
@@ -78,7 +77,7 @@ export class MenuListView extends React.Component {
     return (
       <View style={styles.sectionHeader}>
         <Text>
-          <Text style={styles.sectionHeaderText}>{toLaxTitleCase(sectionName)}</Text>
+          <Text style={styles.sectionHeaderText}>{sectionName}</Text>
           {note ? <Text style={styles.sectionHeaderNote}> — {note}</Text> : null}
         </Text>
       </View>

--- a/views/menus/components/menu.js
+++ b/views/menus/components/menu.js
@@ -66,8 +66,9 @@ export class MenuListView extends React.Component {
   }
 
   props: {
-    data: ProcessedMenuPropsType,
     badgeSpecials: boolean,
+    data: ProcessedMenuPropsType,
+    message?: string,
     stationNotes: {[key: string]: string},
   };
 
@@ -97,6 +98,10 @@ export class MenuListView extends React.Component {
   }
 
   render() {
+    if (this.props.message) {
+      return <NoticeView style={styles.container} text={this.props.message} />
+    }
+
     if (!this.state.dataSource.getRowCount()) {
       return <NoticeView style={styles.container} text='No items to show. Try changing the filters.' />
     }

--- a/views/menus/lib/process-menu-shorthands.js
+++ b/views/menus/lib/process-menu-shorthands.js
@@ -1,6 +1,18 @@
-import type {MenuItemType, StationMenuType} from '../views/menus/types'
+// @flow
+import type {MenuItemType, StationMenuType} from '../types'
 
-export function upgradeMenuItem(item, index): MenuItemType {
+type BasicMenuItemType = {
+  label: string,
+  station: string,
+  special?: boolean,
+  description?: string,
+};
+
+type BasicStationMenuType = {
+  label: string,
+};
+
+export function upgradeMenuItem(item: BasicMenuItemType, index: number): MenuItemType {
   return {
     'connector': '',
     'cor_icon': {},
@@ -27,12 +39,13 @@ export function upgradeMenuItem(item, index): MenuItemType {
   }
 }
 
-export function upgradeStation(station, index): StationMenuType {
+export function upgradeStation(station: BasicStationMenuType, index: number): StationMenuType {
   return {
     'soup': false,
     'price': '',
     'note': '',
     'order_id': String(index),
+    'items': [],
     ...station,
     id: String(index),
   }

--- a/views/menus/menu-bonapp.js
+++ b/views/menus/menu-bonapp.js
@@ -17,6 +17,12 @@ const bonappMenuBaseUrl = 'http://legacy.cafebonappetit.com/api/2/menus'
 const bonappCafeBaseUrl = 'http://legacy.cafebonappetit.com/api/2/cafes'
 const fetchJsonQuery = (url, query) => fetchJson(`${url}?${qs.stringify(query)}`)
 
+type BonAppPropsType = TopLevelViewPropsType & {
+  cafeId: string,
+  loadingMessage: string[],
+  name: string,
+};
+
 export class BonAppHostedMenu extends React.Component {
   state: {
     error: ?Error,
@@ -33,16 +39,16 @@ export class BonAppHostedMenu extends React.Component {
   }
 
   componentWillMount() {
-    this.fetchData()
+    this.fetchData(this.props)
   }
 
-  props: TopLevelViewPropsType & {
-    cafeId: string,
-    loadingMessage: string[],
-    name: string,
+  componentWillReceiveProps(newProps: BonAppPropsType) {
+    this.props.cafeId !== newProps.cafeId && this.fetchData(newProps)
   }
 
-  fetchData = async () => {
+  props: BonAppPropsType;
+
+  fetchData = async (props: BonAppPropsType) => {
     this.setState({loading: true})
 
     let cafeMenu = null
@@ -50,8 +56,8 @@ export class BonAppHostedMenu extends React.Component {
 
     try {
       let requests = await Promise.all([
-        fetchJsonQuery(bonappMenuBaseUrl, {cafe: this.props.cafeId}),
-        fetchJsonQuery(bonappCafeBaseUrl, {cafe: this.props.cafeId}),
+        fetchJsonQuery(bonappMenuBaseUrl, {cafe: props.cafeId}),
+        fetchJsonQuery(bonappCafeBaseUrl, {cafe: props.cafeId}),
       ])
       cafeMenu = (requests[0]: BonAppMenuInfoType)
       cafeInfo = (requests[1]: BonAppCafeInfoType)

--- a/views/menus/menu-bonapp.js
+++ b/views/menus/menu-bonapp.js
@@ -62,6 +62,22 @@ export class BonAppHostedMenu extends React.Component {
     this.setState({loading: false, cafeMenu, cafeInfo, now: moment.tz(CENTRAL_TZ)})
   }
 
+  findCafeMessage = (cafeId: string, cafeInfo: BonAppCafeInfoType, now: momentT) => {
+    let actualCafeInfo = cafeInfo.cafes[cafeId]
+    if (!actualCafeInfo) {
+      return 'BonApp did not return a menu for that café'
+    }
+
+    let today = actualCafeInfo.days.find(({date}) => date === now.format('YYYY-MM-DD'))
+    if (!today) {
+      return 'Closed today'
+    } else if (today.status === 'closed') {
+      return today.message || 'Closed today'
+    }
+
+    return null
+  }
+
   render() {
     if (this.state.loading) {
       return <LoadingView text={sample(this.props.loadingMessage)} />
@@ -80,10 +96,9 @@ export class BonAppHostedMenu extends React.Component {
 
     // We grab the "today" info from here because BonApp returns special
     // messages in this response, like "Closed for Christmas Break"
-    let days = cafeInfo.cafes[cafeId].days
-    let today = days.find(({date}) => date === now.format('YYYY-MM-DD'))
-    if (!today || today.status === 'closed') {
-      return <NoticeView text={today ? today.message : 'Closed today'} />
+    let specialMessage = this.findCafeMessage(cafeId, cafeInfo, now)
+    if (specialMessage) {
+      return <NoticeView text={specialMessage} />
     }
 
     // We hard-code to the first day returned because we're only requesting one day.

--- a/views/menus/types.js
+++ b/views/menus/types.js
@@ -99,7 +99,7 @@ export type BonAppCafeInfoType = {
         date: string,
         dayparts: [{id: string, starttime: string, endtime: string, message: string, label: string}],
         status: 'open'|'closed'|string,
-        message: string,
+        message: false|string,
       }],
     }
   }


### PR DESCRIPTION
> Part of `fancy-menus`

Hokay. This builds on top of #455, and cleans up some logic stuff in the new menus system.

First off: it now only shows items that are present in a "station menu".

A bit of background: BonApp gives us both a giant list of _every food item_ at an establishment, or something like that anyway, and a list of "stations", each of which include a list of item IDs that are present at that station.

One of my first drafts of the fancy-menus stuff used station menus, but when we figured out how to do filters I semi-accidentally removed it in favor of just rendering every food item in the establishment, since the logic was kinda gross.

Later on, though, I realized that we really _do_ want to only see the items listed – otherwise, you'll see, like, Breakfast items during Lunch in the Caf, and who wants that? Or worse, items for Dinner during Lunch, since they share station names.

TL;DR: this makes the menu work more like you'd expect.