### PR TITLE
Remove colon from check script's name

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bundle-data": "node scripts/bundle-data.js data/ docs/",
     "bundle:android": "react-native bundle --entry-file index.android.js --dev true --platform android --bundle-output ./android/app/src/main/assets/index.android.bundle --assets-dest ./android/app/src/main/res/",
     "bundle:ios": "react-native bundle --entry-file index.ios.js --dev true --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --assets-dest ./ios",
-    "check:": "npm run prettier && npm run flow && npm run test",
+    "check": "npm run prettier && npm run flow && npm run test",
     "danger": "danger",
     "data": "node scripts/bundle-data.js data/ docs/",
     "flow": "flow",


### PR DESCRIPTION
:man_facepalming: removing the colon inserted into the `npm run check` script.