### PR TITLE
Remove unneeded NSAppTransportSecurity exceptions

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -43,16 +43,6 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>bamco.com</key>
-			<dict>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>hub.cafebonappetit.com</key>
-			<dict>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 			<key>legacy.cafebonappetit.com</key>
 			<dict>
 				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
@@ -74,16 +64,6 @@
 				<true/>
 			</dict>
 			<key>stolaf-flash.streamguys.net</key>
-			<dict>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>stolaf.cafebonappetit.com</key>
-			<dict>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-			<key>template.cafebonappetit.com</key>
 			<dict>
 				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
 				<true/>


### PR DESCRIPTION
> part of #523 

- remove bamco.com
- remove hub.cafebonappetit.com
- remove stolaf.cafebonappetit.com
- remove template.cafebonappetit.com
