### PR TITLE
Sign Android betas that are pushed to HockeyApp

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -68,6 +68,8 @@ import com.android.build.OutputFile
 project.ext.react = [
     // ignore the ruby deps
     inputExcludes: ["android/**", "ios/**", "vendor/**"],
+    // whether to bundle JS and assets in another build variant (if configured).
+    bundleInRogue: true,
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -105,6 +107,14 @@ android {
                         onesignal_app_id: "aa46a500-ab1c-4127-b9ff-e7373da3ce35",
                         onesignal_google_project_number: "185558680648"]
     }
+    signingConfigs {
+        rogue {
+            storeFile file(APP_RELEASE_STORE_FILE)
+            storePassword APP_RELEASE_STORE_PASSWORD
+            keyAlias APP_RELEASE_KEY_ALIAS
+            keyPassword APP_RELEASE_KEY_PASSWORD
+        }
+    }
     splits {
         abi {
             reset()
@@ -117,6 +127,11 @@ android {
         release {
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+        rogue {
+            // the 'initWith' property allows you to copy configurations from other build types
+            initWith release
+            signingConfig signingConfigs.rogue
         }
     }
     // applicationVariants are e.g. debug, release

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -200,6 +200,7 @@ platform :android do
 
     ci_git_setup
 
+    git_url = "https://github.com/hawkrives/aao-keys"
     dir = Dir.mktmpdir
     command = "git clone --depth 1 '#{git_url}' '#{dir}'"
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -159,12 +159,16 @@ platform :android do
 
   desc "Submit a new Beta Build to HockeyApp"
   lane :beta do
+    # add a keystore
+    ci_keystore
+
+    # build the app
     build
 
     # Upload to HockeyApp
     hockey(
       api_token: ENV["HOCKEYAPP_TOKEN"],
-      apk: "./android/app/build/outputs/apk/app-release-unsigned.apk",
+      apk: "./android/app/build/outputs/apk/app-rogue.apk",
       commit_sha: ENV["TRAVIS_COMMIT"],
       notes: build_notes(platform: 'Android'),
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -190,6 +190,42 @@ platform :android do
       build
     end
   end
+
+  lane :ci_keystore do
+    require 'fileutils'
+
+    ci_git_setup
+
+    dir = Dir.mktmpdir
+    command = "git clone --depth 1 '#{git_url}' '#{dir}'"
+
+    # this block pulled from https://github.com/fastlane/fastlane/blob/master/match/lib/match/git_helper.rb
+    UI.message "Cloning remote git repo..."
+    begin
+      # GIT_TERMINAL_PROMPT will fail the `git clone` command if user credentials are missing
+      FastlaneCore::CommandExecutor.execute(command: "GIT_TERMINAL_PROMPT=0 #{command}",
+                                          print_all: true,
+                                      print_command: true)
+    rescue
+      UI.error("Error cloning certificates repo, please make sure you have read access to the repository you want to use")
+      UI.error("Run the following command manually to make sure you're properly authenticated:")
+      UI.command(command)
+      UI.user_error!("Error cloning certificates git repo, please make sure you have access to the repository - see instructions above")
+    end
+
+    # don't forget – lanes run inside of ./fastlane
+    gradle_file = "gradle.properties"
+    keystore_name = "rogue-release-key.keystore"
+
+    src_dir = "#{dir}/android"
+    dest_dir = "../android/app"
+
+    # FastlaneCore::CommandExecutor.execute(command: "pwd", print_all: true, print_command: true)
+    UI.message "cp #{src_dir}/#{gradle_file} #{ENV["HOME"]}/.gradle/#{gradle_file}"
+    FileUtils.cp("#{src_dir}/#{gradle_file}", "#{ENV["HOME"]}/.gradle/#{gradle_file}")
+    UI.message "#{src_dir}/#{keystore_name} #{dest_dir}/#{keystore_name}"
+    FileUtils.cp("#{src_dir}/#{keystore_name}", "#{dest_dir}/#{keystore_name}")
+  end
 end
 
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,6 +30,18 @@ lane :bump do |options|
   set_package_data(data: {"version" => version})
 end
 
+# Lanes specifically for the CIs
+desc "Do CI-system keychain setup"
+lane :ci_git_setup do
+  token = ENV["CI_USER_TOKEN"]
+
+  # see macoscope.com/blog/simplify-your-life-with-fastlane-match
+  # we're allowing the CI access to the keys repo
+  File.open("#{ENV['HOME']}/.netrc", "a+") do |file|
+    file << "machine github.com\n  login #{token}"
+  end
+end
+
 
 platform :ios do
   desc "Runs all the tests"
@@ -91,15 +103,10 @@ platform :ios do
   # Lanes specifically for the CIs
   desc "Do CI-system keychain setup"
   lane :ci_keychains do
-    token = ENV["CI_USER_TOKEN"]
     keychain = ENV["MATCH_KEYCHAIN_NAME"]
     password = ENV["MATCH_KEYCHAIN_PASSWORD"]
 
-    # see macoscope.com/blog/simplify-your-life-with-fastlane-match
-    # we're allowing the CI access to the keys repo
-    File.open("#{ENV['HOME']}/.netrc", "a+") do |file|
-      file << "machine github.com\n  login #{token}"
-    end
+    ci_git_setup
 
     create_keychain(
       name: keychain,


### PR DESCRIPTION
Android won't run (or doesn't want to run, at least) unsigned APKs that are downloaded from the internet.

So, let's sign them!

This stores an android keystore to sign the rogue betas in my aao-keys private repository, alongside the information that `match` uses for the iOS beta signing.

The giant `android ci_keystore` lane is reimplementing part of `ios match`, because Fastlane doesn't offer a builtin way to store Android keystores.

---


I'm pretty sure that I've managed to only affect the `gradle assembleRogue` with my signing stuff, but I'm not terribly familiar with gradle. So who knows. This branch may well make your computer come alive and eat your kittens.