### PR TITLE
Check if menu items are filtered with no items

### DIFF
--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -136,6 +136,7 @@ class FancyMenuView extends React.Component {
     // group the tuples into an object (because ListView wants {key: value} not [key, value])
     const grouped = fromPairs(filteredByMenu)
 
+    let anyFiltersEnabled = filters.some(f => f.enabled)
     const specialsFilterEnabled = Boolean(
       filters.find(
         f =>
@@ -146,7 +147,6 @@ class FancyMenuView extends React.Component {
     )
 
     let messageView = null
-    let anyFiltersEnabled = filters.some(f => f.enabled)
     if (specialsFilterEnabled && stationMenus.length === 0) {
       messageView = (
         <NoticeView

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -136,7 +136,7 @@ class FancyMenuView extends React.Component {
     // group the tuples into an object (because ListView wants {key: value} not [key, value])
     const grouped = fromPairs(filteredByMenu)
 
-    let anyFiltersEnabled = filters.some(f => f.enabled)
+    const anyFiltersEnabled = filters.some(f => f.enabled)
     const specialsFilterEnabled = Boolean(
       filters.find(
         f =>

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -146,6 +146,7 @@ class FancyMenuView extends React.Component {
     )
 
     let messageView = null
+    let filtersEnabled = filters.some(f => f.enabled)
     if (specialsFilterEnabled && stationMenus.length === 0) {
       messageView = (
         <NoticeView
@@ -154,11 +155,19 @@ class FancyMenuView extends React.Component {
         />
       )
     }
-    if (!size(grouped)) {
+    else if (filtersEnabled && !size(grouped)) {
       messageView = (
         <NoticeView
           style={styles.container}
           text="No items to show. Try changing the filters."
+        />
+      )
+    }
+    else if (!size(grouped)) {
+      messageView = (
+        <NoticeView
+          style={styles.container}
+          text="No items to show."
         />
       )
     }

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -146,7 +146,7 @@ class FancyMenuView extends React.Component {
     )
 
     let messageView = null
-    let filtersEnabled = filters.some(f => f.enabled)
+    let anyFiltersEnabled = filters.some(f => f.enabled)
     if (specialsFilterEnabled && stationMenus.length === 0) {
       messageView = (
         <NoticeView
@@ -155,7 +155,7 @@ class FancyMenuView extends React.Component {
         />
       )
     }
-    else if (filtersEnabled && !size(grouped)) {
+    else if (anyFiltersEnabled && !size(grouped)) {
       messageView = (
         <NoticeView
           style={styles.container}


### PR DESCRIPTION
Fixes the issue where menus showed a "disable filters" message when no filters were enabled... this was due to the case when there were no items to filter.

Closes #709