### PR TITLE
Fix map URL

### DIFF
--- a/data/map.yaml
+++ b/data/map.yaml
@@ -1,4 +1,4 @@
-url: 'https://www.myatlascms.com/map/index.php?id=294"'
+url: 'https://www.myatlascms.com/map/index.php?id=294'
 description: >
   Known as “The Hill”, St. Olaf College’s picturesque 300-acre (120 ha) campus
   is home to 17 academic and administrative buildings, 29 student residences

--- a/docs/map.json
+++ b/docs/map.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "url": "https://www.myatlascms.com/map/index.php?id=294\"",
+    "url": "https://www.myatlascms.com/map/index.php?id=294",
     "description": "Known as “The Hill”, St. Olaf College’s picturesque 300-acre (120 ha) campus is home to 17 academic and administrative buildings, 29 student residences and 10 athletic facilities. St. Olaf is a residential college; 96 percent of St. Olaf students reside in one of the 11 residence halls and 18 academic and special interest group houses. Adjacent to campus are 325 acres (132 ha) of restored wetlands, woodlands, and native tall grass prairie owned and maintained by St. Olaf, and a utility-grade wind turbine that supplies up to one-third of the college’s daily electrical needs.\n"
   }
 }


### PR DESCRIPTION
A rogue " slipped into the URL for the map, causing it to fail on Android. Removed that issue.