### PR TITLE
Restructure Menu components around "meals"

### DIFF
--- a/source/views/components/filter/index.js
+++ b/source/views/components/filter/index.js
@@ -1,5 +1,10 @@
 // @flow
 export {FilterView} from './filter-view'
-export type {FilterType} from './types'
+export type {
+  FilterType,
+  ListType,
+  ToggleType,
+  PickerType,
+} from './types'
 export {applyFiltersToItem} from './apply-filters'
 export {stringifyFilters} from './stringify-filters'

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -55,7 +55,7 @@ class FancyMenuView extends React.Component {
 
   buildFilters({foodItems, meals, corIcons}: {foodItems: MenuItemType[], meals: ProcessedMealType[], corIcons: MasterCorIconMapType}): FilterType[] {
     // Format the items for the stations filter
-    const stations = flatten(meals.map(meal => meal.stationMenus))
+    const stations = flatten(meals.map(meal => meal.stations))
     const stationLabels = uniq(stations.map(station => station.label))
     const allStations = stationLabels.map(label => ({title: label}))
 
@@ -144,7 +144,7 @@ class FancyMenuView extends React.Component {
     }
 
     if (!selectedMeal) {
-      selectedMeal = {label: '', stationMenus: [], starttime: null, endtime: null}
+      selectedMeal = {label: '', stations: [], starttime: '0:00', endtime: '0:00'}
     }
 
     return selectedMeal
@@ -159,7 +159,7 @@ class FancyMenuView extends React.Component {
       meals,
     } = this.props
 
-    const {label: mealName, stationMenus} = this.findMeal(meals, filters, now)
+    const {label: mealName, stations: stationMenus} = this.findMeal(meals, filters, now)
     const stationNotes = fromPairs(stationMenus.map(m => [m.label, m.note]))
 
     const filteredByMenu = stationMenus

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -11,12 +11,13 @@ import type {
   ProcessedMealType,
   MenuItemContainerType,
 } from '../types'
-import type {FilterType} from '../../components/filter'
+import type {FilterType, PickerType} from '../../components/filter'
 import {applyFiltersToItem} from '../../components/filter'
 import {fastGetTrimmedText} from '../../../lib/html'
 import {findMeal} from '../lib/find-menu'
 import fromPairs from 'lodash/fromPairs'
 import filter from 'lodash/filter'
+import find from 'lodash/find'
 import map from 'lodash/map'
 import flatten from 'lodash/flatten'
 import values from 'lodash/values'
@@ -49,11 +50,15 @@ class FancyMenuView extends React.Component {
     }
 
     const foodItemsArray = values(foodItems)
-    filters = this.buildFilters({foodItems: foodItemsArray, corIcons: menuCorIcons, meals})
+    filters = this.buildFilters(foodItemsArray, menuCorIcons, meals)
     this.props.onFiltersChange(filters)
   }
 
-  buildFilters({foodItems, meals, corIcons}: {foodItems: MenuItemType[], meals: ProcessedMealType[], corIcons: MasterCorIconMapType}): FilterType[] {
+  buildFilters(
+    foodItems: MenuItemType[],
+    corIcons: MasterCorIconMapType,
+    meals: ProcessedMealType[]
+  ): FilterType[] {
     // Format the items for the stations filter
     const stations = flatten(meals.map(meal => meal.stations))
     const stationLabels = uniq(stations.map(station => station.label))
@@ -133,7 +138,7 @@ class FancyMenuView extends React.Component {
   }
 
   findMeal(meals: ProcessedMealType[], filters: FilterType[], now: momentT): ProcessedMealType {
-    const mealChooserFilter = filters.find(f => f.type === 'picker' && f.spec.title === "Today's Menus")
+    const mealChooserFilter: ?PickerType = find(filters, f => f.type === 'picker' && f.spec.title === "Today's Menus")
     let selectedMeal = meals[0]
 
     if (mealChooserFilter && mealChooserFilter.spec.selected) {
@@ -177,7 +182,6 @@ class FancyMenuView extends React.Component {
 
     // group the tuples into an object (because ListView wants {key: value} not [key, value])
     const grouped = fromPairs(filteredByMenu)
-
 
     const specialsFilterEnabled = Boolean(filters.find(f =>
       f.enabled && f.type === 'toggle' && f.spec.label === 'Only Show Specials'))

--- a/source/views/menus/lib/find-menu.js
+++ b/source/views/menus/lib/find-menu.js
@@ -55,11 +55,10 @@ function findMenuIndex(dayparts: DayPartMenuType[], now: momentT): number {
   // Otherwise, we make ourselves a list of {starttime, endtime} pairs so we
   // can query times relative to `now`. Also make sure to set dayOfYear to
   // `now`, so that we don't have our days wandering all over the place.
-  const times = dayparts
-    .map(({starttime, endtime}) => ({
-      start: moment.tz(starttime, 'H:mm', true, CENTRAL_TZ).dayOfYear(now.dayOfYear()),
-      end: moment.tz(endtime, 'H:mm', true, CENTRAL_TZ).dayOfYear(now.dayOfYear()),
-    }))
+  const times = dayparts.map(({starttime, endtime}) => ({
+    start: moment.tz(starttime, 'H:mm', true, CENTRAL_TZ).dayOfYear(now.dayOfYear()),
+    end: moment.tz(endtime, 'H:mm', true, CENTRAL_TZ).dayOfYear(now.dayOfYear()),
+  }))
 
   // We grab the first meal that ends sometime after `now`. The only time
   // this really fails is in the early morning, if it's like 1am and you're

--- a/source/views/menus/lib/find-menu.js
+++ b/source/views/menus/lib/find-menu.js
@@ -6,7 +6,6 @@ import type {
   DayPartMenuType,
   DayPartsCollectionType,
   ProcessedMealType,
-  MilitaryTimeStringType,
 } from '../types'
 const CENTRAL_TZ = 'America/Winnipeg'
 
@@ -31,11 +30,22 @@ export function findMeal(meals: ProcessedMealType[], now: momentT): void|Process
     return
   }
 
-  const mealIndex = findMenuIndex(meals, now)
+  // TODO: Revisit this typing stuff here when we go to flow@0.39
+  const dayparts: DayPartMenuType[] = meals
+    .map(m => ({
+      starttime: m.starttime,
+      endtime: m.endtime,
+      label: m.label,
+      stations: m.stations,
+      id: m.label,
+      abbreviation: m.label,
+    }))
+
+  const mealIndex = findMenuIndex(dayparts, now)
   return meals[mealIndex]
 }
 
-function findMenuIndex(dayparts: {starttime: ?MilitaryTimeStringType, endtime: ?MilitaryTimeStringType}[], now: momentT): number {
+function findMenuIndex(dayparts: DayPartMenuType[], now: momentT): number {
   // If there's only a single bonapp menu for this location (think the Cage,
   // instead of the Caf), we just return that item.
   if (dayparts.length === 1) {
@@ -46,7 +56,6 @@ function findMenuIndex(dayparts: {starttime: ?MilitaryTimeStringType, endtime: ?
   // can query times relative to `now`. Also make sure to set dayOfYear to
   // `now`, so that we don't have our days wandering all over the place.
   const times = dayparts
-    .filter(({starttime, endtime}) => starttime && endtime)
     .map(({starttime, endtime}) => ({
       start: moment.tz(starttime, 'H:mm', true, CENTRAL_TZ).dayOfYear(now.dayOfYear()),
       end: moment.tz(endtime, 'H:mm', true, CENTRAL_TZ).dayOfYear(now.dayOfYear()),

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 // @flow
 import React from 'react'
 import LoadingView from '../components/loading'
@@ -5,12 +6,17 @@ import qs from 'querystring'
 import {NoticeView} from '../components/notice'
 import type {TopLevelViewPropsType} from '../types'
 import {FancyMenu} from './components/fancy-menu'
-import type {BonAppMenuInfoType, BonAppCafeInfoType} from './types'
+import type {
+  BonAppMenuInfoType,
+  BonAppCafeInfoType,
+  StationMenuType,
+  ProcessedMealType,
+  DayPartMenuType,
+} from './types'
 import sample from 'lodash/sample'
 import mapValues from 'lodash/mapValues'
 import type momentT from 'moment'
 import moment from 'moment-timezone'
-import {findMenu} from './lib/find-menu'
 import {trimStationName, trimItemLabel} from './lib/trim-names'
 import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
 import {toLaxTitleCase} from 'titlecase'
@@ -90,6 +96,22 @@ export class BonAppHostedMenu extends React.Component {
     return null
   }
 
+  prepareSingleMenu({mealInfo}: {mealInfo: DayPartMenuType}): ProcessedMealType {
+    let stationMenus: StationMenuType[] = mealInfo
+      ? mealInfo.stations
+      : []
+
+    // Make sure to titlecase the station menus list, too, so the sort works
+    stationMenus = stationMenus.map(s => ({...s, label: toLaxTitleCase(s.label)}))
+
+    return {
+      stationMenus: stationMenus,
+      label: mealInfo.label || '',
+      starttime: mealInfo.starttime || null,
+      endtime: mealInfo.endtime || null,
+    }
+  }
+
   render() {
     if (this.state.loading) {
       return <LoadingView text={sample(this.props.loadingMessage)} />
@@ -114,18 +136,7 @@ export class BonAppHostedMenu extends React.Component {
       return <NoticeView text={specialMessage} />
     }
 
-    // We hard-code to the first day returned because we're only requesting
-    // one day. `cafes` is a map of cafe ids to cafes, but we only request one
-    // cafe at a time, so we just grab the one we requested.
-    let dayparts = cafeMenu.days[0].cafes[cafeId].dayparts
-    let mealInfo = findMenu(dayparts, now)
-    let mealName = mealInfo ? mealInfo.label : ''
-    let stationMenus = mealInfo ? mealInfo.stations : []
-
-    // Make sure to titlecase the station menus list, too, so the sort works
-    stationMenus = stationMenus.map(s => ({...s, label: toLaxTitleCase(s.label)}))
-
-    // flow … has issues when we access cafeMenu.items inside a nested closure
+    // prepare all food items from bonapp for rendering
     const foodItems = mapValues(cafeMenu.items, item => ({
       ...item,  // we want to edit the item, not replace it
       station: toLaxTitleCase(trimStationName(item.station)),  // <b>@station names</b> are a mess
@@ -133,16 +144,26 @@ export class BonAppHostedMenu extends React.Component {
       description: getTrimmedTextWithSpaces(parseHtml(item.description || '')),  // clean up the descriptions
     }))
 
+    // We hard-code to the first day returned because we're only requesting
+    // one day. `cafes` is a map of cafe ids to cafes, but we only request one
+    // cafe at a time, so we just grab the one we requested.
+    const dayparts = cafeMenu.days[0].cafes[cafeId].dayparts
+
+    // either use the meals as provided by bonapp, or make our own custom meal info
+    const mealInfoItems = dayparts[0].length
+      ? dayparts[0]
+      : [{label: 'Menu', starttime: '0:00', endtime: '23:59', id: 'na', abbreviation: 'M', stations: []}]
+    const allMeals = mealInfoItems.map(mealInfo => this.prepareSingleMenu({mealInfo}))
+
     return (
       <FancyMenu
         route={this.props.route}
         navigator={this.props.navigator}
         foodItems={foodItems}
         menuCorIcons={cafeMenu.cor_icons}
-        menuLabel={mealName}
+        meals={allMeals}
         now={now}
         name={this.props.name}
-        stationMenus={stationMenus}
       />
     )
   }

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -105,10 +105,10 @@ export class BonAppHostedMenu extends React.Component {
     stationMenus = stationMenus.map(s => ({...s, label: toLaxTitleCase(s.label)}))
 
     return {
-      stationMenus: stationMenus,
+      stations: stationMenus,
       label: mealInfo.label || '',
-      starttime: mealInfo.starttime || null,
-      endtime: mealInfo.endtime || null,
+      starttime: mealInfo.starttime || '0:00',
+      endtime: mealInfo.endtime || '23:59',
     }
   }
 

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -14,6 +14,7 @@ import type {
   MasterCorIconMapType,
   StationMenuType,
   MenuItemContainerType,
+  ProcessedMealType,
 } from './types'
 import {upgradeMenuItem, upgradeStation} from './lib/process-menu-shorthands'
 import {data as fallbackMenu} from '../../../docs/pause-menu.json'
@@ -29,14 +30,14 @@ export class GitHubHostedMenu extends React.Component {
     now: momentT,
     foodItems: MenuItemContainerType,
     corIcons: MasterCorIconMapType,
-    stationMenus: StationMenuType[],
+    meals: ProcessedMealType[],
   } = {
     error: null,
     loading: true,
     now: moment.tz(CENTRAL_TZ),
     foodItems: {},
     corIcons: {},
-    stationMenus: [],
+    meals: [],
   }
 
   componentWillMount() {
@@ -85,7 +86,12 @@ export class GitHubHostedMenu extends React.Component {
       loading: false,
       corIcons,
       foodItems,
-      stationMenus,
+      meals: [{
+        label: 'Menu',
+        stationMenus: stationMenus,
+        starttime: null,
+        endtime: null,
+      }],
       now: moment.tz(CENTRAL_TZ),
     })
   }
@@ -104,9 +110,8 @@ export class GitHubHostedMenu extends React.Component {
         route={this.props.route}
         navigator={this.props.navigator}
         foodItems={this.state.foodItems}
-        stationMenus={this.state.stationMenus}
         menuCorIcons={this.state.corIcons}
-        menuLabel='Menu'
+        meals={this.state.meals}
         now={this.state.now}
         name={this.props.name}
       />

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -88,9 +88,9 @@ export class GitHubHostedMenu extends React.Component {
       foodItems,
       meals: [{
         label: 'Menu',
-        stationMenus: stationMenus,
-        starttime: null,
-        endtime: null,
+        stations: stationMenus,
+        starttime: '0:00',
+        endtime: '23:59',
       }],
       now: moment.tz(CENTRAL_TZ),
     })

--- a/source/views/menus/types.js
+++ b/source/views/menus/types.js
@@ -45,14 +45,14 @@ export type StationMenuType = {
   items: ItemIdReferenceStringType[],
 };
 
-export type DayPartMenuType = {
+export type DayPartMenuType = {|
   starttime: MilitaryTimeStringType,
   endtime: MilitaryTimeStringType,
   id: NumericStringType,
   label: string,
   abbreviation: string,
   stations: StationMenuType[],
-};
+|};
 
 export type DayPartsCollectionType = Array<Array<DayPartMenuType>>;
 
@@ -123,9 +123,9 @@ export type ProcessedMenuPropsType = {
   [key: string]: MenuItemType[],
 };
 
-export type ProcessedMealType = {
-  starttime: ?MilitaryTimeStringType,
-  endtime: ?MilitaryTimeStringType,
+export type ProcessedMealType = {|
+  starttime: MilitaryTimeStringType,
+  endtime: MilitaryTimeStringType,
   label: string,
-  stationMenus: StationMenuType[],
-};
+  stations: StationMenuType[],
+|};

--- a/source/views/menus/types.js
+++ b/source/views/menus/types.js
@@ -122,3 +122,10 @@ export type BonAppCafeInfoType = {
 export type ProcessedMenuPropsType = {
   [key: string]: MenuItemType[],
 };
+
+export type ProcessedMealType = {
+  starttime: ?MilitaryTimeStringType,
+  endtime: ?MilitaryTimeStringType,
+  label: string,
+  stationMenus: StationMenuType[],
+};


### PR DESCRIPTION
This PR reworks the FancyMenu API to accept a list of "meals", instead of a single menu.

BonAppHostedMenu and GithubHostedMenu have had to take on responsibility for producing those "meals", but this lays the groundwork for letting FancyMenu pick between several menus for a single day.

Of note: The GithubHostedMenu uses `{starttime: 0:00, endtime: 23:59}` because I had to provide values, and nothing currently displays the times in the UI. We can revisit that decision at a later date.

Oh, I also somehow broke proptypes validation in menu-bonapp.js? I really don't understand how. I wound up disabling that lint check for that file. 😞 

There are no UI changes yet.