### PR TITLE
Track URL-based homescreen buttons

### DIFF
--- a/source/views/components/open-url.js
+++ b/source/views/components/open-url.js
@@ -76,6 +76,10 @@ export default function openUrl(url: string) {
   }
 }
 
+export function trackedOpenUrl({url, id}: {url: string, id?: string}) {
+  tracker.trackScreenView(id || url)
+  return openUrl(url)
+}
 
 export function canOpenUrl(url: string) {
   // iOS navigates to about:blank when you provide raw HTML to a webview.

--- a/source/views/home/home.js
+++ b/source/views/home/home.js
@@ -19,7 +19,7 @@ import type {TopLevelViewPropsType} from '../types'
 import type {ViewType} from '../views'
 import {allViews} from '../views'
 import {HomeScreenButton, CELL_MARGIN} from './button'
-import openUrl from '../components/open-url'
+import {trackedOpenUrl} from '../components/open-url'
 
 
 function HomePage({navigator, route, order, views=allViews}: {order: string[], views: ViewType[]} & TopLevelViewPropsType) {
@@ -39,17 +39,19 @@ function HomePage({navigator, route, order, views=allViews}: {order: string[], v
         <HomeScreenButton
           view={view}
           key={view.view}
-          onPress={() =>
-            view.type === 'view'
-              ? navigator.push({
+          onPress={() => {
+            if (view.type === 'url') {
+              return trackedOpenUrl({url: view.url, id: view.view})
+            } else {
+              return navigator.push({
                 id: view.view,
                 index: route.index + 1,
                 title: view.title,
                 backButtonTitle: 'Home',
                 sceneConfig: Navigator.SceneConfigs.PushFromRight,
               })
-              : openUrl(view.url)
-          }
+            }
+          }}
         />)
       }
     </ScrollView>


### PR DESCRIPTION
We track every view that we render, but these new homescreen buttons won't be tracked, because they're not rendering one of our views.

So, I added a `trackedOpenUrl({url, id?})` function to track them, instead.

I plan to also use that function to track links from Other Modes and … well, pretty much every link clicked outside of News.