### PR TITLE
Fix Travis command exit statuses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,9 @@ script:
   # These sections will grow over time.
   # Each line is collapsed nicely in the travis output.
 
+  # Make sure that a failing command in a pipe fails the build
+  - set -o pipefail
+
   # ensure the env file exists and fill it out
   - touch .env.js
   - echo "export const GOOGLE_CALENDAR_API_KEY = '$GCAL_KEY'" >> .env.js

--- a/source/views/building-hours/detail.ios.js
+++ b/source/views/building-hours/detail.ios.js
@@ -77,6 +77,8 @@ export class BuildingHoursDetailView extends React.Component {
     now: moment.tz(CENTRAL_TZ),
   }
 
+  props: BuildingType;
+
   componentWillMount() {
     // This updates the screen every ten seconds, so that the building
     // info statuses are updated without needing to leave and come back.
@@ -86,8 +88,6 @@ export class BuildingHoursDetailView extends React.Component {
   componentWillUnmount() {
     clearTimeout(this.state.intervalId)
   }
-
-  props: BuildingType;
 
   updateTime = () => {
     this.setState({now: moment.tz(CENTRAL_TZ)})

--- a/source/views/building-hours/detail.ios.js
+++ b/source/views/building-hours/detail.ios.js
@@ -77,8 +77,6 @@ export class BuildingHoursDetailView extends React.Component {
     now: moment.tz(CENTRAL_TZ),
   }
 
-  props: BuildingType;
-
   componentWillMount() {
     // This updates the screen every ten seconds, so that the building
     // info statuses are updated without needing to leave and come back.
@@ -88,6 +86,8 @@ export class BuildingHoursDetailView extends React.Component {
   componentWillUnmount() {
     clearTimeout(this.state.intervalId)
   }
+
+  props: BuildingType;
 
   updateTime = () => {
     this.setState({now: moment.tz(CENTRAL_TZ)})


### PR DESCRIPTION
> closes #761

Adds `set -o pipefail` to the beginning of Travis so that failing commands in pipes will produce error codes.