### PR TITLE
Add a network cache layer

### DIFF
--- a/android/app/src/main/java/com/allaboutolaf/MainApplication.java
+++ b/android/app/src/main/java/com/allaboutolaf/MainApplication.java
@@ -1,6 +1,8 @@
 package com.allaboutolaf;
 
 import android.app.Application;
+import android.net.http.HttpResponseCache;
+import android.os.Bundle;
 import android.util.Log;
 
 // keep these sorted alphabetically
@@ -18,6 +20,8 @@ import com.microsoft.codepush.react.CodePush;
 import com.oblador.keychain.KeychainPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -59,5 +63,22 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
+
+    // set up network cache
+    try {
+      File httpCacheDir = new File(getApplicationContext().getCacheDir(), "http");
+      long httpCacheSize = 20 * 1024 * 1024; // 20 MiB
+      HttpResponseCache.install(httpCacheDir, httpCacheSize);
+    } catch (IOException e) {
+      Log.i("allaboutolaf", "HTTP response cache installation failed:", e);
+      //      Log.i(TAG, "HTTP response cache installation failed:", e);
+    }
+  }
+
+  public void onStop() {
+    HttpResponseCache cache = HttpResponseCache.getInstalled();
+    if (cache != null) {
+      cache.flush();
+    }
   }
 }

--- a/ios/AllAboutOlaf/AppDelegate.m
+++ b/ios/AllAboutOlaf/AppDelegate.m
@@ -24,7 +24,8 @@
   NSURL *jsCodeLocation;
 
 #ifdef DEBUG
-    jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
+    jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios"
+                                                                    fallbackResource:nil];
 #else
     jsCodeLocation = [CodePush bundleURL];
 #endif
@@ -48,6 +49,12 @@
 
   self.oneSignal = [[RCTOneSignal alloc] initWithLaunchOptions:launchOptions
                                                          appId:@"aa46a500-ab1c-4127-b9ff-e7373da3ce35"];
+
+  // set up the requests cacher
+  NSURLCache *URLCache = [[NSURLCache alloc] initWithMemoryCapacity:4 * 1024 * 1024   // 4 MiB
+                                                       diskCapacity:20 * 1024 * 1024  // 20 MiB
+                                                           diskPath:nil];
+  [NSURLCache setSharedURLCache:URLCache];
 
   return YES;
 }


### PR DESCRIPTION
> "Untold numbers of developers have hacked together an awkward, fragile system for network caching functionality, all because they weren’t aware that NSURLCache could be setup in two lines and do it 100× better. Even more developers have never known the benefits of network caching, and never attempted a solution, causing their apps to make untold numbers of unnecessary requests to the server."

Using https://developer.android.com/reference/android/net/http/HttpResponseCache.html and http://nshipster.com/nsurlcache/ as guides, I implemented a native-level network cache layer.

As I understand it, RN implemented fetch on top of XMLHttpRequest, and they built [XMLHttpRequest on top of the native requests](https://facebook.github.io/react-native/releases/0.26/docs/network.html#xmlhttprequest), so we can just set up the cache at the native code level and it'll "just work". Theoretically.

This still needs some more testing, but… yeah. If it works, this is so simple.