### PR TITLE
ignore flow-bin from greenkeeper updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
       "react-native"
     ]
   },
+  "greenkeeper": {
+    "ignore": [
+      "flow-bin"
+    ]
+  },
   "jest": {
     "testRegex": "/__tests__/.*\\.(test|spec)\\.js$",
     "collectCoverageFrom": [


### PR DESCRIPTION
We can't upgrade `flow` past upstream React Native, so having Greenkeeper tell us about flow updates is just pointless noise IMHO.