### PR TITLE
Fix buttons again again

### DIFF
--- a/app.js
+++ b/app.js
@@ -223,10 +223,11 @@ function LeftButton(route, navigator, index, navState) {
   }
 
   if (route.id === 'HomeView') {
+    let onPressSettings = (settingsButtonActive || editHomeButtonActive) ? null : openSettings(route, navigator)
     return (
       <TouchableOpacity
         style={[styles.settingsButton]}
-        onPress={openSettings(route, navigator)}
+        onPress={onPressSettings}
       >
         <Icon style={styles.settingsIcon} name='ios-settings' />
       </TouchableOpacity>
@@ -265,6 +266,10 @@ function LeftButton(route, navigator, index, navState) {
 // Leaving the boilerplate here for future expansion
 function RightButton(route, navigator) {
   if (route.onDismiss) {
+    if (route.id === 'SettingsView' || route.id === 'EditHomeView') {
+      settingsButtonActive = false
+      editHomeButtonActive = false
+    }
     return (
       <TouchableOpacity
         style={styles.backButtonClose}
@@ -275,10 +280,11 @@ function RightButton(route, navigator) {
     )
   }
   if (route.id === 'HomeView') {
+    let onPressEditHome = (settingsButtonActive || editHomeButtonActive) ? null : openEditHome(route, navigator)
     return (
       <TouchableOpacity
         style={[styles.editHomeButton]}
-        onPress={openEditHome(route, navigator)}
+        onPress={onPressEditHome}
       >
         <Text style={[styles.editHomeText]}>Edit</Text>
       </TouchableOpacity>

--- a/app.js
+++ b/app.js
@@ -174,7 +174,7 @@ const styles = StyleSheet.create({
 let editHomeButtonActive = false
 function openEditHome(route, navigator) {
   return () => {
-    if (editHomeButtonActive) {
+    if (editHomeButtonActive || settingsButtonActive) {
       return
     }
 
@@ -197,7 +197,7 @@ function openEditHome(route, navigator) {
 let settingsButtonActive = false
 function openSettings(route, navigator) {
   return () => {
-    if (settingsButtonActive) {
+    if (settingsButtonActive || editHomeButtonActive) {
       return
     }
 

--- a/app.js
+++ b/app.js
@@ -223,7 +223,7 @@ function LeftButton(route, navigator, index, navState) {
   }
 
   if (route.id === 'HomeView') {
-    let onPressSettings = (settingsButtonActive || editHomeButtonActive) ? null : openSettings(route, navigator)
+    let onPressSettings = (settingsButtonActive || editHomeButtonActive) ? () => {} : openSettings(route, navigator)
     return (
       <TouchableOpacity
         style={[styles.settingsButton]}
@@ -280,7 +280,7 @@ function RightButton(route, navigator) {
     )
   }
   if (route.id === 'HomeView') {
-    let onPressEditHome = (settingsButtonActive || editHomeButtonActive) ? null : openEditHome(route, navigator)
+    let onPressEditHome = (settingsButtonActive || editHomeButtonActive) ? () => {} : openEditHome(route, navigator)
     return (
       <TouchableOpacity
         style={[styles.editHomeButton]}


### PR DESCRIPTION
Two issues are tackled here here:

(1) Blank views can be pushed on a corrupted stack
  * Happens on **settings** button mashing
  * Happens on **edit** button mashing

(2) Multiple views can be pushed to the navigator stack
  * I am able to push an Edit view and a Settings view to the stack one after the other
  * I can touch either the settings or edit buttons sequentially and very quickly to make this happen.
  * It will render both views, as both were pushed individually in sequential order.... we do not check for that yet.

<hr>

Solution for (1) is to check outside of the called function whether the function should be called instead of within the function.

    let onPressEditHome = (settingsButtonActive || editHomeButtonActive) ? null : openEditHome(route, navigator)
    let onPressSettings = (settingsButtonActive || editHomeButtonActive) ? null : openSettings(route, navigator)


Solution for (2) is to check if the opposite navbar button is active in addition to itself. This is a little iffy, which I would like feedback on. The onDismiss is being called for the `HomeView` and changing their values when the `HomeView` disappears instead of when the `EditHomeView` or `SettingsView` views disappear. The logic works the same, but maybe there is a more elegant solution.

     if (editHomeButtonActive || settingsButtonActive)

Closes #155