### PR TITLE
Fix analytics sharing

### DIFF
--- a/source/analytics.js
+++ b/source/analytics.js
@@ -5,18 +5,17 @@ import {
 } from 'react-native-google-analytics-bridge'
 import {stringifyFilters} from './views/components/filter'
 
-import * as storage from './lib/storage'
+import {getAnalyticsOptOut} from './lib/storage'
 
 const trackerId = __DEV__ ? 'UA-90234209-1' : 'UA-90234209-2'
 export const tracker = new GoogleAnalyticsTracker(trackerId)
 
 function disableIfOptedOut() {
-  return storage.getAnalyticsOptOut()
-    .then(didOptOut => {
-      if (didOptOut) {
-        GoogleAnalyticsSettings.setOptOut(true)
-      }
-    })
+  return getAnalyticsOptOut().then(didOptOut => {
+    if (didOptOut) {
+      GoogleAnalyticsSettings.setOptOut(true)
+    }
+  })
 }
 disableIfOptedOut()
 

--- a/source/app.js
+++ b/source/app.js
@@ -104,7 +104,7 @@ const styles = StyleSheet.create({
   },
 })
 
-class App extends React.Component {
+export default class App extends React.Component {
   componentDidMount() {
     tracker.trackEvent('app', 'launch')
     BackAndroid.addEventListener('hardwareBackPress', this.registerAndroidBackButton)
@@ -124,22 +124,22 @@ class App extends React.Component {
     OneSignal.removeEventListener('ids', this.onIds)
   }
 
-  onReceived(notification) {
+  onReceived(notification: any) {
     console.log('Notification received: ', notification)
   }
 
-  onOpened(openResult) {
+  onOpened(openResult: any) {
     console.log('Message: ', openResult.notification.payload.body)
     console.log('Data: ', openResult.notification.payload.additionalData)
     console.log('isActive: ', openResult.notification.isAppInFocus)
     console.log('openResult: ', openResult)
   }
 
-  onRegistered(notifData) {
+  onRegistered(notifData: any) {
     console.log('Device is now registered for push notifications!', notifData)
   }
 
-  onIds(device) {
+  onIds(device: any) {
     console.log('Device info: ', device)
   }
 
@@ -155,6 +155,7 @@ class App extends React.Component {
 
   render() {
     return (
+      <Provider store={store}>
       <Navigator
         ref={nav => this._navigator = nav}
         navigationBar={
@@ -176,14 +177,7 @@ class App extends React.Component {
         sceneStyle={styles.container}
         configureScene={configureScene}
       />
+      </Provider>
     )
   }
-}
-
-export default () => {
-  return (
-    <Provider store={store}>
-      <App />
-    </Provider>
-  )
 }

--- a/source/app.js
+++ b/source/app.js
@@ -125,14 +125,14 @@ export default class App extends React.Component {
   }
 
   onReceived(notification: any) {
-    console.log('Notification received: ', notification)
+    console.log('Notification received:', notification)
   }
 
   onOpened(openResult: any) {
-    console.log('Message: ', openResult.notification.payload.body)
-    console.log('Data: ', openResult.notification.payload.additionalData)
-    console.log('isActive: ', openResult.notification.isAppInFocus)
-    console.log('openResult: ', openResult)
+    console.log('Message:', openResult.notification.payload.body)
+    console.log('Data:', openResult.notification.payload.additionalData)
+    console.log('isActive:', openResult.notification.isAppInFocus)
+    console.log('openResult:', openResult)
   }
 
   onRegistered(notifData: any) {
@@ -140,7 +140,7 @@ export default class App extends React.Component {
   }
 
   onIds(device: any) {
-    console.log('Device info: ', device)
+    console.log('Device info:', device)
   }
 
   _navigator: Navigator;

--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -202,7 +202,7 @@ const initialSettingsState = {
 
   credentials: undefined,
   token: undefined,
-  feedbackEnabled: true,
+  feedbackDisabled: false,
 }
 export function settings(state: Object=initialSettingsState, action: Object) {
   // start out by running the reducers for the complex chunks of the state
@@ -219,7 +219,7 @@ export function settings(state: Object=initialSettingsState, action: Object) {
       return {...state, theme: payload}
 
     case SET_FEEDBACK:
-      return {...state, feedbackEnabled: payload}
+      return {...state, feedbackDisabled: payload}
 
     default:
       return state

--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -33,7 +33,6 @@ export const CHANGE_THEME = 'settings/CHANGE_THEME'
 
 export async function setFeedbackStatus(feedbackEnabled: boolean) {
   await setAnalyticsOptOut(feedbackEnabled)
-  console.log({type: SET_FEEDBACK, payload: feedbackEnabled})
   return {type: SET_FEEDBACK, payload: feedbackEnabled}
 }
 

--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -41,8 +41,8 @@ type SettingsViewPropsType = TopLevelViewPropsType & {
   logInViaToken: (status: boolean) => any,
   logOutViaToken: () => any,
   setLoginCredentials: (username: string, password: string) => any,
-  setFeedbackStatus: (feedbackEnabled: boolean) => any,
-  feedbackEnabled: boolean,
+  setFeedbackStatus: (feedbackDisabled: boolean) => any,
+  feedbackDisabled: boolean,
 };
 
 function SettingsView(props: SettingsViewPropsType) {
@@ -77,7 +77,7 @@ function SettingsView(props: SettingsViewPropsType) {
         <SupportSection />
 
         <OddsAndEndsSection
-          feedbackEnabled={props.feedbackEnabled}
+          feedbackDisabled={props.feedbackDisabled}
           onChangeFeedbackToggle={props.setFeedbackStatus}
           navigator={props.navigator}
           route={props.route}
@@ -94,8 +94,8 @@ function mapStateToProps(state) {
     credentialsValid: state.settings.credentials.valid,
     credentialsMessage: state.settings.credentials.error,
     tokenValid: state.settings.token.valid,
-    feedbackEnabled: state.settings.feedbackEnabled,
     tokenMessage: state.settings.token.error,
+    feedbackDisabled: state.settings.feedbackDisabled,
   }
 }
 

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -53,7 +53,8 @@ export class OddsAndEndsSection extends React.Component {
 
         <CustomCell>
           <Text style={{flex: 1, fontSize: 16}}>Share Analytics</Text>
-          <Switch value={!this.props.feedbackDisabled} onValueChange={val => this.props.onChangeFeedbackToggle(val)} />
+          {/*These are both inverted because the toggle makes more sense as optout/optin, but the code works better as optin/optout */}
+          <Switch value={!this.props.feedbackDisabled} onValueChange={val => this.props.onChangeFeedbackToggle(!val)} />
         </CustomCell>
 
         <Cell cellStyle='Basic'

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -7,8 +7,8 @@ import type {TopLevelViewPropsType} from '../../types'
 
 export class OddsAndEndsSection extends React.Component {
   props: TopLevelViewPropsType & {
-    onChangeFeedbackToggle: (feedbackEnabled: boolean) => any,
-    feedbackEnabled: boolean,
+    onChangeFeedbackToggle: (feedbackDisabled: boolean) => any,
+    feedbackDisabled: boolean,
   };
 
   onPressLegalButton = () => {
@@ -53,7 +53,7 @@ export class OddsAndEndsSection extends React.Component {
 
         <CustomCell>
           <Text style={{flex: 1, fontSize: 16}}>Share Analytics</Text>
-          <Switch value={this.props.feedbackEnabled} onValueChange={val => this.props.onChangeFeedbackToggle(val)} />
+          <Switch value={!this.props.feedbackDisabled} onValueChange={val => this.props.onChangeFeedbackToggle(val)} />
         </CustomCell>
 
         <Cell cellStyle='Basic'


### PR DESCRIPTION
> Well hello there, multi-purpose PR. How nice to see you again.
> Closes #653 

Turns out that we had `feedbackEnabled` and `didOptOut` as synonyms – they were the same value, renamed. Which is a problem, because it means that our "on" state – "share analytics? yes" – was actually the "off" state.

This fixes that.

It also fixes a warning from React about something that Codepush does: 

> Warning: Stateless function components cannot be given refs (See ref "rootComponent" in StatelessComponent created by CodePushComponent). Attempts to access this ref will fail.

And it cleans up some sample code I copied from OneSignal's github during the onesignal@3.0 upgrade.