### PR TITLE
Add a Picker filter type

### DIFF
--- a/source/views/components/filter/apply-filters.js
+++ b/source/views/components/filter/apply-filters.js
@@ -2,7 +2,6 @@
 import type {
   FilterType,
   ToggleType,
-  PickerType,
   ListType,
   ListItemSpecType,
 } from './types'
@@ -29,8 +28,6 @@ export function applyFilter(filter: FilterType, item: any): boolean {
       return applyToggleFilter(filter, item)
     case 'list':
       return applyListFilter(filter, item)
-    case 'picker':
-      return applyPickerFilter(filter, item)
     default:
       return true
   }
@@ -40,14 +37,6 @@ export function applyToggleFilter(filter: ToggleType, item: any): boolean {
   // Dereference the value-to-check
   const itemValue = item[filter.apply.key]
   return Boolean(itemValue)
-}
-
-export function applyPickerFilter(): boolean {
-  // // Dereference the value-to-check
-  // const itemValue = item[filter.apply.key]
-  // // Grab the "selected" item
-  // const filterValue = filter.spec.selected
-  return true
 }
 
 export function applyListFilter(filter: ListType, item: any): boolean {

--- a/source/views/components/filter/apply-filters.js
+++ b/source/views/components/filter/apply-filters.js
@@ -1,5 +1,11 @@
 // @flow
-import type {FilterType, ToggleType, ListType, ListItemSpecType} from './types'
+import type {
+  FilterType,
+  ToggleType,
+  PickerType,
+  ListType,
+  ListItemSpecType,
+} from './types'
 import values from 'lodash/values'
 import difference from 'lodash/difference'
 import isPlainObject from 'lodash/isPlainObject'
@@ -23,6 +29,8 @@ export function applyFilter(filter: FilterType, item: any): boolean {
       return applyToggleFilter(filter, item)
     case 'list':
       return applyListFilter(filter, item)
+    case 'picker':
+      return applyPickerFilter(filter, item)
     default:
       return true
   }
@@ -32,6 +40,14 @@ export function applyToggleFilter(filter: ToggleType, item: any): boolean {
   // Dereference the value-to-check
   const itemValue = item[filter.apply.key]
   return Boolean(itemValue)
+}
+
+export function applyPickerFilter(filter: PickerType, item: any): boolean {
+  // // Dereference the value-to-check
+  // const itemValue = item[filter.apply.key]
+  // // Grab the "selected" item
+  // const filterValue = filter.spec.selected
+  return true
 }
 
 export function applyListFilter(filter: ListType, item: any): boolean {

--- a/source/views/components/filter/apply-filters.js
+++ b/source/views/components/filter/apply-filters.js
@@ -42,7 +42,7 @@ export function applyToggleFilter(filter: ToggleType, item: any): boolean {
   return Boolean(itemValue)
 }
 
-export function applyPickerFilter(filter: PickerType, item: any): boolean {
+export function applyPickerFilter(): boolean {
   // // Dereference the value-to-check
   // const itemValue = item[filter.apply.key]
   // // Grab the "selected" item

--- a/source/views/components/filter/section-picker.js
+++ b/source/views/components/filter/section-picker.js
@@ -1,0 +1,55 @@
+// @flow
+import React from 'react'
+import {Picker, StyleSheet, Platform} from 'react-native'
+import type {PickerType} from './types'
+import {Section} from 'react-native-tableview-simple'
+
+type PropsType = {
+  filter: PickerType,
+  onChange: (filter: PickerType) => any,
+};
+
+export function PickerSection({filter, onChange}: PropsType) {
+  const {spec} = filter
+  const {title='', caption='', options, selected} = spec
+
+  function pickerPicked(pickedValue: string, pickedItemIndex: number) {
+    let pickedItem = spec.options[pickedItemIndex]
+
+    onChange({
+      ...filter,
+      spec: {
+        ...spec,
+        selected: pickedItem,
+      },
+    })
+  }
+
+  return (
+    <Section header={title.toUpperCase()} footer={caption}>
+      <Picker
+        onValueChange={pickerPicked}
+        selectedValue={JSON.stringify(selected || options[0])}
+        style={styles.picker}
+      >
+        {options.map((val, i) =>
+          <Picker.Item
+            key={i}
+            label={val.label}
+            value={JSON.stringify(val)}
+          />
+        )}
+      </Picker>
+    </Section>
+  )
+}
+
+const styles = StyleSheet.create({
+  picker: {
+    ...Platform.select({
+      ios: {
+        backgroundColor: 'white',
+      },
+    }),
+  },
+})

--- a/source/views/components/filter/section.js
+++ b/source/views/components/filter/section.js
@@ -3,6 +3,7 @@ import React from 'react'
 import type {FilterType} from './types'
 import {SingleToggleSection} from './section-toggle'
 import {ListSection} from './section-list'
+import {PickerSection} from './section-picker'
 
 type FilterSectionPropsType = {
   filter: FilterType,
@@ -20,6 +21,14 @@ export function FilterSection({filter, onChange}: FilterSectionPropsType) {
     }
 
     return <ListSection filter={filter} onChange={onChange} />
+  }
+
+  if (filter.type === 'picker') {
+    if (filter.spec.options.length < 2) {
+      return null
+    }
+
+    return <PickerSection filter={filter} onChange={onChange} />
   }
 
   return null

--- a/source/views/components/filter/types.js
+++ b/source/views/components/filter/types.js
@@ -20,7 +20,22 @@ export type ListSpecType = {
   mode: 'AND'|'OR',
 };
 
+export type PickerItemSpecType = {|
+  label: string,
+|};
+
+export type PickerSpecType = {
+  title?: string,
+  caption?: string,
+  options: PickerItemSpecType[],
+  selected: ?PickerItemSpecType,
+}
+
 export type ToggleFilterFunctionType = {
+  key: string,
+};
+
+export type PickerFilterFunctionType = {
   key: string,
 };
 
@@ -36,6 +51,14 @@ export type ToggleType = {
   apply: ToggleFilterFunctionType,
 };
 
+export type PickerType = {
+  type: 'picker',
+  key: string,
+  enabled: true,
+  spec: PickerSpecType,
+  apply: PickerFilterFunctionType,
+};
+
 export type ListType = {
   type: 'list',
   key: string,
@@ -44,4 +67,7 @@ export type ListType = {
   apply: ListFilterFunctionType,
 };
 
-export type FilterType = ToggleType | ListType;
+export type FilterType =
+  | ToggleType
+  | PickerType
+  | ListType;


### PR DESCRIPTION
<img width="401" alt="picker file" src="https://cloud.githubusercontent.com/assets/464441/23095966/08f60daa-f5d9-11e6-91ee-b5089eda380b.png"> 
I'm not sure what it looks like on Android, but we can fix it up later, I'm sure.

This is using a cross-platform `<Picker />` component, so it should _work_ on Android, at least.

This PR does not _implement_ the above screenshot, where you can pick between menus; it simply gives us the base upon which to implement that.