### PR TITLE
Expand the truncated timestrings

### DIFF
--- a/source/views/building-hours/detail.ios.js
+++ b/source/views/building-hours/detail.ios.js
@@ -63,7 +63,7 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   scheduleHours: {
-    flex: 3,
+    flex: 0,
   },
 })
 


### PR DESCRIPTION
Brings back the full text where the iOS building hours detail view rendered incorrectly by shortening the text.

Closes #801