### PR TITLE
Adjust style of news share button

### DIFF
--- a/source/views/components/navigation/button-right.js
+++ b/source/views/components/navigation/button-right.js
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
     color: 'white',
     ...Platform.select({
       ios: {
-        fontSize: 26,
+        fontSize: 32,
       },
       android: {
         fontSize: 24,

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -49,6 +49,7 @@ export class NewsList extends React.Component {
       props: {story, embedFeaturedImage: this.props.embedFeaturedImage},
       rightButton: ({contentContainerStyle, style}) => (
         <Touchable
+          highlight={false}
           style={[contentContainerStyle]}
           onPress={() => this.shareItem(story)}
         >


### PR DESCRIPTION
This changes the news touchable to be larger and eliminates the background color in favor of changing opacity on press.

Closes #804

Before | After
--- | ---
<img width="374" alt="before" src="https://cloud.githubusercontent.com/assets/5240843/23537748/35bf590a-ff9c-11e6-9300-23e3d9612444.png"> | <img width="373" alt="after" src="https://cloud.githubusercontent.com/assets/5240843/23538687/30a0385c-ffa3-11e6-8af6-26d07ce258db.png">