### PR TITLE
Add Bonapp Devtools

### DIFF
--- a/views/menus/dev-bonapp-picker.js
+++ b/views/menus/dev-bonapp-picker.js
@@ -1,0 +1,72 @@
+// @flow
+import React from 'react'
+import {View, TextInput, StyleSheet} from 'react-native'
+import {Toolbar, ToolbarButton} from '../components/toolbar'
+import type {TopLevelViewPropsType} from '../types'
+import {BonAppHostedMenu} from './menu-bonapp'
+
+const styles = StyleSheet.create({
+  default: {
+    height: 44,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: '#0f0f0f',
+    flex: 1,
+    fontSize: 13,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+})
+
+export class BonAppPickerView extends React.Component {
+  state: {
+    cafeId: string,
+    menu: ?any,
+  } = {
+    cafeId: '34',
+    menu: null,
+  }
+
+  componentWillMount() {
+    this.chooseMenu()
+  }
+
+  props: TopLevelViewPropsType;
+
+  chooseCafe = (cafeId: string) => {
+    if (!/^\d*$/.test(cafeId)) {
+      return
+    }
+    this.setState({cafeId})
+  }
+
+  chooseMenu = () => {
+    const menu = (
+      <BonAppHostedMenu
+        route={this.props.route}
+        navigator={this.props.navigator}
+        cafeId={this.state.cafeId}
+        name='BonApp'
+        loadingMessage={['Loading…']}
+      />
+    )
+    this.setState({menu})
+  }
+
+  render() {
+    return (
+      <View style={{flex: 1}}>
+        <Toolbar onPress={this.chooseMenu}>
+          <TextInput
+            keyboardType='numeric'
+            onChangeText={this.chooseCafe}
+            value={this.state.cafeId}
+            style={styles.default}
+            onBlur={this.chooseMenu}
+          />
+          <ToolbarButton title='Go' isActive />
+        </Toolbar>
+        {this.state.menu}
+      </View>
+    )
+  }
+}

--- a/views/menus/tabs.js
+++ b/views/menus/tabs.js
@@ -1,6 +1,7 @@
 // @flow
 import {BonAppHostedMenu} from './menu-bonapp'
 import {GitHubHostedMenu} from './menu-github'
+// import {BonAppPickerView} from './dev-bonapp-picker'
 
 const stolaf = [
   {
@@ -45,6 +46,12 @@ const stolaf = [
       ],
     },
   },
+  // {
+  //   id: 'any',
+  //   title: 'BonApp',
+  //   rnVectorIcon: {iconName: 'ionic'},
+  //   component: BonAppPickerView,
+  // },
 ]
 
 const carleton = [


### PR DESCRIPTION
This PR adds an arbitrary bonapp cafe viewer.

Give it a cafe ID, and it'll load the cafe in our BonAppHostedMenu component.

This is how @drewvolz found #462.

It's disabled by default.

Screenshot:

<img src=https://cloud.githubusercontent.com/assets/464441/21583940/f82a8a1c-d05a-11e6-9bed-b985577f1f2b.png width=320>
