### PR TITLE
Add a "meal switcher" to the menus

### DIFF
--- a/source/views/components/filter/section-picker.js
+++ b/source/views/components/filter/section-picker.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {Picker, StyleSheet, Platform} from 'react-native'
+import {Picker, StyleSheet} from 'react-native'
 import type {PickerType} from './types'
 import {Section} from 'react-native-tableview-simple'
 
@@ -46,10 +46,6 @@ export function PickerSection({filter, onChange}: PropsType) {
 
 const styles = StyleSheet.create({
   picker: {
-    ...Platform.select({
-      ios: {
-        backgroundColor: 'white',
-      },
-    }),
+    backgroundColor: 'white',
   },
 })

--- a/source/views/components/filter/stringify-filters.js
+++ b/source/views/components/filter/stringify-filters.js
@@ -11,8 +11,11 @@ export function stringifyFilters(filters: FilterType[]): string {
 
 function stringifyFilter(filter: FilterType): string {
   let spec = 'n/a'
+
   if (filter.type === 'list') {
     spec = stringifyListFilter(filter)
+  } else if (filter.type === 'picker') {
+    spec = filter.spec.selected
   }
 
   return JSON.stringify({

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -42,7 +42,7 @@ class FancyMenuView extends React.Component {
   }
 
   componentWillMount() {
-    let {foodItems, menuCorIcons, filters, meals} = this.props
+    let {foodItems, menuCorIcons, filters, meals, now} = this.props
 
     // prevent ourselves from overwriting the filters from redux on mount
     if (filters.length) {
@@ -50,14 +50,15 @@ class FancyMenuView extends React.Component {
     }
 
     const foodItemsArray = values(foodItems)
-    filters = this.buildFilters(foodItemsArray, menuCorIcons, meals)
+    filters = this.buildFilters(foodItemsArray, menuCorIcons, meals, now)
     this.props.onFiltersChange(filters)
   }
 
   buildFilters(
     foodItems: MenuItemType[],
     corIcons: MasterCorIconMapType,
-    meals: ProcessedMealType[]
+    meals: ProcessedMealType[],
+    now: momentT
   ): FilterType[] {
     // Format the items for the stations filter
     const stations = flatten(meals.map(meal => meal.stations))
@@ -76,6 +77,10 @@ class FancyMenuView extends React.Component {
     const shouldShowSpecials = filter(foodItems, item =>
       item.special && stationNames.includes(item.station)).length >= 1
 
+    // Decide which meal will be selected by default
+    const mealOptions = meals.map(m => ({label: m.label}))
+    const selectedMeal = this.findMeal(meals, [], now)
+
     return [
       {
         type: 'toggle',
@@ -87,6 +92,19 @@ class FancyMenuView extends React.Component {
         },
         apply: {
           key: 'special',
+        },
+      },
+      {
+        type: 'picker',
+        key: 'meals',
+        enabled: true,
+        spec: {
+          title: "Today's Menus",
+          options: mealOptions,
+          selected: {label: selectedMeal.label},
+        },
+        apply: {
+          key: 'label',
         },
       },
       {

--- a/source/views/menus/components/filter-menu-toolbar.js
+++ b/source/views/menus/components/filter-menu-toolbar.js
@@ -25,7 +25,9 @@ type PropsType = {
 };
 
 export function FilterMenuToolbar({date, title, filters, onPress}: PropsType) {
-  const appliedFilterCount = filters.filter(f => f.enabled).length
+  const appliedFilterCount = filters
+    .filter(f => f.type !== 'picker')
+    .filter(f => f.enabled).length
   const isFiltered = appliedFilterCount > 0
 
   return (


### PR DESCRIPTION
This addresses a user comment from this morning:

> I want to be able to see the lunch and dinner options at all times of the day. 

So. Now, to switch between menus for the day, open the Filter screen, and pick a menu.

<img src=https://cloud.githubusercontent.com/assets/464441/23099206/0c89825a-f627-11e6-99aa-e3d72a9d1555.png width=320>

I have not yet tested this on Android.
