### PR TITLE
Tell flow to ignore .json files

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,9 @@
 ; We fork some components by platform
 .*/*[.]android.js
 
+; Ignore json files from flow
+*.json
+
 ; Ignore "BUCK" generated dirs
 <PROJECT_ROOT>/\.buckd/
 


### PR DESCRIPTION
I don't even know why it checks them. It doesn't seem to report type information from stuff that we import from them, even? And it breaks on various things that include invalid json in their test suites…