### PR TITLE
Add Google Analytics to AAO

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -19,6 +19,7 @@ globals:
   FormData: true
   fetchJson: true
   rawFetch: true
+  __DEV__: true
 
 rules:
   array-callback-return: error

--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,17 @@
+// @flow
+import {AsyncStorage} from 'react-native'
+import {
+  GoogleAnalyticsTracker,
+  GoogleAnalyticsSettings,
+} from 'react-native-google-analytics-bridge'
+
+const trackerId = 'UA-90234209-1'
+export const tracker = new GoogleAnalyticsTracker(trackerId)
+
+async function disableIfOptedOut() {
+  const didOptOut = JSON.parse(await AsyncStorage.getItem('optout'))
+  if (didOptOut) {
+    GoogleAnalyticsSettings.setOptOut(true)
+  }
+}
+disableIfOptedOut()

--- a/analytics.js
+++ b/analytics.js
@@ -5,7 +5,7 @@ import {
   GoogleAnalyticsSettings,
 } from 'react-native-google-analytics-bridge'
 
-const trackerId = 'UA-90234209-1'
+const trackerId = __DEV__ ? 'UA-90234209-1' : 'UA-90234209-2'
 export const tracker = new GoogleAnalyticsTracker(trackerId)
 
 async function disableIfOptedOut() {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -140,6 +140,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-google-analytics-bridge')
     compile project(':react-native-device-info')
     compile project(':react-native-cookies')
     compile project(':react-native-vector-icons')

--- a/android/app/src/main/java/com/allaboutolaf/MainApplication.java
+++ b/android/app/src/main/java/com/allaboutolaf/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.util.Log;
 
 import com.facebook.react.ReactApplication;
+import com.idehub.GoogleAnalyticsBridge.GoogleAnalyticsBridgePackage;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.psykar.cookiemanager.CookieManagerPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
@@ -30,6 +31,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
         new MainReactPackage(),
+        new GoogleAnalyticsBridgePackage(),
         new RNDeviceInfo(),
         new CookieManagerPackage(),
         new VectorIconsPackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -11,3 +11,5 @@ include ':react-native-keychain'
 project(':react-native-keychain').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-keychain/android')
 include ':react-native-onesignal'
 project(':react-native-onesignal').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-onesignal/android')
+include ':react-native-google-analytics-bridge'
+project(':react-native-google-analytics-bridge').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-google-analytics-bridge/android')

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@
 
 // Tweak the global fetch
 import './globalize-fetch'
+import {tracker} from './analytics'
 
 import React from 'react'
 import {
@@ -48,6 +49,7 @@ import NoRoute from './views/components/no-route'
 // Render a given scene
 function renderScene(route, navigator) {
   let props = {route, navigator, ...(route.props || {})}
+  tracker.trackScreenView(route.id)
   switch (route.id) {
     case 'HomeView': return <HomeView {...props} />
     case 'MenusView': return <MenusView {...props} />
@@ -310,6 +312,7 @@ function Title(route) {
 
 class App extends React.Component {
   componentDidMount() {
+    tracker.trackEvent('app', 'launch')
     BackAndroid.addEventListener('hardwareBackPress', this.registerAndroidBackButton)
   }
 

--- a/flux/index.js
+++ b/flux/index.js
@@ -5,6 +5,7 @@ import reduxThunk from 'redux-thunk'
 import {AsyncStorage} from 'react-native'
 import {allViewNames as defaultViewOrder} from '../views/views'
 import difference from 'lodash/difference'
+import {tracker} from '../analytics'
 
 export const SAVE_HOMESCREEN_ORDER = 'SAVE_HOMESCREEN_ORDER'
 
@@ -36,10 +37,11 @@ export const loadHomescreenOrder = async () => {
   let order = updateViewOrder(savedOrder, defaultViewOrder)
 
   // return an action to save it to AsyncStorage
-  return saveHomescreenOrder(order)
+  return saveHomescreenOrder(order, {noTrack: true})
 }
 
-export const saveHomescreenOrder = order => {
+export const saveHomescreenOrder = (order, options={}) => {
+  options.noTrack || tracker.trackEventWithCustomDimensionValues('homescreen', 'reorder', {}, {order})
   AsyncStorage.setItem('homescreen:view-order', JSON.stringify(order))
   return {type: SAVE_HOMESCREEN_ORDER, payload: order}
 }
@@ -62,6 +64,7 @@ function homescreen(state=initialHomescreenState, action) {
 export const UPDATE_MENU_FILTERS = 'menus/UPDATE_MENU_FILTERS'
 
 export const updateMenuFilters = (menuName: string, filters: any[]) => {
+  tracker.trackEventWithCustomDimensionValues('menus', 'filter', {label: menuName}, {filters})
   return {type: UPDATE_MENU_FILTERS, payload: {menuName, filters}}
 }
 

--- a/flux/index.js
+++ b/flux/index.js
@@ -41,7 +41,7 @@ export const loadHomescreenOrder = async () => {
 }
 
 export const saveHomescreenOrder = (order, options={}) => {
-  options.noTrack || tracker.trackEventWithCustomDimensionValues('homescreen', 'reorder', {}, {order})
+  options.noTrack || tracker.trackEventWithCustomDimensionValues('homescreen', 'reorder', {}, {order: order.join(', ')})
   AsyncStorage.setItem('homescreen:view-order', JSON.stringify(order))
   return {type: SAVE_HOMESCREEN_ORDER, payload: order}
 }
@@ -64,7 +64,7 @@ function homescreen(state=initialHomescreenState, action) {
 export const UPDATE_MENU_FILTERS = 'menus/UPDATE_MENU_FILTERS'
 
 export const updateMenuFilters = (menuName: string, filters: any[]) => {
-  tracker.trackEventWithCustomDimensionValues('menus', 'filter', {label: menuName}, {filters})
+  tracker.trackEventWithCustomDimensionValues('menus', 'filter', {label: menuName}, {filters: JSON.stringify(filters)})
   return {type: UPDATE_MENU_FILTERS, payload: {menuName, filters}}
 }
 

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0002961D1E270BD1000909F2 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0002961C1E270BD1000909F2 /* CoreData.framework */; };
+		0002961F1E270BD9000909F2 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0002961E1E270BD9000909F2 /* SystemConfiguration.framework */; };
+		000296211E270BE4000909F2 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 000296201E270BE4000909F2 /* libz.tbd */; };
+		000296231E270BF0000909F2 /* libsqlite3.0.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 000296221E270BF0000909F2 /* libsqlite3.0.tbd */; };
 		008845151DF9FCBB00C23F56 /* AllAboutOlafTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 008845131DF9FCBB00C23F56 /* AllAboutOlafTests.m */; };
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -24,6 +28,7 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		1848577634C04472802C4F91 /* libRCTGoogleAnalyticsBridge.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F803FE6585F04E9F8D3C053F /* libRCTGoogleAnalyticsBridge.a */; };
 		1F8239F6A983407CB8C0A1F7 /* libRNCookieManagerIOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 124A9486664047EEAF7CBCDF /* libRNCookieManagerIOS.a */; };
 		23787DFEFF9747949AE97A42 /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E6FBE71A05CC43E2B4885180 /* Ionicons.ttf */; };
 		3A0CEA921DEA203F0036E739 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A0CEA781DEA20340036E739 /* libRCTAnimation.a */; };
@@ -42,10 +47,16 @@
 		F5A92AB96CCC44F5A4944718 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 25889372CF4341B19A8A69C5 /* FontAwesome.ttf */; };
 		FC4E2995ECB7417EACA2EB99 /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7FB5949CC865470084CDBDC5 /* SimpleLineIcons.ttf */; };
 		FEE667253C1C4F4F891D5B1F /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1A27CF9941A9482697F215C6 /* MaterialIcons.ttf */; };
-		1848577634C04472802C4F91 /* libRCTGoogleAnalyticsBridge.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F803FE6585F04E9F8D3C053F /* libRCTGoogleAnalyticsBridge.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		000296041E270B8A000909F2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 150D47C893AB4ACBA45D7AF8 /* RCTGoogleAnalyticsBridge.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A79185C61C30694E001236A6;
+			remoteInfo = RCTGoogleAnalyticsBridge;
+		};
 		0027B0A31D5C82AA00C2B4FD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A91038679F834707B769D282 /* RNKeychain.xcodeproj */;
@@ -245,6 +256,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0002961C1E270BD1000909F2 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		0002961E1E270BD9000909F2 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		000296201E270BE4000909F2 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
+		000296221E270BF0000909F2 /* libsqlite3.0.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.0.tbd; path = usr/lib/libsqlite3.0.tbd; sourceTree = SDKROOT; };
 		008845131DF9FCBB00C23F56 /* AllAboutOlafTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AllAboutOlafTests.m; sourceTree = "<group>"; };
 		008845141DF9FCBB00C23F56 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
@@ -273,6 +288,7 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = AllAboutOlaf/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = AllAboutOlaf/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		150D47C893AB4ACBA45D7AF8 /* RCTGoogleAnalyticsBridge.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTGoogleAnalyticsBridge.xcodeproj; path = "../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.xcodeproj"; sourceTree = "<group>"; };
 		1A27CF9941A9482697F215C6 /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
 		25889372CF4341B19A8A69C5 /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
 		3A0CEA711DEA20340036E739 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
@@ -299,8 +315,7 @@
 		B997F61616AEE0B6BF79DB54 /* libPods-AllAboutOlaf.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AllAboutOlaf.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF2508C73D024BE2B226091B /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
 		E6FBE71A05CC43E2B4885180 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
-		150D47C893AB4ACBA45D7AF8 /* RCTGoogleAnalyticsBridge.xcodeproj */ = {isa = PBXFileReference; name = "RCTGoogleAnalyticsBridge.xcodeproj"; path = "../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		F803FE6585F04E9F8D3C053F /* libRCTGoogleAnalyticsBridge.a */ = {isa = PBXFileReference; name = "libRCTGoogleAnalyticsBridge.a"; path = "libRCTGoogleAnalyticsBridge.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		F803FE6585F04E9F8D3C053F /* libRCTGoogleAnalyticsBridge.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTGoogleAnalyticsBridge.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -324,6 +339,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				000296231E270BF0000909F2 /* libsqlite3.0.tbd in Frameworks */,
+				000296211E270BE4000909F2 /* libz.tbd in Frameworks */,
+				0002961F1E270BD9000909F2 /* SystemConfiguration.framework in Frameworks */,
+				0002961D1E270BD1000909F2 /* CoreData.framework in Frameworks */,
 				3A0CEA921DEA203F0036E739 /* libRCTAnimation.a in Frameworks */,
 				6AA78AAC1D6D711600BEF0AE /* libRCTOneSignal.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
@@ -348,6 +367,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		000295FD1E270B8A000909F2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				000296051E270B8A000909F2 /* libRCTGoogleAnalyticsBridge.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		0027B0931D5C82AA00C2B4FD /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -512,6 +539,10 @@
 		3C5BFA21338636E7EB4E5E0D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				000296221E270BF0000909F2 /* libsqlite3.0.tbd */,
+				000296201E270BE4000909F2 /* libz.tbd */,
+				0002961E1E270BD9000909F2 /* SystemConfiguration.framework */,
+				0002961C1E270BD1000909F2 /* CoreData.framework */,
 				B997F61616AEE0B6BF79DB54 /* libPods-AllAboutOlaf.a */,
 				9E03F9833020DA82BB00EF77 /* libPods-AllAboutOlafTests.a */,
 			);
@@ -743,6 +774,10 @@
 					ProjectRef = 00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */;
 				},
 				{
+					ProductGroup = 000295FD1E270B8A000909F2 /* Products */;
+					ProjectRef = 150D47C893AB4ACBA45D7AF8 /* RCTGoogleAnalyticsBridge.xcodeproj */;
+				},
+				{
 					ProductGroup = 00C302BC1ABCB91800DB3ED1 /* Products */;
 					ProjectRef = 00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */;
 				},
@@ -813,6 +848,13 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		000296051E270B8A000909F2 /* libRCTGoogleAnalyticsBridge.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTGoogleAnalyticsBridge.a;
+			remoteRef = 000296041E270B8A000909F2 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		0027B0A41D5C82AA00C2B4FD /* libRNKeychain.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		F5A92AB96CCC44F5A4944718 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 25889372CF4341B19A8A69C5 /* FontAwesome.ttf */; };
 		FC4E2995ECB7417EACA2EB99 /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7FB5949CC865470084CDBDC5 /* SimpleLineIcons.ttf */; };
 		FEE667253C1C4F4F891D5B1F /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1A27CF9941A9482697F215C6 /* MaterialIcons.ttf */; };
+		1848577634C04472802C4F91 /* libRCTGoogleAnalyticsBridge.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F803FE6585F04E9F8D3C053F /* libRCTGoogleAnalyticsBridge.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -298,6 +299,8 @@
 		B997F61616AEE0B6BF79DB54 /* libPods-AllAboutOlaf.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AllAboutOlaf.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CF2508C73D024BE2B226091B /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
 		E6FBE71A05CC43E2B4885180 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
+		150D47C893AB4ACBA45D7AF8 /* RCTGoogleAnalyticsBridge.xcodeproj */ = {isa = PBXFileReference; name = "RCTGoogleAnalyticsBridge.xcodeproj"; path = "../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		F803FE6585F04E9F8D3C053F /* libRCTGoogleAnalyticsBridge.a */ = {isa = PBXFileReference; name = "libRCTGoogleAnalyticsBridge.a"; path = "libRCTGoogleAnalyticsBridge.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -338,6 +341,7 @@
 				F0739B3A70BA995B58032C19 /* libPods-AllAboutOlaf.a in Frameworks */,
 				1F8239F6A983407CB8C0A1F7 /* libRNCookieManagerIOS.a in Frameworks */,
 				A0102781BF874C25BD76AD1D /* libRNDeviceInfo.a in Frameworks */,
+				1848577634C04472802C4F91 /* libRCTGoogleAnalyticsBridge.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -566,6 +570,7 @@
 				71D5CCADA66D45008D9A38F2 /* RNVectorIcons.xcodeproj */,
 				10892B9A230345CC9EC09E61 /* RNCookieManagerIOS.xcodeproj */,
 				828A2E49D4E3430FB2853AFF /* RNDeviceInfo.xcodeproj */,
+				150D47C893AB4ACBA45D7AF8 /* RCTGoogleAnalyticsBridge.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1280,6 +1285,7 @@
 					"$(SRCROOT)/../node_modules/react-native-onesignal/**",
 					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1312,6 +1318,7 @@
 					"$(SRCROOT)/../node_modules/react-native-onesignal/**",
 					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1374,6 +1381,7 @@
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -1423,6 +1431,7 @@
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-cookies/RNCookieManagerIOS",
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
+					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-native-communications": "2.1.4",
     "react-native-cookies": "2.0.0",
     "react-native-device-info": "0.9.7",
+    "react-native-google-analytics-bridge": "4.0.2",
     "react-native-keychain": "0.3.2",
     "react-native-onesignal": "1.2.3",
     "react-native-parallax-view": "2.0.6",

--- a/views/building-hours/index.js
+++ b/views/building-hours/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import {View, Text, ListView, RefreshControl, StyleSheet, Platform, Navigator} from 'react-native'
 import {BuildingRow} from './row'
-
+import {tracker} from '../../analytics'
 import type {BuildingType} from './types'
 import delay from 'delay'
 import {data as buildingHours} from '../../docs/building-hours'
@@ -59,18 +59,21 @@ export class BuildingHoursView extends React.Component {
     })
   }
 
+  onPressRow = (data: BuildingType) => {
+    tracker.trackEvent('building-hours', data.name)
+    this.props.navigator.push({
+      id: 'BuildingHoursDetailView',
+      index: this.props.route.index + 1,
+      title: data.name,
+      backButtonTitle: 'Hours',
+      props: data,
+      sceneConfig: Platform.OS === 'android' ? Navigator.SceneConfigs.FloatFromBottom : undefined,
+    })
+  }
+
   renderRow = (data: BuildingType) => {
     return (
-      <Touchable
-        onPress={() => this.props.navigator.push({
-          id: 'BuildingHoursDetailView',
-          index: this.props.route.index + 1,
-          title: data.name,
-          backButtonTitle: 'Hours',
-          props: data,
-          sceneConfig: Platform.OS === 'android' ? Navigator.SceneConfigs.FloatFromBottom : undefined,
-        })}
-      >
+      <Touchable onPress={() => this.onPressRow(data)}>
         <BuildingRow
           name={data.name}
           info={data}

--- a/views/calendar/calendar.js
+++ b/views/calendar/calendar.js
@@ -13,7 +13,7 @@ import {
   RefreshControl,
   View,
 } from 'react-native'
-
+import {tracker} from '../../analytics'
 import groupBy from 'lodash/groupBy'
 import moment from 'moment-timezone'
 import delay from 'delay'
@@ -78,6 +78,7 @@ export default class CalendarView extends React.Component {
       error = result.error
       data = result.items
     } catch (error) {
+      tracker.trackException(error.message)
       this.setState({error: error.message})
       console.error(error)
     }
@@ -104,6 +105,7 @@ export default class CalendarView extends React.Component {
       this.setState({noEvents: true})
     }
     if (error) {
+      tracker.trackException(error.message)
       this.setState({error: error.message})
     }
     this.setState({loaded: true})

--- a/views/calendar/tabs.js
+++ b/views/calendar/tabs.js
@@ -3,28 +3,28 @@ import CalendarView from './calendar'
 
 export default [
   {
-    id: 'master',
+    id: 'StOlafCalendarView',
     title: 'St. Olaf',
     rnVectorIcon: {iconName: 'school'},
     component: CalendarView,
     props: {calendarId: 'le6tdd9i38vgb7fcmha0hu66u9gjus2e%40import.calendar.google.com'},
   },
   {
-    id: 'oleville',
+    id: 'OlevilleCalendarView',
     title: 'Oleville',
     rnVectorIcon: {iconName: 'happy'},
     component: CalendarView,
     props: {calendarId: 'stolaf.edu_fvulqo4larnslel75740vglvko@group.calendar.google.com'},
   },
   {
-    id: 'pause',
+    id: 'PauseCalendarView',
     title: 'The Pause',
     rnVectorIcon: {iconName: 'paw'},
     component: CalendarView,
     props: {calendarId: 'stolaf.edu_qkrej5rm8c8582dlnc28nreboc@group.calendar.google.com'},
   },
   {
-    id: 'northfield',
+    id: 'NorthfieldCalendarView',
     title: 'Northfield',
     rnVectorIcon: {iconName: 'pin'},
     component: CalendarView,

--- a/views/components/tabbed-view/index.android.js
+++ b/views/components/tabbed-view/index.android.js
@@ -1,11 +1,11 @@
 // @flow
-
 import React from 'react'
 import { StyleSheet, Platform, Dimensions } from 'react-native'
 import { TabViewAnimated, TabBarTop } from 'react-native-tab-view'
 import * as c from '../colors'
 import type { TabbedViewPropsType } from './types'
 import { TabbedViewPropTypes } from './types'
+import {tracker} from '../../../analytics'
 
 const styles = StyleSheet.create({
   container: {
@@ -35,6 +35,7 @@ export default class TabbedView extends React.Component {
   props: TabbedViewPropsType
 
   _handleChangeTab = index => {
+    tracker.trackScreenView(this.props.tabs[index].title)
     this.setState({
       index,
     })

--- a/views/components/tabbed-view/index.ios.js
+++ b/views/components/tabbed-view/index.ios.js
@@ -46,7 +46,7 @@ export default class TabbedView extends React.Component {
             style={styles.listViewStyle}
             selected={this.state.selectedTab === tab.id}
             translucent={true}
-            onPress={() => this.setState({selectedTab: tab.id})}
+            onPress={() => this.onChangeTab(tab.id)}
           >
             <tab.component
               {...this.props.childProps}

--- a/views/components/tabbed-view/index.ios.js
+++ b/views/components/tabbed-view/index.ios.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import { TabBarIOS } from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
-
+import {tracker} from '../../../analytics'
 import styles from './styles'
 import type { TabbedViewPropsType } from './types'
 import { TabbedViewPropTypes } from './types'
@@ -17,6 +17,11 @@ export default class TabbedView extends React.Component {
   }
 
   props: TabbedViewPropsType;
+
+  onChangeTab = (tabId: string) => {
+    tracker.trackScreenView(tabId)
+    this.setState({selectedTab: tabId})
+  }
 
   render() {
     let {navigator, route, tabs} = this.props

--- a/views/dictionary/list.js
+++ b/views/dictionary/list.js
@@ -8,7 +8,7 @@ import {StyleSheet, View, Text} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import AlphabetListView from 'react-native-alphabetlistview'
 import {Touchable} from '../components/touchable'
-
+import {tracker} from '../../analytics'
 import groupBy from 'lodash/groupBy'
 import head from 'lodash/head'
 import * as c from '../components/colors'
@@ -81,6 +81,7 @@ export class DictionaryView extends React.Component {
   };
 
   onPressRow = data => {
+    tracker.trackEvent('dictionary', data.word)
     this.props.navigator.push({
       id: 'DictionaryDetailView',
       index: this.props.route.index + 1,

--- a/views/faqs/index.js
+++ b/views/faqs/index.js
@@ -3,6 +3,7 @@ import React from 'react'
 import {WebView, StyleSheet} from 'react-native'
 import LoadingView from '../components/loading'
 import {text as faqs} from '../../docs/faqs.json'
+import {tracker} from '../../analytics'
 
 const styles = StyleSheet.create({
   container: {
@@ -31,7 +32,8 @@ export class FaqView extends React.Component {
       let blob: {text: string} = await fetchJson(this.url)
       html = blob.text
     } catch (err) {
-      console.warn(err)
+      tracker.trackException(err.message)
+      console.warn(err.message)
     }
     this.setState({html: html})
   }

--- a/views/map/index.android.js
+++ b/views/map/index.android.js
@@ -18,13 +18,17 @@ import {
 import * as c from '../components/colors'
 import Button from 'react-native-button'
 import {data as mapInfo} from '../../docs/map.json'
+import {tracker} from '../../analytics'
 
 export default function OlafMapView() {
   return (
     <View style={styles.container}>
       <Text>{mapInfo.description}</Text>
       <Button
-        onPress={() => Linking.openURL(mapInfo.url).catch(err => console.error('An error occurred', err))}
+        onPress={() => Linking.openURL(mapInfo.url).catch(err => {
+          tracker.trackException(err.message)
+          console.error('An error occurred', err)
+        })}
         style={styles.button}
       >
           View Map

--- a/views/menus/menu-bonapp.js
+++ b/views/menus/menu-bonapp.js
@@ -17,6 +17,7 @@ import {findMenu} from './lib/find-menu'
 import {trimStationName, trimItemLabel} from './lib/trim-names'
 import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
 import {toLaxTitleCase} from 'titlecase'
+import {tracker} from '../../analytics'
 
 const bonappMenuBaseUrl = 'http://legacy.cafebonappetit.com/api/2/menus'
 const bonappCafeBaseUrl = 'http://legacy.cafebonappetit.com/api/2/cafes'
@@ -67,6 +68,7 @@ export class BonAppHostedMenu extends React.Component {
       cafeMenu = (requests[0]: BonAppMenuInfoType)
       cafeInfo = (requests[1]: BonAppCafeInfoType)
     } catch (err) {
+      tracker.trackException(err.message)
       this.setState({error: err})
     }
 
@@ -99,6 +101,7 @@ export class BonAppHostedMenu extends React.Component {
     }
 
     if (!this.state.cafeMenu || !this.state.cafeInfo) {
+      tracker.trackException(`Something went wrong loading BonApp cafe ${this.props.cafeId}`)
       return <NoticeView text='Something went wrong. Email odt@stolaf.edu to let them know?' />
     }
 

--- a/views/menus/menu-github.js
+++ b/views/menus/menu-github.js
@@ -11,6 +11,7 @@ import sample from 'lodash/sample'
 import type {MenuItemType, MasterCorIconMapType, StationMenuType} from './types'
 import {upgradeMenuItem, upgradeStation} from './lib/process-menu-shorthands'
 const {data: fallbackMenu} = require('../../docs/pause-menu.json')
+import {tracker} from '../../analytics'
 
 const githubMenuBaseUrl = 'https://stodevx.github.io/AAO-React-Native'
 
@@ -54,6 +55,7 @@ export class GitHubHostedMenu extends React.Component {
       stationMenus = data.stationMenus || []
       corIcons = data.corIcons || {}
     } catch (err) {
+      tracker.trackException(err.message)
       console.warn(err)
       foodItems = fallbackMenu.foodItems || []
       stationMenus = fallbackMenu.stationMenus || []

--- a/views/menus/tabs.js
+++ b/views/menus/tabs.js
@@ -5,7 +5,7 @@ import {GitHubHostedMenu} from './menu-github'
 
 const stolaf = [
   {
-    id: 'stav',
+    id: 'StavHallMenuView',
     title: 'Stav Hall',
     rnVectorIcon: {iconName: 'nutrition'},
     component: BonAppHostedMenu,
@@ -20,7 +20,7 @@ const stolaf = [
     },
   },
   {
-    id: 'cage',
+    id: 'TheCageMenuView',
     title: 'The Cage',
     rnVectorIcon: {iconName: 'cafe'},
     component: BonAppHostedMenu,
@@ -34,7 +34,7 @@ const stolaf = [
     },
   },
   {
-    id: 'pause',
+    id: 'ThePauseMenuView',
     title: 'The Pause',
     rnVectorIcon: {iconName: 'paw'},
     component: GitHubHostedMenu,

--- a/views/menus/tabs.js
+++ b/views/menus/tabs.js
@@ -47,7 +47,7 @@ const stolaf = [
     },
   },
   // {
-  //   id: 'any',
+  //   id: 'BonAppDevToolView',
   //   title: 'BonApp',
   //   rnVectorIcon: {iconName: 'ionic'},
   //   component: BonAppPickerView,
@@ -56,7 +56,7 @@ const stolaf = [
 
 const carleton = [
   {
-    id: 'burton',
+    id: 'CarletonBurtonMenuView',
     title: 'Burton',
     rnVectorIcon: {iconName: 'trophy'},
     component: BonAppHostedMenu,
@@ -68,7 +68,7 @@ const carleton = [
     },
   },
   {
-    id: 'ldc',
+    id: 'CarletonLDCMenuView',
     title: 'LDC',
     rnVectorIcon: {iconName: 'water'},
     component: BonAppHostedMenu,
@@ -80,7 +80,7 @@ const carleton = [
     },
   },
   {
-    id: 'weitz',
+    id: 'CarletonWeitzMenuView',
     title: 'Weitz Center',
     rnVectorIcon: {iconName: 'wine'},
     component: BonAppHostedMenu,
@@ -93,7 +93,7 @@ const carleton = [
     },
   },
   {
-    id: 'sayles',
+    id: 'CarletonSaylesMenuView',
     title: 'Sayles Hill',
     rnVectorIcon: {iconName: 'snow'},
     component: BonAppHostedMenu,

--- a/views/news/news-container.js
+++ b/views/news/news-container.js
@@ -18,6 +18,7 @@ import LoadingView from '../components/loading'
 import {NoticeView} from '../components/notice'
 import type {TopLevelViewPropsType} from '../types'
 import * as c from '../components/colors'
+import {tracker} from '../../analytics'
 
 let Entities = require('html-entities').AllHtmlEntities
 const entities = new Entities()
@@ -52,6 +53,7 @@ export default class NewsContainer extends React.Component {
         dataSource: this.state.dataSource.cloneWithRows(entries),
       })
     } catch (error) {
+      tracker.trackException(error.message)
       console.warn(error)
       this.setState({error})
     }

--- a/views/news/tabs.js
+++ b/views/news/tabs.js
@@ -3,7 +3,7 @@ import NewsContainer from './news-container'
 
 export default [
   {
-    id: 'stolaf',
+    id: 'StOlafNewsView',
     title: 'St. Olaf',
     rnVectorIcon: {iconName: 'school'},
     component: NewsContainer,
@@ -14,7 +14,7 @@ export default [
     },
   },
   {
-    id: 'politicole',
+    id: 'PoliticOleNewsView',
     title: 'PoliticOle',
     rnVectorIcon: {iconName: 'megaphone'},
     component: NewsContainer,
@@ -25,7 +25,7 @@ export default [
     },
   },
   {
-    id: 'mess',
+    id: 'MessNewsView',
     title: 'Mess',
     rnVectorIcon: {iconName: 'paper'},
     component: NewsContainer,

--- a/views/oleville/index.js
+++ b/views/oleville/index.js
@@ -15,7 +15,7 @@ import {
   Navigator,
   RefreshControl,
 } from 'react-native'
-
+import {tracker} from '../../analytics'
 import delay from 'delay'
 import LoadingView from '../components/loading'
 import * as c from '../components/colors'
@@ -82,6 +82,7 @@ export default class OlevilleView extends React.Component {
         return url || defaultOlevilleImageUrl
       }
     } catch (err) {
+      tracker.trackException(err.message)
       console.warn(err)
     }
     return defaultOlevilleImageUrl
@@ -102,6 +103,7 @@ export default class OlevilleView extends React.Component {
       // then we have the _featuredImageUrl key to just get the url
       this.setState({dataSource: this.state.dataSource.cloneWithRows(articles)})
     } catch (error) {
+      tracker.trackException(error.message)
       this.setState({error: true})
       console.error(error)
     }

--- a/views/sis/balances.js
+++ b/views/sis/balances.js
@@ -14,7 +14,7 @@ import {
 } from 'react-native'
 
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
-
+import {tracker} from '../../analytics'
 import {isLoggedIn} from '../../lib/login'
 import delay from 'delay'
 import isNil from 'lodash/isNil'
@@ -111,6 +111,7 @@ export default class BalancesView extends React.Component {
         this.setState({weeklyMeals, dailyMeals})
       }
     } catch (error) {
+      tracker.trackException(error.message)
       this.setState({error})
       console.warn(error)
     }

--- a/views/sis/courses.js
+++ b/views/sis/courses.js
@@ -14,7 +14,7 @@ import {
   RefreshControl,
 } from 'react-native'
 import * as c from '../components/colors'
-
+import {tracker} from '../../analytics'
 import {isLoggedIn} from '../../lib/login'
 import delay from 'delay'
 import zip from 'lodash/zip'
@@ -107,6 +107,7 @@ export default class CoursesView extends React.Component {
       }
       this.setState({dataSource: this.state.dataSource.cloneWithRowsAndSections(courses)})
     } catch (error) {
+      tracker.trackException(error.message)
       this.setState({error})
       console.warn(error)
     }

--- a/views/sis/tabs.js
+++ b/views/sis/tabs.js
@@ -5,19 +5,19 @@ import CoursesView from './courses'
 
 export default [
   {
-    id: 'balances',
+    id: 'BalancesView',
     title: 'Balances',
     rnVectorIcon: {iconName: 'card'},
     component: BalancesView,
   },
   {
-    id: 'courses',
+    id: 'CoursesView',
     title: 'Courses',
     rnVectorIcon: {iconName: 'archive'},
     component: CoursesView,
   },
   // {
-  //   id: 'search',
+  //   id: 'CourseSearchView',
   //   title: 'Search',
   //   icon: {uri: base64Icon, scale: 3},
   //   component: () => <SearchView />,

--- a/views/streaming/radio.js
+++ b/views/streaming/radio.js
@@ -16,6 +16,7 @@ import {
 } from 'react-native'
 import Button from 'react-native-button'
 import * as c from '../components/colors'
+import {tracker} from '../../analytics'
 
 let kstoApp = 'KSTORadio://'
 let kstoDownload = 'itms://itunes.apple.com/us/app/ksto/id953916647'
@@ -31,15 +32,24 @@ export default function KSTOView() {
       <Button
         onPress={() => {
           if (Platform.OS === 'android') {
-            Linking.openURL(kstoWeb).catch(err => console.error('An error occurred opening the Android KSTO url', err))
+            Linking.openURL(kstoWeb).catch(err => {
+              tracker.trackException('opening Android KSTO url: ' + err.message)
+              console.error('An error occurred opening the Android KSTO url', err)
+            })
           } else {
             Linking.canOpenURL(kstoApp).then(supported => {
               if (!supported) {
-                Linking.openURL(kstoDownload).catch(err => console.error('An error occurred opening the KSTO download url', err))
+                Linking.openURL(kstoDownload).catch(err => {
+                  tracker.trackException('opening KSTO download url: ' + err.message)
+                  console.error('An error occurred opening the KSTO download url', err)
+                })
               } else {
                 return Linking.openURL(kstoApp)
               }
-            }).catch(err => console.error('An error occurred opening the iOS KSTO url', err))
+            }).catch(err => {
+              tracker.trackException('opening iOS KSTO url: ' + err.message)
+              console.error('An error occurred opening the iOS KSTO url', err)
+            })
           }
         }}
         style={styles.button}

--- a/views/streaming/tabs.js
+++ b/views/streaming/tabs.js
@@ -6,19 +6,19 @@ import WebcamsView from './webcams'
 
 export default [
   {
-    id: 'radio',
+    id: 'KSTORadioView',
     title: 'KSTO',
     rnVectorIcon: {iconName: 'radio'},
     component: KSTOView,
   },
   // {
-  //   id: 'movie',
+  //   id: 'WeeklyMovieView',
   //   title: 'Weekly Movie',
   //   rnVectorIcon: {iconName: 'film'},
   //   component: WeeklyMovieView,
   // },
   {
-    id: 'webcams',
+    id: 'LiveWebcamsView',
     title: 'Webcams',
     rnVectorIcon: {iconName: 'videocam'},
     component: WebcamsView,

--- a/views/student-orgs/detail.js
+++ b/views/student-orgs/detail.js
@@ -7,6 +7,7 @@ import * as c from '../components/colors'
 import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
 import type {StudentOrgInfoType, StudentOrgAbridgedType} from './types'
 import type {TopLevelViewPropsType} from '../types'
+import {tracker} from '../../analytics'
 
 const orgsUrl = 'https://api.checkimhere.com/stolaf/v1/organizations'
 
@@ -62,6 +63,7 @@ export class StudentOrgsDetailView extends React.Component {
       let response = await fetchJson(orgUrl)
       this.setState({data: response})
     } catch (error) {
+      tracker.trackException(error.message)
       this.setState({error: true})
       console.error(error)
     }

--- a/views/student-orgs/list.js
+++ b/views/student-orgs/list.js
@@ -165,6 +165,7 @@ export class StudentOrgsView extends React.Component {
   }
 
   onPressRow = (data: StudentOrgAbridgedType) => {
+    tracker.trackEvent('student-org', data.name)
     this.props.navigator.push({
       id: 'StudentOrgsDetailView',
       index: this.props.route.index + 1,

--- a/views/student-orgs/list.js
+++ b/views/student-orgs/list.js
@@ -11,6 +11,7 @@ import AlphabetListView from 'react-native-alphabetlistview'
 import LoadingView from '../components/loading'
 import delay from 'delay'
 import {Touchable} from '../components/touchable'
+import {tracker} from '../../analytics'
 import size from 'lodash/size'
 import map from 'lodash/map'
 import sortBy from 'lodash/sortBy'
@@ -120,6 +121,7 @@ export class StudentOrgsView extends React.Component {
       let grouped = groupBy(sorted, '$groupableName')
       this.setState({orgs: grouped})
     } catch (error) {
+      tracker.trackException(error.message)
       this.setState({error: true})
       console.error(error)
     }

--- a/views/transportation/otherModes.js
+++ b/views/transportation/otherModes.js
@@ -11,6 +11,7 @@ import type {OtherModeType} from './types'
 import {data as modes} from '../../docs/transportation.json'
 import * as c from '../components/colors'
 import Button from 'react-native-button' // the button
+import {tracker} from '../../analytics'
 
 let styles = StyleSheet.create({
   container: {
@@ -67,7 +68,10 @@ export default class OtherModesView extends React.Component {
         <Text style={styles.title}>{data.name}</Text>
         <Text style={styles.content}>{data.description}</Text>
         <Button
-          onPress={() => Linking.openURL(data.url).catch(err => console.error('An error occurred', err))}
+          onPress={() => Linking.openURL(data.url).catch(err => {
+            tracker.trackException(err.message)
+            console.error('An error occurred', err)
+          })}
           style={styles.button}>
           More info
         </Button>

--- a/views/transportation/tabs.js
+++ b/views/transportation/tabs.js
@@ -5,28 +5,28 @@ import BusView from './bus'
 
 export default [
   {
-    id: 'express',
+    id: 'ExpressLineBusView',
     title: 'Express Bus',
     rnVectorIcon: {iconName: 'bus'},
     component: BusView,
     props: {line: 'Express Bus'},
   },
   {
-    id: 'red',
+    id: 'RedLineBusView',
     title: 'Red Line',
     rnVectorIcon: {iconName: 'bus'},
     component: BusView,
     props: {line: 'Red Line'},
   },
   {
-    id: 'blue',
+    id: 'BlueLineBusView',
     title: 'Blue Line',
     rnVectorIcon: {iconName: 'bus'},
     component: BusView,
     props: {line: 'Blue Line'},
   },
   {
-    id: 'otherModes',
+    id: 'TransportationOtherModesListView',
     title: 'Other Modes',
     rnVectorIcon: {iconName: 'boat'},
     component: OtherModesView,


### PR DESCRIPTION
> Closes #528. Closes #556.

This is an initial PR as a proof-of-concept for adding analytics to the app, as dreamed up in #528.

It has initial support for letting the user opt out of tracking; we'd just need a toggle in settings somewhere.

This tracks:
- [x] app launches
- [x] new screens pushed onto the stack
- [x] reordered homescreens
- [x] menu filters applied

Any other ideas?

I think it also tracks unhandled exceptions, and I know it reports app versions.

---

I added @drewvolz, @mattk410, and @elijahverdoorn to the Google Analytics account. If you'd like to be able to see the data (but not edit it) just leave a comment or let me know elsewhere.