### PR TITLE
Port MenuView to ListRow&co

### DIFF
--- a/views/menus/components/filter-menu-toolbar.js
+++ b/views/menus/components/filter-menu-toolbar.js
@@ -31,9 +31,10 @@ export function FilterMenuToolbar({date, title, filters, onPress}: PropsType) {
   return (
     <Toolbar onPress={onPress}>
       <View style={[styles.toolbarSection, styles.today]}>
-        <Text>{date.format('MMM. Do')}</Text>
-        {title ? <Text style={{paddingHorizontal: 4}}>—</Text> : null}
-        {title ? <Text>{title}</Text> : null}
+        <Text>
+          <Text>{date.format('MMM. Do')}</Text>
+          {title ? <Text> — {title}</Text> : null}
+        </Text>
       </View>
 
       <ToolbarButton

--- a/views/menus/components/food-item-row.js
+++ b/views/menus/components/food-item-row.js
@@ -1,89 +1,67 @@
 // @flow
 import React from 'react'
-import {View, Text, StyleSheet, Platform} from 'react-native'
+import {View, StyleSheet, Platform} from 'react-native'
 import {DietaryTags} from './dietary-tags'
+import {Row, Column} from '../../components/layout'
+import {ListRow, Detail, Title} from '../../components/list'
 import type {MenuItemType, MasterCorIconMapType} from '../types'
 import * as c from '../../components/colors'
+import Icon from 'react-native-vector-icons/Ionicons'
 
-type FoodItemPropsType = {
+const specialsIcon = Platform.OS === 'ios' ? 'ios-star-outline' : 'md-star-outline'
+
+type FoodItemPropsType = {|
   filters: MasterCorIconMapType,
   data: MenuItemType,
-  style: any,
+  style?: any,
   badgeSpecials?: boolean,
-};
+  spacing: {left: number},
+|};
 
-export function FoodItemRow({data, filters, style, badgeSpecials=true}: FoodItemPropsType) {
+export function FoodItemRow({data, filters, badgeSpecials=true, ...props}: FoodItemPropsType) {
+  const {left=0} = props.spacing
   return (
-    <View style={[styles.container, style]}>
-      <View style={styles.main}>
-        <View style={styles.title}>
-          <View style={styles.badgeView}>
-            <Text style={styles.badgeTextBlob}>{badgeSpecials && data.special ? '✩' : ''}</Text>
-          </View>
-          <Text style={styles.titleText}>
-            {data.label}
-          </Text>
+    <ListRow
+      style={[styles.container, props.style]}
+      fullWidth={true}
+      arrowPosition='none'
+    >
+      <Row>
+        <View style={[styles.badge, {width: left, alignSelf: 'center'}]}>
+          {badgeSpecials && data.special ? <Icon style={styles.badgeIcon} name={specialsIcon} /> : null}
         </View>
-        {data.description
-          ? <View style={styles.description}>
-            <Text style={styles.descriptionText}>
-              {data.description}
-            </Text>
-          </View>
-          : null}
-      </View>
-      <DietaryTags
-        filters={filters}
-        dietary={data.cor_icon}
-        style={styles.iconContainer}
-      />
-    </View>
+
+        <Column flex={1}>
+          <Title bold={false}>{data.label}</Title>
+          {data.description ? <Detail>{data.description}</Detail> : null}
+        </Column>
+
+        <DietaryTags
+          filters={filters}
+          dietary={data.cor_icon}
+          style={styles.iconContainer}
+        />
+      </Row>
+    </ListRow>
   )
 }
 
-const leftSideSpacing = 28
-const rightSideSpacing = 10
-const titleFontSize = 16
-const titleLineHeight = 18
 const styles = StyleSheet.create({
   container: {
-    paddingVertical: 6,
+    minHeight: 36,
     flexDirection: 'row',
     alignItems: 'center',
   },
-  main: {
-    flex: 1,
-  },
-  title: {
-    alignItems: 'center',
-    flexDirection: 'row',
-  },
-  titleText: {
-    color: c.black,
-    fontSize: titleFontSize,
-    lineHeight: titleLineHeight,
-  },
-  description: {
-    paddingTop: 3,
-    marginLeft: 0.5,  // Needed to line up the title and description because of the icon
-  },
-  descriptionText: {
-    color: c.iosDisabledText,
-    fontSize: Platform.OS === 'ios' ? 13 : 14,
-  },
-  badgeView: {
-    width: leftSideSpacing,
-    marginLeft: -leftSideSpacing,
+  badge: {
     alignItems: 'center',
     justifyContent: 'center',
   },
-  badgeTextBlob: {
-    fontSize: titleLineHeight,
-    lineHeight: titleLineHeight,
-    marginBottom: -3,
+  badgeIcon: {
+    fontSize: 16,
     color: c.iosDisabledText,
   },
   iconContainer: {
-    marginLeft: rightSideSpacing,
+    marginLeft: 10,
+    marginRight: 4,
   },
 })

--- a/views/menus/components/menu.js
+++ b/views/menus/components/menu.js
@@ -1,44 +1,17 @@
 // @flow
 import React from 'react'
-import {StyleSheet, View, ListView, Text} from 'react-native'
+import {StyleSheet, ListView} from 'react-native'
 import {NoticeView} from '../../components/notice'
 import {FoodItemRow} from './food-item-row'
 import DietaryFilters from '../../../images/dietary-filters'
-import * as c from '../../components/colors'
-import {Separator} from '../../components/separator'
+import {ListSeparator, ListSectionHeader} from '../../components/list'
 import type {MenuItemType, ProcessedMenuPropsType} from '../types'
 
-const rightSideSpacing = 10
 const leftSideSpacing = 28
 const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: 'white',
-  },
-  row: {
-    minHeight: 52,
-    paddingRight: rightSideSpacing,
-    paddingLeft: leftSideSpacing,
-  },
-  separator: {
-    marginLeft: leftSideSpacing,
-  },
-  sectionHeader: {
-    backgroundColor: c.iosListSectionHeader,
-    paddingVertical: 5,
-    paddingLeft: leftSideSpacing,
-    paddingRight: rightSideSpacing,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderColor: '#ebebeb',
-  },
-  sectionHeaderText: {
-    color: 'black',
-    fontWeight: 'bold',
-  },
-  sectionHeaderNote: {
-    fontSize: 13,
-    color: c.iosDisabledText,
   },
 })
 
@@ -75,23 +48,31 @@ export class MenuListView extends React.Component {
     let note = this.props.stationNotes[sectionName]
 
     return (
-      <View style={styles.sectionHeader}>
-        <Text>
-          <Text style={styles.sectionHeaderText}>{sectionName}</Text>
-          {note ? <Text style={styles.sectionHeaderNote}> — {note}</Text> : null}
-        </Text>
-      </View>
+      <ListSectionHeader
+        title={sectionName}
+        subtitle={note}
+        spacing={{left: leftSideSpacing}}
+      />
     )
   }
 
-  renderFoodItem = (rowData: MenuItemType, sectionId: string, rowId: string) => {
+  renderRow = (rowData: MenuItemType) => {
     return (
       <FoodItemRow
-        key={`${sectionId}-${rowId}`}
         data={rowData}
         filters={DietaryFilters}
-        style={styles.row}
         badgeSpecials={this.props.badgeSpecials}
+        spacing={{left: leftSideSpacing}}
+      />
+    )
+  }
+
+  renderSeparator = (sectionId: string, rowId: string) => {
+    return (
+      <ListSeparator
+        spacing={{left: leftSideSpacing}}
+        key={`${sectionId}-${rowId}`}
+        style={styles.separator}
       />
     )
   }
@@ -111,16 +92,16 @@ export class MenuListView extends React.Component {
         initialListSize={12}
         pageSize={4}
         removeClippedSubviews={false}
-        // we have to disable this here and do it manually, because there
-        // appears to be a bug where the ListView fails to auto-calculate when
-        // the data is loaded after the listview mounts
+        // we have to disable the automatic content-inset calc here and do it
+        // manually, because there appears to be a bug where the ListView
+        // fails to auto-calculate when the data is loaded after the listview
+        // mounts
         automaticallyAdjustContentInsets={false}
         contentInset={{bottom: 49}}
         dataSource={this.state.dataSource}
         enableEmptySections={true}
-        renderRow={this.renderFoodItem}
-        renderSeparator={(sectionId, rowId) =>
-          <Separator key={`${sectionId}-${rowId}`} style={styles.separator} />}
+        renderRow={this.renderRow}
+        renderSeparator={this.renderSeparator}
         renderSectionHeader={this.renderSectionHeader}
       />
     )


### PR DESCRIPTION
> This is a PR in a series of conversion PRs, split out of #499

I switched from using ✩, a unicode char, to using a star icon in Ionicons. Makes the line height more consistent.

I changed the toolbar from using padding to separate the title and subtitle to just using a space.

That's the substantive changes, I think. Beyond that, I switched to using Row, Column, ListRow, and such.

## Stav
| Platform | Before | After |
| ---:| --- | --- |
| iOS | ![ios menu stav a](https://cloud.githubusercontent.com/assets/464441/21948594/cac4fdc2-d9b1-11e6-9b17-7649101873d3.jpg) | ![ios menu stav b](https://cloud.githubusercontent.com/assets/464441/21948595/cac73dda-d9b1-11e6-9c79-5fbe682f74ad.jpg)
| Android | ![android menu stav a](https://cloud.githubusercontent.com/assets/464441/21948601/d0a5ac8c-d9b1-11e6-90a6-9e9dba872dd6.jpg) | ![android menu stav b](https://cloud.githubusercontent.com/assets/464441/21948600/d0a45ecc-d9b1-11e6-8d20-6ba9d33cb9f1.jpg)

## Cage
| Platform | Before | After |
| ---:| --- | --- |
| iOS | ![ios menu cage a](https://cloud.githubusercontent.com/assets/464441/21948593/cac2f2a2-d9b1-11e6-81ad-7480a5185416.jpg) | ![ios menu cage b](https://cloud.githubusercontent.com/assets/464441/21948592/cac28cae-d9b1-11e6-9217-97bd342e3c1a.jpg)
| Android | ![android menu cage a](https://cloud.githubusercontent.com/assets/464441/21948598/d0a0940e-d9b1-11e6-9450-6ea651e18aaf.jpg) | ![android menu cage b](https://cloud.githubusercontent.com/assets/464441/21948597/d09e5ae0-d9b1-11e6-9733-91b127dd44fc.jpg)

## Pause
| Platform | Before | After |
| ---:| --- | --- |
| iOS | ![ios menu pause a](https://cloud.githubusercontent.com/assets/464441/21948590/cac0c144-d9b1-11e6-98ea-ff7184123003.jpg) | ![ios menu pause b](https://cloud.githubusercontent.com/assets/464441/21948591/cac2589c-d9b1-11e6-908e-5f34a76e7bd8.jpg)
| Android | ![android menu pause a](https://cloud.githubusercontent.com/assets/464441/21948599/d0a0cfdc-d9b1-11e6-9de3-1b20bb3f508d.jpg) | ![android menu pause b](https://cloud.githubusercontent.com/assets/464441/21948602/d0a6b438-d9b1-11e6-9c3d-8705a231ebc3.jpg)
