### PR TITLE
Add CircleCI support

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,9 @@
 ; Ignore unexpected extra "@providesModule"
 .*/node_modules/.*/node_modules/fbjs/.*
 
+; Ignore the vendor/ folder, since CIs appear to stuck ruby deps in there
+<PROJECT_ROOT>/vendor/
+
 ; Ignore duplicate module providers
 ; For RN Apps installed via npm, "Libraries" folder is inside
 ; "node_modules/react-native" but in the source repo it is in the root

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,29 @@
+---
+general:
+  branches:
+    ignore:
+      - gh-pages
+
+machine:
+  node:
+    version: 7
+  environment:
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+
+dependencies:
+  override:
+    - yarn
+  cache_directories:
+    - ~/.cache/yarn
+
+compile:
+  override:
+    - yarn run bundle:android
+    - yarn run bundle:ios
+
+test:
+  override:
+    - yarn run lint
+    - yarn run flow -- check
+    - yarn run validate-data
+    - yarn test

--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,8 @@ machine:
 dependencies:
   override:
     - yarn
+    - touch .env.js
+
   cache_directories:
     - ~/.cache/yarn
 

--- a/circle.yml
+++ b/circle.yml
@@ -29,4 +29,4 @@ test:
     - yarn run lint
     - yarn run flow -- check
     - yarn run validate-data
-    - yarn test
+    - yarn test -- --runInBand

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ general:
 machine:
   node:
     version: 7
+
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 


### PR DESCRIPTION
This adds initial CircleCI support, in addition to Travis.

It's currently only running javascript tests, but we hope to move the iOS tests to it soon.