### PR TITLE
Disable dietary restrictions correctly

### DIFF
--- a/views/components/filter/section-list.js
+++ b/views/components/filter/section-list.js
@@ -28,9 +28,16 @@ export function ListSection({filter, onChange}: PropsType) {
       result = concat(selected, tappedValue)
     }
 
+    let enabled = false
+    if (mode === 'AND') {
+      enabled = result.length !== options.length
+    } else if (mode === 'OR') {
+      enabled = result.length !== 0
+    }
+
     onChange({
       ...filter,
-      enabled: result.length !== options.length,
+      enabled: enabled,
       spec: {...spec, selected: result},
     })
   }


### PR DESCRIPTION
It is incorrect for the AND mode, where a filter should be disabled whenever none of the options are selected (aka "this filter should only show items with all of these selected options".)

This pulls out the enabled value into a variable, then performs a check on the mode of the filter, and switches between the two algorithms depending.

Thanks @hawkrives 

Closes #521 