### PR TITLE
reverse and simplify AND filter-enabling code

### DIFF
--- a/views/components/filter/section-list.js
+++ b/views/components/filter/section-list.js
@@ -29,10 +29,10 @@ export function ListSection({filter, onChange}: PropsType) {
     }
 
     let enabled = false
-    if (mode === 'AND') {
+    if (mode === 'OR') {
       enabled = result.length !== options.length
-    } else if (mode === 'OR') {
-      enabled = result.length !== 0
+    } else if (mode === 'AND') {
+      enabled = result.length > 0
     }
 
     onChange({


### PR DESCRIPTION
The OR-enabling logic was being applied to AND-filters and vice versa.

This fixes #521.