### PR TITLE
Fix stylesheet classes for "new org" badges

### DIFF
--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -41,13 +41,13 @@ const styles = StyleSheet.create({
   rowSectionHeader: {
     height: headerHeight,
   },
-  badge: {
+  badgeContainer: {
     alignItems: 'center',
     justifyContent: 'center',
     alignSelf: 'flex-start',
     width: leftSideSpacing,
   },
-  badgeContainer: {
+  badge: {
     fontSize: Platform.OS === 'ios' ? 24 : 28,
     color: c.transparent,
   },


### PR DESCRIPTION
I had flipped the names accidentally, in #830. Closes #832.

Proof:

`master` | Fixed
--- | ---
<img src=https://cloud.githubusercontent.com/assets/464441/23714454/c772efd2-03ee-11e7-89e6-1237f59dc129.jpg width=320> | <img src=https://cloud.githubusercontent.com/assets/464441/23714381/85a240f8-03ee-11e7-9b27-c4d42ce7b7ee.jpg width=320>
