### PR TITLE
put cor_icons in the center of the food item row

### DIFF
--- a/views/menus/components/food-item-row.js
+++ b/views/menus/components/food-item-row.js
@@ -26,8 +26,8 @@ export function FoodItemRow({data, filters, badgeSpecials=true, ...props}: FoodI
       fullWidth={true}
       arrowPosition='none'
     >
-      <Row>
-        <View style={[styles.badge, {width: left, alignSelf: 'center'}]}>
+      <Row alignItems='center'>
+        <View style={[styles.badge, {width: left}]}>
           {badgeSpecials && data.special ? <Icon style={styles.badgeIcon} name={specialsIcon} /> : null}
         </View>
 


### PR DESCRIPTION
![cor-icons-b](https://cloud.githubusercontent.com/assets/464441/21964014/a8ff38de-db09-11e6-9d48-809a259f2fc5.png)


Fixes a regression from #567