### PR TITLE
Sort presence calendar events

### DIFF
--- a/source/views/calendar/calendar-presence.js
+++ b/source/views/calendar/calendar-presence.js
@@ -50,6 +50,7 @@ export class PresenceCalendarView extends React.Component {
           extra: {type: 'presence', data: event},
         }
       })
+      .sort()
       .filter(event => event.endTime.isSameOrAfter(now))
   }
 


### PR DESCRIPTION
This fixes the presence calendar sorting order by sorting before filtering so that the events are in order by date.

Closes #866 