### PR TITLE
Fix button titles

### DIFF
--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -52,7 +52,7 @@ export default function KSTOView() {
             })
           }
         }}
-        text='Listen to KSTO'
+        title='Listen to KSTO'
       />
       <Text style={styles.kstoSubtext}>Look out for changes here soon!</Text>
     </View>

--- a/source/views/transportation/otherModes.js
+++ b/source/views/transportation/otherModes.js
@@ -56,9 +56,8 @@ export default class OtherModesView extends React.Component {
         <Text style={styles.content}>{data.description}</Text>
         <Button
           onPress={() => openUrl(data.url)}
-          style={styles.button}>
-          More info
-        </Button>
+          title='More info'
+        />
       </View>
     )
   }


### PR DESCRIPTION
I forgot to pass them as `title=` during the last refactoring pass, so they were set to "Push Me!"…