### PR TITLE
fix custom dimension tracking in analytics

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -19,9 +19,9 @@ disableIfOptedOut()
 // Google requires that custom dimensions be tracked by index, and we only get
 // 20 custom dimensions, so I decided to centralize them here.
 export function trackMenuFilters(menuName: string, filters: mixed) {
-  tracker.trackEvent('menus', 'filter', {label: menuName}, {'1': JSON.stringify(filters)})
+  tracker.trackEventWithCustomDimensionValues('menus', 'filter', {label: menuName}, {'1': JSON.stringify(filters)})
 }
 
 export function trackHomescreenOrder(order: string[]) {
-  tracker.trackEvent('homescreen', 'reorder', {}, {'2': order.join(', ')})
+  tracker.trackEventWithCustomDimensionValues('homescreen', 'reorder', {}, {'2': order.join(', ')})
 }

--- a/analytics.js
+++ b/analytics.js
@@ -4,6 +4,7 @@ import {
   GoogleAnalyticsTracker,
   GoogleAnalyticsSettings,
 } from 'react-native-google-analytics-bridge'
+import {stringifyFilters} from './views/components/filter'
 
 const trackerId = __DEV__ ? 'UA-90234209-1' : 'UA-90234209-2'
 export const tracker = new GoogleAnalyticsTracker(trackerId)
@@ -18,8 +19,8 @@ disableIfOptedOut()
 
 // Google requires that custom dimensions be tracked by index, and we only get
 // 20 custom dimensions, so I decided to centralize them here.
-export function trackMenuFilters(menuName: string, filters: mixed) {
-  tracker.trackEventWithCustomDimensionValues('menus', 'filter', {label: menuName}, {'1': JSON.stringify(filters)})
+export function trackMenuFilters(menuName: string, filters: any) {
+  tracker.trackEventWithCustomDimensionValues('menus', 'filter', {label: menuName}, {'1': stringifyFilters(filters)})
 }
 
 export function trackHomescreenOrder(order: string[]) {

--- a/views/components/filter/index.js
+++ b/views/components/filter/index.js
@@ -2,3 +2,4 @@
 export {FilterView} from './filter-view'
 export type {FilterType} from './types'
 export {applyFiltersToItem} from './apply-filters'
+export {stringifyFilters} from './stringify-filters'

--- a/views/components/filter/stringify-filters.js
+++ b/views/components/filter/stringify-filters.js
@@ -1,0 +1,30 @@
+/**
+ * @flow
+ * Stringify a set of filters for transfer to GA.
+ * (because we really don't need to ship those descriptions over the network)
+ */
+import type {FilterType, ListType} from './types'
+
+export function stringifyFilters(filters: FilterType[]): string {
+  return filters.map(f => stringifyFilter(f)).join('; ')
+}
+
+function stringifyFilter(filter: FilterType): string {
+  let spec = 'n/a'
+  if (filter.type === 'list') {
+    spec = stringifyListFilter(filter)
+  }
+
+  return JSON.stringify({
+    key: filter.key,
+    type: filter.type,
+    enabled: filter.enabled,
+    spec: spec,
+  })
+}
+
+function stringifyListFilter(filter: ListType): string {
+  // Extract the list of "selected" items
+  const filterValue = filter.spec.selected
+  return filterValue.map(f => f.title).join(', ')
+}


### PR DESCRIPTION
> closes #601

I like data? Now we collect a bit more?

I've tested it on Android 4.3, where it works and sends stuff to Google. I'm still not sure how to _view_ the custom dimensions, but I think we're at least sending them now.
