### PR TITLE
𝕱𝖆𝖓𝖈𝖞𝕸𝖊𝖓𝖚𝖘 ③ (point-oh) — ፕዘቿ ቻጎረፕቿዪጎክኗ

### DIFF
--- a/flux/index.js
+++ b/flux/index.js
@@ -58,9 +58,28 @@ function homescreen(state=initialHomescreenState, action) {
   }
 }
 
+
+export const UPDATE_MENU_FILTERS = 'menus/UPDATE_MENU_FILTERS'
+
+export const updateMenuFilters = (menuName: string, filters: any[]) => {
+  return {type: UPDATE_MENU_FILTERS, payload: {menuName, filters}}
+}
+
+const initialMenusState = {}
+function menus(state=initialMenusState, action) {
+  let {type, payload} = action
+  switch (type) {
+    case UPDATE_MENU_FILTERS:
+      return {...state, [payload.menuName]: payload.filters}
+    default:
+      return state
+  }
+}
+
 export function aao(state={}, action) {
   return {
     homescreen: homescreen(state.homescreen, action),
+    menus: menus(state.menus, action),
   }
 }
 

--- a/views/menus/components/fancy-menu.js
+++ b/views/menus/components/fancy-menu.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {View} from 'react-native'
+import {View, Navigator} from 'react-native'
 import {connect} from 'react-redux'
 import type {TopLevelViewPropsType} from '../../types'
 import type momentT from 'moment'
@@ -11,6 +11,7 @@ import sortBy from 'lodash/sortBy'
 import fromPairs from 'lodash/fromPairs'
 import filter from 'lodash/filter'
 import map from 'lodash/map'
+import {FilterMenuToolbar} from './filter-menu-toolbar'
 import {MenuListView} from './menu'
 
 type FancyMenuPropsType = TopLevelViewPropsType & {
@@ -21,6 +22,7 @@ type FancyMenuPropsType = TopLevelViewPropsType & {
   menuLabel?: string,
   menuCorIcons: MasterCorIconMapType,
   stationMenus: StationMenuType[],
+  onFiltersChange: (f: FilterType[]) => any,
 };
 
 class FancyMenuView extends React.Component {
@@ -87,10 +89,26 @@ class FancyMenuView extends React.Component {
 
   props: FancyMenuPropsType;
 
+  openFilterView = () => {
+    this.props.navigator.push({
+      id: 'FilterView',
+      index: this.props.route.index + 1,
+      title: 'Filter',
+      sceneConfig: Navigator.SceneConfigs.FloatFromBottom,
+      onDismiss: (route: any, navigator: any) => navigator.pop(),
+      props: {
+        pathToFilters: ['menus', this.props.name],
+        onChange: filters => this.props.onFiltersChange(filters),
+      },
+    })
+  }
+
   render() {
     const {
       filters,
       foodItems,
+      menuLabel,
+      now,
       stationMenus,
     } = this.props
 
@@ -114,6 +132,12 @@ class FancyMenuView extends React.Component {
 
     return (
       <View style={{flex: 1}}>
+        <FilterMenuToolbar
+          date={now}
+          title={menuLabel}
+          filters={filters}
+          onPress={this.openFilterView}
+        />
         <MenuListView
           data={grouped}
           stationNotes={stationNotes}
@@ -131,4 +155,10 @@ function mapStateToProps(state, actualProps: FancyMenuPropsType) {
   }
 }
 
-export const FancyMenu = connect(mapStateToProps)(FancyMenuView)
+function mapDispatchToProps(dispatch, actualProps: FancyMenuPropsType) {
+  return {
+    onFiltersChange: (filters: FilterType[]) => dispatch(updateMenuFilters(actualProps.name, filters)),
+  }
+}
+
+export const FancyMenu = connect(mapStateToProps, mapDispatchToProps)(FancyMenuView)

--- a/views/menus/components/fancy-menu.js
+++ b/views/menus/components/fancy-menu.js
@@ -10,6 +10,7 @@ import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
 import fromPairs from 'lodash/fromPairs'
 import filter from 'lodash/filter'
+import map from 'lodash/map'
 import {MenuListView} from './menu'
 
 type FancyMenuPropsType = TopLevelViewPropsType & {
@@ -23,6 +24,67 @@ type FancyMenuPropsType = TopLevelViewPropsType & {
 };
 
 class FancyMenuView extends React.Component {
+  componentWillMount() {
+    let {menuCorIcons, filters, stationMenus} = this.props
+
+    // prevent ourselves from overwriting the filters from redux on mount
+    if (filters.length) {
+      return
+    }
+
+    let stations = stationMenus.map(m => m.label)
+    filters = this.buildFilters({stations, corIcons: menuCorIcons})
+    this.props.onFiltersChange(filters)
+  }
+
+  buildFilters({stations, corIcons}: {stations: string[], corIcons: MasterCorIconMapType}): FilterType[] {
+    // Grab the labels of the COR icons
+    let allDietaryRestrictions = map(corIcons, item => item.label)
+
+    return [
+      {
+        type: 'toggle',
+        key: 'specials',
+        enabled: true,
+        spec: {
+          label: 'Only Show Specials',
+          caption: 'Allows you to either see only the "specials" for today, or everything the location has to offer (e.g., condiments.)',
+        },
+        apply: {
+          key: 'special',
+        },
+      },
+      {
+        type: 'list',
+        key: 'stations',
+        enabled: false,
+        spec: {
+          title: 'Stations',
+          options: stations,
+          mode: 'OR',
+          selected: stations,
+        },
+        apply: {
+          key: 'station',
+        },
+      },
+      {
+        type: 'list',
+        key: 'dietary-restrictions',
+        enabled: false,
+        spec: {
+          title: 'Dietary Restrictions',
+          options: allDietaryRestrictions,
+          mode: 'AND',
+          selected: [],
+        },
+        apply: {
+          key: 'cor_icon',
+        },
+      },
+    ]
+  }
+
   props: FancyMenuPropsType;
 
   render() {

--- a/views/menus/components/fancy-menu.js
+++ b/views/menus/components/fancy-menu.js
@@ -1,9 +1,11 @@
 // @flow
 import React from 'react'
 import {View} from 'react-native'
+import {connect} from 'react-redux'
 import type {TopLevelViewPropsType} from '../../types'
 import type momentT from 'moment'
 import type {MenuItemType, MasterCorIconMapType, StationMenuType} from '../types'
+import type {FilterType} from '../../components/filter'
 import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
 import fromPairs from 'lodash/fromPairs'
@@ -13,21 +15,21 @@ import {MenuListView} from './menu'
 type FancyMenuPropsType = TopLevelViewPropsType & {
   now: momentT,
   name: string,
+  filters: FilterType[],
   foodItems: MenuItemType[],
   menuLabel?: string,
   menuCorIcons: MasterCorIconMapType,
   stationMenus: StationMenuType[],
 };
 
-// We're disabling the stateless-function check for a short while. Only until
-// the next PR comes in, as it requires state. This will make the diff
-// smaller.
-// eslint-disable-next-line react/prefer-stateless-function
-export class FancyMenu extends React.Component {
+class FancyMenuView extends React.Component {
   props: FancyMenuPropsType;
 
   render() {
-    const {foodItems, stationMenus} = this.props
+    const {
+      foodItems,
+      stationMenus,
+    } = this.props
 
     const stationNotes = fromPairs(stationMenus.map(m => [m.label, m.note]))
     const stationsSort = stationMenus.map(m => m.label)
@@ -46,3 +48,11 @@ export class FancyMenu extends React.Component {
     )
   }
 }
+
+function mapStateToProps(state, actualProps: FancyMenuPropsType) {
+  return {
+    filters: state.menus[actualProps.name] || [],
+  }
+}
+
+export const FancyMenu = connect(mapStateToProps)(FancyMenuView)

--- a/views/menus/components/fancy-menu.js
+++ b/views/menus/components/fancy-menu.js
@@ -2,10 +2,12 @@
 import React from 'react'
 import {View, Navigator} from 'react-native'
 import {connect} from 'react-redux'
+import {updateMenuFilters} from '../../../flux'
 import type {TopLevelViewPropsType} from '../../types'
 import type momentT from 'moment'
 import type {MenuItemType, MasterCorIconMapType, StationMenuType} from '../types'
 import type {FilterType} from '../../components/filter'
+import {applyFiltersToItem} from '../../components/filter'
 import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
 import fromPairs from 'lodash/fromPairs'
@@ -15,6 +17,7 @@ import {FilterMenuToolbar} from './filter-menu-toolbar'
 import {MenuListView} from './menu'
 
 type FancyMenuPropsType = TopLevelViewPropsType & {
+  applyFilters: (filters: FilterType[], item: MenuItemType) => boolean,
   now: momentT,
   name: string,
   filters: FilterType[],
@@ -26,6 +29,10 @@ type FancyMenuPropsType = TopLevelViewPropsType & {
 };
 
 class FancyMenuView extends React.Component {
+  static defaultProps = {
+    applyFilters: applyFiltersToItem,
+  }
+
   componentWillMount() {
     let {menuCorIcons, filters, stationMenus} = this.props
 
@@ -105,6 +112,7 @@ class FancyMenuView extends React.Component {
 
   render() {
     const {
+      applyFilters,
       filters,
       foodItems,
       menuLabel,
@@ -116,7 +124,9 @@ class FancyMenuView extends React.Component {
     const stationsSort = stationMenus.map(m => m.label)
 
     // only show items that the menu lists today
-    const filtered = filter(foodItems, item => stationsSort.includes(item.station))
+    const filteredByMenu = filter(foodItems, item => stationsSort.includes(item.station))
+    // apply the selected filters
+    const filtered = filter(filteredByMenu, item => applyFilters(filters, item))
     // sort the remaining items by station
     const sortedByStation = sortBy(filtered, item => stationsSort.indexOf(item.station))
     // group them for the ListView

--- a/views/menus/components/fancy-menu.js
+++ b/views/menus/components/fancy-menu.js
@@ -152,6 +152,9 @@ class FancyMenuView extends React.Component {
           data={grouped}
           stationNotes={stationNotes}
           message={message}
+          // We can't conditionally show the star – wierd things happen, like
+          // the first two items having a star and none of the rest.
+          //badgeSpecials={!specialsFilterEnabled}
           badgeSpecials
         />
       </View>

--- a/views/menus/components/fancy-menu.js
+++ b/views/menus/components/fancy-menu.js
@@ -89,6 +89,7 @@ class FancyMenuView extends React.Component {
 
   render() {
     const {
+      filters,
       foodItems,
       stationMenus,
     } = this.props
@@ -103,9 +104,22 @@ class FancyMenuView extends React.Component {
     // group them for the ListView
     const grouped = groupBy(sortedByStation, item => item.station)
 
+    const specialsFilterEnabled = Boolean(filters.find(f =>
+      f.enabled && f.type === 'toggle' && f.spec.label === 'Only Show Specials'))
+
+    let message = ''
+    if (specialsFilterEnabled && sortedByStation.length === 0) {
+      message = 'No items to show. There may be no specials today.\nTry changing the filters.'
+    }
+
     return (
       <View style={{flex: 1}}>
-        <MenuListView data={grouped} stationNotes={stationNotes} badgeSpecials />
+        <MenuListView
+          data={grouped}
+          stationNotes={stationNotes}
+          message={message}
+          badgeSpecials
+        />
       </View>
     )
   }

--- a/views/menus/components/filter-menu-toolbar.js
+++ b/views/menus/components/filter-menu-toolbar.js
@@ -1,0 +1,46 @@
+// @flow
+import React from 'react'
+import {StyleSheet, View, Text, Platform} from 'react-native'
+import type momentT from 'moment'
+import type {FilterType} from '../../components/filter'
+import {Toolbar, ToolbarButton} from '../../components/toolbar'
+
+const styles = StyleSheet.create({
+  today: {
+    flex: 1,
+    paddingLeft: 12,
+    paddingVertical: 14,
+  },
+  toolbarSection: {
+    flexDirection: 'row',
+  },
+})
+
+
+type PropsType = {
+  date: momentT,
+  title?: string,
+  onPress: () => any,
+  filters: FilterType[],
+};
+
+export function FilterMenuToolbar({date, title, filters, onPress}: PropsType) {
+  const appliedFilterCount = filters.filter(f => f.enabled).length
+  const isFiltered = appliedFilterCount > 0
+
+  return (
+    <Toolbar onPress={onPress}>
+      <View style={[styles.toolbarSection, styles.today]}>
+        <Text>{date.format('MMM. Do')}</Text>
+        {title ? <Text style={{paddingHorizontal: 4}}>—</Text> : null}
+        {title ? <Text>{title}</Text> : null}
+      </View>
+
+      <ToolbarButton
+        isActive={isFiltered}
+        title={isFiltered ? `${appliedFilterCount} ${appliedFilterCount === 1 ? 'Filter' : 'Filters'}` : 'No Filters'}
+        iconName={Platform.OS === 'ios' ? 'ios-funnel' : 'md-funnel'}
+      />
+    </Toolbar>
+  )
+}


### PR DESCRIPTION
> Part of `fancy-menus`. Depends on both #467 and #468. **DO NOT MERGE THIS.** I have a custom base branch set to limit the diff size. I'll be changing that once the dependent PRs have landed.

This PR finally adds filtering support!

You can now take a menu and filter it by:

- specials only! (on by default)
- only certain stations! (just pizza!)
- some required dietary restrictions! (vegetarian and gluten-free only? sure!) 

---

Screenshots:

name | filters | result
---|---|---
Pause (default) | ![pause-default-filters](https://cloud.githubusercontent.com/assets/464441/21583945/33b4aee6-d05b-11e6-9e4c-2496ceb2b56b.png) | ![pause-default-items](https://cloud.githubusercontent.com/assets/464441/21583946/37b2bed4-d05b-11e6-82a2-b09e2da18d8d.png)
Pause (all) | ![pause-no-specials](https://cloud.githubusercontent.com/assets/464441/21583956/78ae8120-d05b-11e6-8f36-7eaa3ffe95cc.png) | ![pause-all-items](https://cloud.githubusercontent.com/assets/464441/21583950/54b98846-d05b-11e6-8245-4fdfac9677d3.png)
Pause (selected stations) | ![pause-filters](https://cloud.githubusercontent.com/assets/464441/21583943/23eeceec-d05b-11e6-8429-db7d37fb89e5.png) | ![pause-selected-stations](https://cloud.githubusercontent.com/assets/464441/21583944/291034b0-d05b-11e6-84c4-ba062c88498c.png)
Caf (default) | ![caf-default-filters](https://cloud.githubusercontent.com/assets/464441/21583970/f7409a5a-d05b-11e6-861f-88504fcab6c0.png) | ![caf-specials-only](https://cloud.githubusercontent.com/assets/464441/21583954/6a9f3afc-d05b-11e6-8fb3-fbca238249d4.png)
Caf (select dietary restrictions) | ![caf-filters](https://cloud.githubusercontent.com/assets/464441/21583958/8b6a8624-d05b-11e6-8cb9-45860eaeb4a8.png) | ![caf-dietary-only](https://cloud.githubusercontent.com/assets/464441/21583955/72bdd28e-d05b-11e6-8af3-42ac276222f6.png)
