### PR TITLE
Fall back to BonApp data on unknown dietary filters

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -10,11 +10,13 @@ import * as storage from './lib/storage'
 const trackerId = __DEV__ ? 'UA-90234209-1' : 'UA-90234209-2'
 export const tracker = new GoogleAnalyticsTracker(trackerId)
 
-async function disableIfOptedOut() {
-  const didOptOut = await storage.getAnalyticsOptOut()
-  if (didOptOut) {
-    GoogleAnalyticsSettings.setOptOut(true)
-  }
+function disableIfOptedOut() {
+  return storage.getAnalyticsOptOut()
+    .then(didOptOut => {
+      if (didOptOut) {
+        GoogleAnalyticsSettings.setOptOut(true)
+      }
+    })
 }
 disableIfOptedOut()
 

--- a/views/menus/types.js
+++ b/views/menus/types.js
@@ -73,9 +73,16 @@ export type BonAppMenuInfoType = {
   items: MenuItemContainerType,
 };
 
+export type CorIconType = {
+  sort: string,
+  label: string,
+  description: string,
+  image: string,
+};
+
 export type MenuItemContainerType = {[key: ItemIdReferenceStringType]: MenuItemType};
 export type ItemCorIconMapType = {[key: NumericStringType]: string} | Array<void>;
-export type MasterCorIconMapType = {[key: NumericStringType]: {label: string, icon: any}};
+export type MasterCorIconMapType = {[key: NumericStringType]: CorIconType};
 
 
 export type BonAppCafeInfoType = {


### PR DESCRIPTION
Sometimes, BonApp throws a new dietary filter our way.

This PR handles that by falling back to their data (and requesting the remote image) if we don't know what filter they're referencing.

Screenshot: 
<img width="375" alt="screen shot 2017-01-26 at 10 40 59 am" src="https://cloud.githubusercontent.com/assets/464441/22340702/fa13310a-e3b3-11e6-9f67-3f0f2149b9c1.png">
