### PR TITLE
Port Building Hours to ListRow&co

### DIFF
--- a/views/building-hours/detail.android.js
+++ b/views/building-hours/detail.android.js
@@ -1,19 +1,12 @@
 // @flow
-
 import React from 'react'
 import {View, Text, StyleSheet} from 'react-native'
-
 import {buildingImages} from '../../images/building-images'
-import type {BuildingType, DayOfWeekEnumType} from './types'
+import type {SingleBuildingScheduleType, BuildingType, DayOfWeekEnumType} from './types'
 import type momentT from 'moment'
-import {Separator} from '../components/separator'
+import {Card} from '../components/card'
 import ParallaxView from 'react-native-parallax-view'
-
 import moment from 'moment-timezone'
-const CENTRAL_TZ = 'America/Winnipeg'
-
-const transparentPixel = require('../../images/transparent.png')
-
 import * as c from '../components/colors'
 import {
   normalizeBuildingSchedule,
@@ -22,6 +15,10 @@ import {
   getShortBuildingStatus,
   isBuildingOpenAtMoment,
 } from './building-hours-helpers'
+
+const transparentPixel = require('../../images/transparent.png')
+
+const CENTRAL_TZ = 'America/Winnipeg'
 
 const styles = StyleSheet.create({
   title: {
@@ -58,29 +55,12 @@ const styles = StyleSheet.create({
     backgroundColor: c.androidLightBackground,
   },
 
-  card: {
-    paddingTop: 10,
-    paddingBottom: 10,
-    marginHorizontal: 10,
-    paddingHorizontal: 10,
-    backgroundColor: 'white',
-    borderRadius: 2,
-    elevation: 2,
-  },
   scheduleContainer: {
     marginBottom: 20,
-    paddingTop: 0,
-    paddingBottom: 6,
   },
-  scheduleTitleWrapper: {
-    paddingTop: 8,
-    paddingBottom: 6,
-  },
-  scheduleTitle: {
-    color: 'rgb(113, 113, 118)',
+
+  bold: {
     fontWeight: 'bold',
-  },
-  scheduleHoursWrapper: {
   },
   scheduleRow: {
     flexDirection: 'row',
@@ -90,9 +70,6 @@ const styles = StyleSheet.create({
     flex: 1,
     textAlign: 'right',
     paddingRight: 16,
-  },
-  bold: {
-    fontWeight: 'bold',
   },
   scheduleHours: {
     flex: 2,
@@ -143,8 +120,8 @@ export class BuildingHoursDetailView extends React.Component {
     const title = <Text style={styles.name}>{this.props.name}{abbr}</Text>
     const subtitle = this.props.subtitle
       ? <View style={styles.subtitle}>
-          <Text style={[styles.name, styles.subtitleText]}>{this.props.subtitle}</Text>
-        </View>
+        <Text style={[styles.name, styles.subtitleText]}>{this.props.subtitle}</Text>
+      </View>
       : null
 
     return (
@@ -162,39 +139,35 @@ export class BuildingHoursDetailView extends React.Component {
           </View>
 
           {schedules.map(set =>
-            <View key={set.title} style={[styles.card, styles.scheduleContainer]}>
-              <View style={styles.scheduleTitleWrapper}>
-                <Text style={styles.scheduleTitle}>{set.title}</Text>
-              </View>
-
+            <Card key={set.title} style={styles.scheduleContainer} header={set.title} footer={set.notes}>
               <View style={styles.scheduleHoursWrapper}>
-                {set.hours.map((schedule, i) => {
-                  let isActiveSchedule = set.isPhysicallyOpen !== false && schedule.days.includes(dayOfWeek) && isBuildingOpenAtMoment(schedule, this.state.now)
-
-                  return (
-                    <View key={i} style={styles.scheduleRow}>
-                      <Text style={[styles.scheduleDays, isActiveSchedule ? styles.bold : null]} numberOfLines={1}>
-                        {summarizeDays(schedule.days)}
-                      </Text>
-
-                      <Text style={[styles.scheduleHours, isActiveSchedule ? styles.bold : null]} numberOfLines={1}>
-                        {formatBuildingTimes(schedule, this.state.now)}
-                      </Text>
-                    </View>
-                  )
-                })}
+                {set.hours.map((schedule, i) =>
+                  <ScheduleRow
+                    key={i}
+                    now={this.state.now}
+                    schedule={schedule}
+                    isActive={set.isPhysicallyOpen !== false && schedule.days.includes(dayOfWeek) && isBuildingOpenAtMoment(schedule, this.state.now)}
+                  />)}
               </View>
-
-              {set.notes
-                ? <View style={[styles.scheduleNotesWrapper]}>
-                    <Separator />
-                    <Text style={styles.scheduleNotes}>{set.notes}</Text>
-                  </View>
-                : null}
-            </View>
+            </Card>
           )}
         </View>
       </ParallaxView>
     )
   }
+}
+
+
+const ScheduleRow = ({schedule, isActive, now}: {schedule: SingleBuildingScheduleType, isActive: boolean, now: momentT}) => {
+  return (
+    <View style={styles.scheduleRow}>
+      <Text style={[styles.scheduleDays, isActive && styles.bold]} numberOfLines={1}>
+        {summarizeDays(schedule.days)}
+      </Text>
+
+      <Text style={[styles.scheduleHours, isActive && styles.bold]} numberOfLines={1}>
+        {formatBuildingTimes(schedule, now)}
+      </Text>
+    </View>
+  )
 }

--- a/views/building-hours/index.js
+++ b/views/building-hours/index.js
@@ -5,21 +5,28 @@
  */
 
 import React from 'react'
-import {View, Text, ListView, RefreshControl, StyleSheet, Platform, Navigator} from 'react-native'
+import {ListView, RefreshControl, StyleSheet, Platform, Navigator} from 'react-native'
 import {BuildingRow} from './row'
 import {tracker} from '../../analytics'
+
+import type {TopLevelViewPropsType} from '../types'
 import type {BuildingType} from './types'
 import delay from 'delay'
 import {data as buildingHours} from '../../docs/building-hours'
-import {Separator} from '../components/separator'
 import groupBy from 'lodash/groupBy'
-import {Touchable} from '../components/touchable'
 
 import * as c from '../components/colors'
+import {ListSeparator, ListSectionHeader} from '../components/list'
 import moment from 'moment-timezone'
 const CENTRAL_TZ = 'America/Winnipeg'
 
 export {BuildingHoursDetailView} from './detail'
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: c.white,
+  },
+})
 
 export class BuildingHoursView extends React.Component {
   state = {
@@ -40,14 +47,11 @@ export class BuildingHoursView extends React.Component {
     clearTimeout(this.state.intervalId)
   }
 
-  props: {
-    navigator: any,
-    route: any,
-  }
+  props: TopLevelViewPropsType;
 
   getDataSource(){
     return new ListView.DataSource({
-      rowHasChanged: (r1: BuildingType, r2: BuildingType) => r1.name !== r2.name,
+      rowHasChanged: (r1: BuildingType, r2: BuildingType) => r1 !== r2,
       sectionHeaderHasChanged: (r1: any, r2: any) => r1 !== r2,
     }).cloneWithRowsAndSections(groupBy(buildingHours, b => b.category || 'Other'))
   }
@@ -73,30 +77,21 @@ export class BuildingHoursView extends React.Component {
 
   renderRow = (data: BuildingType) => {
     return (
-      <Touchable onPress={() => this.onPressRow(data)}>
-        <BuildingRow
-          name={data.name}
-          info={data}
-          now={this.state.now}
-          style={styles.row}
-        />
-      </Touchable>
+      <BuildingRow
+        name={data.name}
+        info={data}
+        now={this.state.now}
+        onPress={() => this.onPressRow(data)}
+      />
     )
   }
 
   renderSectionHeader = (data: any, id: string) => {
-    return (
-      <View style={styles.rowSectionHeader}>
-        <Text style={styles.rowSectionHeaderText}>{id}</Text>
-      </View>
-    )
+    return <ListSectionHeader style={styles.rowSectionHeader} title={id} />
   }
 
   renderSeparator = (sectionID: any, rowID: any) => {
-    if (Platform.OS === 'android') {
-      return null
-    }
-    return <Separator key={`${sectionID}-${rowID}`} style={styles.separator} />
+    return <ListSeparator key={`${sectionID}-${rowID}`} />
   }
 
   refresh = async () => {
@@ -129,31 +124,3 @@ export class BuildingHoursView extends React.Component {
     )
   }
 }
-
-
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: 'white',
-  },
-  separator: {
-    marginLeft: 15,
-  },
-  row: {
-    paddingLeft: 15,
-    paddingRight: Platform.OS === 'ios' ? 6 : 15,
-  },
-
-  rowSectionHeader: {
-    backgroundColor: Platform.OS === 'ios' ? c.iosListSectionHeader : 'white',
-    paddingTop: Platform.OS === 'ios' ? 5 : 10,
-    paddingBottom: Platform.OS === 'ios' ? 5 : 15,
-    paddingLeft: 15,
-    borderTopWidth: Platform.OS === 'ios' ? StyleSheet.hairlineWidth : 1,
-    borderBottomWidth: Platform.OS === 'ios' ? StyleSheet.hairlineWidth : 0,
-    borderColor: '#c8c7cc',
-  },
-  rowSectionHeaderText: {
-    color: 'rgb(113, 113, 118)',
-    fontWeight: Platform.OS === 'ios' ? 'normal' : '500',
-  },
-})


### PR DESCRIPTION
> This is a PR in a series of conversion PRs, split out of #499

Let's see, special things in this PR… mainly componentization, I guess? I split some of the inner loops into their own components, such as ScheduleRow and BuildingTimeSlot.

| Platform | Before | After |
| ---:| --- | --- |
| iOS | ![ios list a](https://cloud.githubusercontent.com/assets/464441/21950832/7f129480-d9c4-11e6-9fca-269aacd29488.jpg) | ![ios list b](https://cloud.githubusercontent.com/assets/464441/21950833/7f17fe98-d9c4-11e6-98ef-0f06c3f986d1.jpg)
| Android | ![android list a](https://cloud.githubusercontent.com/assets/464441/21950831/7f115304-d9c4-11e6-95cc-3119f4b6ac6e.jpg) | ![android list b](https://cloud.githubusercontent.com/assets/464441/21950830/7f0f5770-d9c4-11e6-8cb1-3576f2a82ecf.jpg)

And, just because this is one of the components that got the `<Card/>` treatment, a before/after of that:

| Platform | Before | After |
| ---:| --- | --- |
| Android | ![android detail a](https://cloud.githubusercontent.com/assets/464441/21950828/7f0cb0e2-d9c4-11e6-80c1-7b985bd58fb4.jpg) | ![android detail b](https://cloud.githubusercontent.com/assets/464441/21950829/7f0d0254-d9c4-11e6-8b3e-d56c8e5a8033.jpg)
