### PR TITLE
Chapter 1, or: the Creation of ListRow&co

### DIFF
--- a/views/components/colors.js
+++ b/views/components/colors.js
@@ -27,6 +27,8 @@ export const iosDisabledText = 'rgb(143, 143, 143)'
 export const iosNavbarBottomBorder = 'rgb(200, 200, 202)'
 export const iosListSectionHeader = 'rgb(248, 248, 248)'
 export const iosPlaceholderText = '#C7C7CC'
+export const iosHeaderTopBorder = 'rgb(199, 199, 199)'
+export const iosHeaderBottomBorder = 'rgb(224, 224, 224)'
 
 // MARK: Oleville colors
 export const theLatest = '#00BFFF'

--- a/views/components/list/disclosure-arrow.js
+++ b/views/components/list/disclosure-arrow.js
@@ -1,0 +1,27 @@
+// @flow
+import React from 'react'
+import {Platform, StyleSheet, View} from 'react-native'
+import * as c from '../colors'
+import Icon from 'react-native-vector-icons/Ionicons'
+
+const arrowStyles = StyleSheet.create({
+  wrapper: {
+    marginLeft: 10,
+  },
+  icon: {
+    color: c.iosDisabledText,
+    fontSize: 20,
+  },
+})
+
+export const DisclosureArrow = ({style}: {style?: any}) => {
+  if (Platform.OS === 'android') {
+    return null
+  }
+
+  return (
+    <View style={[arrowStyles.wrapper, style]}>
+      <Icon style={arrowStyles.icon} name='ios-arrow-forward' />
+    </View>
+  )
+}

--- a/views/components/list/index.js
+++ b/views/components/list/index.js
@@ -1,0 +1,6 @@
+// @flow
+export {ListRow} from './list-row'
+export {ListSectionHeader} from './list-section-header'
+export {ListSeparator} from './list-separator'
+export {Title} from './list-item-title'
+export {Detail} from './list-item-detail'

--- a/views/components/list/list-item-detail.js
+++ b/views/components/list/list-item-detail.js
@@ -1,0 +1,32 @@
+// @flow
+import React from 'react'
+import {StyleSheet, Platform, Text} from 'react-native'
+import * as c from '../colors'
+
+const styles = StyleSheet.create({
+  detail: {
+    paddingTop: 4,
+    fontSize: 14,
+    ...Platform.select({
+      ios: {
+        color: c.iosDisabledText,
+      },
+      android: {
+        color: c.iosDisabledText,
+      },
+    }),
+  },
+})
+
+type PropsType = {
+  children?: any,
+  style?: any,
+  lines?: number,
+};
+export function Detail(props: PropsType) {
+  return (
+    <Text numberOfLines={props.lines} style={[styles.detail, props.style]}>
+      {props.children}
+    </Text>
+  )
+}

--- a/views/components/list/list-item-title.js
+++ b/views/components/list/list-item-title.js
@@ -1,0 +1,43 @@
+// @flow
+import React from 'react'
+import {StyleSheet, Platform, Text} from 'react-native'
+import * as c from '../colors'
+
+const styles = StyleSheet.create({
+  title: {
+    color: c.black,
+    fontSize: 17,
+    ...Platform.select({
+      ios: {
+        fontWeight: '500',
+      },
+      android: {
+        fontWeight: '600',
+      },
+    }),
+  },
+  noBold: {
+    fontWeight: '400',
+  },
+})
+
+type PropsType = {
+  children?: any,
+  style?: any,
+  lines?: number,
+  bold?: boolean,
+};
+export function Title(props: PropsType) {
+  return (
+    <Text
+      numberOfLines={props.lines}
+      style={[
+        styles.title,
+        !props.bold && styles.noBold,
+        props.style,
+      ]}
+    >
+      {props.children}
+    </Text>
+  )
+}

--- a/views/components/list/list-row.js
+++ b/views/components/list/list-row.js
@@ -1,0 +1,81 @@
+// @flow
+import React from 'react'
+import {Platform, StyleSheet, View} from 'react-native'
+import {Touchable} from '../touchable'
+import {DisclosureArrow} from './disclosure-arrow'
+import noop from 'lodash/noop'
+import isNil from 'lodash/isNil'
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    paddingLeft: 15,
+    backgroundColor: 'white',
+    ...Platform.select({
+      ios: {
+        paddingVertical: 8,
+        paddingRight: 8,
+      },
+      android: {
+        paddingVertical: 16,
+        paddingRight: 15,
+      },
+    }),
+  },
+  fullWidth: {
+    paddingLeft: 0,
+  },
+  fullHeight: {
+    paddingVertical: 0,
+  },
+})
+
+type PropsType = {
+  style?: any,
+  contentContainerStyle?: any,
+  arrowPosition?: 'center'|'top'|'none',
+  fullWidth?: boolean,
+  fullHeight?: boolean,
+  spacing?: {left?: number, right?: number},
+  onPress?: () => any,
+  children?: any,
+};
+export function ListRow(props: PropsType) {
+  const {
+    style,
+    contentContainerStyle,
+    children,
+    onPress,
+    spacing: {left: leftSpacing = 15, right: rightSpacing = null} = {},
+    fullWidth=false,
+    fullHeight=false,
+  } = props
+
+  const Component = onPress ? Touchable : View
+  const callback = onPress || noop
+
+  const arrowPosition = props.arrowPosition || (onPress ? 'center' : 'none')
+  const arrowPositionStyle = {alignSelf: arrowPosition === 'center' ? 'center' : 'flex-start'}
+  const arrow = arrowPosition === 'none' || Platform.OS === 'android'
+    ? null
+    : <DisclosureArrow style={arrowPositionStyle} />
+
+  return (
+    <Component
+      style={[
+        styles.container,
+        !isNil(leftSpacing) && {paddingLeft: leftSpacing},
+        !isNil(rightSpacing) && {paddingRight: rightSpacing},
+        fullWidth && styles.fullWidth,
+        fullHeight && styles.fullHeight,
+        contentContainerStyle,
+      ]}
+      onPress={callback}
+    >
+      <View style={[{flex: 1}, style]}>
+        {children}
+      </View>
+      {arrow}
+    </Component>
+  )
+}

--- a/views/components/list/list-section-header.js
+++ b/views/components/list/list-section-header.js
@@ -1,0 +1,98 @@
+// @flow
+import React from 'react'
+import {Platform, StyleSheet, Text, View} from 'react-native'
+import * as c from '../colors'
+
+const styles = StyleSheet.create({
+  container: {
+    paddingLeft: 15,
+    ...Platform.select({
+      ios: {
+        backgroundColor: c.iosListSectionHeader,
+        paddingVertical: 6,
+        borderTopWidth: StyleSheet.hairlineWidth,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderTopColor: c.iosHeaderTopBorder,
+        borderBottomColor: c.iosHeaderBottomBorder,
+        paddingRight: 10,
+      },
+      android: {
+        backgroundColor: 'white',
+        paddingTop: 10,
+        paddingBottom: 10,
+        borderTopWidth: 1,
+        borderBottomWidth: 0,
+        borderColor: '#c8c7cc',
+        paddingRight: 15,
+      },
+    }),
+  },
+  bold: {
+    ...Platform.select({
+      ios: {fontWeight: '500'},
+      android: {fontWeight: '600'},
+    }),
+  },
+  title: {
+    fontWeight: '400',
+    ...Platform.select({
+      ios: {
+        fontSize: 16,
+        color: c.black,
+      },
+      android: {
+        fontSize: 16,
+        fontFamily: 'sans-serif-condensed',
+        color: c.tint,
+      },
+    }),
+  },
+  subtitle: {
+    fontWeight: '400',
+    ...Platform.select({
+      ios: {
+        fontSize: 16,
+        color: c.iosDisabledText,
+      },
+      android: {
+        fontSize: 16,
+        fontFamily: 'sans-serif-condensed',
+        color: c.iosDisabledText,  // todo: find android equivalent
+      },
+    }),
+  },
+})
+
+type PropsType = {
+  title: string,
+  bold?: boolean,
+  titleStyle?: any,
+  subtitle?: string,
+  subtitleStyle?: any,
+  separator?: string,
+  style?: any,
+  spacing?: {left?: number, right?: number},
+};
+export function ListSectionHeader(props: PropsType) {
+  const {
+    style,
+    title,
+    bold=true,
+    titleStyle,
+    subtitle=null,
+    subtitleStyle,
+    separator=' — ',
+    spacing: {left: leftSpacing = 15} = {},
+  } = props
+
+  return (
+    <View style={[styles.container, {paddingLeft: leftSpacing}, style]}>
+      <Text>
+        <Text style={[styles.title, titleStyle, bold ? styles.bold : null]}>{title}</Text>
+        {subtitle
+          ? <Text style={[styles.subtitle, subtitleStyle]}>{separator}{subtitle}</Text>
+          : null}
+      </Text>
+    </View>
+  )
+}

--- a/views/components/list/list-separator.js
+++ b/views/components/list/list-separator.js
@@ -1,0 +1,33 @@
+// @flow
+import React from 'react'
+import {Platform, StyleSheet} from 'react-native'
+import {Separator} from '../separator'
+
+const styles = StyleSheet.create({
+  separator: {
+    marginLeft: 15,
+  },
+})
+
+type PropsType = {
+  styles?: any,
+  fullWidth?: boolean,
+  spacing?: {left?: number, right?: number}
+};
+export function ListSeparator(props: PropsType) {
+  if (Platform.OS === 'android') {
+    return null
+  }
+
+  const {
+    fullWidth,
+    spacing: {left: leftSpacing = 15, right: rightSpacing} = {},
+  } = props
+
+  let spacing = {marginLeft: leftSpacing, marginRight: rightSpacing}
+  if (fullWidth) {
+    spacing = {marginLeft: 0, marginRight: 0}
+  }
+
+  return <Separator style={[styles.separator, spacing, props.styles]} />
+}

--- a/views/components/separator.js
+++ b/views/components/separator.js
@@ -9,6 +9,6 @@ const styles = StyleSheet.create({
   },
 })
 
-export function Separator({style}: {style?: Number|Object|Array<Number|Object>}) {
+export function Separator({style}: {style?: mixed}) {
   return <View style={[styles.separator, style]} />
 }


### PR DESCRIPTION
> Depends on #540. The build will fail until `<Touchable/>` is merged.

Common list styles FTW!

~~Descriptions incoming later.~~

This and #538 are a pair of complementary component sets. This PR introduces the `<ListRow/>`, `<ListSectionHeader/>`, `<ListSeparator/>`, `<Title/>`, and `<Detail/>` components.

These are components that apply basic styling to our ListViews, since we have so many of them. These two PRs together are what produced #499.

All of these components are imported from `view/components/list` – `import {ListRow, Title} from '../../components/list'`, for example.

## `<ListSeparator/>`
It's a `<Separator/>` that hides itself on Android, takes a `fullWidth={true}` and a `spacing={{left: NUMBER}}`` prop to make adjusting the left margin easy, and applies default styling on iOS.

Soon, I'll have to update it for proper 3-line Android ListView styles, but that'll be a subsequent PR.

Example usage:

```js
<ListSeparator />
```

## `<ListSectionHeader/>`
Applies default styling to the SectionHeaders, as appropriate for both iOS and Android.

Takes a `title` prop for supplying the title text, as well as optional `subtitle` (and `separator`) props to supply a secondary title, as seen on Menus. Also takes `bold={true|false}`, to change if it should be bold or not. Finally, you can apply styles to the title and subtitle with `titleStyle` and `subtitleStyle`, and adjust the left margin with `spacing={{left: NUMBER}}`, just like `<ListSeparator/>`.

Example usage:

```js
<ListSectionHeader 
  title='Pizza' 
  subtitle='Orders larger than 4 pizzas should be placed 24 hours in advance, through Oleville' 
/>
```

## `<ListRow/>`
The big kahuna. Applies appropriate row styles to a row for both iOS and Android, as well as displaying a disclosure caret as appropriate on iOS.

Any ListView's renderRow should wind up returning a ListRow, either directly or by supplying a component whose top-level is ListRow.

ListRow takes several props:

- `style`: styles, for the element that contains the children.
- `contentContainerStyle`: styles, for the wrapping View.
- `arrowPosition=center|top|none`: where to show the arrow on iOS. Defaults to `center` if onPress is given; else hides itself.
- `onPress`: called when the row is tapped.
- `fullWidth` / `fullHeight`: remove the default padding around the row; used for the BusTransit rows (both options), and Calendar (just fullWidth), among others.
- `spacing={{left, right}}`: control the paddingLeft/paddingRight of the row.

Example usage:

```js
<ListRow onPress={onPress} arrowPosition='top'>
  {normal contents of building-hour-row}
</ListRow>
```

## `<Title/>` and `<Detail/>`
These two both apply default styles as appropriate, for a list "title" or "detail" section (the top row / subsequent rows of a list row).

The normal `<Text numberOfLines/>` prop can be controlled via a simple `lines` prop. `<Title/>` also takes a `bold={true}` prop, to control boldness.

These two only accept strings and `<Text/>` elements as their children. This allows us to format the text that is displayed, as in the details section of the BuildingHours view, where the various rows need to bold/unbold themselves as they open/close.

Example usage:

```js
<Title>Wrestling vs. Central College Open</Title>
<Detail>Pella, Iowa</Detail>
```

```js
<Title>Stav Hall</Title>
<Detail>
  <Text>Breakfast: 7:00am — 9:45am</Text>
  <Text>Lunch: 10:30am — 2:00pm</Text>
  <Text style={{fontWeight: bold}}>Dinner: 4:30pm — 7:30pm</Text>
</Detail>
```