### PR TITLE
Semi-automate component screenshots

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -149,6 +149,7 @@ dependencies {
     compile project(':react-native-keychain')
     compile project(':react-native-onesignal')
     compile project(':react-native-vector-icons')
+    compile project(':react-native-view-shot')
     // this is for react-native itself
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"

--- a/android/app/src/main/java/com/allaboutolaf/MainApplication.java
+++ b/android/app/src/main/java/com/allaboutolaf/MainApplication.java
@@ -19,6 +19,7 @@ import com.learnium.RNDeviceInfo.RNDeviceInfo;
 import com.microsoft.codepush.react.CodePush;
 import com.oblador.keychain.KeychainPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
+import fr.greweb.reactnativeviewshot.RNViewShotPackage;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,6 +50,7 @@ public class MainApplication extends Application implements ReactApplication {
         new KeychainPackage(),
         new ReactNativeOneSignalPackage(),
         new RNDeviceInfo(),
+        new RNViewShotPackage(),
         new VectorIconsPackage()
       );
     }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -22,3 +22,6 @@ project(':react-native-onesignal').projectDir = new File(rootProject.projectDir,
 
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
+
+include ':react-native-view-shot'
+project(':react-native-view-shot').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-view-shot/android')

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		3A0CEA921DEA203F0036E739 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A0CEA781DEA20340036E739 /* libRCTAnimation.a */; };
 		3AE408501E1E280800F0FD83 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3AE4084F1E1E280800F0FD83 /* LaunchScreen.storyboard */; };
 		56DC65C1BF07427AA1F84CFC /* libSafariViewManager.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D530CE76BA714A59B2BECB28 /* libSafariViewManager.a */; };
+		570ACE6B68F941838FFABAA9 /* libRNViewShot.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CBE5D51CAA854462BCB6C610 /* libRNViewShot.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		9304AFEA1BEF4D77A9BE9E47 /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EFDF596D3434455B7F672D3 /* libRNVectorIcons.a */; };
 		A0102781BF874C25BD76AD1D /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A2D51A8982104BF29657933B /* libRNDeviceInfo.a */; };
@@ -75,6 +76,13 @@
 			proxyType = 2;
 			remoteGlobalIDString = 5DBEB1501B18CEA900B34395;
 			remoteInfo = RNVectorIcons;
+		};
+		002D2C491E7216B2002F518B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 17311DD2DB1B4EE0AFAA0BC4 /* RNViewShot.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNViewShot;
 		};
 		0035C1021E4F59AE00768B84 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -322,6 +330,7 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = AllAboutOlaf/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
 		150D47C893AB4ACBA45D7AF8 /* RCTGoogleAnalyticsBridge.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTGoogleAnalyticsBridge.xcodeproj; path = "../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/RCTGoogleAnalyticsBridge.xcodeproj"; sourceTree = "<group>"; };
+		17311DD2DB1B4EE0AFAA0BC4 /* RNViewShot.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNViewShot.xcodeproj; path = "../node_modules/react-native-view-shot/ios/RNViewShot.xcodeproj"; sourceTree = "<group>"; };
 		203BE3D7758C4020A78210B2 /* libRCTOneSignal.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTOneSignal.a; sourceTree = "<group>"; };
 		209B4AAEEC3F4290A1ED9491 /* libRNKeychain.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNKeychain.a; sourceTree = "<group>"; };
 		2560C43708D64866AA01FCC8 /* RNKeychain.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNKeychain.xcodeproj; path = "../node_modules/react-native-keychain/RNKeychain.xcodeproj"; sourceTree = "<group>"; };
@@ -339,6 +348,7 @@
 		A2D51A8982104BF29657933B /* libRNDeviceInfo.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNDeviceInfo.a; sourceTree = "<group>"; };
 		A91038679F834707B769D282 /* RNKeychain.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNKeychain.xcodeproj; path = "../node_modules/react-native-keychain/RNKeychain.xcodeproj"; sourceTree = "<group>"; };
 		AECB3DDD098E445D8AB3555F /* CodePush.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = CodePush.xcodeproj; path = "../node_modules/react-native-code-push/ios/CodePush.xcodeproj"; sourceTree = "<group>"; };
+		CBE5D51CAA854462BCB6C610 /* libRNViewShot.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNViewShot.a; sourceTree = "<group>"; };
 		CE0A6E16923B40C9930B546C /* ReactNativeCustomTabs.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = ReactNativeCustomTabs.xcodeproj; path = "../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs.xcodeproj"; sourceTree = "<group>"; };
 		D222CA78E6554BBB83448435 /* libDBCustomTabs.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libDBCustomTabs.a; sourceTree = "<group>"; };
 		D530CE76BA714A59B2BECB28 /* libSafariViewManager.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libSafariViewManager.a; sourceTree = "<group>"; };
@@ -382,6 +392,7 @@
 				A3D56267BEA24AB583A6D2A2 /* libCodePush.a in Frameworks */,
 				56DC65C1BF07427AA1F84CFC /* libSafariViewManager.a in Frameworks */,
 				A90299E6C1BD45C385BBF8F0 /* libDBCustomTabs.a in Frameworks */,
+				570ACE6B68F941838FFABAA9 /* libRNViewShot.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -424,6 +435,14 @@
 			isa = PBXGroup;
 			children = (
 				0027B0A71D5C82AA00C2B4FD /* libRNVectorIcons.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		002D2C241E7216B2002F518B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				002D2C4A1E7216B2002F518B /* libRNViewShot.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -629,6 +648,7 @@
 				2560C43708D64866AA01FCC8 /* RNKeychain.xcodeproj */,
 				71D5CCADA66D45008D9A38F2 /* RNVectorIcons.xcodeproj */,
 				89FC2AFC0A394CFFAE89242D /* SafariViewManager.xcodeproj */,
+				17311DD2DB1B4EE0AFAA0BC4 /* RNViewShot.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -827,6 +847,10 @@
 					ProjectRef = 43E420DADB24468C9E296F25 /* RNVectorIcons.xcodeproj */;
 				},
 				{
+					ProductGroup = 002D2C241E7216B2002F518B /* Products */;
+					ProjectRef = 17311DD2DB1B4EE0AFAA0BC4 /* RNViewShot.xcodeproj */;
+				},
+				{
 					ProductGroup = 009845971E5DEE6800194E4A /* Products */;
 					ProjectRef = 89FC2AFC0A394CFFAE89242D /* SafariViewManager.xcodeproj */;
 				},
@@ -873,6 +897,13 @@
 			fileType = archive.ar;
 			path = libRNVectorIcons.a;
 			remoteRef = 0027B0A61D5C82AA00C2B4FD /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		002D2C4A1E7216B2002F518B /* libRNViewShot.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNViewShot.a;
+			remoteRef = 002D2C491E7216B2002F518B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		0035C1031E4F59AE00768B84 /* libyoga.a */ = {
@@ -1222,6 +1253,7 @@
 					"$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1257,6 +1289,7 @@
 					"$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
+					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
 				);
 				INFOPLIST_FILE = AllAboutOlaf/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "pify": "2.3.0",
     "prettier": "0.22.0",
     "react-native-mock": "0.3.1",
+    "react-native-view-shot": "1.8.0",
     "react-test-renderer": "15.4.2"
   }
 }

--- a/source/app.js
+++ b/source/app.js
@@ -45,6 +45,7 @@ import PrivacyView from './views/settings/privacy'
 import LegalView from './views/settings/legal'
 import {StudentOrgsView, StudentOrgsDetailView} from './views/student-orgs'
 import {FaqView} from './views/faqs'
+import {SnapshotsView} from './storybook'
 
 import NoRoute from './views/components/no-route'
 
@@ -52,6 +53,7 @@ import NoRoute from './views/components/no-route'
 function renderScene(route, navigator) {
   let props = {route, navigator, ...(route.props || {})}
   tracker.trackScreenView(route.id)
+
   switch (route.id) {
     case 'HomeView':
       return <HomeView {...props} />
@@ -103,6 +105,8 @@ function renderScene(route, navigator) {
       return <StudentOrgsDetailView {...props} />
     case 'FaqView':
       return <FaqView {...props} />
+    case 'SnapshotsView':
+      return <SnapshotsView {...props} />
     default:
       return <NoRoute {...props} />
   }

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -19,7 +19,7 @@ import {takeSnapshot, dirs} from 'react-native-view-shot'
 import get from 'lodash/get'
 import flatten from 'lodash/flatten'
 import toPairs from 'lodash/toPairs'
-import {white} from '../views/components/colors'
+import * as c from '../views/components/colors'
 
 import CalendarView from '../views/calendar'
 
@@ -196,7 +196,7 @@ export class SnapshotsView extends React.Component {
       <ScrollView style={styles.container}>
         <StatusBar barStyle="light-content" />
 
-        <View>
+        <View style={styles.settings}>
           <Picker
             onValueChange={this.onChangeView}
             selectedValue={this.state.viewPath}
@@ -225,11 +225,22 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  settings: {
+    backgroundColor: c.white,
+  },
   buttonBar: {
     flexDirection: 'row',
     justifyContent: 'space-around',
+    marginBottom: 15,
   },
   viewContainer: {
-    backgroundColor: white,
+    ...Platform.select({
+      ios: {
+        backgroundColor: c.iosLightBackground,
+      },
+      android: {
+        backgroundColor: c.androidLightBackground,
+      },
+    })
   },
 })

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -47,11 +47,10 @@ import {
 import TransportationView from '../views/transportation'
 
 import SettingsView from '../views/settings'
-import SISLoginView from '../views/settings/login'
 import CreditsView from '../views/settings/credits'
 import PrivacyView from '../views/settings/privacy'
-
 import LegalView from '../views/settings/legal'
+
 import {StudentOrgsView, StudentOrgsDetailView} from '../views/student-orgs'
 import {FaqView} from '../views/faqs'
 
@@ -62,7 +61,6 @@ type ViewCollectionType = {
   [key: string]: {
     [key: string]: {
       view: ReactClass<*>,
-      props: Object,
       delay: number,
     },
   },
@@ -76,40 +74,43 @@ export class SnapshotsView extends React.Component {
   _ref: any;
 
   views: ViewCollectionType = {
+    buildinghours: {
+      list: {view: () => <BuildingHoursView />, delay: 100}
+    },
     contacts: {
-      list: {view: ContactsView, props: {}, delay: 100},
+      list: {view: () => <ContactsView />, delay: 100},
     },
     dictionary: {
-      list: {view: DictionaryView, props: {}, delay: 100},
+      list: {view: () => <DictionaryView />, delay: 100},
     },
     home: {
-      home: {view: HomeView, props: {}, delay: 100},
-      edit: {view: EditHomeView, props: {}, delay: 100},
+      home: {view: () => <HomeView />, delay: 100},
+      edit: {view: () => <EditHomeView />, delay: 100},
     },
     news: {
-      tabs: {view: NewsView, props: {}, delay: 5000},
+      tabs: {view: () => <NewsView />, delay: 5000},
     },
     settings: {
-      index: {view: SettingsView, props: {}, delay: 100},
-      credits: {view: CreditsView, props: {}, delay: 100},
-      faqs: {view: FaqView, props: {}, delay: 100},
-      legal: {view: LegalView, props: {}, delay: 100},
-      privacy: {view: PrivacyView, props: {}, delay: 100},
+      index: {view: () => <SettingsView />, delay: 100},
+      credits: {view: () => <CreditsView />, delay: 100},
+      faqs: {view: () => <FaqView />, delay: 100},
+      legal: {view: () => <LegalView />, delay: 100},
+      privacy: {view: () => <PrivacyView />, delay: 100},
     },
     sis: {
-      tabs: {view: SISView, props: {}, delay: 100},
-      balances: {view: BalancesView, props: {}, delay: 100},
+      tabs: {view: () => <SISView />, delay: 100},
+      balances: {view: () => <BalancesView />, delay: 100},
     },
     streaming: {
-      tabs: {view: StreamingView, props: {}, delay: 100},
-      radio: {view: KSTOView, props: {}, delay: 100},
-      webcams: {view: WebcamsView, props: {}, delay: 1000},
+      tabs: {view: () => <StreamingView />, delay: 100},
+      radio: {view: () => <KSTOView />, delay: 100},
+      webcams: {view: () => <WebcamsView />, delay: 1000},
     },
     studentorgs: {
-      list: {view: StudentOrgsView, props: {}, delay: 2000},
+      list: {view: () => <StudentOrgsView />, delay: 2000},
     },
     transit: {
-      tabs: {view: TransportationView, props: {}, delay: 100},
+      tabs: {view: () => <TransportationView />, delay: 100},
     },
   };
 
@@ -188,7 +189,7 @@ export class SnapshotsView extends React.Component {
           ref={ref => this._ref = ref}
           style={[styles.viewContainer, childStyle]}
         >
-          <selected.view {...selected.props} />
+          {selected.view()}
         </View>
       </ScrollView>
     )

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -3,14 +3,15 @@
 
 import React from 'react'
 import {
-  View,
   Button,
-  Picker,
-  ScrollView,
   Dimensions,
+  Navigator,
+  Picker,
   Platform,
+  ScrollView,
   StatusBar,
   StyleSheet,
+  View,
 } from 'react-native'
 
 import delay from 'delay'
@@ -21,6 +22,7 @@ import toPairs from 'lodash/toPairs'
 import {white} from '../views/components/colors'
 
 import CalendarView from '../views/calendar'
+
 import {ContactsView} from '../views/contacts'
 
 import {DictionaryView, DictionaryDetailView} from '../views/dictionary'
@@ -34,6 +36,7 @@ import WebcamsView from '../views/streaming/webcams'
 import {MenusView} from '../views/menus'
 import {BonAppHostedMenu} from '../views/menus/menu-bonapp'
 import {FilterView} from '../views/components/filter'
+
 import NewsView from '../views/news'
 import NewsItemView from '../views/news/news-item'
 
@@ -44,15 +47,16 @@ import {
   BuildingHoursView,
   BuildingHoursDetailView,
 } from '../views/building-hours'
+
 import TransportationView from '../views/transportation'
 
 import SettingsView from '../views/settings'
 import CreditsView from '../views/settings/credits'
 import PrivacyView from '../views/settings/privacy'
 import LegalView from '../views/settings/legal'
+import {FaqView} from '../views/faqs'
 
 import {StudentOrgsView, StudentOrgsDetailView} from '../views/student-orgs'
-import {FaqView} from '../views/faqs'
 
 const {DocumentDir} = dirs
 const outputDir = `${DocumentDir}/aao-view-shots`
@@ -66,6 +70,11 @@ type ViewCollectionType = {
   },
 };
 
+const defaultProps = {
+  navigator: Navigator,
+  route: {id: '', title: '', index: 0},
+}
+
 export class SnapshotsView extends React.Component {
   state = {
     viewPath: 'streaming.radio',
@@ -75,7 +84,7 @@ export class SnapshotsView extends React.Component {
 
   views: ViewCollectionType = {
     buildinghours: {
-      list: {view: () => <BuildingHoursView />, delay: 100}
+      list: {view: () => <BuildingHoursView {...defaultProps} />, delay: 100}
     },
     contacts: {
       list: {view: () => <ContactsView />, delay: 100},
@@ -88,17 +97,17 @@ export class SnapshotsView extends React.Component {
       edit: {view: () => <EditHomeView />, delay: 100},
     },
     news: {
-      tabs: {view: () => <NewsView />, delay: 5000},
+      tabs: {view: () => <NewsView {...defaultProps} />, delay: 5000},
     },
     settings: {
-      index: {view: () => <SettingsView />, delay: 100},
+      index: {view: () => <SettingsView {...defaultProps} />, delay: 100},
       credits: {view: () => <CreditsView />, delay: 100},
       faqs: {view: () => <FaqView />, delay: 100},
       legal: {view: () => <LegalView />, delay: 100},
       privacy: {view: () => <PrivacyView />, delay: 100},
     },
     sis: {
-      tabs: {view: () => <SISView />, delay: 100},
+      tabs: {view: () => <SISView {...defaultProps} />, delay: 100},
       balances: {view: () => <BalancesView />, delay: 100},
     },
     streaming: {

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -19,7 +19,12 @@ import {takeSnapshot, dirs} from 'react-native-view-shot'
 import get from 'lodash/get'
 import flatten from 'lodash/flatten'
 import toPairs from 'lodash/toPairs'
+
 import * as c from '../views/components/colors'
+import SimpleListView from '../views/components/listview'
+SimpleListView.initialListSize = 18
+import {StyledAlphabetListView} from '../views/components/alphabet-listview'
+StyledAlphabetListView.initialListSize = 18
 
 import CalendarView from '../views/calendar'
 
@@ -89,7 +94,7 @@ export class SnapshotsView extends React.Component {
 
   views: ViewCollectionType = {
     buildinghours: {
-      list: {view: () => <BuildingHoursView {...defaultProps} />, delay: 100}
+      list: {view: () => <BuildingHoursView {...defaultProps} />, delay: 1500}
     },
     calendar: {
       tabs: {view: () => <CalendarView {...defaultProps} />, delay: 1000},
@@ -98,11 +103,11 @@ export class SnapshotsView extends React.Component {
       list: {view: () => <ContactsView />, delay: 100},
     },
     dictionary: {
-      list: {view: () => <DictionaryView />, delay: 100},
+      list: {view: () => <DictionaryView />, delay: 1000},
     },
     home: {
       home: {view: () => <HomeView />, delay: 100},
-      edit: {view: () => <EditHomeView />, delay: 100},
+      edit: {view: () => <EditHomeView />, delay: 500},
     },
     menus: {
       tabs: {view: () => <MenusView {...defaultProps} />, delay: 2000},
@@ -132,7 +137,7 @@ export class SnapshotsView extends React.Component {
       webcams: {view: () => <WebcamsView />, delay: 1000},
     },
     studentorgs: {
-      list: {view: () => <StudentOrgsView />, delay: 2000},
+      list: {view: () => <StudentOrgsView />, delay: 2500},
     },
     transit: {
       tabs: {view: () => <TransportationView />, delay: 100},
@@ -158,7 +163,6 @@ export class SnapshotsView extends React.Component {
       this.setState({viewPath})
       await delay(args.delay || 1000)
       await this.saveSnapshot()
-      await delay(100)
     }
   };
 

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -30,7 +30,7 @@ import CalendarView from '../views/calendar'
 
 import {ContactsView} from '../views/contacts'
 
-import {DictionaryView, DictionaryDetailView} from '../views/dictionary'
+import {DictionaryView} from '../views/dictionary'
 
 import {HomeView, EditHomeView} from '../views/home'
 
@@ -39,20 +39,13 @@ import KSTOView from '../views/streaming/radio'
 import WebcamsView from '../views/streaming/webcams'
 
 import {MenusView} from '../views/menus'
-import {BonAppHostedMenu} from '../views/menus/menu-bonapp'
-import {GitHubHostedMenu} from '../views/menus/menu-github'
-import {FilterView} from '../views/components/filter'
 
 import NewsView from '../views/news'
-import NewsItemView from '../views/news/news-item'
 
 import SISView from '../views/sis'
 import BalancesView from '../views/sis/balances'
 
-import {
-  BuildingHoursView,
-  BuildingHoursDetailView,
-} from '../views/building-hours'
+import {BuildingHoursView} from '../views/building-hours'
 
 import TransportationView from '../views/transportation'
 
@@ -67,7 +60,7 @@ import OddsAndEndsSection from '../views/settings/sections/odds-and-ends'
 import SupportSection from '../views/settings/sections/support'
 import {FaqView} from '../views/faqs'
 
-import {StudentOrgsView, StudentOrgsDetailView} from '../views/student-orgs'
+import {StudentOrgsView} from '../views/student-orgs'
 
 const {DocumentDir} = dirs
 const outputDir = `${DocumentDir}/aao-view-shots`
@@ -112,16 +105,6 @@ export class SnapshotsView extends React.Component {
     },
     menus: {
       tabs: {view: () => <MenusView {...defaultProps} />, delay: 2000},
-      pause: {
-        view: () => (
-          <GitHubHostedMenu
-            {...defaultProps}
-            name="pause"
-            loadingMessage={[]}
-          />
-        ),
-        delay: 2000,
-      },
     },
     news: {
       tabs: {view: () => <NewsView {...defaultProps} />, delay: 5000},

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -1,0 +1,209 @@
+// @flow
+/* eslint-disable no-await-in-loop */
+
+import React from 'react'
+import {
+  View,
+  Button,
+  Picker,
+  ScrollView,
+  Dimensions,
+  Platform,
+  StatusBar,
+  StyleSheet,
+} from 'react-native'
+
+import delay from 'delay'
+import {takeSnapshot, dirs} from 'react-native-view-shot'
+import get from 'lodash/get'
+import flatten from 'lodash/flatten'
+import toPairs from 'lodash/toPairs'
+import {white} from '../views/components/colors'
+
+import CalendarView from '../views/calendar'
+import {ContactsView} from '../views/contacts'
+
+import {DictionaryView, DictionaryDetailView} from '../views/dictionary'
+
+import {HomeView, EditHomeView} from '../views/home'
+
+import StreamingView from '../views/streaming'
+import KSTOView from '../views/streaming/radio'
+import WebcamsView from '../views/streaming/webcams'
+
+import {MenusView} from '../views/menus'
+import {BonAppHostedMenu} from '../views/menus/menu-bonapp'
+import {FilterView} from '../views/components/filter'
+import NewsView from '../views/news'
+import NewsItemView from '../views/news/news-item'
+
+import SISView from '../views/sis'
+import BalancesView from '../views/sis/balances'
+
+import {
+  BuildingHoursView,
+  BuildingHoursDetailView,
+} from '../views/building-hours'
+import TransportationView from '../views/transportation'
+
+import SettingsView from '../views/settings'
+import SISLoginView from '../views/settings/login'
+import CreditsView from '../views/settings/credits'
+import PrivacyView from '../views/settings/privacy'
+
+import LegalView from '../views/settings/legal'
+import {StudentOrgsView, StudentOrgsDetailView} from '../views/student-orgs'
+import {FaqView} from '../views/faqs'
+
+const {DocumentDir} = dirs
+const outputDir = `${DocumentDir}/aao-view-shots`
+
+type ViewCollectionType = {
+  [key: string]: {
+    [key: string]: {
+      view: ReactClass<*>,
+      props: Object,
+      delay: number,
+    },
+  },
+};
+
+export class SnapshotsView extends React.Component {
+  state = {
+    viewPath: 'streaming.radio',
+  };
+
+  _ref: any;
+
+  views: ViewCollectionType = {
+    contacts: {
+      list: {view: ContactsView, props: {}, delay: 100},
+    },
+    dictionary: {
+      list: {view: DictionaryView, props: {}, delay: 100},
+    },
+    home: {
+      home: {view: HomeView, props: {}, delay: 100},
+      edit: {view: EditHomeView, props: {}, delay: 100},
+    },
+    news: {
+      tabs: {view: NewsView, props: {}, delay: 5000},
+    },
+    settings: {
+      index: {view: SettingsView, props: {}, delay: 100},
+      credits: {view: CreditsView, props: {}, delay: 100},
+      faqs: {view: FaqView, props: {}, delay: 100},
+      legal: {view: LegalView, props: {}, delay: 100},
+      privacy: {view: PrivacyView, props: {}, delay: 100},
+    },
+    sis: {
+      tabs: {view: SISView, props: {}, delay: 100},
+      balances: {view: BalancesView, props: {}, delay: 100},
+    },
+    streaming: {
+      tabs: {view: StreamingView, props: {}, delay: 100},
+      radio: {view: KSTOView, props: {}, delay: 100},
+      webcams: {view: WebcamsView, props: {}, delay: 1000},
+    },
+    studentorgs: {
+      list: {view: StudentOrgsView, props: {}, delay: 2000},
+    },
+    transit: {
+      tabs: {view: TransportationView, props: {}, delay: 100},
+    },
+  };
+
+  saveSnapshot = () => {
+    const name = this.state.viewPath
+    return takeSnapshot(this._ref, {
+      format: 'png',
+      path: `${outputDir}/${name}.png`,
+    }).then(
+      uri => console.log('saved to', uri),
+      err => console.error('snapstho failed', err),
+    )
+  };
+
+  saveAll = async () => {
+    for (const [parent, child] of this.viewsAsList()) {
+      const viewPath = `${parent}.${child}`
+      const args = get(this.views, viewPath)
+
+      this.setState({viewPath})
+      await delay(args.delay || 1000)
+      await this.saveSnapshot()
+      await delay(100)
+    }
+  };
+
+  viewsAsList = () => {
+    // goes from {name: {inner: {}}} to [[name, inner]]
+    const choices = toPairs(this.views).map(([key, val]) =>
+      toPairs(val).map(([innerKey]) => [key, innerKey]))
+
+    return flatten(choices)
+  };
+
+  onChangeView = (value: string) => {
+    this.setState({viewPath: value})
+  };
+
+  render() {
+    const selected = get(this.views, this.state.viewPath, {})
+
+    const options = this.viewsAsList().map(([parent, child]) => (
+      <Picker.Item
+        key={`${parent}.${child}`}
+        label={`${parent} ❯ ${child}`}
+        value={`${parent}.${child}`}
+      />
+    ))
+
+    const height = Dimensions.get('window').height
+    const heightDiff = Platform.OS === 'ios' ? 64 : 56
+
+    const childStyle = {
+      height: height - heightDiff,
+    }
+
+    return (
+      <ScrollView style={styles.container}>
+        <StatusBar barStyle="light-content" />
+
+        <View>
+          <Picker
+            onValueChange={this.onChangeView}
+            selectedValue={this.state.viewPath}
+          >
+            {options}
+          </Picker>
+
+          <View style={styles.buttonBar}>
+            <Button onPress={this.saveSnapshot} title="Snapshot" />
+            <Button onPress={this.saveAll} title="Run All" />
+          </View>
+        </View>
+
+        <View
+          ref={ref => this._ref = ref}
+          style={[styles.viewContainer, childStyle]}
+        >
+          <selected.view {...selected.props} />
+        </View>
+      </ScrollView>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  buttonBar: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+  viewContainer: {
+    backgroundColor: white,
+  },
+})

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -74,11 +74,11 @@ type ViewCollectionType = {
   },
 };
 
-const Nav = ({children}: {children?: Function}) =>
+const Nav = ({children}: {children?: Function}) => (
   <Navigator
     renderScene={(route, navigator) => children && children({route, navigator})}
   />
-
+)
 
 export class SnapshotsView extends React.Component {
   state = {
@@ -89,10 +89,16 @@ export class SnapshotsView extends React.Component {
 
   views: ViewCollectionType = {
     buildinghours: {
-      list: {view: () => <Nav>{props => <BuildingHoursView {...props} />}</Nav>, delay: 1500},
+      list: {
+        view: () => <Nav>{props => <BuildingHoursView {...props} />}</Nav>,
+        delay: 1500,
+      },
     },
     calendar: {
-      tabs: {view: () => <Nav>{props => <CalendarView {...props} />}</Nav>, delay: 1000},
+      tabs: {
+        view: () => <Nav>{props => <CalendarView {...props} />}</Nav>,
+        delay: 1000,
+      },
     },
     contacts: {
       list: {view: () => <ContactsView />, delay: 100},
@@ -105,13 +111,22 @@ export class SnapshotsView extends React.Component {
       edit: {view: () => <EditHomeView />, delay: 500},
     },
     menus: {
-      tabs: {view: () => <Nav>{props => <MenusView {...props} />}</Nav>, delay: 2000},
+      tabs: {
+        view: () => <Nav>{props => <MenusView {...props} />}</Nav>,
+        delay: 2000,
+      },
     },
     news: {
-      tabs: {view: () => <Nav>{props => <NewsView {...props} />}</Nav>, delay: 5000},
+      tabs: {
+        view: () => <Nav>{props => <NewsView {...props} />}</Nav>,
+        delay: 5000,
+      },
     },
     settings: {
-      index: {view: () => <Nav>{props => <SettingsView {...props} />}</Nav>, delay: 100},
+      index: {
+        view: () => <Nav>{props => <SettingsView {...props} />}</Nav>,
+        delay: 100,
+      },
       credits: {view: () => <CreditsView />, delay: 100},
       faqs: {view: () => <FaqView />, delay: 100},
       legal: {view: () => <LegalView />, delay: 100},
@@ -125,7 +140,10 @@ export class SnapshotsView extends React.Component {
       'section-odds and ends': {view: () => <OddsAndEndsSection />, delay: 100},
     },
     sis: {
-      tabs: {view: () => <Nav>{props => <SISView {...props} />}</Nav>, delay: 100},
+      tabs: {
+        view: () => <Nav>{props => <SISView {...props} />}</Nav>,
+        delay: 100,
+      },
       balances: {view: () => <BalancesView />, delay: 100},
     },
     streaming: {

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -35,6 +35,7 @@ import WebcamsView from '../views/streaming/webcams'
 
 import {MenusView} from '../views/menus'
 import {BonAppHostedMenu} from '../views/menus/menu-bonapp'
+import {GitHubHostedMenu} from '../views/menus/menu-github'
 import {FilterView} from '../views/components/filter'
 
 import NewsView from '../views/news'
@@ -54,6 +55,10 @@ import SettingsView from '../views/settings'
 import CreditsView from '../views/settings/credits'
 import PrivacyView from '../views/settings/privacy'
 import LegalView from '../views/settings/legal'
+import CredentialsLoginSection from '../views/settings/sections/login-credentials'
+import TokenLoginSection from '../views/settings/sections/login-token'
+import OddsAndEndsSection from '../views/settings/sections/odds-and-ends'
+import SupportSection from '../views/settings/sections/support'
 import {FaqView} from '../views/faqs'
 
 import {StudentOrgsView, StudentOrgsDetailView} from '../views/student-orgs'
@@ -86,6 +91,9 @@ export class SnapshotsView extends React.Component {
     buildinghours: {
       list: {view: () => <BuildingHoursView {...defaultProps} />, delay: 100}
     },
+    calendar: {
+      tabs: {view: () => <CalendarView {...defaultProps} />, delay: 1000},
+    },
     contacts: {
       list: {view: () => <ContactsView />, delay: 100},
     },
@@ -96,6 +104,10 @@ export class SnapshotsView extends React.Component {
       home: {view: () => <HomeView />, delay: 100},
       edit: {view: () => <EditHomeView />, delay: 100},
     },
+    menus: {
+      tabs: {view: () => <MenusView {...defaultProps} />, delay: 2000},
+      pause: {view: () => <GitHubHostedMenu {...defaultProps} name='pause' loadingMessage={[]} />, delay: 2000},
+    },
     news: {
       tabs: {view: () => <NewsView {...defaultProps} />, delay: 5000},
     },
@@ -105,6 +117,10 @@ export class SnapshotsView extends React.Component {
       faqs: {view: () => <FaqView />, delay: 100},
       legal: {view: () => <LegalView />, delay: 100},
       privacy: {view: () => <PrivacyView />, delay: 100},
+      'section-credentials': {view: () => <CredentialsLoginSection />, delay: 100},
+      'section-token': {view: () => <TokenLoginSection />, delay: 100},
+      'section-support': {view: () => <SupportSection />, delay: 100},
+      'section-odds and ends': {view: () => <OddsAndEndsSection />, delay: 100},
     },
     sis: {
       tabs: {view: () => <SISView {...defaultProps} />, delay: 100},

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -74,10 +74,11 @@ type ViewCollectionType = {
   },
 };
 
-const defaultProps = {
-  navigator: Navigator,
-  route: {id: '', title: '', index: 0},
-}
+const Nav = ({children}: {children?: Function}) =>
+  <Navigator
+    renderScene={(route, navigator) => children && children({route, navigator})}
+  />
+
 
 export class SnapshotsView extends React.Component {
   state = {
@@ -88,10 +89,10 @@ export class SnapshotsView extends React.Component {
 
   views: ViewCollectionType = {
     buildinghours: {
-      list: {view: () => <BuildingHoursView {...defaultProps} />, delay: 1500},
+      list: {view: () => <Nav>{props => <BuildingHoursView {...props} />}</Nav>, delay: 1500},
     },
     calendar: {
-      tabs: {view: () => <CalendarView {...defaultProps} />, delay: 1000},
+      tabs: {view: () => <Nav>{props => <CalendarView {...props} />}</Nav>, delay: 1000},
     },
     contacts: {
       list: {view: () => <ContactsView />, delay: 100},
@@ -104,13 +105,13 @@ export class SnapshotsView extends React.Component {
       edit: {view: () => <EditHomeView />, delay: 500},
     },
     menus: {
-      tabs: {view: () => <MenusView {...defaultProps} />, delay: 2000},
+      tabs: {view: () => <Nav>{props => <MenusView {...props} />}</Nav>, delay: 2000},
     },
     news: {
-      tabs: {view: () => <NewsView {...defaultProps} />, delay: 5000},
+      tabs: {view: () => <Nav>{props => <NewsView {...props} />}</Nav>, delay: 5000},
     },
     settings: {
-      index: {view: () => <SettingsView {...defaultProps} />, delay: 100},
+      index: {view: () => <Nav>{props => <SettingsView {...props} />}</Nav>, delay: 100},
       credits: {view: () => <CreditsView />, delay: 100},
       faqs: {view: () => <FaqView />, delay: 100},
       legal: {view: () => <LegalView />, delay: 100},
@@ -124,7 +125,7 @@ export class SnapshotsView extends React.Component {
       'section-odds and ends': {view: () => <OddsAndEndsSection />, delay: 100},
     },
     sis: {
-      tabs: {view: () => <SISView {...defaultProps} />, delay: 100},
+      tabs: {view: () => <Nav>{props => <SISView {...props} />}</Nav>, delay: 100},
       balances: {view: () => <BalancesView />, delay: 100},
     },
     streaming: {

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -60,7 +60,8 @@ import SettingsView from '../views/settings'
 import CreditsView from '../views/settings/credits'
 import PrivacyView from '../views/settings/privacy'
 import LegalView from '../views/settings/legal'
-import CredentialsLoginSection from '../views/settings/sections/login-credentials'
+import CredentialsLoginSection
+  from '../views/settings/sections/login-credentials'
 import TokenLoginSection from '../views/settings/sections/login-token'
 import OddsAndEndsSection from '../views/settings/sections/odds-and-ends'
 import SupportSection from '../views/settings/sections/support'
@@ -94,7 +95,7 @@ export class SnapshotsView extends React.Component {
 
   views: ViewCollectionType = {
     buildinghours: {
-      list: {view: () => <BuildingHoursView {...defaultProps} />, delay: 1500}
+      list: {view: () => <BuildingHoursView {...defaultProps} />, delay: 1500},
     },
     calendar: {
       tabs: {view: () => <CalendarView {...defaultProps} />, delay: 1000},
@@ -111,7 +112,16 @@ export class SnapshotsView extends React.Component {
     },
     menus: {
       tabs: {view: () => <MenusView {...defaultProps} />, delay: 2000},
-      pause: {view: () => <GitHubHostedMenu {...defaultProps} name='pause' loadingMessage={[]} />, delay: 2000},
+      pause: {
+        view: () => (
+          <GitHubHostedMenu
+            {...defaultProps}
+            name="pause"
+            loadingMessage={[]}
+          />
+        ),
+        delay: 2000,
+      },
     },
     news: {
       tabs: {view: () => <NewsView {...defaultProps} />, delay: 5000},
@@ -122,7 +132,10 @@ export class SnapshotsView extends React.Component {
       faqs: {view: () => <FaqView />, delay: 100},
       legal: {view: () => <LegalView />, delay: 100},
       privacy: {view: () => <PrivacyView />, delay: 100},
-      'section-credentials': {view: () => <CredentialsLoginSection />, delay: 100},
+      'section-credentials': {
+        view: () => <CredentialsLoginSection />,
+        delay: 100,
+      },
       'section-token': {view: () => <TokenLoginSection />, delay: 100},
       'section-support': {view: () => <SupportSection />, delay: 100},
       'section-odds and ends': {view: () => <OddsAndEndsSection />, delay: 100},
@@ -245,6 +258,6 @@ const styles = StyleSheet.create({
       android: {
         backgroundColor: c.androidLightBackground,
       },
-    })
+    }),
   },
 })

--- a/source/views/components/alphabet-listview.js
+++ b/source/views/components/alphabet-listview.js
@@ -20,9 +20,11 @@ export function StyledAlphabetListView(props: Object) {
     <AlphabetListView
       contentContainerStyle={styles.listView}
       sectionListStyle={styles.sectionItems}
-      initialListSize={12}
-      pageSize={8}
+      initialListSize={StyledAlphabetListView.initialListSize}
+      pageSize={StyledAlphabetListView.pageSize}
       {...props}
     />
   )
 }
+StyledAlphabetListView.initialListSize = 12
+StyledAlphabetListView.pageSize = 8

--- a/source/views/components/listview.js
+++ b/source/views/components/listview.js
@@ -14,6 +14,9 @@ type PropsType = {
 };
 
 export default class SimpleListView extends React.Component {
+  static initialListSize = 6;
+  static pageSize = 6;
+
   state = {
     dataSource: new ListView.DataSource({
       rowHasChanged: () => true,
@@ -71,8 +74,8 @@ export default class SimpleListView extends React.Component {
       <ListView
         {...iosInset}
         {...refresher}
-        initialListSize={6}
-        pageSize={6}
+        initialListSize={SimpleListView.initialListSize}
+        pageSize={SimpleListView.pageSize}
         removeClippedSubviews={false}
         dataSource={this.state.dataSource}
         renderRow={rowData => renderRow(rowData)}

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -25,6 +25,9 @@ class OddsAndEndsSection extends React.Component {
   onCreditsButton = () => this.onPressButton('CreditsView', 'Credits');
   onPrivacyButton = () => this.onPressButton('PrivacyView', 'Privacy Policy');
   onLegalButton = () => this.onPressButton('LegalView', 'Legal');
+  onSnapshotsButton = () =>
+    this.onPressButton('SnapshotsView', 'Snapshot Time');
+
   render() {
     return (
       <Section header="ODDS &amp; ENDS">
@@ -43,6 +46,12 @@ class OddsAndEndsSection extends React.Component {
         <PushButtonCell title="Privacy Policy" onPress={this.onPrivacyButton} />
         <PushButtonCell title="Legal" onPress={this.onLegalButton} />
 
+        {__DEV__
+          ? <PushButtonCell
+              title="Snapshots"
+              onPress={this.onSnapshotsButton}
+            />
+          : null}
       </Section>
     )
   }

--- a/source/views/types.js
+++ b/source/views/types.js
@@ -7,7 +7,7 @@ export type RouteType = {
   id: string,
   title: string,
   backButtonTitle?: string,
-  rightButton?: () => ReactComponent<any>,
+  rightButton?: () => ReactClass<*>,
   onDismiss?: (r: RouteType, n: Navigator) => any,
   sceneConfig?: Object | 'fromBottom' | string,
 };


### PR DESCRIPTION
This PR allows us to semi-automatically take screenshots of view within the app.

Examples: 

&nbsp; | &nbsp; | &nbsp;
--- | --- | ---
<img alt="buildinghours list" src="https://cloud.githubusercontent.com/assets/464441/23775919/d76e039c-04f0-11e7-90b3-207b5b7a81f9.png"> | <img alt="calendar tabs" src="https://cloud.githubusercontent.com/assets/464441/23775920/d76f9716-04f0-11e7-9d65-0867fe765b5f.png"> | <img alt="contacts list" src="https://cloud.githubusercontent.com/assets/464441/23775921/d76fbca0-04f0-11e7-9b87-7f18c6bf2e23.png">
<img alt="dictionary list" src="https://cloud.githubusercontent.com/assets/464441/23775922/d770929c-04f0-11e7-9745-2983259af37f.png"> | <img alt="home edit" src="https://cloud.githubusercontent.com/assets/464441/23775923/d771d4fe-04f0-11e7-8d4c-8aaa96c8f62a.png"> | <img alt="home home" src="https://cloud.githubusercontent.com/assets/464441/23775924/d775f82c-04f0-11e7-94d6-5e2cded6a717.png">
<img alt="menus pause" src="https://cloud.githubusercontent.com/assets/464441/23775925/d77d85ce-04f0-11e7-89c1-14485ad79a82.png"> | <img alt="menus tabs" src="https://cloud.githubusercontent.com/assets/464441/23775926/d78b3f5c-04f0-11e7-91bd-d68361c924ec.png"> | <img alt="news tabs" src="https://cloud.githubusercontent.com/assets/464441/23775927/d78ba820-04f0-11e7-852d-cce167925a8c.png">
<img alt="settings credits" src="https://cloud.githubusercontent.com/assets/464441/23775928/d792803c-04f0-11e7-87ca-4da92114c5a9.png"> | <img alt="settings faqs" src="https://cloud.githubusercontent.com/assets/464441/23775929/d795e31c-04f0-11e7-9a2e-202df07f3b9b.png"> | <img alt="settings index" src="https://cloud.githubusercontent.com/assets/464441/23775930/d79e20ea-04f0-11e7-8666-fad8c296a5f6.png">
<img alt="settings legal" src="https://cloud.githubusercontent.com/assets/464441/23775931/d7a34534-04f0-11e7-90d0-a2efc757eedd.png"> | <img alt="settings privacy" src="https://cloud.githubusercontent.com/assets/464441/23775932/d7a47b16-04f0-11e7-9a96-f2db56a54691.png"> | <img alt="settings section-credentials" src="https://cloud.githubusercontent.com/assets/464441/23775933/d7a64040-04f0-11e7-811e-38195c87861a.png">
<img alt="settings section-odds and ends" src="https://cloud.githubusercontent.com/assets/464441/23775935/d7acd338-04f0-11e7-8ebd-c4f319cac87a.png"> | <img alt="settings section-support" src="https://cloud.githubusercontent.com/assets/464441/23775934/d7a8af56-04f0-11e7-96e3-1688b82e7ea6.png"> | <img alt="settings section-token" src="https://cloud.githubusercontent.com/assets/464441/23775936/d7b11a38-04f0-11e7-9110-129bea25bf0a.png">
<img alt="sis balances" src="https://cloud.githubusercontent.com/assets/464441/23775937/d7b8f014-04f0-11e7-8cd4-8352c3314dee.png"> | <img alt="sis tabs" src="https://cloud.githubusercontent.com/assets/464441/23775938/d7ba60fc-04f0-11e7-94f8-aadcdd7299d7.png"> | <img alt="streaming radio" src="https://cloud.githubusercontent.com/assets/464441/23775940/d7c90bb6-04f0-11e7-88e5-0d722d53662c.png">
<img alt="streaming tabs" src="https://cloud.githubusercontent.com/assets/464441/23775939/d7c815bc-04f0-11e7-8edb-aabdc7703778.png"> | <img alt="streaming webcams" src="https://cloud.githubusercontent.com/assets/464441/23775942/d7d26562-04f0-11e7-9977-37fd0db4812c.png"> | <img alt="studentorgs list" src="https://cloud.githubusercontent.com/assets/464441/23775943/d7d45bb0-04f0-11e7-9cec-47fcf52dd346.png">
<img alt="transit tabs" src="https://cloud.githubusercontent.com/assets/464441/23775944/d7e3d054-04f0-11e7-88d5-aa1e532d5e63.png"> | |

Screenshot of the tool itself:

<img src=https://cloud.githubusercontent.com/assets/464441/23776019/41816be8-04f1-11e7-980a-83170e79cb9e.png width=320>

The tool lives in Settings > Snapshots. If you run it in the simulator, search within `~/Library/Developer/CoreSimulator/Devices` for the folder named "aao-view-shots" and you'll find the screenshots.

The simulator stores its files on the filesystem, at `~/Library/Developer/CoreSimulator/Devices/<UUID>/data/Containers/Data/Application/<UUID>/Documents/`. The first UUID is the UUID of the simulator you ran it on; you can find those by using `xcrun simctl list`. The second one apparently changes with each run of the app, so I can't help you there.

> Hence my advice to just search for the folder name ;-)

Anyway. This will continue to be improved! Over time!

My end goal is to somehow present visual diffs of each component touched by a PR within that PR; whether that's by way of storing each component's screenshot in the codebase or by just publishing before/after screenshots in a comment. Haven't worked that out yet. Also don't know how Android simulators store their filesystem.

Anyway!