### PR TITLE
Rework danger logging into the table itself

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -73,9 +73,9 @@ const fileLog = (name, log, lang = null) => {
     <details>
       <summary>${name}</summary>
 
-      \`\`\`${lang || ''}
-      ${log}
-      \`\`\`
+\`\`\`${lang || ''}
+${log}
+\`\`\`
 
     </details>
   `,

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -9,7 +9,7 @@ const readFile = filename => {
   }
 }
 
-const jsFiles = danger.git.created_files.filter(path => path.endsWith('.js'));
+const jsFiles = danger.git.created_files.filter(path => path.endsWith('.js'))
 
 // new js files should have `@flow` at the top
 jsFiles

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -67,12 +67,16 @@ const isBadBundleLog = log => {
   return requiredLines.some(line => !allLines.includes(line))
 }
 
-const fileLog = (name, log) => {
+const fileLog = (name, log, lang = null) => {
   message(
     dedent`
     <details>
       <summary>${name}</summary>
-      <pre><code>${log}</code></pre>
+
+      \`\`\`${lang || ''}
+      ${log}
+      \`\`\`
+
     </details>
   `,
   )
@@ -87,7 +91,7 @@ const androidJsBundleLog = readFile('logs/bundle-android').trim()
 const jestLog = readFile('logs/jest').trim()
 
 if (prettierLog) {
-  fileLog('Prettier made some changes', prettierLog)
+  fileLog('Prettier made some changes', prettierLog, 'diff')
 }
 
 if (eslintLog) {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -72,9 +72,7 @@ const fileLog = (name, log) => {
     dedent`
     <details>
       <summary>${name}</summary>
-      <pre><code>
-        ${log}
-      </code></pre>
+      <pre><code>${log}</code></pre>
     </details>
   `,
   )

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -9,7 +9,7 @@ const readFile = filename => {
   }
 }
 
-const jsFiles = danger.git.created_files.filter(path => path.endsWith('.js'))
+const jsFiles = danger.git.created_files.filter(path => path.endsWith('.js'));
 
 // new js files should have `@flow` at the top
 jsFiles


### PR DESCRIPTION
If this works as intended, it'll inline the danger messages into the logging table, instead of printing them beneath.