### PR TITLE
Add regents image to building hours

### DIFF
--- a/data/building-hours/8-rns.yaml
+++ b/data/building-hours/8-rns.yaml
@@ -1,5 +1,6 @@
 name: Regents Hall
 category: Academia
+image: regents-hall
 
 schedule:
   - title: Hours


### PR DESCRIPTION
We have access to a regents image but it was not in use.