### PR TITLE
Change student orgs calendar icon

### DIFF
--- a/source/views/calendar/tabs.js
+++ b/source/views/calendar/tabs.js
@@ -33,7 +33,7 @@ export default [
   {
     id: 'StudentOrgsCalendarView',
     title: 'Student Orgs',
-    rnVectorIcon: {iconName: 'happy'},
+    rnVectorIcon: {iconName: 'people'},
     component: PresenceCalendarView,
     props: {url: 'https://api.presence.io/stolaf/v1/events'},
   },


### PR DESCRIPTION
Swapped duplicate icon (student orgs vs oleville) for people/group icon.

<img width="368" alt="screen shot 2017-03-07 at 1 18 28 am" src="https://cloud.githubusercontent.com/assets/5240843/23644198/1c87199c-02d4-11e7-967c-5502c8ab53e2.png">
