### PR TITLE
Allow wider Android screen titles

### DIFF
--- a/source/views/components/navigation/title.js
+++ b/source/views/components/navigation/title.js
@@ -8,9 +8,13 @@ import {Text, Dimensions, StyleSheet, Platform} from 'react-native'
 import type {RouteType} from '../../types'
 
 export function Title(route: RouteType) {
+  const maxWidth = Platform.OS === 'ios'
+      ? Dimensions.get('window').width / 2.5
+      : Dimensions.get('window').width - 100
+
   return (
     <Text
-      style={[styles.text, {maxWidth: Dimensions.get('window').width / 2.5}]}
+      style={[styles.text, {maxWidth}]}
       numberOfLines={1}
       ellipsizeMode='tail'
     >


### PR DESCRIPTION
> Closes #507.

• | Before | After
--- | --- | ---
&nbsp; | ![screen shot 2017-02-27 at 2 58 49 pm](https://cloud.githubusercontent.com/assets/464441/23379704/9225bf6e-fcfd-11e6-8332-8d311c386c4d.png) | ![screen shot 2017-02-27 at 2 58 43 pm](https://cloud.githubusercontent.com/assets/464441/23379714/97c7bde6-fcfd-11e6-939a-959b9064cf52.png)

I can't do this as easily on iOS, since iOS centers its screen title.