### PR TITLE
Fix busview wrapping issues

### DIFF
--- a/views/transportation/bus/bus-stop-row.js
+++ b/views/transportation/bus/bus-stop-row.js
@@ -48,7 +48,7 @@ export function BusStopRow({time, now, barColor, currentStopColor, place, times}
       <Row>
         <ProgressChunk {...{barColor, afterStop, beforeStop, atStop, skippingStop, currentStopColor}} />
 
-        <Column style={styles.internalPadding}>
+        <Column flex={1} style={styles.internalPadding}>
           <Title
             bold={false}
             style={[
@@ -59,7 +59,7 @@ export function BusStopRow({time, now, barColor, currentStopColor, place, times}
           >
             {place}
           </Title>
-          <Detail>
+          <Detail lines={1}>
             <ScheduleTimes {...{times, skippingStop}} />
           </Detail>
         </Column>
@@ -73,10 +73,7 @@ const ScheduleTimes = ({times, skippingStop}: {
   times: FancyBusTimeListType,
 }) => {
   return (
-    <Text
-      style={skippingStop && styles.skippingStopDetail}
-      numberOfLines={1}
-    >
+    <Text style={skippingStop && styles.skippingStopDetail}>
       {times
         // and format the times
         .map(time => time === false ? 'None' : time.format(TIME_FORMAT))


### PR DESCRIPTION
How did this slip by? Well, https://github.com/StoDevX/AAO-React-Native/pull/573 was screenshotted at such a time as when there was only one column remaining, and this bug only exhibits itself at the edge of the screen.

Solution: give the main body of the view a flex-width and tell the right Text component to only show one line of text.

| Before | After |
| --- | --- |
| ![830932367_3042400012835837350](https://cloud.githubusercontent.com/assets/464441/21953039/022d6402-d9f3-11e6-819c-9ace1fdf8880.jpg) | ![screen shot 2017-01-14 at 12 45 00 am](https://cloud.githubusercontent.com/assets/464441/21953040/0230f1b2-d9f3-11e6-87d9-502e2a51bdb2.png) |
