### PR TITLE
make the pause menu aware of the new data format

### DIFF
--- a/views/menus/menu-github.js
+++ b/views/menus/menu-github.js
@@ -48,7 +48,8 @@ export class GitHubHostedMenu extends React.Component {
     let stationMenus: StationMenuType[] = []
     let corIcons: MasterCorIconMapType = {}
     try {
-      let data = await fetchJson(`${githubMenuBaseUrl}/pause-menu.json`)
+      let container = await fetchJson(`${githubMenuBaseUrl}/pause-menu.json`)
+      let data = container.data
       foodItems = data.foodItems || []
       stationMenus = data.stationMenus || []
       corIcons = data.corIcons || {}


### PR DESCRIPTION
wherein data is wrapped in `{data: <actual data>}` instead of being barren
top-level data. to allow future metadata expansion, or other things…

but I borked some of the implementations. oops.