### PR TITLE
add ios-simulator and android-emulator commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "android": "react-native run-android",
+    "android-emulator": "VBoxManage list vms | peco --select-1 --query API --on-cancel error | sed  's~.*{\\(.*\\)}.*~\\1~' | xargs /Applications/Genymotion.app/Contents/MacOS/player.app/Contents/MacOS/player --vm-name",
     "bundle-data": "node scripts/bundle-data.js data/ docs/",
     "bundle:android": "react-native bundle --entry-file index.android.js --dev true --platform android --bundle-output ./android/app/src/main/assets/index.android.bundle --assets-dest ./android/app/src/main/res/",
     "bundle:ios": "react-native bundle --entry-file index.ios.js --dev true --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --assets-dest ./ios",
@@ -15,6 +16,7 @@
     "data": "node scripts/bundle-data.js data/ docs/",
     "flow": "flow",
     "ios": "react-native run-ios",
+    "ios-simulator": "xcrun instruments -s devices | peco --select-1 --query 'Simulator iPhone' --on-cancel error | sed  's~.*\\[\\(.*\\)\\].*~\\1~' | xargs open -n -a Simulator --args -CurrentDeviceUDID",
     "lint": "eslint --cache source/ *.js",
     "prettier": "prettier --write $npm_package_config_prettier_args 'source/**/*.js' '*.js' && eslint --cache --fix 'source/' '*.js'",
     "prettier:changed": "FILES=$(git diff --name-only | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES; eslint --cache --fix $FILES",


### PR DESCRIPTION
This PR adds two commands:

- `npm run android-emulator`: query genymotion for the list of installed emulators, lets you pick one, then launches it.
- `npm run ios-simulator`: queries xcrun for the list of installed simulators, lets you pick one, then launches it.

It uses [`peco`](https://github.com/peco/peco) to filter the list, so you'll need to install that first: `brew install peco`.

Screenshot:

![image](https://cloud.githubusercontent.com/assets/464441/23874922/7c448532-0805-11e7-902c-f80f43177716.png)
