### PR TITLE
Convert CircleCI to macOS builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,9 @@ general:
 
 machine:
   pre:
-    - brew install rvm
+    - brew install gnupg
+    - gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+    - curl -sSL https://get.rvm.io | bash -s stable --ruby
 
   xcode:
     version: "8.2"

--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,8 @@ machine:
 
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+    MATCH_KEYCHAIN_NAME: circle-ios-keychain
+    MATCH_KEYCHAIN_PASSWORD: alpine
 
 dependencies:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -6,11 +6,14 @@ general:
 
 machine:
   pre:
+    - brew update
     # install ruby2.3
-    - brew install homebrew/versions/ruby23 || exit 0
+    - brew install homebrew/versions/ruby23 || true
     - brew link --overwrite ruby23
-    # install nvm
-    - brew install node
+    # install node
+    - brew unlink node || true
+    - brew install node || true
+    - brew link --overwrite node
 
   xcode:
     version: "8.2"

--- a/circle.yml
+++ b/circle.yml
@@ -6,16 +6,10 @@ general:
 
 machine:
   pre:
-    - cat ~/.profile
-    - unset GEM_HOME
-    # install rvm
-    - brew install gpg
-    - gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-    - curl -sSL https://get.rvm.io | bash -s stable --ruby=2.3.3
-    - source ~/.rvm/scripts/rvm
+    # install ruby2.3
+    - brew install homebrew/versions/ruby23
     # install nvm
-    - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
-    - source ~/.nvm/nvm.sh
+    - brew install node
 
   xcode:
     version: "8.2"
@@ -25,8 +19,6 @@ machine:
 
 dependencies:
   override:
-    - nvm install 7
-    - nvm use 7
     - gem install bundler
     - bundle install --deployment
     - yarn

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,8 @@ machine:
     - brew unlink node || true
     - brew install node || true
     - brew link --overwrite node
+    # install yarn
+    - brew install yarn
 
   xcode:
     version: "8.2"

--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,8 @@ dependencies:
 
 compile:
   override:
-    - touch .env.js  
+    - touch .env.js
+    - bundle exec fastlane ios ci_keychains
     - bundle exec fastlane ios ci_run
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -6,9 +6,14 @@ general:
 
 machine:
   pre:
+    # install rvm
     - brew install gpg
     - gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-    - curl -sSL https://get.rvm.io | bash -s stable --ruby
+    - curl -sSL https://get.rvm.io | bash -s stable --ruby=2.3.3
+    - source ~/.rvm/scripts/rvm
+    # install nvm
+    - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
+    - source ~/.nvm/nvm.sh
 
   xcode:
     version: "8.2"
@@ -20,7 +25,6 @@ dependencies:
   override:
     - nvm install 7
     - nvm use 7
-    - rvm use 2.3 --install --binary --fuzzy
     - gem install bundler
     - bundle install --deployment
     - yarn
@@ -40,4 +44,3 @@ test:
     - yarn run flow -- check
     - yarn run validate-data
     - yarn test -- --runInBand
-

--- a/circle.yml
+++ b/circle.yml
@@ -38,3 +38,4 @@ test:
     - yarn run flow -- check
     - yarn run validate-data
     - yarn test -- --runInBand
+

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,8 @@ general:
 machine:
   pre:
     # install ruby2.3
-    - brew install homebrew/versions/ruby23
+    - brew install homebrew/versions/ruby23 || exit 0
+    - brew link --overwrite ruby23
     # install nvm
     - brew install node
 

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ general:
 
 machine:
   pre:
-    - brew install gnupg
+    - brew install gpg
     - gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
     - curl -sSL https://get.rvm.io | bash -s stable --ruby
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,24 +5,32 @@ general:
       - gh-pages
 
 machine:
-  node:
-    version: 7
+  pre:
+    - brew install rvm
+
+  xcode:
+    version: "8.2"
 
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 
 dependencies:
   override:
+    - nvm install 7
+    - nvm use 7
+    - rvm use 2.3 --install --binary --fuzzy
+    - gem install bundler
+    - bundle install --deployment
     - yarn
-    - touch .env.js
 
   cache_directories:
     - ~/.cache/yarn
+    - ~/rvm_binaries
 
 compile:
   override:
-    - yarn run bundle:android
-    - yarn run bundle:ios
+    - touch .env.js  
+    - bundle exec fastlane ios ci_run
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,8 @@ general:
 
 machine:
   pre:
+    - cat ~/.profile
+    - unset GEM_HOME
     # install rvm
     - brew install gpg
     - gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3


### PR DESCRIPTION
I think we've got them enabled now.

See the build status at https://circleci.com/gh/StoDevX/AAO-React-Native/24