### PR TITLE
Split the ASC into three "buildings"

### DIFF
--- a/data/building-hours/5-2-asc.yaml
+++ b/data/building-hours/5-2-asc.yaml
@@ -3,27 +3,11 @@ abbreviation: 'ASC'
 category: 'Help and Support'
 
 schedule:
-  - title: 'Study Space'
+  - title: 'Hours'
     hours:
       - {days: [Mo, Tu, We, Th], from: '8:00am', to: '9:00pm'}
       - {days: [Fr], from: '8:00am', to: '5:00pm'}
       - {days: [Su], from: '1:00pm', to: '9:00pm'}
-
-  - title: 'Speaking Space'
-    isPhysicallyOpen: false
-    hours:
-      - {days: [Mo, Tu, We, Th], from: '7:00pm', to: '9:00pm'}
-      - {days: [Sa], from: '2:00pm', to: '5:00pm'}
-      - {days: [Su], from: '6:00pm', to: '9:00pm'}
-
-  - title: 'Writing Desk Appointments'
-    isPhysicallyOpen: false
-    hours:
-      - {days: [Mo, Tu, We, Th, Fr], from: '10:00am', to: '5:00pm'}
-      - {days: [Mo, Tu, We, Th], from: '7:00pm', to: '10:00pm'}
-      - {days: [Sa], from: '11:30am', to: '5:00pm'}
-      - {days: [Su], from: '1:00pm', to: '5:00pm'}
-      - {days: [Su], from: '7:00pm', to: '10:00pm'}
 
 breakSchedule:
   fall: []

--- a/data/building-hours/5-3-asc-speaking-space.yaml
+++ b/data/building-hours/5-3-asc-speaking-space.yaml
@@ -1,0 +1,18 @@
+name: 'ASC – Speaking Space'
+category: 'Help and Support'
+
+schedule:
+  - title: 'Hours'
+    hours:
+      - {days: [Mo, Tu, We, Th], from: '7:00pm', to: '9:00pm'}
+      - {days: [Sa], from: '2:00pm', to: '5:00pm'}
+      - {days: [Su], from: '6:00pm', to: '9:00pm'}
+
+breakSchedule:
+  fall: []
+  thanksgiving: []
+  winter: []
+  interim: []
+  spring: []
+  easter: []
+  summer: []

--- a/data/building-hours/5-4-asc-writing-desk.yaml
+++ b/data/building-hours/5-4-asc-writing-desk.yaml
@@ -1,0 +1,21 @@
+name: 'ASC – Writing Desk'
+category: 'Help and Support'
+
+schedule:
+  - title: 'Hours'
+    notes: 'Times by appointment.'
+    hours:
+      - {days: [Mo, Tu, We, Th, Fr], from: '10:00am', to: '5:00pm'}
+      - {days: [Mo, Tu, We, Th], from: '7:00pm', to: '10:00pm'}
+      - {days: [Sa], from: '11:30am', to: '5:00pm'}
+      - {days: [Su], from: '1:00pm', to: '5:00pm'}
+      - {days: [Su], from: '7:00pm', to: '10:00pm'}
+
+breakSchedule:
+  fall: []
+  thanksgiving: []
+  winter: []
+  interim: []
+  spring: []
+  easter: []
+  summer: []

--- a/docs/building-hours.json
+++ b/docs/building-hours.json
@@ -742,7 +742,7 @@
       "category": "Help and Support",
       "schedule": [
         {
-          "title": "Study Space",
+          "title": "Hours",
           "hours": [
             {
               "days": [
@@ -769,10 +769,42 @@
               "to": "9:00pm"
             }
           ]
-        },
+        }
+      ],
+      "breakSchedule": {
+        "fall": [],
+        "thanksgiving": [],
+        "winter": [],
+        "interim": [],
+        "spring": [],
+        "easter": [],
+        "summer": [
+          {
+            "days": [
+              "Mo",
+              "Tu",
+              "We",
+              "Th"
+            ],
+            "from": "7:30am",
+            "to": "4:30pm"
+          },
+          {
+            "days": [
+              "Fr"
+            ],
+            "from": "7:45am",
+            "to": "12:00pm"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ASC – Speaking Space",
+      "category": "Help and Support",
+      "schedule": [
         {
-          "title": "Speaking Space",
-          "isPhysicallyOpen": false,
+          "title": "Hours",
           "hours": [
             {
               "days": [
@@ -799,10 +831,25 @@
               "to": "9:00pm"
             }
           ]
-        },
+        }
+      ],
+      "breakSchedule": {
+        "fall": [],
+        "thanksgiving": [],
+        "winter": [],
+        "interim": [],
+        "spring": [],
+        "easter": [],
+        "summer": []
+      }
+    },
+    {
+      "name": "ASC – Writing Desk",
+      "category": "Help and Support",
+      "schedule": [
         {
-          "title": "Writing Desk Appointments",
-          "isPhysicallyOpen": false,
+          "title": "Hours",
+          "notes": "Times by appointment.",
           "hours": [
             {
               "days": [
@@ -856,25 +903,7 @@
         "interim": [],
         "spring": [],
         "easter": [],
-        "summer": [
-          {
-            "days": [
-              "Mo",
-              "Tu",
-              "We",
-              "Th"
-            ],
-            "from": "7:30am",
-            "to": "4:30pm"
-          },
-          {
-            "days": [
-              "Fr"
-            ],
-            "from": "7:45am",
-            "to": "12:00pm"
-          }
-        ]
+        "summer": []
       }
     },
     {


### PR DESCRIPTION
Drew pointed out that the ASC is confusing. Elsewhere in building hours, one row = one physical location, but the ASC has three locations grouped into one entry.

There's precedent for this, in the Pool – it's separate from Skoglund in general – and in the climbing wall – also separate.

What do you all think?