### PR TITLE
Open News links in platform-specific web browsers

### DIFF
--- a/source/views/components/list/list-item-detail.js
+++ b/source/views/components/list/list-item-detail.js
@@ -8,12 +8,14 @@ const styles = StyleSheet.create({
   detail: {
     paddingTop: 4,
     fontSize: FONT_SIZE,
-    lineHeight: FONT_SIZE * 1.25,
     ...Platform.select({
       ios: {
+        lineHeight: FONT_SIZE * 1.25,
         color: c.iosDisabledText,
       },
       android: {
+        // android lineHeight must be an integer: see kinda https://github.com/facebook/react-native/issues/10607
+        lineHeight: Math.round(FONT_SIZE * 1.25),
         color: c.iosDisabledText,
       },
     }),

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -129,6 +129,7 @@ export class HtmlView extends React.Component {
       })
     } catch (err) {
       // fall back to opening in Chrome / Browser / platform default
+      this.genericOpen(url)
     }
   }
 

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -133,6 +133,13 @@ export class HtmlView extends React.Component {
   }
 
   onNavigationStateChange = ({url}: {url: string}) => {
+    if (url.startsWith('about:')) {
+      return
+    }
+
+    this._webview.stopLoading()
+    this._webview.goBack()
+
     switch (Platform.OS) {
       case 'android':
         return this.androidOpen(url)
@@ -146,6 +153,7 @@ export class HtmlView extends React.Component {
   render() {
     return (
       <WebView
+        ref={ref => this._webview = ref}
         source={{html: this.props.html}}
         onNavigationStateChange={this.onNavigationStateChange}
       />

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -66,12 +66,6 @@ export class HtmlView extends React.Component {
     iosOnDismissListener: null,
   }
 
-  props: {
-    html: string,
-  }
-
-  _webview: WebView;
-
   componentWillMount() {
     SafariView.isAvailable()
       .then(() => {
@@ -96,6 +90,12 @@ export class HtmlView extends React.Component {
         SafariView.removeEventListener('onDismiss', this.state.iosOnDismissListener)
       }).catch(() => {})
   }
+
+  props: {
+    html: string,
+  }
+
+  _webview: WebView;
 
   genericOpen(url: string) {
     Linking.canOpenURL(url)

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -120,16 +120,14 @@ export class HtmlView extends React.Component {
   }
 
   androidOpen(url: string) {
-    try {
-      CustomTabs.openURL(url, {
+    CustomTabs
+      .openURL(url, {
         showPageTitle: true,
         enableUrlBarHiding: true,
         enableDefaultShare: true,
       })
-    } catch (err) {
       // fall back to opening in Chrome / Browser / platform default
-      this.genericOpen(url)
-    }
+      .catch(() => this.genericOpen(url))
   }
 
   onNavigationStateChange = ({url}: {url: string}) => {

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -105,7 +105,7 @@ export class HtmlView extends React.Component {
       case 'ios':
         return this.iosOpen(url)
       default:
-        return
+        return this.genericOpen(url)
     }
   }
 

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -136,7 +136,7 @@ export class HtmlView extends React.Component {
   onNavigationStateChange = ({url}: {url: string}) => {
     // iOS navigates to about:blank when you provide raw HTML to a webview.
     // Android navigates to data:text/html;$stuff (that is, the document you passed) instead.
-    if (url.startsWith('about:') || url.startsWith('data:')) {
+    if (/^about|data:/.test(url)) {
       return
     }
 

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -122,7 +122,6 @@ export class HtmlView extends React.Component {
   androidOpen(url: string) {
     try {
       CustomTabs.openURL(url, {
-        toolbarColor: c.olevilleGold,
         showPageTitle: true,
         enableUrlBarHiding: true,
         enableDefaultShare: true,

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -98,7 +98,13 @@ export class HtmlView extends React.Component {
   }
 
   genericOpen(url: string) {
-    Linking.openURL(url)
+    Linking.canOpenURL(url)
+      .then(isSupported => {
+        if (!isSupported) {
+          console.warn('cannot handle', url)
+        }
+        return Linking.openURL(url)
+      })
       .catch(err => {
         tracker.trackException(err)
         console.error(err)

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -134,6 +134,8 @@ export class HtmlView extends React.Component {
   }
 
   onNavigationStateChange = ({url}: {url: string}) => {
+    // iOS navigates to about:blank when you provide raw HTML to a webview.
+    // Android navigates to data:text/html;$stuff (that is, the document you passed) instead.
     if (url.startsWith('about:') || url.startsWith('data:')) {
       return
     }

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -56,7 +56,13 @@ export function NewsStory({story, embedFeaturedImage, ...props}: {story: StoryTy
       : ''}
     ${story.content}
   `
-  return <WebView {...props} onNavigationStateChange={props.onNavigationStateChange()} source={{html: content}} />
+
+  return (
+    <WebView
+      {...props}
+      source={{html: content}}
+    />
+  )
 }
 
 export default class NewsItem extends React.Component {
@@ -116,7 +122,7 @@ export default class NewsItem extends React.Component {
       <NewsStory
         story={story}
         embedFeaturedImage={embedFeaturedImage}
-        onNavigationStateChange={() => this.onNavigationStateChange}
+        onNavigationStateChange={this.onNavigationStateChange}
       />
     )
   }

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -10,7 +10,7 @@ import {CustomTabs} from 'react-native-custom-tabs'
 
 import type {StoryType} from './types'
 
-export function NewsStory({story, embedFeaturedImage, ...props}: {story: StoryType, embedFeaturedImage: ?boolean}) {
+export default function NewsItem({story, embedFeaturedImage}: {story: StoryType, embedFeaturedImage: ?boolean}) {
   const content = `
     <style>
       body {
@@ -57,18 +57,12 @@ export function NewsStory({story, embedFeaturedImage, ...props}: {story: StoryTy
     ${story.content}
   `
 
-  return (
-    <WebView
-      {...props}
-      source={{html: content}}
-    />
-  )
+  return <HtmlView html={content} />
 }
 
-export default class NewsItem extends React.Component {
+export class HtmlView extends React.Component {
   props: {
-    story: StoryType,
-    embedFeaturedImage: ?boolean,
+    html: string,
   }
 
   genericOpen(url: string) {
@@ -116,12 +110,9 @@ export default class NewsItem extends React.Component {
   }
 
   render() {
-    const {story, embedFeaturedImage} = this.props
-
     return (
-      <NewsStory
-        story={story}
-        embedFeaturedImage={embedFeaturedImage}
+      <WebView
+        source={{html: this.props.html}}
         onNavigationStateChange={this.onNavigationStateChange}
       />
     )

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {WebView, Platform, Linking} from 'react-native'
+import {WebView, Platform, Linking, StatusBar} from 'react-native'
 
 import * as c from '../components/colors'
 
@@ -61,8 +61,40 @@ export default function NewsItem({story, embedFeaturedImage}: {story: StoryType,
 }
 
 export class HtmlView extends React.Component {
+  state = {
+    iosOnShowListener: null,
+    iosOnDismissListener: null,
+  }
+
   props: {
     html: string,
+  }
+
+  _webview: WebView;
+
+  componentWillMount() {
+    SafariView.isAvailable()
+      .then(() => {
+        const iosOnShowListener = SafariView.addEventListener('onShow',
+          () => StatusBar.setBarStyle('dark-content'))
+
+        const iosOnDismissListener = SafariView.addEventListener('onDismiss',
+          () => StatusBar.setBarStyle('light-content'))
+
+        this.setState({
+          iosOnShowListener,
+          iosOnDismissListener,
+        })
+      })
+      .catch(() => {})
+  }
+
+  componentWillUnmount() {
+    SafariView.isAvailable()
+      .then(() => {
+        SafariView.removeEventListener('onShow', this.state.iosOnShowListener)
+        SafariView.removeEventListener('onDismiss', this.state.iosOnDismissListener)
+      }).catch(() => {})
   }
 
   genericOpen(url: string) {

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -134,7 +134,7 @@ export class HtmlView extends React.Component {
   }
 
   onNavigationStateChange = ({url}: {url: string}) => {
-    if (url.startsWith('about:')) {
+    if (url.startsWith('about:') || url.startsWith('data:')) {
       return
     }
 

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -107,12 +107,8 @@ export class HtmlView extends React.Component {
 
   iosOpen(url: string) {
     SafariView.isAvailable()
-      .then(() => {
-        SafariView.show({
-          url: url,
-          barTintColor: c.olevilleGold,
-        })
-      })
+    // if it's around, open in safari
+      .then(() => SafariView.show({url}))
       // fall back to opening in default browser
       .catch(() => this.genericOpen(url))
   }


### PR DESCRIPTION
> Closes #68

This PR takes over the links in News views and opens them in either an SFWebView (iOS) or a Chrome Custom Tab™ (Android).

• | iOS | Android
--- | --- | ---
News article | <img src=https://cloud.githubusercontent.com/assets/464441/23180697/d866b340-f837-11e6-9707-06328f9816b1.png width=320> | <img src=https://cloud.githubusercontent.com/assets/464441/23236550/416c754a-f91f-11e6-8572-9b192d4556ea.png width=320>
Web view | <img src=https://cloud.githubusercontent.com/assets/464441/23180696/d8646bf8-f837-11e6-96f7-adb682afd62e.png width=320> | <img src=https://cloud.githubusercontent.com/assets/464441/23236551/4177a82a-f91f-11e6-9aee-7bb9c03b5598.png width=320>

