### PR TITLE
Center android tabs when there are only 2 tabs

### DIFF
--- a/views/components/tabbed-view/index.android.js
+++ b/views/components/tabbed-view/index.android.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import { StyleSheet, Platform } from 'react-native'
+import { StyleSheet, Platform, Dimensions } from 'react-native'
 import { TabViewAnimated, TabBarTop } from 'react-native-tab-view'
 import * as c from '../colors'
 import type { TabbedViewPropsType } from './types'
@@ -41,15 +41,28 @@ export default class TabbedView extends React.Component {
   }
 
   _renderHeader = props => {
-    return (
-      <TabBarTop
-        {...props}
-        scrollEnabled={true}
-        indicatorStyle={styles.indicator}
-        style={styles.tabbar}
-        labelStyle={styles.label}
-      />
-    )
+    if (this.props.tabs.length > 2) {
+      return (
+        <TabBarTop
+          {...props}
+          scrollEnabled={true}
+          indicatorStyle={styles.indicator}
+          style={styles.tabbar}
+          labelStyle={styles.label}
+        />
+      )
+    } else {
+      return (
+        <TabBarTop
+          {...props}
+          scrollEnabled={true}
+          indicatorStyle={styles.indicator}
+          style={styles.tabbar}
+          labelStyle={styles.label}
+          tabWidth={Dimensions.get('window').width / 2}
+        />
+      )
+    }
   }
 
   _renderScene = ({ route }) => {


### PR DESCRIPTION
When there are only 2 tabs in a tabview on android, the tabs are not centered properly. This PR fixes that.

**Before:**
<img width="350" alt="before" src="https://cloud.githubusercontent.com/assets/12042702/21778844/aeb4ec72-d66a-11e6-8636-8dd263a46ec0.png">

**After:**
<img width="350" alt="after" src="https://cloud.githubusercontent.com/assets/12042702/21778859/ba0f8672-d66a-11e6-92b4-b11fb9ca60fc.png">
