### PR TITLE
Remove Travis' node_module cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_cache:
 cache:
   bundler: true
   directories:
-    - ./node_modules
     - $HOME/.gradle
 
 env:


### PR DESCRIPTION
We've started getting sporadic build failures from react-native-google-analytics-bridge, which is really really odd since it has absolutely no dependencies outside of its folder.
