### PR TITLE
Fix typo where specialty pizzas would not show

### DIFF
--- a/data/pause-menu.yaml
+++ b/data/pause-menu.yaml
@@ -31,24 +31,24 @@ foodItems:
     description: 'Marinara, Ranch, BBQ, Honey Mustard'
 
   - label: BBQ Chicken
-    station: Specialty Pizzas
+    station: Specialty Pizza
     special: true
 
   - label: Buffalo Chicken
-    station: Specialty Pizzas
+    station: Specialty Pizza
     special: true
 
   - label: Chicken Bacon Ranch
-    station: Specialty Pizzas
+    station: Specialty Pizza
     special: true
 
   - label: Chicken Pesto
-    station: Specialty Pizzas
+    station: Specialty Pizza
     description: 'Includes tomatoes'
     special: true
 
   - label: Ole Pizza
-    station: Specialty Pizzas
+    station: Specialty Pizza
     description: 'Includes pepperoni, sausage, onions, green peppers, and black olives'
     special: true
 

--- a/docs/pause-menu.json
+++ b/docs/pause-menu.json
@@ -62,28 +62,28 @@
       },
       {
         "label": "BBQ Chicken",
-        "station": "Specialty Pizzas",
+        "station": "Specialty Pizza",
         "special": true
       },
       {
         "label": "Buffalo Chicken",
-        "station": "Specialty Pizzas",
+        "station": "Specialty Pizza",
         "special": true
       },
       {
         "label": "Chicken Bacon Ranch",
-        "station": "Specialty Pizzas",
+        "station": "Specialty Pizza",
         "special": true
       },
       {
         "label": "Chicken Pesto",
-        "station": "Specialty Pizzas",
+        "station": "Specialty Pizza",
         "description": "Includes tomatoes",
         "special": true
       },
       {
         "label": "Ole Pizza",
-        "station": "Specialty Pizzas",
+        "station": "Specialty Pizza",
         "description": "Includes pepperoni, sausage, onions, green peppers, and black olives",
         "special": true
       },


### PR DESCRIPTION
Specialty pizzas were marked as "Specialty Pizzas" when the category itself is singular, or "Specialty Pizza".

<img width="402" alt="pizzas" src="https://cloud.githubusercontent.com/assets/5240843/21752784/935e141c-d5ac-11e6-8083-afff6568d335.png">