### PR TITLE
Clear cache on memory warning

### DIFF
--- a/ios/AllAboutOlaf/AppDelegate.m
+++ b/ios/AllAboutOlaf/AppDelegate.m
@@ -65,7 +65,7 @@
 }
 
 - (void)applicationDidReceiveMemoryWarning:(UIApplication *)application {
-    [[NSURLCache sharedURLCache] removeAllCachedResponses];
+  [[NSURLCache sharedURLCache] removeAllCachedResponses];
 }
 
 @end

--- a/ios/AllAboutOlaf/AppDelegate.m
+++ b/ios/AllAboutOlaf/AppDelegate.m
@@ -62,7 +62,10 @@
 // Required for the notification event.
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
   [RCTOneSignal didReceiveRemoteNotification:notification];
-  [[NSURLCache sharedURLCache] removeAllCachedResponses];
+}
+
+- (void)applicationDidReceiveMemoryWarning:(UIApplication *)application {
+    [[NSURLCache sharedURLCache] removeAllCachedResponses];
 }
 
 @end

--- a/ios/AllAboutOlaf/AppDelegate.m
+++ b/ios/AllAboutOlaf/AppDelegate.m
@@ -62,6 +62,7 @@
 // Required for the notification event.
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
   [RCTOneSignal didReceiveRemoteNotification:notification];
+  [[NSURLCache sharedURLCache] removeAllCachedResponses];
 }
 
 @end


### PR DESCRIPTION
One of the most frequent cause of crashes seen in apps is being ejected for not freeing up enough memory when a memory warning comes in. When the app receives a memory warning, we should purge the shared cache to free up memory.