### PR TITLE
fix in-menu image loading on android

### DIFF
--- a/views/menus/components/dietary-tags.js
+++ b/views/menus/components/dietary-tags.js
@@ -25,7 +25,7 @@ export function DietaryTags({corIcons, dietary, style}: {corIcons: MasterCorIcon
 
   // turn the remaining items into images
   let tags = map(filtered, (dietaryIcon, key) => {
-    return <Image key={key} source={{url: dietaryIcon.image}} style={styles.icons} />
+    return <Image key={key} source={{uri: dietaryIcon.image}} style={styles.icons} />
   })
 
   return <View style={[styles.container, style]}>{tags}</View>


### PR DESCRIPTION
… I was providing the `url` prop instead of `uri`.

Now it works.

![pasted image at 2017_01_27 04_02 pm](https://cloud.githubusercontent.com/assets/464441/22389261/45d3fba0-e4aa-11e6-90e0-e8c9c12bea1a.png)

