### PR TITLE
Port Calendar to ListRow&co

### DIFF
--- a/views/calendar/calendar.js
+++ b/views/calendar/calendar.js
@@ -5,25 +5,17 @@
  */
 
 import React from 'react'
-import {
-  StyleSheet,
-  Text,
-  Platform,
-  ListView,
-  RefreshControl,
-  View,
-} from 'react-native'
+import {StyleSheet, Platform, ListView, RefreshControl} from 'react-native'
 import {tracker} from '../../analytics'
 import type {EventType} from './types'
 import groupBy from 'lodash/groupBy'
 import moment from 'moment-timezone'
 import delay from 'delay'
-import {Separator} from '../components/separator'
+import {ListSeparator, ListSectionHeader} from '../components/list'
 import {NoticeView} from '../components/notice'
 import LoadingView from '../components/loading'
 import qs from 'querystring'
 import EventView from './event'
-import * as c from '../components/colors'
 import { GOOGLE_CALENDAR_API_KEY } from '../../lib/config'
 const TIMEZONE = 'America/Winnipeg'
 
@@ -131,30 +123,15 @@ export default class CalendarView extends React.Component {
   }
 
   renderRow = (data: EventType) => {
-    return (
-      <EventView
-        style={styles.row}
-        summary={data.summary}
-        startTime={data.startTime}
-        endTime={data.endTime}
-        location={data.location}
-        isOngoing={data.isOngoing}
-      />
-    )
+    return <EventView {...data} />
   }
 
-  renderSectionHeader = (sectionData: Object, sectionIdentifier: any) => {
-    return (
-      <View style={styles.rowSectionHeader}>
-        <Text style={styles.rowSectionHeaderText} numberOfLines={1}>
-          {sectionIdentifier}
-        </Text>
-      </View>
-    )
+  renderSectionHeader = (sectionData: EventType[], sectionIdentifier: string) => {
+    return <ListSectionHeader title={sectionIdentifier} spacing={{left: 10}} />
   }
 
   renderSeparator = (sectionID: any, rowID: any) => {
-    return <Separator key={`${sectionID}-${rowID}`} />
+    return <ListSeparator fullWidth={true} key={`${sectionID}-${rowID}`} />
   }
 
   render() {
@@ -194,22 +171,5 @@ let styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#ffffff',
-  },
-  row: {
-    // marginLeft: 10,
-    paddingRight: 10,
-  },
-  rowSectionHeader: {
-    backgroundColor: c.iosListSectionHeader,
-    paddingTop: 5,
-    paddingBottom: 5,
-    paddingLeft: 10,
-    borderTopWidth: StyleSheet.hairlineWidth,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderColor: '#ebebeb',
-  },
-  rowSectionHeaderText: {
-    color: 'black',
-    fontWeight: 'bold',
   },
 })

--- a/views/calendar/event.js
+++ b/views/calendar/event.js
@@ -1,95 +1,87 @@
 // @flow
 import React from 'react'
-import {StyleSheet, View, Text} from 'react-native'
+import {StyleSheet, Text} from 'react-native'
 import type {EventType} from './types'
 import moment from 'moment-timezone'
 import * as c from '../components/colors'
-import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
+import {Row, Column} from '../components/layout'
+import {ListRow, Detail, Title} from '../components/list'
+import {fastGetTrimmedText} from '../../lib/html'
+import {Bar} from './vertical-bar'
 
 const styles = StyleSheet.create({
-  container: {
-    paddingVertical: 2,
-    flexDirection: 'row',
-  },
-  rowIllusion: {
-    paddingVertical: 4,
-  },
-  times: {
+  timeContainer: {
     width: 70,
-    flexDirection: 'column',
     justifyContent: 'space-between',
-    paddingRight: 12,
-    paddingLeft: 4,
+    paddingVertical: 3,
   },
-  timeText: {
+  time: {
     textAlign: 'right',
-    fontSize: 10,
   },
-  startTime: {
+  start: {
     color: c.black,
   },
-  endTime: {
+  end: {
     color: c.iosDisabledText,
-  },
-  texts: {
-    paddingLeft: 10,
-    flex: 1,
-    borderLeftWidth: 2,
-    borderLeftColor: c.iosGray,
-  },
-  title: {
-    color: c.black,
-    fontWeight: '500',
-    paddingBottom: 3,
-    fontSize: 14,
-  },
-  location: {
-    color: c.iosDisabledText,
-    fontSize: 10,
   },
 })
 
 export default function EventView(props: EventType) {
-  let title = getTrimmedTextWithSpaces(parseHtml(props.summary))
+  const title = fastGetTrimmedText(props.summary)
 
-  let eventLength = moment.duration(props.endTime.diff(props.startTime)).asHours()
-  let allDay = eventLength === 24
-  let multiDay = eventLength > 24
+  return (
+    <ListRow
+      contentContainerStyle={{paddingVertical: 2}}
+      arrowPosition='none'
+      fullWidth={true}
+    >
+      <Row>
+        <CalendarTimes {...props} style={styles.timeContainer} />
+
+        <Bar style={{marginHorizontal: 10}} />
+
+        <Column flex={1} paddingTop={2} paddingBottom={3}>
+          <Title style={styles.title}>{title}</Title>
+          <Detail style={styles.detail}>{props.location}</Detail>
+        </Column>
+      </Row>
+    </ListRow>
+  )
+}
+
+function CalendarTimes(props: EventType) {
+  const eventLength = moment.duration(props.endTime.diff(props.startTime)).asHours()
+  const allDay = eventLength === 24
+  const multiDay = eventLength > 24
 
   let times = null
   if (allDay) {
-    times = <Text style={[styles.timeText, styles.startTime]}>all-day</Text>
+    times = <Text style={[styles.time, styles.start]}>all-day</Text>
   } else if (props.isOngoing) {
     times = [
-      <Text key={0} style={[styles.timeText, styles.startTime]}>{props.startTime.format('MMM. D')}</Text>,
-      <Text key={1} style={[styles.timeText, styles.endTime]}>{props.endTime.format('MMM. D')}</Text>,
+      <Text key={0} style={[styles.time, styles.start]}>{props.startTime.format('MMM. D')}</Text>,
+      <Text key={1} style={[styles.time, styles.end]}>{props.endTime.format('MMM. D')}</Text>,
     ]
   } else if (multiDay) {
     times = [
-      <Text key={0} style={[styles.timeText, styles.startTime]}>{props.startTime.format('h:mma')}</Text>,
-      <Text key={1} style={[styles.timeText, styles.endTime]}>to {props.endTime.format('MMM. D h:mma')}</Text>,
+      <Text key={0} style={[styles.time, styles.start]}>{props.startTime.format('h:mm A')}</Text>,
+      <Text key={1} style={[styles.time, styles.end]}>to {props.endTime.format('MMM. D h:mm A')}</Text>,
     ]
   } else if (props.startTime.isSame(props.endTime, 'minute')) {
     times = [
-      <Text key={0} style={[styles.timeText, styles.startTime]}>{props.startTime.format('h:mma')}</Text>,
-      <Text key={1} style={[styles.timeText, styles.endTime]}>until ???</Text>,
+      <Text key={0} style={[styles.time, styles.start]}>{props.startTime.format('h:mm A')}</Text>,
+      <Text key={1} style={[styles.time, styles.end]}>until ???</Text>,
     ]
   } else {
     times = [
-      <Text key={0} style={[styles.timeText, styles.startTime]}>{props.startTime.format('h:mma')}</Text>,
-      <Text key={1} style={[styles.timeText, styles.endTime]}>{props.endTime.format('h:mma')}</Text>,
+      <Text key={0} style={[styles.time, styles.start]}>{props.startTime.format('h:mm A')}</Text>,
+      <Text key={1} style={[styles.time, styles.end]}>{props.endTime.format('h:mm A')}</Text>,
     ]
   }
 
   return (
-    <View style={[styles.container, props.style]}>
-      <View style={[styles.rowIllusion, styles.times]}>
-        {times}
-      </View>
-      <View style={[styles.rowIllusion, styles.texts]}>
-        <Text style={styles.title}>{title}</Text>
-        <Text style={styles.location}>{props.location}</Text>
-      </View>
-    </View>
+    <Column style={props.style}>
+      {times}
+    </Column>
   )
 }

--- a/views/calendar/vertical-bar.js
+++ b/views/calendar/vertical-bar.js
@@ -1,0 +1,53 @@
+// @flow
+import React from 'react'
+import {StyleSheet, View, Platform} from 'react-native'
+import * as c from '../components/colors'
+
+const dotBarStyles = StyleSheet.create({
+  diagram: {
+    marginTop: 9,
+    marginBottom: 8,
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  circle: {
+    height: 5,
+    width: 5,
+    borderRadius: 5,
+    backgroundColor: c.tint,
+  },
+  line: {
+    width: 1,
+    backgroundColor: c.tint,
+    flex: 1,
+  },
+})
+
+function DottedBar({style}: {style?: any}) {
+  return (
+    <View style={[dotBarStyles.diagram, style]}>
+      <View style={dotBarStyles.circle} />
+      <View style={dotBarStyles.line} />
+      <View style={dotBarStyles.circle} />
+    </View>
+  )
+}
+
+const solidBarStyles = StyleSheet.create({
+  border: {
+    width: 1.5,
+    backgroundColor: c.black75Percent,
+  },
+})
+
+function SolidBar({style}: {style?: any}) {
+  return <View style={[solidBarStyles.border, style]} />
+}
+
+export function Bar(props: Object) {
+  switch (Platform.OS) {
+    case 'ios': return <SolidBar {...props} />
+    case 'android': return <DottedBar {...props} />
+    default: return <SolidBar {...props} />
+  }
+}


### PR DESCRIPTION
> This is a PR in a series of conversion PRs, split out of #499

Calendar! Redesign-ish?

- Uses ListRow and friends
- Extracted the calendar times thingy into a component (CalendarTimes) for easier reading of the layout composition
- Added VerticalBar, the fancy bar component

Man, the fonts got bigger on iOS.

The advantage is, now all of the views use the same basic underpinnings, so to edit them only requires editing in one place and all the views will be consistent. DRY ;)

| Platform | Before | After |
| ---:| --- | --- |
| iOS | ![ios a](https://cloud.githubusercontent.com/assets/464441/21952323/0ae783c6-d9de-11e6-9d78-706cc963ab52.jpg) | ![ios b](https://cloud.githubusercontent.com/assets/464441/21952321/0ae5fc0e-d9de-11e6-9c20-4bf85a801152.jpg)
| Android | ![android a](https://cloud.githubusercontent.com/assets/464441/21952320/0ad42fd8-d9de-11e6-9a80-9eb8ba7bd64b.jpg) | ![android b](https://cloud.githubusercontent.com/assets/464441/21952322/0ae6041a-d9de-11e6-9ff1-9a68fc7d090f.jpg)
