### PR TITLE
Add support for recreating the station menus from the food items

### DIFF
--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -184,7 +184,8 @@ export class BonAppHostedMenu extends React.Component {
     const mealInfoItems = dayparts[0].length
       ? dayparts[0]
       : [{label: 'Menu', starttime: '0:00', endtime: '23:59', id: 'na', abbreviation: 'M', stations: []}]
-    const allMeals = mealInfoItems.map(mealInfo => this.prepareSingleMenu(mealInfo, foodItems, ignoreProvidedMenus))
+    const ignoreMenus = dayparts[0].length ? ignoreProvidedMenus : true
+    const allMeals = mealInfoItems.map(mealInfo => this.prepareSingleMenu(mealInfo, foodItems, ignoreMenus))
 
     return (
       <FancyMenu

--- a/source/views/menus/tabs.js
+++ b/source/views/menus/tabs.js
@@ -28,6 +28,7 @@ const stolaf = [
     props: {
       name: 'cage',
       cafeId: '262',
+      ignoreProvidedMenus: true,
       loadingMessage: [
         'Checking for vegan cookies…',
         'Serving up some shakes…',


### PR DESCRIPTION
> Closes #660

This PR allows us to opt-in to ignoring the provided list of menu items, in favor of creating the stations from the food items themselves.

This is only necessary because the Cage menu refuses to reference their normal menu items, even though they send them down.

• | Before | After
--- | --- | ---
iOS | ![screen shot 2017-02-18 at 10 19 00 pm](https://cloud.githubusercontent.com/assets/464441/23099285/8db525d6-f628-11e6-8a89-7d98991d3528.png) | ![screen shot 2017-02-18 at 10 18 45 pm](https://cloud.githubusercontent.com/assets/464441/23099286/8db63584-f628-11e6-8675-b515ededd938.png)
