### PR TITLE
Fix automatic data bundling on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
     # variables that are used later on
     - PUSH_BRANCH=0
     - CAN_DEPLOY=0
+    - USE_EMULATOR=no
     - run_deploy=0
 
 matrix:
@@ -150,7 +151,7 @@ install:
 before_script:
   # Fire up the Android emulator
   - |
-    if [[ $ANDROID && $USE_EMULATOR ]]; then
+    if [[ $ANDROID && $USE_EMULATOR = yes ]]; then
       set -x
       EmuName="react-native"
       mkdir -p "$HOME/.android/avd/$EmuName.avd/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,8 @@ before_install:
   # ensure that the PR branch exists locally
   - git config --add remote.origin.fetch "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
   - git fetch --depth 10
-  - git branch "$BRANCH"
+  # if the branch doesn't exist, make it (the branch only exists on push builds, not PR ones)
+  - if ! git rev-parse --quiet --verify "$BRANCH" > /dev/null; then git branch "$BRANCH"; fi
 
   # only deploy from the once-daily cron-triggered jobs
   - if [[ $CAN_DEPLOY = yes && $TRAVIS_EVENT_TYPE = cron ]]; then run_deploy=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,8 +220,8 @@ script:
 
 
 after_success:
+  # todo: test this on a forked build w/maintainer access to the branch
   - |
-    # todo: test this on a forked build w/maintainer access to the branch
     if [[ $js && $TRAVIS_PULL_REQUEST != "false" ]]; then
       set -x
       git checkout "$BRANCH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -201,8 +201,10 @@ script:
       set -x
       npm run bundle-data
       if ! git diff --quiet docs/; then
-        git checkout "$BRANCH"
         git add docs/
+        git stash
+        git checkout "$BRANCH"~1
+        git stash apply
         git commit -m "update docs [skip ci]"
         git checkout "$TRAVIS_COMMIT"
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - ENCRYPTION_LABEL=199c454344e1
     # variables that are used later on
     - PUSH_BRANCH=0
+    - CAN_DEPLOY=0
     - run_deploy=0
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - PUSH_BRANCH=0
     - CAN_DEPLOY=0
     - USE_EMULATOR=no
+    - DEPLOY_KEY=scripts/travisci_deploy_key
     - run_deploy=0
 
 matrix:
@@ -124,7 +125,6 @@ before_install:
   - export ENCRYPTED_IV_VAR="encrypted_${ENCRYPTION_LABEL}_iv"
   - export ENCRYPTED_KEY=${!ENCRYPTED_KEY_VAR}
   - export ENCRYPTED_IV=${!ENCRYPTED_IV_VAR}
-  - export DEPLOY_KEY="scripts/travisci_deploy_key"
   - openssl aes-256-cbc -K "$ENCRYPTED_KEY" -iv "$ENCRYPTED_IV" -in "$DEPLOY_KEY.enc" -out "$DEPLOY_KEY" -d
   - chmod 600 "$DEPLOY_KEY"
   - eval $(ssh-agent -s)

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,31 +28,31 @@ matrix:
       node_js: '7'
       env: {js: true}
 
-    - os: linux
-      dist: precise
-      sudo: required
-      language: android
-      jdk: oraclejdk8
-      env: {android: true, can_deploy: true}
-      android:
-        components:
-          - tools
-          - platform-tools
-          - build-tools-23.0.1
-          - build-tools-23.0.2
-          - build-tools-25.0.2
-          - android-23
-          - android-25
-          - extra-android-m2repository
-          - extra-google-m2repository
-          - extra-android-support
+    # - os: linux
+    #   dist: precise
+    #   sudo: required
+    #   language: android
+    #   jdk: oraclejdk8
+    #   env: [android=true, can_deploy=true]
+    #   android:
+    #     components:
+    #       - tools
+    #       - platform-tools
+    #       - build-tools-23.0.1
+    #       - build-tools-23.0.2
+    #       - build-tools-25.0.2
+    #       - android-23
+    #       - android-25
+    #       - extra-android-m2repository
+    #       - extra-google-m2repository
+    #       - extra-android-support
 
     # - os: linux
     #   dist: precise
     #   sudo: required
     #   language: android
     #   jdk: oraclejdk8
-    #   env: {android: true, emulator: true}
+    #   env: [android=true, emulator=true]
     #   android:
     #     components:
     #       - tools
@@ -64,11 +64,11 @@ matrix:
     #       - extra-android-support
     #       - sys-img-armeabi-v7a-google_apis-23
 
-    - os: osx
-      language: objective-c
-      osx_image: xcode8.1
-      node_js: '7'
-      env: {ios: true, can_deploy: true}
+    # - os: osx
+    #   language: objective-c
+    #   osx_image: xcode8.1
+    #   node_js: '7'
+    #   env: [ios=true, can_deploy=true]
 
 
 # As seen in http://stackoverflow.com/a/31882307/2347774

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ matrix:
     #   sudo: required
     #   language: android
     #   jdk: oraclejdk8
-    #   env: [android=true, emulator=true]
+    #   env: [android=true, USE_EMULATOR=yes]
     #   android:
     #     components:
     #       - tools
@@ -83,7 +83,7 @@ branches:
 
 before_install:
   - echo "Now testing $type on $TRAVIS_OS_NAME"
-  - echo "Using the android emulator? $emulator"
+  - echo "Using the android emulator? $USE_EMULATOR"
   - echo "Travis branch is $TRAVIS_BRANCH"
   - echo "Travis is in pull request $TRAVIS_PULL_REQUEST"
   - echo "Build triggered by $TRAVIS_EVENT_TYPE"
@@ -154,7 +154,7 @@ install:
 before_script:
   # Fire up the Android emulator
   - |
-    if [[ $android && $emulator ]]; then
+    if [[ $android && $USE_EMULATOR ]]; then
       set -x
       EmuName="react-native"
       mkdir -p "$HOME/.android/avd/$EmuName.avd/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -203,6 +203,7 @@ script:
       if ! git diff --quiet docs/; then
         git stash
         git checkout "$BRANCH"~1
+        git reset --hard "$(git rev-parse HEAD)"
         git stash apply
         git add docs/
         git commit -m "update docs [skip ci]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - ENCRYPTION_LABEL=199c454344e1
     # variables that are used later on
     - PUSH_BRANCH=0
+    - run_deploy=0
 
 matrix:
   fast_finish: true
@@ -35,7 +36,7 @@ matrix:
     #   sudo: required
     #   language: android
     #   jdk: oraclejdk8
-    #   env: [android=true, can_deploy=true]
+    #   env: [android=true, CAN_DEPLOY=yes]
     #   android:
     #     components:
     #       - tools
@@ -70,7 +71,7 @@ matrix:
     #   language: objective-c
     #   osx_image: xcode8.1
     #   node_js: '7'
-    #   env: [ios=true, can_deploy=true]
+    #   env: [ios=true, CAN_DEPLOY=yes]
 
 
 # As seen in http://stackoverflow.com/a/31882307/2347774
@@ -99,9 +100,7 @@ before_install:
   - git branch "$BRANCH"
 
   # only deploy from the once-daily cron-triggered jobs
-  - run_deploy=0
-  - if [[ $can_deploy && $TRAVIS_EVENT_TYPE == "cron" ]]; then run_deploy=1; fi
-  - export run_deploy=$run_deploy
+  - if [[ $CAN_DEPLOY = yes && $TRAVIS_EVENT_TYPE = cron ]]; then run_deploy=1; fi
 
   # force node 7 on the android builds
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,11 +64,11 @@ matrix:
     #       - extra-android-support
     #       - sys-img-armeabi-v7a-google_apis-23
 
-    # - os: osx
-    #   language: objective-c
-    #   osx_image: xcode8.1
-    #   node_js: '7'
-    #   env: [ios=true, CAN_DEPLOY=yes]
+    - os: osx
+      language: objective-c
+      osx_image: xcode8.1
+      node_js: '7'
+      env: [ios=true, CAN_DEPLOY=yes]
 
 
 # As seen in http://stackoverflow.com/a/31882307/2347774

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,7 @@ before_install:
   - npm config set progress=false
 
   # Dirty hack for https://github.com/travis-ci/travis-ci/issues/5092
+  - echo $PATH
   - PATH=`echo $PATH | sed "s/\.\/node_modules\/\.bin//g"`
   - export PATH=$PATH
   - echo $PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - MATCH_KEYCHAIN_PASSWORD=alpine
     # this just gives us a nice label to use
     - ENCRYPTION_LABEL=199c454344e1
+    # variables that are used later on
+    - PUSH_BRANCH=0
 
 matrix:
   fast_finish: true
@@ -205,6 +207,7 @@ script:
         git checkout "$BRANCH"
         git commit -m "update docs [skip ci]"
         git checkout "$TRAVIS_COMMIT"
+        PUSH_BRANCH=1
       fi
       set +x
     fi
@@ -228,7 +231,7 @@ script:
 after_success:
   # todo: test this on a forked build w/maintainer access to the branch
   - |
-    if [[ $js && $TRAVIS_PULL_REQUEST != "false" ]]; then
+    if [[ $js && $TRAVIS_PULL_REQUEST != false && $PUSH_BRANCH = 1 ]]; then
       set -x
       git checkout "$BRANCH"
       git push "$SSH_REPO" "$BRANCH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -201,10 +201,10 @@ script:
       set -x
       npm run bundle-data
       if ! git diff --quiet docs/; then
-        git add docs/
         git stash
         git checkout "$BRANCH"~1
         git stash apply
+        git add docs/
         git commit -m "update docs [skip ci]"
         git checkout "$TRAVIS_COMMIT"
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,8 +115,7 @@ before_install:
 
   # Dirty hack for https://github.com/travis-ci/travis-ci/issues/5092
   - echo $PATH
-  - PATH=`echo $PATH | sed "s/\.\/node_modules\/\.bin//g"`
-  - export PATH=$PATH
+  - export PATH=${PATH/\.\/node_modules\/\.bin/}
   - echo $PATH
 
   # Get the deploy key by using Travis's stored variables to decrypt deploy_key.enc

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       sudo: false
       language: node_js
       node_js: '7'
-      env: {js: true}
+      env: [JS=yes]
 
     - &android-base
       os: linux
@@ -38,7 +38,7 @@ matrix:
       sudo: required
       language: android
       jdk: oraclejdk8
-      env: [android=true, CAN_DEPLOY=yes]
+      env: [ANDROID=yes, CAN_DEPLOY=yes]
       android:
         components:
           - tools
@@ -53,7 +53,7 @@ matrix:
           - extra-android-support
 
     # - <<: *android-base
-    #   env: [android=true, USE_EMULATOR=yes]
+    #   env: [ANDROID=yes, USE_EMULATOR=yes]
     #   android:
     #     components:
     #       - tools
@@ -69,7 +69,7 @@ matrix:
       language: objective-c
       osx_image: xcode8.1
       node_js: '7'
-      env: [ios=true, CAN_DEPLOY=yes]
+      env: [IOS=yes, CAN_DEPLOY=yes]
 
 
 # As seen in http://stackoverflow.com/a/31882307/2347774
@@ -102,7 +102,7 @@ before_install:
 
   # force node 7 on the android builds
   - |
-    if [[ $android ]]; then
+    if [[ $ANDROID ]]; then
       set -x
       nvm install 7
       nvm use 7
@@ -131,7 +131,7 @@ before_install:
 
   # make sure to use ruby 2.3
   - |
-    if [[ $android || $ios ]]; then
+    if [[ $ANDROID || $IOS ]]; then
       set -x
       rvm use 2.3 --install --binary --fuzzy
       gem install bundler
@@ -144,13 +144,13 @@ install:
   # install packages
   - npm install
   # install fastlane
-  - if [[ $android || $ios ]]; then bundle install --deployment; fi
+  - if [[ $ANDROID || $IOS ]]; then bundle install --deployment; fi
 
 
 before_script:
   # Fire up the Android emulator
   - |
-    if [[ $android && $USE_EMULATOR ]]; then
+    if [[ $ANDROID && $USE_EMULATOR ]]; then
       set -x
       EmuName="react-native"
       mkdir -p "$HOME/.android/avd/$EmuName.avd/"
@@ -162,7 +162,7 @@ before_script:
     fi
 
   # Fix keychain issues for iOS signing
-  - if [[ $ios ]]; then bundle exec fastlane ios ci_keychains; fi
+  - if [[ $IOS ]]; then bundle exec fastlane ios ci_keychains; fi
 
 
 script:
@@ -183,19 +183,19 @@ script:
   # JS
   # Ensure prettiness
   - |
-    if [[ $js ]]; then
+    if [[ $JS ]]; then
       set -x
       npm run prettier
       git diff --exit-code *.js source/ | tee logs/prettier
       set +x
     fi
   # Lint
-  - if [[ $js ]]; then npm run lint | tee logs/eslint; fi
+  - if [[ $JS ]]; then npm run lint | tee logs/eslint; fi
   # Validate data
-  - if [[ $js ]]; then npm run validate-data -- --quiet | tee logs/validate-data; fi
+  - if [[ $JS ]]; then npm run validate-data -- --quiet | tee logs/validate-data; fi
   # Ensure that the data files have been updated
   - |
-    if [[ $js ]]; then
+    if [[ $JS ]]; then
       set -x
       npm run bundle-data
       if ! git diff --quiet docs/; then
@@ -208,26 +208,26 @@ script:
       set +x
     fi
   # Type check
-  - if [[ $js ]]; then npm run flow -- check --quiet | tee logs/flow; fi
+  - if [[ $JS ]]; then npm run flow -- check --quiet | tee logs/flow; fi
   # Build the bundles
-  - if [[ $js ]]; then npm run bundle:ios | tee logs/bundle-ios; fi
-  - if [[ $js ]]; then npm run bundle:android | tee logs/bundle-android; fi
+  - if [[ $JS ]]; then npm run bundle:ios | tee logs/bundle-ios; fi
+  - if [[ $JS ]]; then npm run bundle:android | tee logs/bundle-android; fi
   # Run tests + collect coverage info
-  - if [[ $js ]]; then npm run test -- --coverage 2>&1 | tee logs/jest; fi
+  - if [[ $JS ]]; then npm run test -- --coverage 2>&1 | tee logs/jest; fi
   # Danger?
-  - if [[ $js ]]; then npm run danger; fi
+  - if [[ $JS ]]; then npm run danger; fi
 
   # iOS
-  - if [[ $ios ]]; then bundle exec fastlane ios ci_run; fi
+  - if [[ $IOS ]]; then bundle exec fastlane ios ci_run; fi
 
   # Android
-  - if [[ $android ]]; then bundle exec fastlane android ci_run; fi
+  - if [[ $ANDROID ]]; then bundle exec fastlane android ci_run; fi
 
 
 after_success:
   # todo: test this on a forked build w/maintainer access to the branch
   - |
-    if [[ $js && $TRAVIS_PULL_REQUEST != false && $PUSH_BRANCH = 1 ]]; then
+    if [[ $JS && $TRAVIS_PULL_REQUEST != false && $PUSH_BRANCH = 1 ]]; then
       set -x
       git checkout "$BRANCH"
       git push "$SSH_REPO" "$BRANCH"
@@ -235,7 +235,7 @@ after_success:
       set +x
     fi
   - |
-    if [[ $js ]]; then
+    if [[ $JS ]]; then
       set -x
       npm install coveralls
       ./node_modules/.bin/coveralls < ./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -201,11 +201,8 @@ script:
       set -x
       npm run bundle-data
       if ! git diff --quiet docs/; then
-        git stash
-        git checkout "$BRANCH"~1
-        git reset --hard "$(git rev-parse HEAD)"
-        git stash apply
         git add docs/
+        git checkout "$BRANCH"
         git commit -m "update docs [skip ci]"
         git checkout "$TRAVIS_COMMIT"
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,11 @@ before_install:
   - export REPO=$(git config remote.origin.url)
   - export SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
 
+  # ensure that the PR branch exists locally
+  - git config --add remote.origin.fetch "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+  - git fetch --depth 10
+  - git branch "$BRANCH"
+
   # only deploy from the once-daily cron-triggered jobs
   - run_deploy=0
   - if [[ $can_deploy && $TRAVIS_EVENT_TYPE == "cron" ]]; then run_deploy=1; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,30 +31,27 @@ matrix:
       node_js: '7'
       env: {js: true}
 
-    # - os: linux
-    #   dist: precise
-    #   sudo: required
-    #   language: android
-    #   jdk: oraclejdk8
-    #   env: [android=true, CAN_DEPLOY=yes]
-    #   android:
-    #     components:
-    #       - tools
-    #       - platform-tools
-    #       - build-tools-23.0.1
-    #       - build-tools-23.0.2
-    #       - build-tools-25.0.2
-    #       - android-23
-    #       - android-25
-    #       - extra-android-m2repository
-    #       - extra-google-m2repository
-    #       - extra-android-support
+    - &android-base
+      os: linux
+      dist: precise
+      sudo: required
+      language: android
+      jdk: oraclejdk8
+      env: [android=true, CAN_DEPLOY=yes]
+      android:
+        components:
+          - tools
+          - platform-tools
+          - build-tools-23.0.1
+          - build-tools-23.0.2
+          - build-tools-25.0.2
+          - android-23
+          - android-25
+          - extra-android-m2repository
+          - extra-google-m2repository
+          - extra-android-support
 
-    # - os: linux
-    #   dist: precise
-    #   sudo: required
-    #   language: android
-    #   jdk: oraclejdk8
+    # - <<: *android-base
     #   env: [android=true, USE_EMULATOR=yes]
     #   android:
     #     components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,10 @@ before_install:
   # force node 7 on the android builds
   - |
     if [[ $android ]]; then
+      set -x
       nvm install 7
       nvm use 7
+      set +x
     fi
 
   # turn off fancy npm stuff
@@ -126,8 +128,10 @@ before_install:
   # make sure to use ruby 2.3
   - |
     if [[ $android || $ios ]]; then
+      set -x
       rvm use 2.3 --install --binary --fuzzy
       gem install bundler
+      set +x
     fi
 
 
@@ -143,12 +147,14 @@ before_script:
   # Fire up the Android emulator
   - |
     if [[ $android && $emulator ]]; then
+      set -x
       EmuName="react-native"
       mkdir -p "$HOME/.android/avd/$EmuName.avd/"
       echo no | android create avd --force -n "$EmuName" -t android-23 --abi google_apis/armeabi-v7a
       emulator -avd "$EmuName" -no-audio -no-window &
       android-wait-for-emulator
       adb shell input keyevent 82 &
+      set +x
     fi
 
   # Fix keychain issues for iOS signing
@@ -161,7 +167,6 @@ script:
 
   # Make sure that a failing command in a pipe fails the build
   - set -o pipefail
-  - set -x
 
   # ensure the env file exists and fill it out
   - touch .env.js
@@ -175,8 +180,10 @@ script:
   # Ensure prettiness
   - |
     if [[ $js ]]; then
+      set -x
       npm run prettier
       git diff --exit-code *.js source/ | tee logs/prettier
+      set +x
     fi
   # Lint
   - if [[ $js ]]; then npm run lint | tee logs/eslint; fi
@@ -185,6 +192,7 @@ script:
   # Ensure that the data files have been updated
   - |
     if [[ $js ]]; then
+      set -x
       npm run bundle-data
       if ! git diff --quiet docs/; then
         git checkout "$BRANCH"
@@ -192,6 +200,7 @@ script:
         git commit -m "update docs [skip ci]"
         git checkout "$TRAVIS_COMMIT"
       fi
+      set +x
     fi
   # Type check
   - if [[ $js ]]; then npm run flow -- check --quiet | tee logs/flow; fi
@@ -211,16 +220,19 @@ script:
 
 
 after_success:
-  - set -x
   - |
     # todo: test this on a forked build w/maintainer access to the branch
     if [[ $js && $TRAVIS_PULL_REQUEST != "false" ]]; then
+      set -x
       git checkout "$BRANCH"
       git push "$SSH_REPO" "$BRANCH"
       git checkout "$TRAVIS_COMMIT"
+      set +x
     fi
   - |
     if [[ $js ]]; then
+      set -x
       npm install coveralls
       ./node_modules/.bin/coveralls < ./coverage/lcov.info
+      set +x
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ env:
   global:
     # `match` keychain info – the values don't matter, they're defined
     # here so they're consistent throughout
-    MATCH_KEYCHAIN_NAME: travis-ios-keychain
-    MATCH_KEYCHAIN_PASSWORD: alpine
+    - MATCH_KEYCHAIN_NAME=travis-ios-keychain
+    - MATCH_KEYCHAIN_PASSWORD=alpine
     # this just gives us a nice label to use
-    ENCRYPTION_LABEL: 199c454344e1
+    - ENCRYPTION_LABEL=199c454344e1
 
 matrix:
   fast_finish: true

--- a/docs/building-hours.json
+++ b/docs/building-hours.json
@@ -1523,49 +1523,9 @@
       }
     },
     {
-      "name": "CHM",
-      "subtitle": "Christiansen Hall",
-      "image": "christiansen",
+      "name": "Center for Arts and Dance",
       "category": "Academia",
-      "schedule": [
-        {
-          "title": "Hours",
-          "hours": [
-            {
-              "days": [
-                "Mo",
-                "Tu",
-                "We",
-                "Th",
-                "Fr"
-              ],
-              "from": "7:00am",
-              "to": "12:00am"
-            },
-            {
-              "days": [
-                "Sa",
-                "Su"
-              ],
-              "from": "8:00am",
-              "to": "12:00am"
-            }
-          ]
-        }
-      ],
-      "breakSchedule": {
-        "fall": [],
-        "thanksgiving": [],
-        "winter": [],
-        "interim": [],
-        "spring": [],
-        "easter": [],
-        "summer": []
-      }
-    },
-    {
-      "name": "Dittmann Center",
-      "category": "Academia",
+      "image": "center-for-arts-and-dance",
       "schedule": [
         {
           "title": "Hours",
@@ -1609,8 +1569,50 @@
       }
     },
     {
+      "name": "CHM",
+      "subtitle": "Christiansen Hall",
+      "image": "christiansen",
+      "category": "Academia",
+      "schedule": [
+        {
+          "title": "Hours",
+          "hours": [
+            {
+              "days": [
+                "Mo",
+                "Tu",
+                "We",
+                "Th",
+                "Fr"
+              ],
+              "from": "7:00am",
+              "to": "12:00am"
+            },
+            {
+              "days": [
+                "Sa",
+                "Su"
+              ],
+              "from": "8:00am",
+              "to": "12:00am"
+            }
+          ]
+        }
+      ],
+      "breakSchedule": {
+        "fall": [],
+        "thanksgiving": [],
+        "winter": [],
+        "interim": [],
+        "spring": [],
+        "easter": [],
+        "summer": []
+      }
+    },
+    {
       "name": "Holland Hall",
-      "category": "Under Construction",
+      "subtitle": "Under Construction",
+      "category": "Academia",
       "schedule": [
         {
           "title": "Hours",
@@ -1717,6 +1719,7 @@
     {
       "name": "Regents Hall",
       "category": "Academia",
+      "image": "regents-hall",
       "schedule": [
         {
           "title": "Hours",

--- a/docs/dictionary.json
+++ b/docs/dictionary.json
@@ -149,8 +149,8 @@
       "definition": "The Political Awareness Committee (PAC) plans and hosts dinner debates in which students can bring their caf trays and go, listen, and participate in debates on a variety of issues on campus.\n"
     },
     {
-      "word": "Dittmann Center",
-      "definition": "Before Buntrock Commons was built, Dittmann was the student center. By adding more natural lighting with strategic window placement, Dittmann is now home to the Studio Art, Art History and Dance Department. The building also houses the Flaten Art Museum.\n"
+      "word": "Center for Arts and Dance",
+      "definition": "Before Buntrock Commons was built, the Center for Arts and Dance housed the  student center. By adding more natural lighting with strategic window placement,  the Center is now home to the Studio Art, Art History and Dance departments. The  building also houses the Flaten Art Museum.\n"
     },
     {
       "word": "Drag Ball",


### PR DESCRIPTION
- [x] Reduce verbosity from `set -x`
- [x] Fix data bundling
- [x] Simplify some string replacements
- [x] Uppercase some variables
- [x] Bundle the data

---

We realized a few days ago, after #839 was merged, that the data bundles weren't being updated.

My original idea was to check out the branch that was being built, commit the bundled data changes on top of the branch, then go back to the commit. Once the build was done, it would push the committed and bundled data back to the branch, with `[skip ci]` in the commit message so as to avoid an endless rebuilding situation.

I had tested that this worked in my original branch, but what I didn't realize was that Travis clones differently if you're building a PR versus a push to a branch.

Travis configures git to only fetch the branch that's being built. If it's building a push, it'll clone the pushed branch; if it's building a PR, it clones `master`. Travis sets the `git config remote.origin.fetch` value to restrict the branches.

So, when I built the test branch, Travis worked perfectly, because it checked out the branch that it needed to. When I built the PRs, though, Travis only knew about `master`, so `git checkout $OTHER_BRANCH` couldn't work.

I solved this by adding OTHER_BRANCH (whatever it may be; it's stored in the `$BRANCH` environment variable) to the `remote.origin.fetch` config value, then running `git fetch` so that Travis knows about both `master` and the other branch.

Then, we do the bundle/checkout-branch/commit/checkout-commit dance, and we set the PUSH_BRANCH env variable so that we know that we need to push to the remote. We don't want to always push, because the PR builds include a merge commit, which would result in a never-ending series of builds (Merge, Merge, Merge, Merge, …).

So! We can see that this works, in the commit history of this PR.