### PR TITLE
Remove forms and blank news stories

### DIFF
--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -65,11 +65,9 @@ export class NewsList extends React.Component {
   render() {
     // remove all entries with blank excerpts
     // remove all entries with a <form from the list
-    const entries = (this.props.entries.filter(
-      entry => entry.excerpt.trim() !== '').filter(
-        entry => !entry.content.includes('<form')
-      )
-    )
+    const entries = this.props.entries
+      .filter(entry => entry.excerpt.trim() !== '')
+      .filter(entry => !entry.content.includes('<form'))
 
     if (!entries.length) {
       return <NoticeView text="No news." />

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -63,9 +63,12 @@ export class NewsList extends React.Component {
   };
 
   render() {
-    // remove all entries with a <form> from the list
-    const entries = this.props.entries.filter(
-      entry => !entry.content.includes('<form>'),
+    // remove all entries with blank excerpts
+    // remove all entries with a <form from the list
+    const entries = (this.props.entries.filter(
+      entry => entry.excerpt.trim() !== '').filter(
+        entry => !entry.content.includes('<form')
+      )
     )
 
     if (!entries.length) {


### PR DESCRIPTION
This PR aims to filter out two types of stories:

* Blank stories
* Stories with forms

Blank stories are removed by checking for a blank excerpt. That way, we won't run into trouble stripping html and can simply remove any story that presumably has no textual content.

We do not want to render forms as they are problematic upon submission. Forms also don't belong in the category of digestible content.

Old | New
--- | ---
 ![1](https://cloud.githubusercontent.com/assets/5240843/23880580/e9cfaad0-082a-11e7-961b-78118f13b50d.png) | ![2](https://cloud.githubusercontent.com/assets/5240843/23880581/e9cfb49e-082a-11e7-9440-4bd7f605666a.png) 
 ![3](https://cloud.githubusercontent.com/assets/5240843/23880578/e9cf9838-082a-11e7-923b-e585612eb5cc.png) | ![4](https://cloud.githubusercontent.com/assets/5240843/23880579/e9cf9482-082a-11e7-9736-9236952fae16.png)