### PR TITLE
Fix new org badge styles

### DIFF
--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -143,11 +143,11 @@ export class StudentOrgsView extends React.Component {
         fullWidth={true}
       >
         <Row alignItems="flex-start">
-          <View style={styles.badgeContainer}>
-            <Text style={[styles.badge, item.newOrg && styles.newOrgBadge]}>
+          <Text style={[styles.badge, styles.badgeContainer]}>
+            <Text style={[item.newOrg && styles.newOrgBadge]}>
               •
             </Text>
-          </View>
+          </Text>
 
           <Column flex={1}>
             <Title lines={1}>{item.name}</Title>


### PR DESCRIPTION
This fixes an issue where the styles for new badges were accidentally applied to all rows. The issue came from applying a styling meant for a `<Text/>` tag to a `<View/>` tag.

Closes #832 