### PR TITLE
Trim carleton menu icons

### DIFF
--- a/source/views/menus/lib/trim-names.js
+++ b/source/views/menus/lib/trim-names.js
@@ -7,7 +7,7 @@ export function trimStationName(stationName: string) {
 
 function removeParenTags(str: string) {
   const parensRegex = / \([^)]*?\)$/
-  while (str !== str.replace(parensRegex, '')) {
+  while (str.match(parensRegex)) {
     str = str.replace(parensRegex, '')
   }
   return str

--- a/source/views/menus/lib/trim-names.js
+++ b/source/views/menus/lib/trim-names.js
@@ -7,5 +7,5 @@ export function trimStationName(stationName: string) {
 
 export function trimItemLabel(label: string) {
   // remove extraneous whitespace and title-case the bonapp titles
-  return toLaxTitleCase(label.replace(/\s+/g, ' '))
+  return toLaxTitleCase((label.replace(/\s+/g, ' ')).replace(/\([^)]?.?.\)/g, ''))
 }

--- a/source/views/menus/lib/trim-names.js
+++ b/source/views/menus/lib/trim-names.js
@@ -5,7 +5,17 @@ export function trimStationName(stationName: string) {
   return stationName.replace(/<strong>@(.*)<\/strong>/, '$1')
 }
 
+function removeParenTags(str: string) {
+  const parensRegex = / \([^)]*?\)$/
+  while (str !== str.replace(parensRegex, '')) {
+    str = str.replace(parensRegex, '')
+  }
+  return str
+}
+
 export function trimItemLabel(label: string) {
   // remove extraneous whitespace and title-case the bonapp titles
-  return toLaxTitleCase((label.replace(/\s+/g, ' ')).replace(/\([^)]?.?.\)/g, ''))
+  const evenedWhitespace = label.replace(/\s+/g, ' ')
+  const noParens = removeParenTags(evenedWhitespace)
+  return toLaxTitleCase(noParens)
 }


### PR DESCRIPTION
Carleton's bonapp adds `(H) (F2F) (VG) (V) (↓G)` and various other dietary markers to food item labels. We already provide the icons in the view which means there is duplication of information.

This PR proposes we check for any open and closing paren `(` and `)` and remove any including the contents that have 3 or less characters. `F2F` appears to be the largest of the bunch. 

The regex is `/\([^)]?.?.\)/g`. 

There might be a better way, but this seems efficient to say the least. @hawkrives ?

| Before | After
--- | ---
<img src=https://cloud.githubusercontent.com/assets/5240843/23333607/17b5792e-fb5c-11e6-8a0c-9f004c6f27a2.png width=320> | <img src=https://cloud.githubusercontent.com/assets/5240843/23333604/109fb0e6-fb5c-11e6-958a-9e1b917c5376.png width=320>