### PR TITLE
Change self-closing <string/> to open/close tags in Info.plist

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -106,7 +106,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string/>
+	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Entypo.ttf</string>


### PR DESCRIPTION
Xcode likes to have this key with open/close tags, while other tools coerce it to a self-closing tag. We've got the rest of of this file formatted as Xcode likes, so let's make this like that too.
