### PR TITLE
add prettier:changed and prettier:since-master commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "AllAboutOlaf",
   "version": "2.1.2",
   "private": true,
+  "config": {
+    "prettier_args": "--single-quote --trailing-comma all --no-bracket-spacing"
+  },
   "scripts": {
     "android": "react-native run-android",
     "bundle-data": "node scripts/bundle-data.js data/ docs/",
@@ -13,7 +16,9 @@
     "flow": "flow",
     "ios": "react-native run-ios",
     "lint": "eslint --cache source/ *.js",
-    "prettier": "prettier --single-quote --trailing-comma all --no-bracket-spacing --write 'source/**/*.js' '*.js' && eslint --cache --fix 'source/' '*.js'",
+    "prettier": "prettier --write $npm_package_config_prettier_args 'source/**/*.js' '*.js' && eslint --cache --fix 'source/' '*.js'",
+    "prettier:changed": "FILES=$(git diff --name-only | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES; eslint --cache --fix $FILES",
+    "prettier:since-master": "FILES=$(git diff --name-only master | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES; eslint --cache --fix $FILES",
     "start": "react-native start",
     "test": "jest",
     "validate-data": "node scripts/validate-data.js"


### PR DESCRIPTION
Hawken Rives, [Mar 13, 2017, 11:21 AM]: 
> wow
> so i just made a command to only prettify the changed files
> and it takes like 1.5 seconds instead of 20
> and so I'm running it more often
> and, just
> i can toss in a bunch of code and run, and it'll reformat it
> it's amazing
> and quick

`npm run prettier:changed` only runs prettier on the files that have changed since the last commit.

`npm run prettier:since-master` runs on all files changed since the current branch diverged from master.