### PR TITLE
Port Dictionary to ListRow&co

### DIFF
--- a/views/dictionary/list.js
+++ b/views/dictionary/list.js
@@ -1,76 +1,28 @@
+// @flow
 /**
  * All About Olaf
  * Dictionary page
  */
-
 import React from 'react'
-import {StyleSheet, View, Text} from 'react-native'
-import Icon from 'react-native-vector-icons/Ionicons'
-import AlphabetListView from 'react-native-alphabetlistview'
-import {Touchable} from '../components/touchable'
+import {StyleSheet, Platform} from 'react-native'
+import {StyledAlphabetListView} from '../components/alphabet-listview'
+import {Column} from '../components/layout'
+import {Detail, Title, ListRow, ListSectionHeader, ListSeparator} from '../components/list'
+import type {WordType} from './types'
 import {tracker} from '../../analytics'
 import groupBy from 'lodash/groupBy'
 import head from 'lodash/head'
-import * as c from '../components/colors'
-
 import {data as terms} from '../../docs/dictionary.json'
 
-let styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#ffffff',
-  },
-  listView: {
-    paddingRight: 16,
-  },
-  textRows: {
-    marginLeft: 20,
-    paddingRight: 10,
-    paddingTop: 8,
-    paddingBottom: 8,
-    height: 70,
-    flexDirection: 'column',
-    flex: 1,
-  },
-  notLastRow: {
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderColor: '#c8c7cc',
-  },
-  itemTitle: {
-    color: c.black,
-    fontWeight: '500',
-    paddingBottom: 1,
-    fontSize: 16,
-    textAlign: 'left',
-  },
-  itemPreview: {
-    color: c.iosDisabledText,
-    fontSize: 13,
-    textAlign: 'left',
+const rowHeight = Platform.OS === 'ios' ? 76 : 89
+const headerHeight = Platform.OS === 'ios' ? 33 : 41
+
+const styles = StyleSheet.create({
+  row: {
+    height: rowHeight,
   },
   rowSectionHeader: {
-    backgroundColor: c.iosListSectionHeader,
-    paddingTop: 5,
-    paddingBottom: 5,
-    paddingLeft: 20,
-    height: 27,
-    borderBottomWidth: 1,
-    borderColor: '#ebebeb',
-  },
-  rowSectionHeaderText: {
-    color: 'black',
-    fontWeight: 'bold',
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-  },
-  arrowIcon: {
-    color: c.iosDisabledText,
-    fontSize: 20,
-    marginRight: 6,
-    marginLeft: 4,
-    marginTop: 8,
+    height: headerHeight,
   },
 })
 
@@ -80,7 +32,7 @@ export class DictionaryView extends React.Component {
     route: React.PropTypes.object.isRequired,
   };
 
-  onPressRow = data => {
+  onPressRow = (data: WordType) => {
     tracker.trackEvent('dictionary', data.word)
     this.props.navigator.push({
       id: 'DictionaryDetailView',
@@ -91,40 +43,46 @@ export class DictionaryView extends React.Component {
     })
   }
 
-  renderRow = ({isLast, item}) => {
+  renderRow = ({item}: {item: WordType}) => {
     return (
-      <Touchable onPress={() => this.onPressRow(item)} style={[styles.row, !isLast && styles.notLastRow]}>
-        <View style={[styles.textRows]}>
-          <Text style={styles.itemTitle} numberOfLines={1}>{item.word}</Text>
-          <Text style={styles.itemPreview} numberOfLines={2}>{item.definition}</Text>
-        </View>
-        <Icon style={[styles.arrowIcon]} name='ios-arrow-forward' />
-      </Touchable>
+      <ListRow
+        onPress={() => this.onPressRow(item)}
+        contentContainerStyle={styles.row}
+        arrowPosition='none'
+      >
+        <Column>
+          <Title lines={1}>{item.word}</Title>
+          <Detail lines={2} style={{fontSize: 14}}>{item.definition}</Detail>
+        </Column>
+      </ListRow>
     )
   }
 
-  renderHeader = ({title}) => {
+  renderHeader = ({title}: {title: string}) => {
     return (
-      <View style={styles.rowSectionHeader}>
-        <Text style={styles.rowSectionHeaderText}>{title}</Text>
-      </View>
+      <ListSectionHeader
+        title={title}
+        style={styles.rowSectionHeader}
+      />
     )
+  }
+
+  renderSeparator = (sectionId: string, rowId: string) => {
+    return <ListSeparator key={`${sectionId}-${rowId}`} />
   }
 
   render() {
-    // console.error(groupBy(terms, item => head(item.word)))
     return (
-      <View style={styles.container}>
-      <AlphabetListView
-        contentContainerStyle={styles.listView}
+      <StyledAlphabetListView
         data={groupBy(terms, item => head(item.word))}
         cell={this.renderRow}
+        // just setting cellHeight sends the wrong values on iOS.
+        cellHeight={rowHeight + (Platform.OS === 'ios' ? (11/12 * StyleSheet.hairlineWidth) : 0)}
         sectionHeader={this.renderHeader}
-        sectionHeaderHeight={28}
-        cellHeight={70}
+        sectionHeaderHeight={headerHeight}
         showsVerticalScrollIndicator={false}
+        renderSeparator={this.renderSeparator}
       />
-      </View>
     )
   }
 }

--- a/views/dictionary/types.js
+++ b/views/dictionary/types.js
@@ -1,0 +1,6 @@
+// @flow
+
+export type WordType = {
+  word: string,
+  definition: string,
+};


### PR DESCRIPTION
> This is a PR in a series of conversion PRs, split out of #499

The biggest "huh?" in this PR is likely the same as in #565, with the same reasoning.

This view should probably have lines between the rows on Android, as the rows are three lines long.

This PR also turns on Flow for the Dictionary view.

| Platform | Before | After |
| ---:| --- | --- |
| iOS | ![ios dictionary a](https://cloud.githubusercontent.com/assets/464441/21948394/9fd83562-d9b0-11e6-815b-dd46b25c7b9a.jpg) | ![ios dictionary b](https://cloud.githubusercontent.com/assets/464441/21948396/9fdabc88-d9b0-11e6-8192-27270d6f6e18.jpg)
| Android | ![android dictionary a](https://cloud.githubusercontent.com/assets/464441/21948393/9fd65ef4-d9b0-11e6-956d-f1c4810c1833.jpg) | ![android dictionary b](https://cloud.githubusercontent.com/assets/464441/21948404/ae962da2-d9b0-11e6-9159-526f6537726b.jpg)
