### PR TITLE
Pause late night menu hours

### DIFF
--- a/data/building-hours/1-2-pause-kitchen.yaml
+++ b/data/building-hours/1-2-pause-kitchen.yaml
@@ -4,10 +4,15 @@ category: 'Food'
 
 schedule:
   - title: 'Hours'
+    notes: 'The late night menu starts at 9 p.m.'
     hours:
       - {days: [Mo, Tu, We, Th], from: '10:30am', to: '12:00am'}
-      - {days: [Fr, Sa], from: '10:30am', to: '2:00am'}
+      - {days: [Fr, Sa], from: '10:30am', to: '9:00pm'}
       - {days: [Su], from: '10:30am', to: '12:00am'}
+
+  - title: 'Late Night'
+    hours:
+      - {days: [Fr, Sa], from: '9:00pm', to: '2:00am'}
 
 breakSchedule:
   fall: []

--- a/data/building-hours/1-2-pause-kitchen.yaml
+++ b/data/building-hours/1-2-pause-kitchen.yaml
@@ -3,7 +3,7 @@ image: 'pause-kitchen'
 category: 'Food'
 
 schedule:
-  - title: 'Hours'
+  - title: 'Daylight'
     notes: 'The late night menu starts at 9 p.m.'
     hours:
       - {days: [Mo, Tu, We, Th], from: '10:30am', to: '12:00am'}

--- a/docs/building-hours.json
+++ b/docs/building-hours.json
@@ -82,6 +82,7 @@
       "schedule": [
         {
           "title": "Hours",
+          "notes": "The late night menu starts at 9 p.m.",
           "hours": [
             {
               "days": [
@@ -99,7 +100,7 @@
                 "Sa"
               ],
               "from": "10:30am",
-              "to": "2:00am"
+              "to": "9:00pm"
             },
             {
               "days": [
@@ -107,6 +108,19 @@
               ],
               "from": "10:30am",
               "to": "12:00am"
+            }
+          ]
+        },
+        {
+          "title": "Late Night",
+          "hours": [
+            {
+              "days": [
+                "Fr",
+                "Sa"
+              ],
+              "from": "9:00pm",
+              "to": "2:00am"
             }
           ]
         }

--- a/docs/building-hours.json
+++ b/docs/building-hours.json
@@ -81,7 +81,7 @@
       "category": "Food",
       "schedule": [
         {
-          "title": "Hours",
+          "title": "Daylight",
           "notes": "The late night menu starts at 9 p.m.",
           "hours": [
             {


### PR DESCRIPTION
This adds the schedule for the Pause late night menu. Fridays and Saturdays from 9pm to 2am.

Closes #508 

Main | Detail
---|---
<img width="432" alt="main" src="https://cloud.githubusercontent.com/assets/5240843/21752821/33190b88-d5ad-11e6-8e8f-0087d2ea72a5.png"> | <img width="432" alt="detail" src="https://cloud.githubusercontent.com/assets/5240843/21752822/332090b0-d5ad-11e6-86f9-c2603d02df70.png">