### PR TITLE
upgrade fastlane

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.0.1)
       addressable (~> 2)
-    fastlane (2.5.0)
+    fastlane (2.6.0)
       activesupport (< 5)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -49,7 +49,7 @@ GEM
       faraday_middleware (~> 0.9)
       fastimage (>= 1.6)
       gh_inspector (>= 1.0.1, < 2.0.0)
-      google-api-client (~> 0.9.1)
+      google-api-client (~> 0.9.2)
       highline (>= 1.7.2, < 2.0.0)
       json (< 3.0.0)
       mini_magick (~> 4.5.1)
@@ -195,4 +195,4 @@ DEPENDENCIES
   xcodeproj
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.0.1)
       addressable (~> 2)
-    fastlane (2.6.0)
+    fastlane (2.7.0)
       activesupport (< 5)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)


### PR DESCRIPTION
Changelog: https://github.com/fastlane/fastlane/releases/tag/2.6.0

> More stable spaceship, improved frameit, other improvements
> * Make waiting for build processing more stable by retrying failed requests
> * Fix FastlaneRequire#gem_installed? to handle already-loaded libs
> * [supply] Added support for google service account credentials via environment variable
> * Update in-code documentation tool calls to use new fastlane syntax
> * Update screengrab tooling and dependency versions
> * Update gemspec to require correct version of Play API
> * Fix frameit 'easy mode' problem in landscape
> * frameit: support resuming of interrupted downloads of frames
> * Store spaceship and frameit config in ~/.fastlane
> * Detect if session was set via env variable if session is invalid, and show appropriate error message