### PR TITLE
Decode html entities in menu

### DIFF
--- a/source/views/menus/lib/build-filters.js
+++ b/source/views/menus/lib/build-filters.js
@@ -12,8 +12,10 @@ import map from 'lodash/map'
 import uniq from 'lodash/uniq'
 import type {FilterType} from '../../components/filter'
 import {fastGetTrimmedText} from '../../../lib/html'
+import {AllHtmlEntities} from 'html-entities'
 import {chooseMeal} from './choose-meal'
 
+const entities = new AllHtmlEntities()
 
 export function buildFilters(
   foodItems: MenuItemType[],
@@ -28,9 +30,9 @@ export function buildFilters(
 
   // Grab the labels of the COR icons
   const allDietaryRestrictions = map(corIcons, cor => ({
-    title: cor.label,
+    title: entities.decode(cor.label),
     image: cor.image ? {uri: cor.image} : null,
-    detail: cor.description ? fastGetTrimmedText(cor.description) : '',
+    detail: cor.description ? entities.decode(fastGetTrimmedText(cor.description)) : '',
   }))
 
   // Decide which meal will be selected by default

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -21,13 +21,16 @@ import type momentT from 'moment'
 import moment from 'moment-timezone'
 import {trimStationName, trimItemLabel} from './lib/trim-names'
 import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
+import {AllHtmlEntities} from 'html-entities'
 import {toLaxTitleCase} from 'titlecase'
 import {tracker} from '../../analytics'
 const CENTRAL_TZ = 'America/Winnipeg'
 
+
 const bonappMenuBaseUrl = 'http://legacy.cafebonappetit.com/api/2/menus'
 const bonappCafeBaseUrl = 'http://legacy.cafebonappetit.com/api/2/cafes'
 const fetchJsonQuery = (url, query) => fetchJson(`${url}?${qs.stringify(query)}`)
+const entities = new AllHtmlEntities()
 
 type BonAppPropsType = TopLevelViewPropsType & {
   cafeId: string,
@@ -170,8 +173,8 @@ export class BonAppHostedMenu extends React.Component {
     // prepare all food items from bonapp for rendering
     const foodItems = mapValues(cafeMenu.items, item => ({
       ...item,  // we want to edit the item, not replace it
-      station: toLaxTitleCase(trimStationName(item.station)),  // <b>@station names</b> are a mess
-      label: trimItemLabel(item.label),  // clean up the titles
+      station: entities.decode(toLaxTitleCase(trimStationName(item.station))),  // <b>@station names</b> are a mess
+      label: entities.decode(trimItemLabel(item.label)),  // clean up the titles
       description: getTrimmedTextWithSpaces(parseHtml(item.description || '')),  // clean up the descriptions
     }))
 

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -26,7 +26,6 @@ import {toLaxTitleCase} from 'titlecase'
 import {tracker} from '../../analytics'
 const CENTRAL_TZ = 'America/Winnipeg'
 
-
 const bonappMenuBaseUrl = 'http://legacy.cafebonappetit.com/api/2/menus'
 const bonappCafeBaseUrl = 'http://legacy.cafebonappetit.com/api/2/cafes'
 const fetchJsonQuery = (url, query) => fetchJson(`${url}?${qs.stringify(query)}`)


### PR DESCRIPTION
This decodes html entities that appear on station names, item names and diet names. Dietary descriptions from the menu filter view showed text that said `Aquarium&#039;s` and this will change it to say `Aquarium's`.

Closes #805  