### PR TITLE
Add ability to specify description to a filter item

### DIFF
--- a/views/components/filter/__tests__/apply-and-list-filter.test.js
+++ b/views/components/filter/__tests__/apply-and-list-filter.test.js
@@ -1,15 +1,16 @@
 /* eslint-env jest */
 // @flow
 import {applyAndListFilter} from '../apply-filters'
+import {filterValue} from './filter-value.helper'
 
 it("should return `true` if the item's value is a superset of the needle", () => {
-  expect(applyAndListFilter(['1'], ['1', '2'])).toBeTruthy()
+  expect(applyAndListFilter(filterValue('1'), ['1', '2'])).toBeTruthy()
 })
 
 it("should return `false` if the item's value is a subset of the needle", () => {
-  expect(applyAndListFilter(['1', '2', '3'], ['1'])).toBeFalsy()
+  expect(applyAndListFilter(filterValue('1', '2', '3'), ['1'])).toBeFalsy()
 })
 
 it('should convert objects into an array of values to act as the value', () => {
-  expect(applyAndListFilter(['1', '2'], {key: '1', alt: '2'})).toBeTruthy()
+  expect(applyAndListFilter(filterValue('1', '2'), {key: '1', alt: '2'})).toBeTruthy()
 })

--- a/views/components/filter/__tests__/apply-filter.test.js
+++ b/views/components/filter/__tests__/apply-filter.test.js
@@ -1,13 +1,14 @@
 /* eslint-env jest */
 // @flow
 import {applyFilter} from '../apply-filters'
+import {filterValue} from './filter-value.helper'
 
-it('should return `true` if the fitler is disabled', () => {
+it('should return `true` if the filter is disabled', () => {
   let filter = {
     type: 'list',
     key: 'key',
     enabled: false,
-    spec: {label: 'label', options: ['1', '2', '3'], selected: [], mode: 'OR'},
+    spec: {label: 'label', options: filterValue('1', '2', '3'), selected: [], mode: 'OR'},
     apply: {key: 'categories'},
   }
   expect(applyFilter(filter, {categories: []})).toBeTruthy()

--- a/views/components/filter/__tests__/apply-or-list-filter.test.js
+++ b/views/components/filter/__tests__/apply-or-list-filter.test.js
@@ -1,11 +1,12 @@
 /* eslint-env jest */
 // @flow
 import {applyOrListFilter} from '../apply-filters'
+import {filterValue} from './filter-value.helper'
 
 it("should return `true` if the item's value contains the needle", () => {
-  expect(applyOrListFilter(['1', '2', '3'], '1')).toBeTruthy()
+  expect(applyOrListFilter(filterValue('1', '2', '3'), '1')).toBeTruthy()
 })
 
 it("should return `false` if the item's value does not contain the needle", () => {
-  expect(applyOrListFilter(['1', '2', '3'], ['-1'])).toBeFalsy()
+  expect(applyOrListFilter(filterValue('1', '2', '3'), '-1')).toBeFalsy()
 })

--- a/views/components/filter/__tests__/filter-value.helper.js
+++ b/views/components/filter/__tests__/filter-value.helper.js
@@ -1,0 +1,3 @@
+export function filterValue(...arr) {
+  return arr.map(item => ({title: item}))
+}

--- a/views/components/filter/apply-filters.js
+++ b/views/components/filter/apply-filters.js
@@ -1,5 +1,5 @@
 // @flow
-import type {FilterType, ToggleType, ListType} from './types'
+import type {FilterType, ToggleType, ListType, ListItemSpecType} from './types'
 import values from 'lodash/values'
 import difference from 'lodash/difference'
 import isPlainObject from 'lodash/isPlainObject'
@@ -50,12 +50,12 @@ export function applyListFilter(filter: ListType, item: any): boolean {
   }
 }
 
-export function applyOrListFilter<T>(filterValue: T[], itemValue: T): boolean {
+export function applyOrListFilter(filterValue: ListItemSpecType[], itemValue: string): boolean {
   // An item passes, if its value is in the filter's selected items array
-  return filterValue.includes(itemValue)
+  return filterValue.map(f => f.title).includes(itemValue)
 }
 
-export function applyAndListFilter<T>(filterValue: T[], itemValue: T[]|{[key: string]: T}): boolean {
+export function applyAndListFilter(filterValue: ListItemSpecType[], itemValue: string[]|{[key: string]: string}): boolean {
   // In case the value is an object, instead of an array, convert it to an array
   if (isPlainObject(itemValue)) {
     itemValue = values(itemValue)
@@ -68,6 +68,7 @@ export function applyAndListFilter<T>(filterValue: T[], itemValue: T[]|{[key: st
 
   // Check that the number of different items between the two lists is 0, to
   // ensure that all of the restrictions we're seeking are present.
-  const differentItems = difference(filterValue, itemValue)
+  const valueToCheckAgainst = filterValue.map(f => f.title)
+  const differentItems = difference(valueToCheckAgainst, itemValue)
   return differentItems.length === 0
 }

--- a/views/components/filter/section-list.js
+++ b/views/components/filter/section-list.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import type {ListType} from './types'
+import type {ListType, ListItemSpecType} from './types'
 import {Section, Cell} from 'react-native-tableview-simple'
 import includes from 'lodash/includes'
 import without from 'lodash/without'
@@ -16,7 +16,7 @@ export function ListSection({filter, onChange}: PropsType) {
   const {title='', options, selected, mode} = spec
   const {caption=`Show items with ${mode === 'AND' ? 'all' : 'any'} of these options.`} = spec
 
-  function buttonPushed(tappedValue: string) {
+  function buttonPushed(tappedValue: ListItemSpecType) {
     let result
 
     if (includes(selected, tappedValue)) {
@@ -62,10 +62,12 @@ export function ListSection({filter, onChange}: PropsType) {
 
   let buttons = options.map(val =>
     <Cell
-      key={val}
+      key={val.title}
+      cellStyle={val.detail ? 'Subtitle' : 'Basic'}
       onPress={() => buttonPushed(val)}
       accessory={includes(selected, val) ? 'Checkmark' : null}
-      title={val}
+      title={val.title}
+      detail={val.detail}
     />
   )
 

--- a/views/components/filter/types.js
+++ b/views/components/filter/types.js
@@ -5,11 +5,17 @@ export type ToggleSpecType = {
   caption?: string,
 };
 
+export type ListItemSpecType = {|
+  title: string,
+  detail?: string,
+  image?: ?any,
+|};
+
 export type ListSpecType = {
   title?: string,
   caption?: string,
-  options: string[],
-  selected: string[],
+  options: ListItemSpecType[],
+  selected: ListItemSpecType[],
   mode: 'AND'|'OR',
 };
 

--- a/views/menus/components/fancy-menu.js
+++ b/views/menus/components/fancy-menu.js
@@ -15,6 +15,7 @@ import filter from 'lodash/filter'
 import map from 'lodash/map'
 import {FilterMenuToolbar} from './filter-menu-toolbar'
 import {MenuListView} from './menu'
+import DietaryFilters from '../../../images/dietary-filters'
 
 type FancyMenuPropsType = TopLevelViewPropsType & {
   applyFilters: (filters: FilterType[], item: MenuItemType) => boolean,
@@ -47,8 +48,14 @@ class FancyMenuView extends React.Component {
   }
 
   buildFilters({stations, corIcons}: {stations: string[], corIcons: MasterCorIconMapType}): FilterType[] {
+    // Format the items for the stations filter
+    const allStations = map(stations, name => ({title: name}))
     // Grab the labels of the COR icons
-    let allDietaryRestrictions = map(corIcons, item => item.label)
+    const allDietaryRestrictions = map(corIcons, (item, key) => ({
+      title: item.label,
+      image: DietaryFilters[key] ? DietaryFilters[key].icon : null,
+      detail: DietaryFilters[key].description,
+    }))
 
     return [
       {
@@ -69,9 +76,9 @@ class FancyMenuView extends React.Component {
         enabled: false,
         spec: {
           title: 'Stations',
-          options: stations,
+          options: allStations,
           mode: 'OR',
-          selected: stations,
+          selected: allStations,
         },
         apply: {
           key: 'station',


### PR DESCRIPTION
also sets up ability to render an image for a row

This changes the type of data in the list filters from an array of strings to an array of `{title, description?, image?}` objects.

<img width=320 src=https://cloud.githubusercontent.com/assets/464441/21814823/34052e36-d720-11e6-88fe-57b67e51f63c.png>
