### PR TITLE
Fix back title on Homescreen

### DIFF
--- a/app.js
+++ b/app.js
@@ -142,7 +142,6 @@ class App extends React.Component {
         initialRoute={{
           id: 'HomeView',
           title: 'All About Olaf',
-          backButtonTitle: 'Home',
           index: 0,
         }}
         renderScene={renderScene}

--- a/views/home.js
+++ b/views/home.js
@@ -60,6 +60,7 @@ function HomePage({navigator, route, order, views=allViews}: {order: string[], v
             id: view.view,
             index: route.index + 1,
             title: view.title,
+            backButtonTitle: 'Home',
             sceneConfig: Navigator.SceneConfigs.PushFromRight,
           })}
         />)


### PR DESCRIPTION
I accidentally specified it on App, instead of the children of Home. 

So, if Home had a back button instead of a settings button, it would have read "Home". 

Now, the children of Home will read "Home" instead. 