### PR TITLE
Send event for the first tab when opening a tab view

### DIFF
--- a/source/views/components/tabbed-view/index.android.js
+++ b/source/views/components/tabbed-view/index.android.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
-import { StyleSheet, Platform, Dimensions } from 'react-native'
-import { TabViewAnimated, TabBar } from 'react-native-tab-view'
+import {StyleSheet, Platform, Dimensions} from 'react-native'
+import {TabViewAnimated, TabBar} from 'react-native-tab-view'
 import * as c from '../colors'
 import type { TabbedViewPropsType } from './types'
 import {tracker} from '../../../analytics'
@@ -27,6 +27,10 @@ const styles = StyleSheet.create({
 export default class TabbedView extends React.Component {
   state = {
     index: 0,
+  }
+
+  componentWillMount() {
+    this._handleChangeTab(0)
   }
 
   props: TabbedViewPropsType

--- a/source/views/components/tabbed-view/index.ios.js
+++ b/source/views/components/tabbed-view/index.ios.js
@@ -16,6 +16,10 @@ export default class TabbedView extends React.Component {
     selectedTab: this.props.tabs[0].id,
   }
 
+  componentWillMount() {
+    this.onChangeTab(this.props.tabs[0].id)
+  }
+
   props: TabbedViewPropsType;
 
   onChangeTab = (tabId: string) => {

--- a/source/views/components/tabbed-view/index.ios.js
+++ b/source/views/components/tabbed-view/index.ios.js
@@ -1,12 +1,12 @@
 // @flow
 
 import React from 'react'
-import { TabBarIOS } from 'react-native'
+import {TabBarIOS} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {tracker} from '../../../analytics'
 import styles from './styles'
-import type { TabbedViewPropsType } from './types'
-import { TabbedViewPropTypes } from './types'
+import type {TabbedViewPropsType} from './types'
+import {TabbedViewPropTypes} from './types'
 import * as c from '../../components/colors'
 
 export default class TabbedView extends React.Component {
@@ -34,15 +34,12 @@ export default class TabbedView extends React.Component {
             let name = tab.rnVectorIcon.iconName
             icon.iconName = `ios-${name}-outline`
             icon.selectedIconName = `ios-${name}`
-          } else if (tab.rnRasterIcon) {
-            icon = tab.rnRasterIcon
           }
           return <Icon.TabBarItemIOS
             key={tab.id}
             // apply either the vector icon, a given raster (base64) icon, or nothing.
-            {...(tab.rnVectorIcon || tab.rnRasterIcon || {})}
-            title={tab.title}
             {...icon}
+            title={tab.title}
             style={styles.listViewStyle}
             selected={this.state.selectedTab === tab.id}
             translucent={true}


### PR DESCRIPTION
> Closes #717 

This PR sends an analytics event for the first tab opened in a tab view.

The existing behavior only sent events for the tabs you tapped on while in the tabbed view, but not the first tab itself.