### PR TITLE
Fix relative links in news articles

### DIFF
--- a/source/views/components/html-view.js
+++ b/source/views/components/html-view.js
@@ -18,16 +18,14 @@ export class HtmlView extends React.Component {
       return
     }
 
-    // I had to disable the stopLoading call, because it was cancelling the
-    // image loads.
-    // this._webview.stopLoading()
-    this._webview.goBack()
-
     // We don't want to open the web browser unless the user actuall clicked
     // on a link.
     if (url === this.props.baseUrl) {
       return
     }
+
+    this._webview.stopLoading()
+    this._webview.goBack()
 
     return openUrl(url)
   };

--- a/source/views/components/html-view.js
+++ b/source/views/components/html-view.js
@@ -7,6 +7,7 @@ import openUrl, {canOpenUrl} from '../components/open-url'
 export class HtmlView extends React.Component {
   props: {
     html: string,
+    baseUrl?: ?string,
   };
   _webview: WebView;
 
@@ -17,8 +18,16 @@ export class HtmlView extends React.Component {
       return
     }
 
-    this._webview.stopLoading()
+    // I had to disable the stopLoading call, because it was cancelling the
+    // image loads.
+    // this._webview.stopLoading()
     this._webview.goBack()
+
+    // We don't want to open the web browser unless the user actuall clicked
+    // on a link.
+    if (url === this.props.baseUrl) {
+      return
+    }
 
     return openUrl(url)
   };
@@ -27,7 +36,7 @@ export class HtmlView extends React.Component {
     return (
       <WebView
         ref={ref => this._webview = ref}
-        source={{html: this.props.html}}
+        source={{html: this.props.html, baseUrl: this.props.baseUrl}}
         onNavigationStateChange={this.onNavigationStateChange}
       />
     )

--- a/source/views/components/html-view.js
+++ b/source/views/components/html-view.js
@@ -18,7 +18,7 @@ export class HtmlView extends React.Component {
       return
     }
 
-    // We don't want to open the web browser unless the user actuall clicked
+    // We don't want to open the web browser unless the user actually clicked
     // on a link.
     if (url === this.props.baseUrl) {
       return

--- a/source/views/components/open-url.js
+++ b/source/views/components/open-url.js
@@ -82,7 +82,7 @@ export function trackedOpenUrl({url, id}: {url: string, id?: string}) {
 export function canOpenUrl(url: string) {
   // iOS navigates to about:blank when you provide raw HTML to a webview.
   // Android navigates to data:text/html;$stuff (that is, the document you passed) instead.
-  if (/^about|data:/.test(url)) {
+  if (/^(?:about|data):/.test(url)) {
     return false
   }
   return true

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -50,5 +50,5 @@ export default function NewsItem(
     ${story.content}
   `
 
-  return <HtmlView html={content} />
+  return <HtmlView html={content} baseUrl={story.link} />
 }


### PR DESCRIPTION
Turns out that `<WebView/>` accepts a `baseUrl` parameter to set the base URL for the webview, allowing us to let the web platform handle relative hrefs.

Um.

This fixes bugs. More detail probably available upon request.

Closes #864.