### PR TITLE
Require that the map URL be valid

### DIFF
--- a/data/_schemas/map.yaml
+++ b/data/_schemas/map.yaml
@@ -3,5 +3,5 @@ $schema: http://json-schema.org/draft-04/schema#
 additionalProperties: false
 required: [url, description]
 properties:
-  url: {type: string}
+  url: {type: string, format: uri}
   description: {type: string}

--- a/data/_schemas/transportation.yaml
+++ b/data/_schemas/transportation.yaml
@@ -4,5 +4,5 @@ additionalProperties: false
 required: [name, url, description]
 properties:
   name: {type: string}
-  url: {type: string}
+  url: {type: string, format: uri}
   description: {type: string}

--- a/data/_schemas/webcams.yaml
+++ b/data/_schemas/webcams.yaml
@@ -4,4 +4,4 @@ additionalProperties: false
 required: [name, url]
 properties:
   name: {type: string}
-  url: {type: string}
+  url: {type: string, format: uri}


### PR DESCRIPTION
Are there any other schemas that need uri?

- [x] map
- [x] transportation (the "other" options)
- [x] webcams

Or other formats. We can choose from the following:

> "date-time": Date representation, as defined by RFC 3339, section 5.6.
> "email": Internet email address, see RFC 5322, section 3.4.1.
> "hostname": Internet host name, see RFC 1034, section 3.1.
> "ipv4": IPv4 address, according to dotted-quad ABNF syntax as defined in RFC 2673, section 3.2.
> "ipv6": IPv6 address, as defined in RFC 2373, section 2.2.
> "uri": A universal resource identifier (URI), according to RFC3986.