### PR TITLE
Wrapper for trimmed text with spaces

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -28,5 +28,5 @@ function getTextWithSpaces(elem: Object|Object[]): string {
 }
 
 export function getTrimmedTextWithSpaces(elem: Object|Object[]): string {
-  return getTextWithSpaces(elem).split(/\s+/).join(' ')
+  return getTextWithSpaces(elem).split(/\s+/).join(' ').trim()
 }

--- a/lib/html.js
+++ b/lib/html.js
@@ -20,9 +20,13 @@ export function getText(elem: Object|Object[]): string {
   return ''
 }
 
-export function getTextWithSpaces(elem: Object|Object[]): string {
+function getTextWithSpaces(elem: Object|Object[]): string {
   if (Array.isArray(elem)) return elem.map(getText).join(' ')
   if (elem.type === 'tag') return getText(elem.children)
   if (elem.type === 'text') return elem.data
   return ''
+}
+
+export function getTrimmedTextWithSpaces(elem: Object|Object[]): string {
+  return getTextWithSpaces(elem).split(/\s+/).join(' ')
 }

--- a/views/calendar/event.js
+++ b/views/calendar/event.js
@@ -7,7 +7,7 @@ import {
 
 import moment from 'moment-timezone'
 import * as c from '../components/colors'
-import {getText, parseHtml} from '../../lib/html'
+import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
 
 let styles = StyleSheet.create({
   container: {
@@ -56,7 +56,7 @@ let styles = StyleSheet.create({
 
 // PROPS: eventTitle, location, startTime, endTime
 export default function EventView(props: {eventTitle: string, location: string, startTime?: Object, endTime?: Object, style?: any, isOngoing: bool}) {
-  let title = getText(parseHtml(props.eventTitle))
+  let title = getTrimmedTextWithSpaces(parseHtml(props.eventTitle))
 
   let eventLength = moment.duration(props.endTime.diff(props.startTime)).asHours()
   let allDay = eventLength === 24

--- a/views/menus/menu-bonapp.js
+++ b/views/menus/menu-bonapp.js
@@ -15,6 +15,7 @@ import moment from 'moment-timezone'
 const CENTRAL_TZ = 'America/Winnipeg'
 import {findMenu} from './lib/find-menu'
 import {trimStationName, trimItemLabel} from './lib/trim-names'
+import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
 import {toLaxTitleCase} from 'titlecase'
 
 const bonappMenuBaseUrl = 'http://legacy.cafebonappetit.com/api/2/menus'
@@ -134,6 +135,7 @@ export class BonAppHostedMenu extends React.Component {
       ...item,  // we want to edit the item, not replace it
       station: toLaxTitleCase(trimStationName(item.station)),  // <b>@station names</b> are a mess
       label: trimItemLabel(item.label),  // clean up the titles
+      description: getTrimmedTextWithSpaces(parseHtml(item.description || '')),  // clean up the descriptions
     }))
 
     // And finally, because BonApp is silly, we clean up the food items by

--- a/views/oleville/index.js
+++ b/views/oleville/index.js
@@ -19,7 +19,7 @@ import {
 import delay from 'delay'
 import LoadingView from '../components/loading'
 import * as c from '../components/colors'
-import { getText, parseHtml } from '../../lib/html'
+import { getTrimmedTextWithSpaces, parseHtml } from '../../lib/html'
 import get from 'lodash/get'
 import zipWith from 'lodash/zipWith'
 
@@ -137,7 +137,7 @@ export default class OlevilleView extends React.Component {
   }
 
   renderRow = (data: Object) => {
-    let title = getText(parseHtml(data.title.rendered))
+    let title = getTrimmedTextWithSpaces(parseHtml(data.title.rendered))
     let content = data.content.rendered
     let image = data._featuredImageUrl
     //console.log(content)

--- a/views/student-orgs/detail.js
+++ b/views/student-orgs/detail.js
@@ -4,7 +4,7 @@ import {ScrollView, Text, View, StyleSheet} from 'react-native'
 
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import * as c from '../components/colors'
-import {getTextWithSpaces, parseHtml} from '../../lib/html'
+import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
 import type {StudentOrgInfoType, StudentOrgAbridgedType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 
@@ -108,8 +108,7 @@ export class StudentOrgsDetailView extends React.Component {
       return null
     }
 
-    orgDescription = getTextWithSpaces(parseHtml(orgDescription))
-    orgDescription = orgDescription.split(/\s+/).join(' ')
+    orgDescription = getTrimmedTextWithSpaces(parseHtml(orgDescription))
 
     return (
       <Section header='DESCRIPTION'>


### PR DESCRIPTION
This solves #462 where we noticed html within item descriptions on the Bon Appetit menus.

Introduces a helper function that wraps `getTextWithSpaces` with `getTrimmedTextWithSpaces`. Allows for us to slim down on code duplication when splitting/joining spaces on the returned strings. The duplication of code would have existed in Orgs, Oleville, Calendar, and Menus.

Thanks @hawkrives for the direction on this.

Closes #462