### PR TITLE
Fix more building hour comparisons

### DIFF
--- a/source/views/building-hours/__tests__/get-status-of-building-at-moment.test.js
+++ b/source/views/building-hours/__tests__/get-status-of-building-at-moment.test.js
@@ -36,3 +36,17 @@ it('handles after the schedule closes', () => {
 
   expect(getStatusOfBuildingAtMoment(schedule, m)).toBe('Closed')
 })
+
+it('rounds the second down when calculating times (pre-30s)', () => {
+  let m = dayMoment('Tue 7:43:30am', 'ddd h:mm:ssa')
+  let schedule = {days: ['Tu'], from: '8:00am', to: '1:00pm'}
+
+  expect(getStatusOfBuildingAtMoment(schedule, m)).toBe('Opens in 17 minutes')
+})
+
+it('rounds the second down when calculating times (post-30s)', () => {
+  let m = dayMoment('Tue 7:43:31am', 'ddd h:mm:ssa')
+  let schedule = {days: ['Tu'], from: '8:00am', to: '1:00pm'}
+
+  expect(getStatusOfBuildingAtMoment(schedule, m)).toBe('Opens in 17 minutes')
+})

--- a/source/views/building-hours/__tests__/parse-hours.test.js
+++ b/source/views/building-hours/__tests__/parse-hours.test.js
@@ -31,8 +31,8 @@ it('will add a day to the close time with nextDay:true', () => {
   let input = {days: [], from: '10:00am', to: '2:00am'}
   let {open, close} = parseHours(input, now)
 
-  expect(close.isAfter(open, 'minute')).toBe(true)
-  expect(close.isAfter(now, 'minute')).toBe(true)
+  expect(close.isAfter(open)).toBe(true)
+  expect(close.isAfter(now)).toBe(true)
 })
 
 describe('handles wierd times', () => {
@@ -41,7 +41,7 @@ describe('handles wierd times', () => {
     let input = {days: [], from: '10:00am', to: '2:00am'}
     let {open, close} = parseHours(input, now)
 
-    expect(now.isBetween(open, close, 'minute')).toBe(true)
+    expect(now.isBetween(open, close)).toBe(true)
   })
 
   it('handles Saturday at 1:30am', () => {
@@ -49,6 +49,6 @@ describe('handles wierd times', () => {
     let input = {days: [], from: '10:00am', to: '2:00am'}
     let {open, close} = parseHours(input, now)
 
-    expect(now.isBetween(open, close, 'minute')).toBe(true)
+    expect(now.isBetween(open, close)).toBe(true)
   })
 })

--- a/source/views/building-hours/building-hours-helpers.js
+++ b/source/views/building-hours/building-hours-helpers.js
@@ -27,7 +27,7 @@ export function parseHours({from: fromTime, to: toTime}: SingleBuildingScheduleT
   let close = moment.tz(toTime, TIME_FORMAT, true, CENTRAL_TZ)
   close.dayOfYear(dayOfYear)
 
-  if (close.isBefore(open, 'minute')) {
+  if (close.isBefore(open)) {
     close.add(1, 'day')
   }
 
@@ -77,11 +77,11 @@ export function formatBuildingTimes(schedule: SingleBuildingScheduleType, m: mom
 export function getStatusOfBuildingAtMoment(schedule: SingleBuildingScheduleType, m: momentT): string {
   let {open, close} = parseHours(schedule, m)
 
-  if (m.isBefore(open, 'minute') && m.clone().add(30, 'minutes').isSameOrAfter(open, 'minute')) {
+  if (m.isBefore(open) && m.clone().add(30, 'minutes').isSameOrAfter(open)) {
     return `Opens ${m.to(open)}`
   }
   if (m.isBetween(open, close, 'minute', '[)')) {
-    if (m.clone().add(30, 'minutes').isSameOrAfter(close, 'minute')) {
+    if (m.clone().add(30, 'minutes').isSameOrAfter(close)) {
       return `Closes ${m.to(close)}`
     }
     return 'Open'

--- a/source/views/building-hours/building-hours-helpers.js
+++ b/source/views/building-hours/building-hours-helpers.js
@@ -62,7 +62,7 @@ export function getTimeUntilChapelCloses(m: momentT, schedules: SingleBuildingSc
     return 'No chapel'
   }
   let {close} = parseHours(sched, m)
-  return m.to(close)
+  return m.clone().seconds(0).to(close)
 }
 
 export function formatBuildingTimes(schedule: SingleBuildingScheduleType, m: momentT): string {
@@ -78,11 +78,11 @@ export function getStatusOfBuildingAtMoment(schedule: SingleBuildingScheduleType
   let {open, close} = parseHours(schedule, m)
 
   if (m.isBefore(open) && m.clone().add(30, 'minutes').isSameOrAfter(open)) {
-    return `Opens ${m.to(open)}`
+    return `Opens ${m.clone().seconds(0).to(open)}`
   }
   if (m.isBetween(open, close, 'minute', '[)')) {
     if (m.clone().add(30, 'minutes').isSameOrAfter(close)) {
-      return `Closes ${m.to(close)}`
+      return `Closes ${m.clone().seconds(0).to(close)}`
     }
     return 'Open'
   }

--- a/source/views/menus/lib/find-menu.js
+++ b/source/views/menus/lib/find-menu.js
@@ -63,7 +63,7 @@ function findMenuIndex(dayparts: DayPartMenuType[], now: momentT): number {
   // We grab the first meal that ends sometime after `now`. The only time
   // this really fails is in the early morning, if it's like 1am and you're
   // wondering what there was at dinner.
-  let mealIndex = findIndex(times, ({end}) => now.isSameOrBefore(end, 'minute'))
+  let mealIndex = findIndex(times, ({end}) => now.isSameOrBefore(end))
 
   // If we didn't find a meal, we must be after the last meal, so we want to
   // return the last meal of the day.

--- a/source/views/transportation/bus/bus-line.js
+++ b/source/views/transportation/bus/bus-line.js
@@ -39,9 +39,9 @@ const stopColors = {
 function makeSubtitle({now, moments, isLastBus}) {
   let lineDetail = 'Running'
 
-  if (now.isBefore(head(moments), 'minute')) {
+  if (now.isBefore(head(moments))) {
     lineDetail = `Starts ${now.to(head(moments))}`
-  } else if (now.isAfter(last(moments), 'minute')) {
+  } else if (now.isAfter(last(moments))) {
     lineDetail = 'Over for Today'
   } else if (isLastBus) {
     lineDetail = 'Last Bus'

--- a/source/views/transportation/bus/bus-line.js
+++ b/source/views/transportation/bus/bus-line.js
@@ -40,7 +40,7 @@ function makeSubtitle({now, moments, isLastBus}) {
   let lineDetail = 'Running'
 
   if (now.isBefore(head(moments))) {
-    lineDetail = `Starts ${now.to(head(moments))}`
+    lineDetail = `Starts ${now.clone().seconds(0).to(head(moments))}`
   } else if (now.isAfter(last(moments))) {
     lineDetail = 'Over for Today'
   } else if (isLastBus) {


### PR DESCRIPTION
This is a followup to #737.

We realized that it's not the comparisons that are printing out off-by-a-minute times, but it's instead the calls to `Moment#to`, which changes the "in N minutes" at the 31 second mark.

This sets the moment to 0 seconds, so it will always report the same "minutes until" until the minute changes.