### PR TITLE
Make validate-data quieter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ script:
   # Lint
   - if [[ "$type" == "js" ]]; then npm run lint; fi
   # Validate data
-  - if [[ "$type" == "js" ]]; then npm run validate-data; fi
+  - if [[ "$type" == "js" ]]; then npm run validate-data -- --quiet; fi
   # Ensure that the data files have been updated
   - |
     if [[ "$type" == "js" ]]; then

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -57,7 +57,7 @@ for (const multitudes of iterator) {
 function parseArgs(argv) {
   const allSchemas = readDir(SCHEMA_BASE).map(f => f.replace('.yaml', ''))
   const args = minimist(argv, {
-    boolean: ['help', 'bail', 'quiet],
+    boolean: ['help', 'bail', 'quiet'],
     string: ['data', 'schema'],
     alias: {d: 'data', s: 'schema'},
     default: {

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -48,7 +48,7 @@ for (const multitudes of iterator) {
       }
       break
     }
-    console.log(`${filename} is valid`)
+    args.quiet || console.log(`${filename} is valid`)
   }
 }
 
@@ -57,7 +57,7 @@ for (const multitudes of iterator) {
 function parseArgs(argv) {
   const allSchemas = readDir(SCHEMA_BASE).map(f => f.replace('.yaml', ''))
   const args = minimist(argv, {
-    boolean: ['help', 'bail'],
+    boolean: ['help', 'bail', 'quiet],
     string: ['data', 'schema'],
     alias: {d: 'data', s: 'schema'},
     default: {


### PR DESCRIPTION
This adds a `--quiet` flag to the validate-data script, so it will only print lines that are problematic files.