### PR TITLE
Add missing conversation programs to campus dictionary

### DIFF
--- a/data/dictionary/amcon.yaml
+++ b/data/dictionary/amcon.yaml
@@ -1,11 +1,11 @@
-word: Am Con
+word: AmCon
 definition: >
   Short for American Conversations, an interdisciplinary General Education
   program and learning community in which students analyze America’s history
   and culture. Over four successive semesters in their first and sophomore
-  years, Am Con students encounter many of the texts, topics, and historical
+  years, AmCon students encounter many of the texts, topics, and historical
   developments that have defined “America” from its earliest colonization to
-  the present. Am Con students make up a true academic community, living in a
+  the present. AmCon students make up a true academic community, living in a
   common dorm in their first year and complementing their in-class education
   with dinners, informal gatherings and field trips. Through the inclusion of
   an academic civic engagement component, moreover, students develop as active

--- a/data/dictionary/amcon.yaml
+++ b/data/dictionary/amcon.yaml
@@ -1,4 +1,4 @@
-word: Amcon
+word: Am Con
 definition: >
   Short for American Conversations, an interdisciplinary General Education
   program and learning community in which students analyze America’s history

--- a/data/dictionary/amcon.yaml
+++ b/data/dictionary/amcon.yaml
@@ -3,9 +3,9 @@ definition: >
   Short for American Conversations, an interdisciplinary General Education
   program and learning community in which students analyze America’s history
   and culture. Over four successive semesters in their first and sophomore
-  years, Amcon students encounter many of the texts, topics, and historical
+  years, Am Con students encounter many of the texts, topics, and historical
   developments that have defined “America” from its earliest colonization to
-  the present. Amcon students make up a true academic community, living in a
+  the present. Am Con students make up a true academic community, living in a
   common dorm in their first year and complementing their in-class education
   with dinners, informal gatherings and field trips. Through the inclusion of
   an academic civic engagement component, moreover, students develop as active

--- a/data/dictionary/asian-conversations.yaml
+++ b/data/dictionary/asian-conversations.yaml
@@ -1,4 +1,4 @@
-word: Asian Con
+word: AsianCon
 definition: >
   Asian Conversations offers you a dynamic cultural exploration that
   begins with two semesters of Chinese or Japanese language study

--- a/data/dictionary/asian-conversations.yaml
+++ b/data/dictionary/asian-conversations.yaml
@@ -1,0 +1,11 @@
+word: Asian Conversations
+definition: >
+  Asian Conversations offers you a dynamic cultural exploration that
+  begins with two semesters of Chinese or Japanese language study
+  during your first year on campus. During sophomore year you continue
+  your language study while taking three linked courses organized around
+  the theme of “Journeys Through Asia.”  Readings include historic and
+  contemporary narratives from Asian travelers, pilgrims, migrants, great
+  writers, and political leaders. You explore connections across Asia
+  from diverse perspectives in the humanities and social sciences,
+  complemented with language skills in Chinese or Japanese.

--- a/data/dictionary/asian-conversations.yaml
+++ b/data/dictionary/asian-conversations.yaml
@@ -1,4 +1,4 @@
-word: Asian Conversations
+word: Asian Con
 definition: >
   Asian Conversations offers you a dynamic cultural exploration that
   begins with two semesters of Chinese or Japanese language study

--- a/data/dictionary/encon.yaml
+++ b/data/dictionary/encon.yaml
@@ -1,9 +1,9 @@
-word: En Con
+word: EnCon
 definition: >
   In a world needing to tackle climate change and other
   ecological crises, environmental concerns have become
   relevant for everyone. As such, St. Olaf is proud to
-  offer the Environmental Conversations (En Con) program. It is
+  offer the Environmental Conversations (EnCon) program. It is
   open to any admitted student wanting to start college
   in a learning community inquiring after a life of
   environmental thoughtfulness.

--- a/data/dictionary/encon.yaml
+++ b/data/dictionary/encon.yaml
@@ -1,0 +1,9 @@
+word: En Con
+definition: >
+  In a world needing to tackle climate change and other
+  ecological crises, environmental concerns have become
+  relevant for everyone. As such, St. Olaf is proud to
+  offer the Environmental Conversations (En Con) program. It is
+  open to any admitted student wanting to start college
+  in a learning community inquiring after a life of
+  environmental thoughtfulness.

--- a/data/dictionary/paccon.yaml
+++ b/data/dictionary/paccon.yaml
@@ -1,6 +1,6 @@
-word: Pac Con
+word: PaCon
 definition: >
-  The Public Affairs Conversation (Pac Con) engages students
+  The Public Affairs Conversation (PaCon) engages students
   and faculty in a search to develop an interdisciplinary
   perspective on American public policy. This yearlong
   program for juniors and seniors consists of two courses

--- a/data/dictionary/paccon.yaml
+++ b/data/dictionary/paccon.yaml
@@ -1,0 +1,18 @@
+word: Pac Con
+definition: >
+  The Public Affairs Conversation (Pac Con) engages students
+  and faculty in a search to develop an interdisciplinary
+  perspective on American public policy. This yearlong
+  program for juniors and seniors consists of two courses
+  (fall and spring) and an internship (in interim, spring,
+  or summer). The courses focus on contested ideals and
+  contemporary controversies in American public affairs.
+  The first course looks at the evolution of contested
+  ideals in American politics as they develop in the
+  founding period and throughout the history of the
+  republic. The course also engages a range of contemporary
+  normative perspectives that are the foundation of the
+  contemporary debate. The second course blends normative
+  and empirical analysis of contemporary public policy.
+  Both courses will be supplemented by co-curricular
+  activities and events.

--- a/data/dictionary/scicon.yaml
+++ b/data/dictionary/scicon.yaml
@@ -1,12 +1,12 @@
-word: Sci Con
+word: SciCon
 definition: >
-  The Science Conversation (Sci Con) is a sequence of
+  The Science Conversation (SciCon) is a sequence of
   three linked courses (fall, interim, spring) for
   sophomore students. The program brings together
   students and faculty with a broad range of academic
   interests for a critical exploration of science
   within its historical, cultural, and social contexts.
-  Sci Con encourages a philosophically and theologically
+  SciCon encourages a philosophically and theologically
   informed appreciation for the development of science,
   the relationship between reason and faith, questions
   of meaning and purpose, and the complex interplay of

--- a/data/dictionary/scicon.yaml
+++ b/data/dictionary/scicon.yaml
@@ -1,0 +1,15 @@
+word: Sci Con
+definition: >
+  The Science Conversation (Sci Con) is a sequence of
+  three linked courses (fall, interim, spring) for
+  sophomore students. The program brings together
+  students and faculty with a broad range of academic
+  interests for a critical exploration of science
+  within its historical, cultural, and social contexts.
+  Sci Con encourages a philosophically and theologically
+  informed appreciation for the development of science,
+  the relationship between reason and faith, questions
+  of meaning and purpose, and the complex interplay of
+  science and society. It is designed to illuminate the
+  distinctive character of science and its relevance to
+  the challenges facing our world.

--- a/docs/dictionary.json
+++ b/docs/dictionary.json
@@ -29,8 +29,8 @@
       "definition": "The term for a group of email addresses made for an easier way to mass email. Professors use aliases for easy communication with their classes and students use aliases for easy communications with student organizations they participate in.\n"
     },
     {
-      "word": "Am Con",
-      "definition": "Short for American Conversations, an interdisciplinary General Education program and learning community in which students analyze America’s history and culture. Over four successive semesters in their first and sophomore years, Amcon students encounter many of the texts, topics, and historical developments that have defined “America” from its earliest colonization to the present. Amcon students make up a true academic community, living in a common dorm in their first year and complementing their in-class education with dinners, informal gatherings and field trips. Through the inclusion of an academic civic engagement component, moreover, students develop as active citizens, bringing their ideas and energy into the larger community.\n"
+      "word": "AmCon",
+      "definition": "Short for American Conversations, an interdisciplinary General Education program and learning community in which students analyze America’s history and culture. Over four successive semesters in their first and sophomore years, AmCon students encounter many of the texts, topics, and historical developments that have defined “America” from its earliest colonization to the present. AmCon students make up a true academic community, living in a common dorm in their first year and complementing their in-class education with dinners, informal gatherings and field trips. Through the inclusion of an academic civic engagement component, moreover, students develop as active citizens, bringing their ideas and energy into the larger community.\n"
     },
     {
       "word": "ARMS",
@@ -41,7 +41,7 @@
       "definition": "The professional and student staff in the Academic Support Center is committed to working with students to help facilitate an understanding of what it means to fully participate in the academic experience at St. Olaf. Students interested in examining their own learning and study strategies as well as effective study, efficient time use, writing clearly, taking valuable notes, constructive class and test preparation, or other components of their plan to be a better student are encouraged to make an appointment or attend My Plan: Academic Strategies on the first and third Saturdays of every month. Call ext. 3288 with questions.\n"
     },
     {
-      "word": "Asian Conversations",
+      "word": "AsianCon",
       "definition": "Asian Conversations offers you a dynamic cultural exploration that begins with two semesters of Chinese or Japanese language study during your first year on campus. During sophomore year you continue your language study while taking three linked courses organized around the theme of “Journeys Through Asia.”  Readings include historic and contemporary narratives from Asian travelers, pilgrims, migrants, great writers, and political leaders. You explore connections across Asia from diverse perspectives in the humanities and social sciences, complemented with language skills in Chinese or Japanese.\n"
     },
     {
@@ -177,8 +177,8 @@
       "definition": "As a four-story first-year residence hall, Ellingson houses 198 students. Spacious lounges enable students to study and relax at ease.\n"
     },
     {
-      "word": "En Con",
-      "definition": "In a world needing to tackle climate change and other ecological crises, environmental concerns have become relevant for everyone. As such, St. Olaf is proud to offer the Environmental Conversations (En Con) program. It is open to any admitted student wanting to start college in a learning community inquiring after a life of environmental thoughtfulness.\n"
+      "word": "EnCon",
+      "definition": "In a world needing to tackle climate change and other ecological crises, environmental concerns have become relevant for everyone. As such, St. Olaf is proud to offer the Environmental Conversations (EnCon) program. It is open to any admitted student wanting to start college in a learning community inquiring after a life of environmental thoughtfulness.\n"
     },
     {
       "word": "Fall Concert",
@@ -409,8 +409,8 @@
       "definition": "The Political Awareness Committee is a branch of the Student Government Association (SGA) and is the primary student promoter of political awareness and activity on the St. Olaf campus. Committed to nonpartisan political education and activism, PAC seeks to serve all members of the St. Olaf student body as a political resource, ultimately making students into responsible and knowledgeable citizens. PAC brings in big-name speakers for very large events twice a year, known as the fall and spring speaker.\n"
     },
     {
-      "word": "Pac Con",
-      "definition": "The Public Affairs Conversation (Pac Con) engages students and faculty in a search to develop an interdisciplinary perspective on American public policy. This yearlong program for juniors and seniors consists of two courses (fall and spring) and an internship (in interim, spring, or summer). The courses focus on contested ideals and contemporary controversies in American public affairs. The first course looks at the evolution of contested ideals in American politics as they develop in the founding period and throughout the history of the republic. The course also engages a range of contemporary normative perspectives that are the foundation of the contemporary debate. The second course blends normative and empirical analysis of contemporary public policy. Both courses will be supplemented by co-curricular activities and events.\n"
+      "word": "PaCon",
+      "definition": "The Public Affairs Conversation (PaCon) engages students and faculty in a search to develop an interdisciplinary perspective on American public policy. This yearlong program for juniors and seniors consists of two courses (fall and spring) and an internship (in interim, spring, or summer). The courses focus on contested ideals and contemporary controversies in American public affairs. The first course looks at the evolution of contested ideals in American politics as they develop in the founding period and throughout the history of the republic. The course also engages a range of contemporary normative perspectives that are the foundation of the contemporary debate. The second course blends normative and empirical analysis of contemporary public policy. Both courses will be supplemented by co-curricular activities and events.\n"
     },
     {
       "word": "Pause",
@@ -509,8 +509,8 @@
       "definition": "The student improv group at St. Olaf. Their mission is to entertain the community through improvisational theater. In addition, Scared Scriptless gives students the opportunity to perform improv theater regardless of their amount of previous experience.\n"
     },
     {
-      "word": "Sci Con",
-      "definition": "The Science Conversation (Sci Con) is a sequence of three linked courses (fall, interim, spring) for sophomore students. The program brings together students and faculty with a broad range of academic interests for a critical exploration of science within its historical, cultural, and social contexts. Sci Con encourages a philosophically and theologically informed appreciation for the development of science, the relationship between reason and faith, questions of meaning and purpose, and the complex interplay of science and society. It is designed to illuminate the distinctive character of science and its relevance to the challenges facing our world.\n"
+      "word": "SciCon",
+      "definition": "The Science Conversation (SciCon) is a sequence of three linked courses (fall, interim, spring) for sophomore students. The program brings together students and faculty with a broad range of academic interests for a critical exploration of science within its historical, cultural, and social contexts. SciCon encourages a philosophically and theologically informed appreciation for the development of science, the relationship between reason and faith, questions of meaning and purpose, and the complex interplay of science and society. It is designed to illuminate the distinctive character of science and its relevance to the challenges facing our world.\n"
     },
     {
       "word": "Senate",

--- a/docs/dictionary.json
+++ b/docs/dictionary.json
@@ -29,7 +29,7 @@
       "definition": "The term for a group of email addresses made for an easier way to mass email. Professors use aliases for easy communication with their classes and students use aliases for easy communications with student organizations they participate in.\n"
     },
     {
-      "word": "Amcon",
+      "word": "Am Con",
       "definition": "Short for American Conversations, an interdisciplinary General Education program and learning community in which students analyze America’s history and culture. Over four successive semesters in their first and sophomore years, Amcon students encounter many of the texts, topics, and historical developments that have defined “America” from its earliest colonization to the present. Amcon students make up a true academic community, living in a common dorm in their first year and complementing their in-class education with dinners, informal gatherings and field trips. Through the inclusion of an academic civic engagement component, moreover, students develop as active citizens, bringing their ideas and energy into the larger community.\n"
     },
     {
@@ -39,6 +39,10 @@
     {
       "word": "ASC",
       "definition": "The professional and student staff in the Academic Support Center is committed to working with students to help facilitate an understanding of what it means to fully participate in the academic experience at St. Olaf. Students interested in examining their own learning and study strategies as well as effective study, efficient time use, writing clearly, taking valuable notes, constructive class and test preparation, or other components of their plan to be a better student are encouraged to make an appointment or attend My Plan: Academic Strategies on the first and third Saturdays of every month. Call ext. 3288 with questions.\n"
+    },
+    {
+      "word": "Asian Conversations",
+      "definition": "Asian Conversations offers you a dynamic cultural exploration that begins with two semesters of Chinese or Japanese language study during your first year on campus. During sophomore year you continue your language study while taking three linked courses organized around the theme of “Journeys Through Asia.”  Readings include historic and contemporary narratives from Asian travelers, pilgrims, migrants, great writers, and political leaders. You explore connections across Asia from diverse perspectives in the humanities and social sciences, complemented with language skills in Chinese or Japanese.\n"
     },
     {
       "word": "BASICS",
@@ -171,6 +175,10 @@
     {
       "word": "Ellingson",
       "definition": "As a four-story first-year residence hall, Ellingson houses 198 students. Spacious lounges enable students to study and relax at ease.\n"
+    },
+    {
+      "word": "En Con",
+      "definition": "In a world needing to tackle climate change and other ecological crises, environmental concerns have become relevant for everyone. As such, St. Olaf is proud to offer the Environmental Conversations (En Con) program. It is open to any admitted student wanting to start college in a learning community inquiring after a life of environmental thoughtfulness.\n"
     },
     {
       "word": "Fall Concert",
@@ -401,6 +409,10 @@
       "definition": "The Political Awareness Committee is a branch of the Student Government Association (SGA) and is the primary student promoter of political awareness and activity on the St. Olaf campus. Committed to nonpartisan political education and activism, PAC seeks to serve all members of the St. Olaf student body as a political resource, ultimately making students into responsible and knowledgeable citizens. PAC brings in big-name speakers for very large events twice a year, known as the fall and spring speaker.\n"
     },
     {
+      "word": "Pac Con",
+      "definition": "The Public Affairs Conversation (Pac Con) engages students and faculty in a search to develop an interdisciplinary perspective on American public policy. This yearlong program for juniors and seniors consists of two courses (fall and spring) and an internship (in interim, spring, or summer). The courses focus on contested ideals and contemporary controversies in American public affairs. The first course looks at the evolution of contested ideals in American politics as they develop in the founding period and throughout the history of the republic. The course also engages a range of contemporary normative perspectives that are the foundation of the contemporary debate. The second course blends normative and empirical analysis of contemporary public policy. Both courses will be supplemented by co-curricular activities and events.\n"
+    },
+    {
       "word": "Pause",
       "definition": "The Lion’s Pause, a branch of the Student Government Association (SGA),is most commonly shortened to just the Pause. This is a student-run nightclub located on the first floor of Buntrock Commons. Students are lucky to have a facility like this at their disposal — very few other schools in the nation have such a nice space! The Pause consists of 5 rooms: The Den, Lair, Jungle, Kitchen, and Mane Stage. The Kitchen is a student-staffed kitchen serving pizza, shakes, and more.\n"
     },
@@ -495,6 +507,10 @@
     {
       "word": "Scared Scriptless",
       "definition": "The student improv group at St. Olaf. Their mission is to entertain the community through improvisational theater. In addition, Scared Scriptless gives students the opportunity to perform improv theater regardless of their amount of previous experience.\n"
+    },
+    {
+      "word": "Sci Con",
+      "definition": "The Science Conversation (Sci Con) is a sequence of three linked courses (fall, interim, spring) for sophomore students. The program brings together students and faculty with a broad range of academic interests for a critical exploration of science within its historical, cultural, and social contexts. Sci Con encourages a philosophically and theologically informed appreciation for the development of science, the relationship between reason and faith, questions of meaning and purpose, and the complex interplay of science and society. It is designed to illuminate the distinctive character of science and its relevance to the challenges facing our world.\n"
     },
     {
       "word": "Senate",


### PR DESCRIPTION
Added 
- Asian Conversations
- Environmental Conversation
- Public Affairs Conversation
- Science Conversation

to the campus dictionary and changed abbreviation of Am Con to match all other abbreviations. 