### PR TITLE
Remove all <form> articles from the list of news articles

### DIFF
--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -45,8 +45,8 @@ export class NewsList extends React.Component {
 
   init(props: NewsListPropsType) {
     // remove all entries with a <form> from the list
-    const entries = props.entries.filter(entry => entry.content.includes('<form>'))
-    this.setState({dataSource: this.state.dataSource.cloneWithRows(props.entries)})
+    const entries = props.entries.filter(entry => !entry.content.includes('<form>'))
+    this.setState({dataSource: this.state.dataSource.cloneWithRows(entries)})
   }
 
   renderRow = (story: StoryType) => {

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -44,6 +44,8 @@ export class NewsList extends React.Component {
   props: NewsListPropsType;
 
   init(props: NewsListPropsType) {
+    // remove all entries with a <form> from the list
+    const entries = props.entries.filter(entry => entry.content.includes('<form>'))
     this.setState({dataSource: this.state.dataSource.cloneWithRows(props.entries)})
   }
 


### PR DESCRIPTION
> closes https://github.com/StoDevX/AAO-React-Native/issues/744

This just does `entries.filter(entry => entry.content.includes('<form>'))`, which should avoid people talking about forms – that'd be encoded as `&lt;form&gt;`.

This does hide articles that include a form in the middle of other content, though… but so far, I think, all of our `form` entries have been entirely forms.

I want to prefer the `form {display: none}` approach, but I don't want the user to see blank stories in the list.

Actually. What about, like, `form {opacity: 0.5; pointer-events: none}`? That would essentially just disable the form, while still leaving it visible.

Thoughts?