### PR TITLE
Adjust whitespace in menu regex

### DIFF
--- a/source/views/menus/lib/trim-names.js
+++ b/source/views/menus/lib/trim-names.js
@@ -6,7 +6,7 @@ export function trimStationName(stationName: string) {
 }
 
 function removeParenTags(str: string) {
-  const parensRegex = / \([^)]*?\)$/
+  const parensRegex = /\s?\([^)]*?\)\s?$/
   while (str.match(parensRegex)) {
     str = str.replace(parensRegex, '')
   }


### PR DESCRIPTION
Search for optional whitespace before `(` and after `)`. The Carleton Bon Appetit seem as if they are added manually, resulting in an inconsistent format... including ones where parens are forgotten altogether. This is an attempt to catch *some* cases.

`/ \([^)]*?\)$/` => `/\s?\([^)]*?\)\s?$/`