### PR TITLE
Make SimpleListView rerender every list item on every render

### DIFF
--- a/source/views/components/listview.js
+++ b/source/views/components/listview.js
@@ -16,8 +16,8 @@ type PropsType = {
 export default class SimpleListView extends React.Component {
   state = {
     dataSource: new ListView.DataSource({
-      rowHasChanged: (r1, r2) => r1 !== r2,
-      sectionHeaderHasChanged: (s1, s2) => s1 !== s2,
+      rowHasChanged: () => true,
+      sectionHeaderHasChanged: () => true,
     }),
   };
 


### PR DESCRIPTION
> Fixes #831.

So, um, this changes SimpleListView to do what I had intended for it to already do – that is, to always render everything that's been rendered whenever it needs to render.

The problem behind #831 was that our list rows were depending on an outside variable – `now` – and I couldn't figure out how to pass that into SimpleListView so the datasource could check it.