### PR TITLE
Fix automatic betas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ before_install:
   # only deploy from the once-daily cron-triggered jobs
   - run_deploy="no"
   - if [[ "$can_deploy" == "yes" && "$TRAVIS_EVENT_TYPE" == "cron" ]]; then run_deploy="yes"; fi
+  - export run_deploy=$run_deploy
 
   # force node 7 on the android builds
   - |


### PR DESCRIPTION
I accidentally broke them in #557, when I moved the should-we-beta logic into the `Fastfile`, because the `run_deploy` variable wasn't exported to child processes.

This PR exports the variable, so fastlane can access it.
