### PR TITLE
Check for android version before using borderless touchable

### DIFF
--- a/views/components/touchable.js
+++ b/views/components/touchable.js
@@ -38,7 +38,8 @@ export const Touchable = ({
       )
     }
     case 'android': {
-      const background = borderless
+      const canBorderless = Platform.Version >= 21
+      const background = borderless && canBorderless
         ? TouchableNativeFeedback.SelectableBackgroundBorderless()
         : TouchableNativeFeedback.SelectableBackground()
       return (


### PR DESCRIPTION
> Closes #604 

… because, as it says in the docs, 

> SelectableBackgroundBorderless: Creates an object that represent android theme's default background for borderless selectable elements. Available on android API level 21+.

So. That's that.