### PR TITLE
Remove the unused "execa" dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "eslint-plugin-flowtype": "2.30.3",
     "eslint-plugin-react": "6.10.0",
     "eslint-plugin-react-native": "2.3.1",
-    "execa": "0.6.1",
     "flow-bin": "0.38.0",
     "jest": "18.1.0",
     "js-yaml": "3.8.1",


### PR DESCRIPTION
I was going to use it in Danger, but then I figured out that I can print the logs to the filesystem with `tee`, so it's never been used.