### PR TITLE
Fix News by adding local RSS feed parsing

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -30,3 +30,7 @@ function getTextWithSpaces(elem: Object|Object[]): string {
 export function getTrimmedTextWithSpaces(elem: Object|Object[]): string {
   return getTextWithSpaces(elem).split(/\s+/).join(' ').trim()
 }
+
+export function fastGetTrimmedText(str: string): string {
+  return str.replace(/<[^>]*>|\s+/g, ' ').replace(/\s+/g, ' ').trim()
+}

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "junk": "2.0.0",
     "marked": "0.3.6",
     "minimist": "1.2.0",
+    "pify": "2.3.0",
     "react-test-renderer": "15.4.2"
   }
 }

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -9,7 +9,7 @@ import {
   TouchableHighlight,
   RefreshControl,
 } from 'react-native'
-import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
+import {fastGetTrimmedText} from '../../lib/html'
 import delay from 'delay'
 import {parseXml} from './parse-feed'
 import Icon from 'react-native-vector-icons/Ionicons'
@@ -75,7 +75,7 @@ export default class NewsContainer extends React.Component {
 
   renderRow = (story: StoryType) => {
     let title = entities.decode(story.title[0])
-    let snippet = getTrimmedTextWithSpaces(parseHtml(story.description[0]))
+    let snippet = entities.decode(fastGetTrimmedText(story.description[0]))
     return (
       <TouchableHighlight underlayColor={'#ebebeb'} onPress={() => this.onPressNews(title, story)}>
         <View style={[styles.row]}>

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -1,12 +1,11 @@
 // @flow
-import React, {PropTypes} from 'react'
+import React from 'react'
 import {
   StyleSheet,
   View,
   ListView,
   Platform,
   Text,
-  Navigator,
   TouchableHighlight,
   RefreshControl,
 } from 'react-native'

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -16,6 +16,7 @@ import delay from 'delay'
 import Icon from 'react-native-vector-icons/Ionicons'
 import type {StoryType} from './types'
 import LoadingView from '../components/loading'
+import {NoticeView} from '../components/notice'
 import * as c from '../components/colors'
 
 let Entities = require('html-entities').AllHtmlEntities
@@ -31,12 +32,11 @@ export default class NewsContainer extends React.Component {
 
   state = {
     dataSource: new ListView.DataSource({
-      rowHasChanged: (r1: StoryType, r2: StoryType) => r1.title != r2.title,
+      rowHasChanged: (r1: StoryType, r2: StoryType) => r1 != r2,
     }),
     refreshing: false,
     loaded: false,
     error: false,
-    noNews: false,
   }
 
   componentWillMount() {
@@ -47,9 +47,6 @@ export default class NewsContainer extends React.Component {
     try {
       let response = await fetch(this.props.url).then(r => r.json())
       let entries = response.responseData.feed.entries
-      if (!entries.length) {
-        this.setState({noNews: true})
-      }
       this.setState({dataSource: this.state.dataSource.cloneWithRows(entries)})
     } catch (error) {
       this.setState({error: true})
@@ -104,19 +101,8 @@ export default class NewsContainer extends React.Component {
       return <LoadingView />
     }
 
-    if (this.state.noNews) {
-      return (
-        <View style={{
-          flex: 1,
-          justifyContent: 'center',
-          alignItems: 'center',
-          backgroundColor: '#ffffff',
-        }}>
-          <Text>
-            No news.
-          </Text>
-        </View>
-      )
+    if (!this.state.dataSource.getRowCount()) {
+      return <NoticeView text='No news.' />
     }
 
     return (

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -36,7 +36,7 @@ export default class NewsContainer extends React.Component {
     }),
     refreshing: false,
     loaded: false,
-    error: false,
+    error: null,
   }
 
   componentWillMount() {
@@ -49,8 +49,8 @@ export default class NewsContainer extends React.Component {
       let entries = response.responseData.feed.entries
       this.setState({dataSource: this.state.dataSource.cloneWithRows(entries)})
     } catch (error) {
-      this.setState({error: true})
-      console.error(error)
+      console.warn(error)
+      this.setState({error})
     }
 
     this.setState({loaded: true})
@@ -103,6 +103,10 @@ export default class NewsContainer extends React.Component {
 
     if (!this.state.dataSource.getRowCount()) {
       return <NoticeView text='No news.' />
+    }
+
+    if (this.state.error) {
+      return <NoticeView text={'Error: ' + this.state.error.message} />
     }
 
     return (

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -12,7 +12,7 @@ import {
 } from 'react-native'
 
 import delay from 'delay'
-
+import {parseXml} from './parse-feed'
 import Icon from 'react-native-vector-icons/Ionicons'
 import type {StoryType} from './types'
 import LoadingView from '../components/loading'
@@ -45,9 +45,13 @@ export default class NewsContainer extends React.Component {
 
   fetchData = async () => {
     try {
-      let response = await fetch(this.props.url).then(r => r.json())
-      let entries = response.responseData.feed.entries
-      this.setState({dataSource: this.state.dataSource.cloneWithRows(entries)})
+      const responseText = await fetch(this.props.url).then(r => r.text())
+      const feed = await parseXml(responseText)
+
+      const entries = feed.rss.channel[0].item
+      this.setState({
+        dataSource: this.state.dataSource.cloneWithRows(entries),
+      })
     } catch (error) {
       console.warn(error)
       this.setState({error})
@@ -71,8 +75,8 @@ export default class NewsContainer extends React.Component {
   }
 
   renderRow = (story: StoryType) => {
-    let title = entities.decode(story.title)
-    let snippet = entities.decode(story.contentSnippet)
+    let title = entities.decode(story.title[0])
+    let snippet = entities.decode(story.description[0])
     return (
       <TouchableHighlight underlayColor={'#ebebeb'} onPress={() => this.onPressNews(title, story)}>
         <View style={[styles.row]}>

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -17,19 +17,13 @@ import Icon from 'react-native-vector-icons/Ionicons'
 import type {StoryType} from './types'
 import LoadingView from '../components/loading'
 import {NoticeView} from '../components/notice'
+import type {TopLevelViewPropsType} from '../types'
 import * as c from '../components/colors'
 
 let Entities = require('html-entities').AllHtmlEntities
 const entities = new Entities()
 
 export default class NewsContainer extends React.Component {
-  static propTypes = {
-    name: PropTypes.string.isRequired,
-    navigator: PropTypes.instanceOf(Navigator).isRequired,
-    route: PropTypes.object.isRequired,
-    url: PropTypes.string.isRequired,
-  }
-
   state = {
     dataSource: new ListView.DataSource({
       rowHasChanged: (r1: StoryType, r2: StoryType) => r1 != r2,
@@ -42,6 +36,12 @@ export default class NewsContainer extends React.Component {
   componentWillMount() {
     this.refresh()
   }
+
+  props: TopLevelViewPropsType & {
+    name: string,
+    url: string,
+    mode: 'rss'|'wp-json',
+  };
 
   fetchData = async () => {
     try {

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -9,7 +9,7 @@ import {
   TouchableHighlight,
   RefreshControl,
 } from 'react-native'
-
+import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
 import delay from 'delay'
 import {parseXml} from './parse-feed'
 import Icon from 'react-native-vector-icons/Ionicons'
@@ -75,7 +75,7 @@ export default class NewsContainer extends React.Component {
 
   renderRow = (story: StoryType) => {
     let title = entities.decode(story.title[0])
-    let snippet = entities.decode(story.description[0])
+    let snippet = getTrimmedTextWithSpaces(parseHtml(story.description[0]))
     return (
       <TouchableHighlight underlayColor={'#ebebeb'} onPress={() => this.onPressNews(title, story)}>
         <View style={[styles.row]}>

--- a/views/news/news-item.js
+++ b/views/news/news-item.js
@@ -4,8 +4,8 @@ import {WebView} from 'react-native'
 
 import type {StoryType} from './types'
 
-export default function NewsItemView({story: {content, title}}: {source: string, story: StoryType}) {
-  content = `
+export default function NewsItemView({story}: {source: string, story: StoryType}) {
+  const content = `
     <style>
       body {
         font-family: -apple-system, Roboto, sans-serif;
@@ -47,9 +47,9 @@ export default function NewsItemView({story: {content, title}}: {source: string,
       }
     </style>
     <header class="aao-header">
-      <h1>${title}</h1>
+      <h1>${story.title[0]}</h1>
     </header>
-    ${content}
+    ${story['content:encoded'][0]}
   `
   return (
     <WebView source={{html: content}} />

--- a/views/news/news-item.js
+++ b/views/news/news-item.js
@@ -55,14 +55,3 @@ export default function NewsItemView({story: {content, title}}: {source: string,
     <WebView source={{html: content}} />
   )
 }
-
-NewsItemView.propTypes = {
-  story: PropTypes.shape({
-    author: PropTypes.string,
-    categories: PropTypes.arrayOf(PropTypes.string),
-    content: PropTypes.string,
-    link: PropTypes.string,
-    publishedDate: PropTypes.string,
-    title: PropTypes.string,
-  }).isRequired,
-}

--- a/views/news/news-item.js
+++ b/views/news/news-item.js
@@ -49,7 +49,7 @@ export default function NewsItemView({story}: {story: StoryType}) {
     <header class="aao-header">
       <h1>${story.title[0]}</h1>
     </header>
-    ${story['content:encoded'][0]}
+    ${(story['content:encoded'] || story['description'])[0]}
   `
   return (
     <WebView source={{html: content}} />

--- a/views/news/news-item.js
+++ b/views/news/news-item.js
@@ -1,10 +1,10 @@
 // @flow
-import React, {PropTypes} from 'react'
+import React from 'react'
 import {WebView} from 'react-native'
 
 import type {StoryType} from './types'
 
-export default function NewsItemView({story}: {source: string, story: StoryType}) {
+export default function NewsItemView({story}: {story: StoryType}) {
   const content = `
     <style>
       body {

--- a/views/news/parse-feed.js
+++ b/views/news/parse-feed.js
@@ -1,0 +1,6 @@
+// @flow
+import {parseString} from 'xml2js'
+import pify from 'pify'
+import type {FeedResponseType} from './types'
+
+export const parseXml: ((text: string) => FeedResponseType) = pify(parseString)

--- a/views/news/tabs.js
+++ b/views/news/tabs.js
@@ -8,7 +8,8 @@ export default [
     rnVectorIcon: {iconName: 'school'},
     component: NewsContainer,
     props: {
-      url: 'https://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=-1&q=https://wp.stolaf.edu/feed',
+      url: 'https://wp.stolaf.edu/feed/',
+      mode: 'rss',
       name: 'St. Olaf',
     },
   },
@@ -18,7 +19,8 @@ export default [
     rnVectorIcon: {iconName: 'megaphone'},
     component: NewsContainer,
     props: {
-      url: 'https://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=-1&q=http://oleville.com/politicole/feed',
+      url: 'http://oleville.com/politicole/feed',
+      mode: 'rss',
       name: 'PoliticOle',
     },
   },
@@ -28,7 +30,8 @@ export default [
     rnVectorIcon: {iconName: 'paper'},
     component: NewsContainer,
     props: {
-      url: 'https://ajax.googleapis.com/ajax/services/feed/load?v=1.0&num=-1&q=http://manitoumessenger.com/feed',
+      url: 'http://manitoumessenger.com/feed',
+      mode: 'rss',
       name: 'Mess',
     },
   },

--- a/views/news/tabs.js
+++ b/views/news/tabs.js
@@ -19,7 +19,7 @@ export default [
     rnVectorIcon: {iconName: 'megaphone'},
     component: NewsContainer,
     props: {
-      url: 'http://oleville.com/politicole/feed',
+      url: 'http://oleville.com/politicole/feed/',
       mode: 'rss',
       name: 'PoliticOle',
     },
@@ -30,7 +30,7 @@ export default [
     rnVectorIcon: {iconName: 'paper'},
     component: NewsContainer,
     props: {
-      url: 'http://manitoumessenger.com/feed',
+      url: 'http://manitoumessenger.com/feed/',
       mode: 'rss',
       name: 'Mess',
     },

--- a/views/news/types.js
+++ b/views/news/types.js
@@ -1,5 +1,4 @@
 // @flow
-import {Navigator} from 'react-native'
 
 export type StoryType = {
   author: string,
@@ -9,10 +8,4 @@ export type StoryType = {
   link: string,
   publishedDate: string,
   title: string,
-};
-
-export type NewsViewPropsType = {
-  navigator: typeof Navigator,
-  route: Object,
-  url: string,
 };

--- a/views/news/types.js
+++ b/views/news/types.js
@@ -9,3 +9,15 @@ export type StoryType = {
   publishedDate: string,
   title: string,
 };
+
+export type FeedResponseType = {
+  rss: {
+    channel: Array<{
+      title: string[],
+      'atom:link': mixed[],
+      link: string[],
+      description: string[],
+      item: StoryType[],
+    }>,
+  }
+};

--- a/views/news/types.js
+++ b/views/news/types.js
@@ -1,13 +1,13 @@
 // @flow
 
 export type StoryType = {
-  author: string,
-  categories: string[],
-  content: string,
-  contentSnippet: string,
-  link: string,
-  publishedDate: string,
-  title: string,
+  'dc:creator': string[],
+  category: string[],
+  'content:encoded': string[],
+  description: string[],
+  link: string[],
+  pubDate: string[],
+  title: string[],
 };
 
 export type FeedResponseType = {


### PR DESCRIPTION
> Closes https://github.com/StoDevX/AAO-React-Native/issues/549

We already had an XML parser in the app, for my never-finished Stalkernet screen. I've reused that to create an RSS feed parser.

It lives in `/views/news` currently, and I figure we'll pull it out if anything else ever want to parse xml.

This also cleans up some of the News view – NoticeView, getRowCount, etc.

Result:

| Oleville | PoliticOle | Mess |
| --- | --- | --- |
![olaf](https://cloud.githubusercontent.com/assets/464441/21861877/74d30488-d7fc-11e6-9be5-227c890c1958.png) | ![politicole](https://cloud.githubusercontent.com/assets/464441/21861876/74d0da6e-d7fc-11e6-98b6-442f29ec9690.png) | ![mess](https://cloud.githubusercontent.com/assets/464441/21861875/74c83c88-d7fc-11e6-876a-8ba7bd02bdbf.png)

---

Sorry, @drewvolz – you'll have to do some work to rebase #463 onto this 😞 