### PR TITLE
Read package version from package.json instead of app package

### DIFF
--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import {Text, Switch} from 'react-native'
 import {Cell, CustomCell, Section} from 'react-native-tableview-simple'
-import {getVersion} from 'react-native-device-info'
+import {version} from '../../../../package.json'
 import type {TopLevelViewPropsType} from '../../types'
 
 export class OddsAndEndsSection extends React.Component {
@@ -48,7 +48,7 @@ export class OddsAndEndsSection extends React.Component {
       <Section header='ODDS & ENDS'>
         <Cell cellStyle='RightDetail'
           title='Version'
-          detail={getVersion()}
+          detail={version}
         />
 
         <CustomCell>

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -60,7 +60,7 @@ export class OddsAndEndsSection extends React.Component {
         <Cell cellStyle='Basic'
           title='FAQ'
           accessory='DisclosureIndicator'
-          onPress={() => this.onPressFaqButton()}
+          onPress={this.onPressFaqButton}
         />
 
         <Cell cellStyle='Basic'

--- a/source/views/settings/sections/support.js
+++ b/source/views/settings/sections/support.js
@@ -3,6 +3,7 @@ import React from 'react'
 import {Cell, Section} from 'react-native-tableview-simple'
 import Communications from 'react-native-communications'
 import DeviceInfo from 'react-native-device-info'
+import {version} from '../../../../package.json'
 
 export class SupportSection extends React.Component {
   getDeviceInfo = () => {
@@ -12,6 +13,7 @@ export class SupportSection extends React.Component {
       ${DeviceInfo.getDeviceId()}
       ${DeviceInfo.getSystemName()} ${DeviceInfo.getSystemVersion()}
       ${DeviceInfo.getReadableVersion()}
+      Codepush: ${version}
     `
   }
 


### PR DESCRIPTION
> Closes #712

This PR pulls the app version from package.json instead of `react-native-get-device-info`.

This allows us to update the version via Codepush.