### PR TITLE
Use prettier to remove semicolons, instead of eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.1.2",
   "private": true,
   "config": {
-    "prettier_args": "--single-quote --trailing-comma all --no-bracket-spacing"
+    "prettier_args": "--single-quote --trailing-comma all --no-bracket-spacing --no-semi"
   },
   "scripts": {
     "android": "react-native run-android",
@@ -18,9 +18,9 @@
     "ios": "react-native run-ios",
     "ios-simulator": "xcrun instruments -s devices | peco --select-1 --query 'Simulator iPhone' --on-cancel error | sed  's~.*\\[\\(.*\\)\\].*~\\1~' | xargs open -n -a Simulator --args -CurrentDeviceUDID",
     "lint": "eslint --cache source/ *.js",
-    "prettier": "prettier --write $npm_package_config_prettier_args 'source/**/*.js' '*.js' && eslint --cache --fix 'source/' '*.js'",
-    "prettier:changed": "FILES=$(git diff --name-only | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES; eslint --cache --fix $FILES",
-    "prettier:since-master": "FILES=$(git diff --name-only master | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES; eslint --cache --fix $FILES",
+    "prettier": "prettier --write $npm_package_config_prettier_args 'source/**/*.js' '*.js'",
+    "prettier:changed": "FILES=$(git diff --name-only | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES",
+    "prettier:since-master": "FILES=$(git diff --name-only master | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES",
     "start": "react-native start",
     "test": "jest",
     "validate-data": "node scripts/validate-data.js"

--- a/source/app.js
+++ b/source/app.js
@@ -178,7 +178,7 @@ export default class App extends React.Component {
     console.log('Device info:', device)
   }
 
-  _navigator: Navigator;
+  _navigator: Navigator
 
   registerAndroidBackButton = () => {
     if (this._navigator && this._navigator.getCurrentRoutes().length > 1) {
@@ -186,7 +186,7 @@ export default class App extends React.Component {
       return true
     }
     return false
-  };
+  }
 
   render() {
     return (

--- a/source/flux/parts/sis.js
+++ b/source/flux/parts/sis.js
@@ -31,10 +31,7 @@ export function updateBalances(forceFromServer: boolean = false) {
 export function updateCourses(forceFromServer: boolean = false) {
   return async (dispatch: () => {}, getState: any) => {
     const state = getState()
-    const courses = await loadAllCourses(
-      state.app.isConnected,
-      forceFromServer,
-    )
+    const courses = await loadAllCourses(state.app.isConnected, forceFromServer)
     dispatch({
       type: UPDATE_COURSES,
       error: courses.error,

--- a/source/globalize-fetch.js
+++ b/source/globalize-fetch.js
@@ -6,9 +6,8 @@ function status(response) {
   if (response.status >= 200 && response.status < 300) {
     return response
   } else {
-    let error = new Error(response.statusText)
-    ;// attach the original response to the thrown error
-    (error: any).response = response
+    let error = new Error(response.statusText) // attach the original response to the thrown error
+    ;(error: any).response = response
     throw error
   }
 }

--- a/source/globalize-fetch.js
+++ b/source/globalize-fetch.js
@@ -6,8 +6,8 @@ function status(response) {
   if (response.status >= 200 && response.status < 300) {
     return response
   } else {
-    let error = new Error(response.statusText);
-    // attach the original response to the thrown error
+    let error = new Error(response.statusText)
+    ;// attach the original response to the thrown error
     (error: any).response = response
     throw error
   }

--- a/source/lib/cache.js
+++ b/source/lib/cache.js
@@ -8,9 +8,9 @@ type BaseCacheResultType<T> = {
   isExpired: boolean,
   isCached: boolean,
   value: ?T,
-};
+}
 
-type CacheResultType<T> = Promise<BaseCacheResultType<T>>;
+type CacheResultType<T> = Promise<BaseCacheResultType<T>>
 
 function needsUpdate(time: Date, [count, unit]: [number, string]): boolean {
   return moment(time).isBefore(moment().subtract(count, unit))
@@ -128,7 +128,7 @@ type BalancesInputType = {
   print: ?number,
   daily: ?string,
   weekly: ?string,
-};
+}
 export function setBalances({
   flex,
   ole,
@@ -153,7 +153,7 @@ type BalancesOutputType = {
   weekly: BaseCacheResultType<?string>,
   _isExpired: boolean,
   _isCached: boolean,
-};
+}
 export async function getBalances(): Promise<BalancesOutputType> {
   const [flex, ole, print, daily, weekly] = await Promise.all([
     getFlexBalance(),

--- a/source/lib/courses/index.js
+++ b/source/lib/courses/index.js
@@ -1,7 +1,3 @@
 // @flow
 export {loadAllCourses} from './load-all-courses'
-export type {
-  CourseType,
-  CourseCollectionType,
-  CoursesByTermType,
-} from './types'
+export type {CourseType, CourseCollectionType, CoursesByTermType} from './types'

--- a/source/lib/courses/load-courses-from-unofficial-transcript.js
+++ b/source/lib/courses/load-courses-from-unofficial-transcript.js
@@ -12,7 +12,7 @@ import {GRADES_PAGE, LANDING_PAGE} from './urls'
 import {parseCoursesFromDom} from './parse-courses'
 import type {CourseCollectionType} from './types'
 
-type PromisedDataType = Promise<CourseCollectionType>;
+type PromisedDataType = Promise<CourseCollectionType>
 
 export async function loadCoursesFromUnofficialTranscript({
   stnum,

--- a/source/lib/courses/load-student-number.js
+++ b/source/lib/courses/load-student-number.js
@@ -12,7 +12,7 @@ import {parseStudentNumberFromDom} from './parse-student-number'
 
 type PromisedDataType = Promise<
   {error: true, value: Error} | {error: false, value: number}
->;
+>
 
 export async function loadStudentNumber({
   force,

--- a/source/lib/courses/types.js
+++ b/source/lib/courses/types.js
@@ -13,10 +13,10 @@ export type CourseType = {
   instructors: string,
   // clbid: number,
   // term: number,
-};
+}
 
 export type CourseCollectionType =
   | {error: true, value: Error}
-  | {error: false, value: CoursesByTermType};
+  | {error: false, value: CoursesByTermType}
 
-export type CoursesByTermType = {[key: string]: CourseType[]};
+export type CoursesByTermType = {[key: string]: CourseType[]}

--- a/source/lib/financials/balances.js
+++ b/source/lib/financials/balances.js
@@ -10,7 +10,7 @@ import * as cache from '../cache'
 
 type BalancesOrErrorType =
   | {error: true, value: Error}
-  | {error: false, value: BalancesShapeType};
+  | {error: false, value: BalancesShapeType}
 
 export async function getBalances(
   isConnected: boolean,

--- a/source/lib/financials/types.js
+++ b/source/lib/financials/types.js
@@ -5,4 +5,4 @@ export type BalancesShapeType = {
   print: ?number,
   weekly: ?string,
   daily: ?string,
-};
+}

--- a/source/storybook/index.js
+++ b/source/storybook/index.js
@@ -72,7 +72,7 @@ type ViewCollectionType = {
       delay: number,
     },
   },
-};
+}
 
 const Nav = ({children}: {children?: Function}) => (
   <Navigator
@@ -83,9 +83,9 @@ const Nav = ({children}: {children?: Function}) => (
 export class SnapshotsView extends React.Component {
   state = {
     viewPath: 'streaming.radio',
-  };
+  }
 
-  _ref: any;
+  _ref: any
 
   views: ViewCollectionType = {
     buildinghours: {
@@ -157,7 +157,7 @@ export class SnapshotsView extends React.Component {
     transit: {
       tabs: {view: () => <TransportationView />, delay: 100},
     },
-  };
+  }
 
   saveSnapshot = () => {
     const name = this.state.viewPath
@@ -168,7 +168,7 @@ export class SnapshotsView extends React.Component {
       uri => console.log('saved to', uri),
       err => console.error('snapstho failed', err),
     )
-  };
+  }
 
   saveAll = async () => {
     for (const [parent, child] of this.viewsAsList()) {
@@ -179,7 +179,7 @@ export class SnapshotsView extends React.Component {
       await delay(args.delay || 1000)
       await this.saveSnapshot()
     }
-  };
+  }
 
   viewsAsList = () => {
     // goes from {name: {inner: {}}} to [[name, inner]]
@@ -188,11 +188,11 @@ export class SnapshotsView extends React.Component {
     )
 
     return flatten(choices)
-  };
+  }
 
   onChangeView = (value: string) => {
     this.setState({viewPath: value})
-  };
+  }
 
   render() {
     const selected = get(this.views, this.state.viewPath, {})

--- a/source/views/building-hours/building-hours-helpers.js
+++ b/source/views/building-hours/building-hours-helpers.js
@@ -16,7 +16,7 @@ import sortBy from 'lodash/sortBy'
 import {data as chapelData} from '../../../docs/chapel.json'
 const {chapelSchedule} = chapelData
 
-type HourPairType = {open: momentT, close: momentT};
+type HourPairType = {open: momentT, close: momentT}
 
 export function parseHours(
   {from: fromTime, to: toTime}: SingleBuildingScheduleType,

--- a/source/views/building-hours/detail.android.js
+++ b/source/views/building-hours/detail.android.js
@@ -88,7 +88,7 @@ export class BuildingHoursDetailView extends React.Component {
     intervalId: 0,
     // now: moment.tz('Wed 7:25pm', 'ddd h:mma', null, CENTRAL_TZ),
     now: moment.tz(CENTRAL_TZ),
-  };
+  }
 
   componentWillMount() {
     // This updates the screen every ten seconds, so that the building
@@ -100,11 +100,11 @@ export class BuildingHoursDetailView extends React.Component {
     clearTimeout(this.state.intervalId)
   }
 
-  props: BuildingType;
+  props: BuildingType
 
   updateTime = () => {
     this.setState({now: moment.tz(CENTRAL_TZ)})
-  };
+  }
 
   render() {
     const bgColors = {

--- a/source/views/building-hours/detail.ios.js
+++ b/source/views/building-hours/detail.ios.js
@@ -63,7 +63,7 @@ export class BuildingHoursDetailView extends React.Component {
     intervalId: 0,
     // now: moment.tz('Wed 7:25pm', 'ddd h:mma', null, CENTRAL_TZ),
     now: moment.tz(CENTRAL_TZ),
-  };
+  }
 
   componentWillMount() {
     // This updates the screen every ten seconds, so that the building
@@ -75,11 +75,11 @@ export class BuildingHoursDetailView extends React.Component {
     clearTimeout(this.state.intervalId)
   }
 
-  props: BuildingType;
+  props: BuildingType
 
   updateTime = () => {
     this.setState({now: moment.tz(CENTRAL_TZ)})
-  };
+  }
 
   render() {
     const bgColors = {

--- a/source/views/building-hours/index.js
+++ b/source/views/building-hours/index.js
@@ -40,7 +40,7 @@ export class BuildingHoursView extends React.Component {
     now: moment.tz(CENTRAL_TZ),
     buildings: groupBuildings(fallbackBuildingHours),
     intervalId: 0,
-  };
+  }
 
   componentWillMount() {
     this.fetchData()
@@ -54,11 +54,11 @@ export class BuildingHoursView extends React.Component {
     clearTimeout(this.state.intervalId)
   }
 
-  props: TopLevelViewPropsType;
+  props: TopLevelViewPropsType
 
   updateTime = () => {
     this.setState({now: moment.tz(CENTRAL_TZ)})
-  };
+  }
 
   fetchData = async () => {
     this.setState({loading: true})
@@ -83,7 +83,7 @@ export class BuildingHoursView extends React.Component {
       buildings: groupBuildings(buildings),
       now: moment.tz(CENTRAL_TZ),
     })
-  };
+  }
 
   render() {
     if (this.state.error) {

--- a/source/views/building-hours/list.js
+++ b/source/views/building-hours/list.js
@@ -30,10 +30,10 @@ type BuildingHoursPropsType = TopLevelViewPropsType & {
   loading: boolean,
   onRefresh: () => any,
   buildings: {[key: string]: BuildingType[]},
-};
+}
 
 export class BuildingHoursList extends React.Component {
-  props: BuildingHoursPropsType;
+  props: BuildingHoursPropsType
 
   onPressRow = (data: BuildingType) => {
     tracker.trackEvent('building-hours', data.name)
@@ -45,15 +45,15 @@ export class BuildingHoursList extends React.Component {
       props: data,
       sceneConfig: Platform.OS === 'android' ? 'fromBottom' : undefined,
     })
-  };
+  }
 
   renderSectionHeader = (data: any, id: string) => {
     return <ListSectionHeader style={styles.rowSectionHeader} title={id} />
-  };
+  }
 
   renderSeparator = (sectionID: any, rowID: any) => {
     return <ListSeparator key={`${sectionID}-${rowID}`} />
-  };
+  }
 
   render() {
     return (

--- a/source/views/building-hours/row.js
+++ b/source/views/building-hours/row.js
@@ -47,7 +47,7 @@ type PropsType = {
   name: string,
   now: momentT,
   onPress: () => any,
-};
+}
 
 export function BuildingRow({info, name, now, onPress}: PropsType) {
   let bgColors = {

--- a/source/views/building-hours/types.js
+++ b/source/views/building-hours/types.js
@@ -5,9 +5,9 @@ export type BuildingStatusType =
   | 'Closed'
   | 'Almost Closed'
   | 'Almost Open'
-  | 'Chapel';
+  | 'Chapel'
 
-export type DayOfWeekEnumType = 'Mo' | 'Tu' | 'We' | 'Th' | 'Fr' | 'Sa' | 'Su';
+export type DayOfWeekEnumType = 'Mo' | 'Tu' | 'We' | 'Th' | 'Fr' | 'Sa' | 'Su'
 
 export type BreakNameEnumType =
   | 'fall'
@@ -17,13 +17,13 @@ export type BreakNameEnumType =
   | 'interim'
   | 'spring'
   | 'easter'
-  | 'summer';
+  | 'summer'
 
 export type SingleBuildingScheduleType = {|
   days: DayOfWeekEnumType[],
   from: string,
   to: string,
-|};
+|}
 
 export type NamedBuildingScheduleType = {|
   title: 'Hours' | string,
@@ -31,11 +31,11 @@ export type NamedBuildingScheduleType = {|
   isPhysicallyOpen?: boolean,
   closedForChapelTime?: boolean,
   hours: SingleBuildingScheduleType[],
-|};
+|}
 
 export type BreakScheduleContainerType = {
   [key: BreakNameEnumType]: SingleBuildingScheduleType[],
-};
+}
 
 export type BuildingType = {|
   name: string,
@@ -45,4 +45,4 @@ export type BuildingType = {|
   category: string,
   schedule: NamedBuildingScheduleType[],
   breakSchedule?: BreakScheduleContainerType,
-|};
+|}

--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -28,7 +28,7 @@ export class GoogleCalendarView extends React.Component {
     refreshing: true,
     error: null,
     now: moment.tz(TIMEZONE),
-  };
+  }
 
   componentWillMount() {
     this.refresh()
@@ -36,7 +36,7 @@ export class GoogleCalendarView extends React.Component {
 
   props: {
     calendarId: string,
-  };
+  }
 
   buildCalendarUrl(calendarId: string) {
     let calendarUrl = `https://www.googleapis.com/calendar/v3/calendars/${calendarId}/events`
@@ -90,7 +90,7 @@ export class GoogleCalendarView extends React.Component {
       loaded: true,
       events: this.convertEvents(data, now),
     })
-  };
+  }
 
   refresh = async () => {
     let start = Date.now()
@@ -105,7 +105,7 @@ export class GoogleCalendarView extends React.Component {
     }
 
     this.setState({refreshing: false})
-  };
+  }
 
   render() {
     if (!this.state.loaded) {

--- a/source/views/calendar/event-list.js
+++ b/source/views/calendar/event-list.js
@@ -23,7 +23,7 @@ export class EventList extends React.Component {
     refreshing: boolean,
     onRefresh: () => any,
     now: moment,
-  };
+  }
 
   groupEvents = (
     events: EventType[],
@@ -38,18 +38,18 @@ export class EventList extends React.Component {
       }
       return event.startTime.format('ddd  MMM Do') // google returns events in CST
     })
-  };
+  }
 
   renderSectionHeader = (
     sectionData: EventType[],
     sectionIdentifier: string,
   ) => {
     return <ListSectionHeader title={sectionIdentifier} spacing={{left: 10}} />
-  };
+  }
 
   renderSeparator = (sectionID: any, rowID: any) => {
     return <ListSeparator fullWidth={true} key={`${sectionID}-${rowID}`} />
-  };
+  }
 
   render() {
     if (this.props.message) {

--- a/source/views/calendar/types.js
+++ b/source/views/calendar/types.js
@@ -3,13 +3,13 @@ import type moment from 'moment'
 
 type GoogleTimeType = {
   dateTime: string,
-};
+}
 export type GoogleEventType = {
   summary: string,
   start: GoogleTimeType,
   end: GoogleTimeType,
   location: string,
-};
+}
 
 export type PresenceEventType = {
   uri: string,
@@ -27,11 +27,11 @@ export type PresenceEventType = {
   startDateTimeUtc: string,
   endDateTimeUtc: string,
   tags: string[],
-};
+}
 
 type EmbeddedEventDetailType =
   | {type: 'google', data: GoogleEventType}
-  | {type: 'presence', data: PresenceEventType};
+  | {type: 'presence', data: PresenceEventType}
 
 export type EventType = {
   summary: string,
@@ -40,4 +40,4 @@ export type EventType = {
   endTime: moment,
   isOngoing: boolean,
   extra: EmbeddedEventDetailType,
-};
+}

--- a/source/views/components/badge.js
+++ b/source/views/components/badge.js
@@ -9,7 +9,7 @@ type PropsType = {
   textColor?: string,
   style?: Number | Object | Array<Number | Object>,
   textStyle?: Number | Object | Array<Number | Object>,
-};
+}
 
 let styles = StyleSheet.create({
   accessoryBadge: {

--- a/source/views/components/cell-toggle.js
+++ b/source/views/components/cell-toggle.js
@@ -7,7 +7,7 @@ type PropsType = {
   label: string,
   value: boolean,
   onChange: (val: boolean) => any,
-};
+}
 
 export function CellToggle({value, onChange, label}: PropsType) {
   return (

--- a/source/views/components/filter/filter-view.js
+++ b/source/views/components/filter/filter-view.js
@@ -17,7 +17,7 @@ type PropsType = {
   pathToFilters: string[],
   filters: FilterType[],
   onChange: (x: FilterType[]) => any,
-};
+}
 
 export function FilterViewComponent(props: PropsType) {
   const onFilterChanged = (filter: FilterType) => {

--- a/source/views/components/filter/section-list.js
+++ b/source/views/components/filter/section-list.js
@@ -11,7 +11,7 @@ import concat from 'lodash/concat'
 type PropsType = {
   filter: ListType,
   onChange: (filter: ListType) => any,
-};
+}
 
 export function ListSection({filter, onChange}: PropsType) {
   const {spec} = filter

--- a/source/views/components/filter/section-picker.js
+++ b/source/views/components/filter/section-picker.js
@@ -8,7 +8,7 @@ import {Section} from 'react-native-tableview-simple'
 type PropsType = {
   filter: PickerType,
   onChange: (filter: PickerType) => any,
-};
+}
 
 export function PickerSection({filter, onChange}: PropsType) {
   const {spec} = filter

--- a/source/views/components/filter/section-toggle.js
+++ b/source/views/components/filter/section-toggle.js
@@ -7,7 +7,7 @@ import {CellToggle} from '../../components/cell-toggle'
 type PropsType = {
   filter: ToggleType,
   onChange: (filterSpec: ToggleType) => any,
-};
+}
 
 export function SingleToggleSection({filter, onChange}: PropsType) {
   const {spec, enabled} = filter

--- a/source/views/components/filter/section.js
+++ b/source/views/components/filter/section.js
@@ -8,7 +8,7 @@ import {PickerSection} from './section-picker'
 type FilterSectionPropsType = {
   filter: FilterType,
   onChange: (filter: FilterType) => any,
-};
+}
 
 export function FilterSection({filter, onChange}: FilterSectionPropsType) {
   if (filter.type === 'toggle') {

--- a/source/views/components/filter/types.js
+++ b/source/views/components/filter/types.js
@@ -3,13 +3,13 @@ export type ToggleSpecType = {
   label: string,
   title?: string,
   caption?: string,
-};
+}
 
 export type ListItemSpecType = {|
   title: string,
   detail?: string,
   image?: ?any,
-|};
+|}
 
 export type ListSpecType = {
   title?: string,
@@ -18,30 +18,30 @@ export type ListSpecType = {
   options: ListItemSpecType[],
   selected: ListItemSpecType[],
   mode: 'AND' | 'OR',
-};
+}
 
 export type PickerItemSpecType = {|
   label: string,
-|};
+|}
 
 export type PickerSpecType = {
   title?: string,
   caption?: string,
   options: PickerItemSpecType[],
   selected: ?PickerItemSpecType,
-};
+}
 
 export type ToggleFilterFunctionType = {
   key: string,
-};
+}
 
 export type PickerFilterFunctionType = {
   key: string,
-};
+}
 
 export type ListFilterFunctionType = {
   key: string,
-};
+}
 
 export type ToggleType = {
   type: 'toggle',
@@ -49,7 +49,7 @@ export type ToggleType = {
   enabled: boolean,
   spec: ToggleSpecType,
   apply: ToggleFilterFunctionType,
-};
+}
 
 export type PickerType = {
   type: 'picker',
@@ -57,7 +57,7 @@ export type PickerType = {
   enabled: true,
   spec: PickerSpecType,
   apply: PickerFilterFunctionType,
-};
+}
 
 export type ListType = {
   type: 'list',
@@ -65,6 +65,6 @@ export type ListType = {
   enabled: boolean,
   spec: ListSpecType,
   apply: ListFilterFunctionType,
-};
+}
 
-export type FilterType = ToggleType | PickerType | ListType;
+export type FilterType = ToggleType | PickerType | ListType

--- a/source/views/components/html-view.js
+++ b/source/views/components/html-view.js
@@ -8,8 +8,8 @@ export class HtmlView extends React.Component {
   props: {
     html: string,
     baseUrl?: ?string,
-  };
-  _webview: WebView;
+  }
+  _webview: WebView
 
   onNavigationStateChange = ({url}: {url: string}) => {
     // iOS navigates to about:blank when you provide raw HTML to a webview.
@@ -28,7 +28,7 @@ export class HtmlView extends React.Component {
     this._webview.goBack()
 
     return openUrl(url)
-  };
+  }
 
   render() {
     return (

--- a/source/views/components/layout/styled-component.js
+++ b/source/views/components/layout/styled-component.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import {View} from 'react-native'
 
-export type PropsType = {children?: any, style?: any, props: mixed};
+export type PropsType = {children?: any, style?: any, props: mixed}
 export const StyledComponent = ({children, style, ...props}: PropsType) => {
   return (
     <View style={[props, style]}>

--- a/source/views/components/list/list-item-detail.js
+++ b/source/views/components/list/list-item-detail.js
@@ -26,7 +26,7 @@ type PropsType = {
   children?: any,
   style?: any,
   lines?: number,
-};
+}
 export function Detail(props: PropsType) {
   return (
     <Text numberOfLines={props.lines} style={[styles.detail, props.style]}>

--- a/source/views/components/list/list-item-title.js
+++ b/source/views/components/list/list-item-title.js
@@ -26,7 +26,7 @@ type PropsType = {
   style?: any,
   lines?: number,
   bold?: boolean,
-};
+}
 export function Title(props: PropsType) {
   return (
     <Text

--- a/source/views/components/list/list-row.js
+++ b/source/views/components/list/list-row.js
@@ -43,7 +43,7 @@ type PropsType = {
   spacing?: {left?: number, right?: number},
   onPress?: () => any,
   children?: any,
-};
+}
 export function ListRow(props: PropsType) {
   const {
     style,

--- a/source/views/components/list/list-section-header.js
+++ b/source/views/components/list/list-section-header.js
@@ -72,7 +72,7 @@ type PropsType = {
   separator?: string,
   style?: any,
   spacing?: {left?: number, right?: number},
-};
+}
 export function ListSectionHeader(props: PropsType) {
   const {
     style,

--- a/source/views/components/list/list-separator.js
+++ b/source/views/components/list/list-separator.js
@@ -13,7 +13,7 @@ type PropsType = {
   styles?: any,
   fullWidth?: boolean,
   spacing?: {left?: number, right?: number},
-};
+}
 export function ListSeparator(props: PropsType) {
   if (Platform.OS === 'android') {
     return null

--- a/source/views/components/listview.js
+++ b/source/views/components/listview.js
@@ -4,25 +4,25 @@ import React from 'react'
 import {ListView, Platform, RefreshControl} from 'react-native'
 import isFunction from 'lodash/isFunction'
 
-type DataType = Array<any> | {[key: string]: any};
+type DataType = Array<any> | {[key: string]: any}
 type PropsType = {
   data: DataType,
   forceBottomInset?: boolean,
   children?: any => React$Component<*, *, *>,
   onRefresh?: () => any,
   refreshing?: boolean,
-};
+}
 
 export default class SimpleListView extends React.Component {
-  static initialListSize = 6;
-  static pageSize = 6;
+  static initialListSize = 6
+  static pageSize = 6
 
   state = {
     dataSource: new ListView.DataSource({
       rowHasChanged: () => true,
       sectionHeaderHasChanged: () => true,
     }),
-  };
+  }
 
   componentWillMount() {
     this.setup(this.props)
@@ -32,13 +32,13 @@ export default class SimpleListView extends React.Component {
     this.setup(nextProps)
   }
 
-  props: PropsType;
+  props: PropsType
 
   setup = (props: PropsType) => {
     this.setState(state => ({
       dataSource: this.cloneDatasource(state.dataSource, props.data),
     }))
-  };
+  }
 
   cloneDatasource(dataSource: ListView.DataSource, data: DataType) {
     return Array.isArray(data)

--- a/source/views/components/navigation/special-share.js
+++ b/source/views/components/navigation/special-share.js
@@ -9,7 +9,7 @@ import {rightButtonStyles as styles} from './styles'
 export class ShareButton extends React.PureComponent {
   props: {
     onPress: () => any,
-  };
+  }
 
   render() {
     return (

--- a/source/views/components/tabbed-view/index.android.js
+++ b/source/views/components/tabbed-view/index.android.js
@@ -25,18 +25,18 @@ const styles = StyleSheet.create({
 export default class TabbedView extends React.Component {
   state = {
     index: 0,
-  };
+  }
 
   componentWillMount() {
     this._handleChangeTab(0)
   }
 
-  props: TabbedViewPropsType;
+  props: TabbedViewPropsType
 
   _handleChangeTab = index => {
     tracker.trackScreenView(this.props.tabs[index].id)
     this.setState({index})
-  };
+  }
 
   _renderHeader = props => {
     return (
@@ -50,7 +50,7 @@ export default class TabbedView extends React.Component {
         labelStyle={styles.label}
       />
     )
-  };
+  }
 
   _renderScene = ({route}) => {
     const thisTabIndex = this.props.tabs.findIndex(tab => tab.id === route.id)
@@ -59,7 +59,7 @@ export default class TabbedView extends React.Component {
     }
 
     return route.component()
-  };
+  }
 
   render() {
     // see react-native-tab-view's readme for the rationale

--- a/source/views/components/tabbed-view/index.ios.js
+++ b/source/views/components/tabbed-view/index.ios.js
@@ -11,18 +11,18 @@ import * as c from '../../components/colors'
 export default class TabbedView extends React.Component {
   state = {
     selectedTab: this.props.tabs[0].id,
-  };
+  }
 
   componentWillMount() {
     this.onChangeTab(this.props.tabs[0].id)
   }
 
-  props: TabbedViewPropsType;
+  props: TabbedViewPropsType
 
   onChangeTab = (tabId: string) => {
     tracker.trackScreenView(tabId)
     this.setState({selectedTab: tabId})
-  };
+  }
 
   render() {
     let {tabs} = this.props
@@ -49,11 +49,11 @@ class TabBarItem extends React.PureComponent {
     isSelected: boolean,
     onChangeTab: (id: string) => any,
     tab: TabDefinitionType,
-  };
+  }
 
   onChange = () => {
     this.props.onChangeTab(this.props.tab.id)
-  };
+  }
 
   render() {
     const {isSelected, tab} = this.props

--- a/source/views/components/tabbed-view/types.js
+++ b/source/views/components/tabbed-view/types.js
@@ -5,9 +5,9 @@ export type TabDefinitionType = {
   title: string,
   icon: string,
   component: () => ReactElement<*>,
-};
+}
 
 export type TabbedViewPropsType = {
   style?: Object | number | Array<Object | number>,
   tabs: TabDefinitionType[],
-};
+}

--- a/source/views/components/toolbar/toolbar-button.js
+++ b/source/views/components/toolbar/toolbar-button.js
@@ -37,7 +37,7 @@ type ButtonPropsType = {
   iconName?: string,
   title: string,
   isActive: boolean,
-};
+}
 
 export function ToolbarButton({title, iconName, isActive}: ButtonPropsType) {
   let icon

--- a/source/views/components/toolbar/toolbar.js
+++ b/source/views/components/toolbar/toolbar.js
@@ -25,7 +25,7 @@ const toolbarStyles = StyleSheet.create({
 type ToolbarPropsType = {
   children?: any,
   onPress: () => any,
-};
+}
 
 export function Toolbar({children, onPress}: ToolbarPropsType) {
   return (

--- a/source/views/components/touchable.js
+++ b/source/views/components/touchable.js
@@ -14,7 +14,7 @@ type PropsType = {
   children?: any,
   borderless?: boolean,
   style?: any,
-};
+}
 export const Touchable = ({
   children,
   style,

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -39,7 +39,7 @@ export class DictionaryView extends React.Component {
   static propTypes = {
     navigator: React.PropTypes.object.isRequired,
     route: React.PropTypes.object.isRequired,
-  };
+  }
 
   onPressRow = (data: WordType) => {
     tracker.trackEvent('dictionary', data.word)
@@ -50,7 +50,7 @@ export class DictionaryView extends React.Component {
       backButtonTitle: 'Dictionary',
       props: {item: data},
     })
-  };
+  }
 
   renderRow = ({item}: {item: WordType}) => {
     return (
@@ -67,15 +67,15 @@ export class DictionaryView extends React.Component {
         </Column>
       </ListRow>
     )
-  };
+  }
 
   renderHeader = ({title}: {title: string}) => {
     return <ListSectionHeader title={title} style={styles.rowSectionHeader} />
-  };
+  }
 
   renderSeparator = (sectionId: string, rowId: string) => {
     return <ListSeparator key={`${sectionId}-${rowId}`} />
-  };
+  }
 
   render() {
     return (

--- a/source/views/dictionary/types.js
+++ b/source/views/dictionary/types.js
@@ -3,4 +3,4 @@
 export type WordType = {
   word: string,
   definition: string,
-};
+}

--- a/source/views/faqs/index.js
+++ b/source/views/faqs/index.js
@@ -19,13 +19,13 @@ const styles = StyleSheet.create({
 export class FaqView extends React.Component {
   state = {
     html: faqs,
-  };
+  }
 
   componentWillMount() {
     this.fetchData()
   }
 
-  url = 'https://stodevx.github.io/AAO-React-Native/faqs.json';
+  url = 'https://stodevx.github.io/AAO-React-Native/faqs.json'
 
   fetchData = async () => {
     let html = faqs
@@ -43,14 +43,12 @@ export class FaqView extends React.Component {
     }
 
     this.setState({html: html})
-  };
+  }
 
   render() {
     if (!this.state.html) {
       return <LoadingView />
     }
-    return (
-      <WebView style={styles.container} source={{html: this.state.html}} />
-    )
+    return <WebView style={styles.container} source={{html: this.state.html}} />
   }
 }

--- a/source/views/home/edit.js
+++ b/source/views/home/edit.js
@@ -53,7 +53,7 @@ class Row extends React.Component {
       opacity: new Animated.Value(1.0),
       elevation: new Animated.Value(2),
     },
-  };
+  }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.active !== nextProps.active) {
@@ -68,7 +68,7 @@ class Row extends React.Component {
   props: {
     data: ViewType,
     active: boolean,
-  };
+  }
 
   startActivationAnimation = () => {
     const {style} = this.state
@@ -94,7 +94,7 @@ class Row extends React.Component {
         toValue: 4,
       }),
     ]).start()
-  };
+  }
 
   startDeactivationAnimation = () => {
     const {style} = this.state
@@ -120,7 +120,7 @@ class Row extends React.Component {
         toValue: 2,
       }),
     ]).start()
-  };
+  }
 
   render() {
     return (

--- a/source/views/menus/carleton-list.js
+++ b/source/views/menus/carleton-list.js
@@ -61,7 +61,7 @@ const styles = StyleSheet.create({
 })
 
 export class CarletonMenuPicker extends React.Component {
-  props: TopLevelViewPropsType;
+  props: TopLevelViewPropsType
 
   onPressRow = (data: CarletonDetailMenuType) => {
     this.props.navigator.push({
@@ -75,7 +75,7 @@ export class CarletonMenuPicker extends React.Component {
         cafeId: data.props.cafeId,
       },
     })
-  };
+  }
 
   render() {
     if (!carleton) {

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -35,7 +35,7 @@ type FancyMenuPropsType = TopLevelViewPropsType & {
   meals: ProcessedMealType[],
   menuCorIcons: MasterCorIconMapType,
   onFiltersChange: (f: FilterType[]) => any,
-};
+}
 
 const leftSideSpacing = 28
 const styles = StyleSheet.create({
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({
 class FancyMenuView extends React.Component {
   static defaultProps = {
     applyFilters: applyFiltersToItem,
-  };
+  }
 
   componentWillMount() {
     let {foodItems, menuCorIcons, filters, meals, now} = this.props
@@ -67,7 +67,7 @@ class FancyMenuView extends React.Component {
     )
   }
 
-  props: FancyMenuPropsType;
+  props: FancyMenuPropsType
 
   openFilterView = () => {
     this.props.navigator.push({
@@ -81,7 +81,7 @@ class FancyMenuView extends React.Component {
         onChange: filters => this.props.onFiltersChange(filters),
       },
     })
-  };
+  }
 
   renderSectionHeader = (sectionData: MenuItemType[], sectionName: string) => {
     const {filters, now, meals} = this.props
@@ -96,7 +96,7 @@ class FancyMenuView extends React.Component {
         spacing={{left: leftSideSpacing}}
       />
     )
-  };
+  }
 
   renderSeparator = (sectionId: string, rowId: string) => {
     return (
@@ -106,7 +106,7 @@ class FancyMenuView extends React.Component {
         style={styles.separator}
       />
     )
-  };
+  }
 
   render() {
     const {applyFilters, filters, foodItems, now, meals} = this.props

--- a/source/views/menus/components/filter-menu-toolbar.js
+++ b/source/views/menus/components/filter-menu-toolbar.js
@@ -21,7 +21,7 @@ type PropsType = {
   title?: string,
   onPress: () => any,
   filters: FilterType[],
-};
+}
 
 export function FilterMenuToolbar({date, title, filters, onPress}: PropsType) {
   const appliedFilterCount = filters

--- a/source/views/menus/components/food-item-row.js
+++ b/source/views/menus/components/food-item-row.js
@@ -18,7 +18,7 @@ type FoodItemPropsType = {|
   style?: any,
   badgeSpecials?: boolean,
   spacing: {left: number},
-|};
+|}
 
 export function FoodItemRow({
   data,

--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -28,20 +28,20 @@ export class BonAppPickerView extends React.Component {
   } = {
     cafeId: '34',
     menu: null,
-  };
+  }
 
   componentWillMount() {
     this.chooseMenu()
   }
 
-  props: TopLevelViewPropsType;
+  props: TopLevelViewPropsType
 
   chooseCafe = (cafeId: string) => {
     if (!/^\d*$/.test(cafeId)) {
       return
     }
     this.setState({cafeId})
-  };
+  }
 
   chooseMenu = () => {
     const menu = (
@@ -54,7 +54,7 @@ export class BonAppPickerView extends React.Component {
       />
     )
     this.setState({menu})
-  };
+  }
 
   render() {
     return (

--- a/source/views/menus/lib/process-menu-shorthands.js
+++ b/source/views/menus/lib/process-menu-shorthands.js
@@ -7,11 +7,11 @@ type BasicMenuItemType = {
   station: string,
   special?: boolean,
   description?: string,
-};
+}
 
 type BasicStationMenuType = {
   label: string,
-};
+}
 
 export function upgradeMenuItem(
   item: BasicMenuItemType,

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -37,7 +37,7 @@ type BonAppPropsType = TopLevelViewPropsType & {
   ignoreProvidedMenus?: boolean,
   loadingMessage: string[],
   name: string,
-};
+}
 
 export class BonAppHostedMenu extends React.Component {
   state: {
@@ -52,7 +52,7 @@ export class BonAppHostedMenu extends React.Component {
     now: moment.tz(CENTRAL_TZ),
     cafeMenu: null,
     cafeInfo: null,
-  };
+  }
 
   componentWillMount() {
     this.fetchData(this.props)
@@ -62,7 +62,7 @@ export class BonAppHostedMenu extends React.Component {
     this.props.cafeId !== newProps.cafeId && this.fetchData(newProps)
   }
 
-  props: BonAppPropsType;
+  props: BonAppPropsType
 
   fetchData = async (props: BonAppPropsType) => {
     this.setState({loading: true})
@@ -88,7 +88,7 @@ export class BonAppHostedMenu extends React.Component {
       cafeInfo,
       now: moment.tz(CENTRAL_TZ),
     })
-  };
+  }
 
   findCafeMessage = (
     cafeId: string,
@@ -109,7 +109,7 @@ export class BonAppHostedMenu extends React.Component {
     }
 
     return null
-  };
+  }
 
   prepareSingleMenu(
     mealInfo: DayPartMenuType,

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -38,7 +38,7 @@ export class GitHubHostedMenu extends React.Component {
     foodItems: {},
     corIcons: {},
     meals: [],
-  };
+  }
 
   componentWillMount() {
     this.fetchData()
@@ -47,7 +47,7 @@ export class GitHubHostedMenu extends React.Component {
   props: TopLevelViewPropsType & {
     name: string,
     loadingMessage: string[],
-  };
+  }
 
   fetchData = async () => {
     this.setState({loading: true})
@@ -99,7 +99,7 @@ export class GitHubHostedMenu extends React.Component {
       ],
       now: moment.tz(CENTRAL_TZ),
     })
-  };
+  }
 
   render() {
     if (this.state.loading) {

--- a/source/views/menus/types.js
+++ b/source/views/menus/types.js
@@ -1,9 +1,9 @@
 // @flow
-export type CurrencyStringType = string;
-export type HtmlStringType = string;
-export type ItemIdReferenceStringType = string;
-export type MilitaryTimeStringType = string; // H:mm
-export type NumericStringType = string;
+export type CurrencyStringType = string
+export type HtmlStringType = string
+export type ItemIdReferenceStringType = string
+export type MilitaryTimeStringType = string // H:mm
+export type NumericStringType = string
 
 export type MenuItemType = {
   connector: string,
@@ -37,7 +37,7 @@ export type MenuItemType = {
   sub_station_order: NumericStringType,
   tier3: boolean,
   zero_entree: NumericStringType,
-};
+}
 
 export type StationMenuType = {
   order_id: string, // sort on order_id instead of sorting on id
@@ -47,7 +47,7 @@ export type StationMenuType = {
   note: string,
   soup: boolean,
   items: ItemIdReferenceStringType[],
-};
+}
 
 export type DayPartMenuType = {|
   starttime: MilitaryTimeStringType,
@@ -56,48 +56,48 @@ export type DayPartMenuType = {|
   label: string,
   abbreviation: string,
   stations: StationMenuType[],
-|};
+|}
 
-export type DayPartsCollectionType = Array<Array<DayPartMenuType>>;
+export type DayPartsCollectionType = Array<Array<DayPartMenuType>>
 
 export type CafeMenuType = {
   name: string,
   menu_id: NumericStringType,
   dayparts: DayPartsCollectionType,
-};
+}
 
 export type CarletonDetailMenuType = {
   component: any,
   id: string,
   props: {cafeId: string, loadingMessage: Array<string>},
   title: string,
-};
+}
 
 export type MenuForDayType = {
   date: string,
   cafes: {[key: string]: CafeMenuType},
-};
+}
 
 export type BonAppMenuInfoType = {
   cor_icons: {[key: string]: Object},
   days: MenuForDayType[],
   items: MenuItemContainerType,
-};
+}
 
 export type CorIconType = {
   sort: string,
   label: string,
   description: string,
   image: string,
-};
+}
 
 export type MenuItemContainerType = {
   [key: ItemIdReferenceStringType]: MenuItemType,
-};
+}
 export type ItemCorIconMapType =
   | {[key: NumericStringType]: string}
-  | Array<void>;
-export type MasterCorIconMapType = {[key: NumericStringType]: CorIconType};
+  | Array<void>
+export type MasterCorIconMapType = {[key: NumericStringType]: CorIconType}
 
 export type BonAppCafeInfoType = {
   cafes: {
@@ -134,11 +134,11 @@ export type BonAppCafeInfoType = {
       ],
     },
   },
-};
+}
 
 export type ProcessedMealType = {|
   starttime: MilitaryTimeStringType,
   endtime: MilitaryTimeStringType,
   label: string,
   stations: StationMenuType[],
-|};
+|}

--- a/source/views/news/news-container.js
+++ b/source/views/news/news-container.js
@@ -20,7 +20,7 @@ export default class NewsContainer extends React.Component {
     loading: true,
     error: null,
     refreshing: false,
-  };
+  }
 
   componentWillMount() {
     this.fetchData().then(() => this.setState({loading: false}))
@@ -32,7 +32,7 @@ export default class NewsContainer extends React.Component {
     query?: Object,
     embedFeaturedImage?: boolean,
     mode: 'rss' | 'wp-json',
-  };
+  }
 
   fetchData = async () => {
     try {
@@ -61,7 +61,7 @@ export default class NewsContainer extends React.Component {
         this.setState({error})
       }
     }
-  };
+  }
 
   refresh = async () => {
     let start = Date.now()
@@ -75,7 +75,7 @@ export default class NewsContainer extends React.Component {
       await delay(500 - elapsed)
     }
     this.setState({refreshing: false})
-  };
+  }
 
   render() {
     if (this.state.error) {

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -21,14 +21,14 @@ type NewsListPropsType = TopLevelViewPropsType & {
   entries: StoryType[],
   loading: boolean,
   embedFeaturedImage: ?boolean,
-};
+}
 
 export class NewsList extends React.Component {
-  props: NewsListPropsType;
+  props: NewsListPropsType
 
   renderSeparator = (sectionId: string, rowId: string) => {
     return <ListSeparator key={`${sectionId}-${rowId}`} />
-  };
+  }
 
   shareItem = (story: StoryType) => {
     Share.share({
@@ -37,7 +37,7 @@ export class NewsList extends React.Component {
     })
       .then(result => console.log(result))
       .catch(error => console.log(error.message))
-  };
+  }
 
   onPressNews = (title: string, story: StoryType) => {
     this.props.navigator.push({
@@ -49,7 +49,7 @@ export class NewsList extends React.Component {
       onRightButton: () => this.shareItem(story),
       rightButton: 'share',
     })
-  };
+  }
 
   render() {
     // remove all entries with blank excerpts

--- a/source/views/news/news-row.js
+++ b/source/views/news/news-row.js
@@ -9,7 +9,7 @@ import type {StoryType} from './types'
 type NewsRowPropsType = {
   onPress: () => any,
   story: StoryType,
-};
+}
 
 export function NewsRow({onPress, story}: NewsRowPropsType) {
   return (

--- a/source/views/news/types.js
+++ b/source/views/news/types.js
@@ -9,7 +9,7 @@ export type StoryType = {
   featuredImage: ?string,
   link: ?string,
   title: string,
-};
+}
 
 export type RssFeedItemType = {
   'dc:creator': string[],
@@ -19,7 +19,7 @@ export type RssFeedItemType = {
   link: string[],
   pubDate: string[],
   title: string[],
-};
+}
 
 export type FeedResponseType = {
   rss: {
@@ -31,7 +31,7 @@ export type FeedResponseType = {
       item: RssFeedItemType[],
     }>,
   },
-};
+}
 
 export type WpEmbeddedAuthorType = {
   avatar_urls: {[key: string]: string},
@@ -40,7 +40,7 @@ export type WpEmbeddedAuthorType = {
   link: string,
   name: string,
   slug: string,
-};
+}
 
 export type WpEmbeddedFeaturedMediaType = {
   alt_text: string,
@@ -69,7 +69,7 @@ export type WpEmbeddedFeaturedMediaType = {
     rendered: string,
   },
   type: 'attachment',
-};
+}
 
 export type WpJsonItemType = {
   _embedded?: {
@@ -86,6 +86,6 @@ export type WpJsonItemType = {
   link: string,
   modified_gmt: string,
   title: {rendered: string},
-};
+}
 
-export type WpJsonResponseType = WpJsonItemType[];
+export type WpJsonResponseType = WpJsonItemType[]

--- a/source/views/settings/components/login-field.js
+++ b/source/views/settings/components/login-field.js
@@ -37,15 +37,15 @@ export class LoginField extends React.Component {
     returnKeyType: 'done' | 'next',
     secureTextEntry: boolean,
     value: string,
-  };
+  }
 
-  _input: any;
-  focusInput = () => this._input.focus();
+  _input: any
+  focusInput = () => this._input.focus()
 
   cacheRef = (ref: any) => {
     this._input = ref
     this.props._ref(ref)
-  };
+  }
 
   render() {
     const label = (

--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
   },
 })
 
-type SettingsViewPropsType = TopLevelViewPropsType;
+type SettingsViewPropsType = TopLevelViewPropsType
 
 export default function SettingsView(props: SettingsViewPropsType) {
   return (

--- a/source/views/settings/login.js
+++ b/source/views/settings/login.js
@@ -11,9 +11,9 @@ const HOME_URL = 'https://www.stolaf.edu/sis/index.cfm'
 const LOGIN_URL = 'https://www.stolaf.edu/sis/login.cfm'
 
 export default class SISLoginView extends React.Component {
-  state = {complete: false};
+  state = {complete: false}
 
-  props: TopLevelViewPropsType & {onLoginComplete: (status: boolean) => any};
+  props: TopLevelViewPropsType & {onLoginComplete: (status: boolean) => any}
 
   onNavigationStateChange = (navState: {url: string}) => {
     console.info(navState.url)
@@ -22,11 +22,11 @@ export default class SISLoginView extends React.Component {
       this.setState({complete: true})
       this.props.onLoginComplete(true)
     }
-  };
+  }
 
   onComplete = () => {
     this.props.navigator.pop()
-  };
+  }
 
   render() {
     if (this.state.complete) {

--- a/source/views/settings/sections/login-credentials.js
+++ b/source/views/settings/sections/login-credentials.js
@@ -22,31 +22,31 @@ type CredentialsSectionPropsType = {
   logOut: () => any,
   validateCredentials: (username: string, password: string) => any,
   setCredentials: (username: string, password: string) => any,
-};
+}
 
 class CredentialsLoginSection extends React.Component {
   state = {
     loading: false,
     username: this.props.username,
     password: this.props.password,
-  };
+  }
 
-  props: CredentialsSectionPropsType;
+  props: CredentialsSectionPropsType
 
-  _usernameInput: any;
-  _passwordInput: any;
-  focusUsername = () => this._usernameInput.focus();
-  focusPassword = () => this._passwordInput.focus();
+  _usernameInput: any
+  _passwordInput: any
+  focusUsername = () => this._usernameInput.focus()
+  focusPassword = () => this._passwordInput.focus()
 
   logIn = async () => {
     this.setState({loading: true})
     await this.props.logIn(this.state.username, this.state.password)
     this.setState({loading: false})
-  };
+  }
 
   logOut = () => {
     this.props.logOut()
-  };
+  }
 
   render() {
     let {loggedIn, message} = this.props

--- a/source/views/settings/sections/login-token.js
+++ b/source/views/settings/sections/login-token.js
@@ -9,14 +9,14 @@ import {connect} from 'react-redux'
 class TokenLoginSection extends React.Component {
   state = {
     loading: false,
-  };
+  }
 
   props: TopLevelViewPropsType & {
     loggedIn: boolean,
     logIn: (tokenStatus: boolean) => any,
     logOut: () => any,
     message: ?string,
-  };
+  }
 
   logIn = () => {
     this.props.navigator.push({
@@ -28,11 +28,11 @@ class TokenLoginSection extends React.Component {
         onLoginComplete: this.props.logIn,
       },
     })
-  };
+  }
 
   logOut = () => {
     this.props.logOut()
-  };
+  }
 
   render() {
     let {loggedIn, message} = this.props

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -11,7 +11,7 @@ class OddsAndEndsSection extends React.Component {
   props: TopLevelViewPropsType & {
     onChangeFeedbackToggle: (feedbackDisabled: boolean) => any,
     feedbackDisabled: boolean,
-  };
+  }
 
   onPressButton = (id: string, title: string) => {
     this.props.navigator.push({
@@ -19,14 +19,13 @@ class OddsAndEndsSection extends React.Component {
       title: title,
       index: this.props.route.index + 1,
     })
-  };
+  }
 
-  onFaqButton = () => this.onPressButton('FaqView', 'FAQs');
-  onCreditsButton = () => this.onPressButton('CreditsView', 'Credits');
-  onPrivacyButton = () => this.onPressButton('PrivacyView', 'Privacy Policy');
-  onLegalButton = () => this.onPressButton('LegalView', 'Legal');
-  onSnapshotsButton = () =>
-    this.onPressButton('SnapshotsView', 'Snapshot Time');
+  onFaqButton = () => this.onPressButton('FaqView', 'FAQs')
+  onCreditsButton = () => this.onPressButton('CreditsView', 'Credits')
+  onPrivacyButton = () => this.onPressButton('PrivacyView', 'Privacy Policy')
+  onLegalButton = () => this.onPressButton('LegalView', 'Legal')
+  onSnapshotsButton = () => this.onPressButton('SnapshotsView', 'Snapshot Time')
 
   render() {
     return (

--- a/source/views/settings/sections/support.js
+++ b/source/views/settings/sections/support.js
@@ -15,11 +15,11 @@ export default class SupportSection extends React.Component {
       ${DeviceInfo.getReadableVersion()}
       Codepush: ${version}
     `
-  };
+  }
 
   getSupportBody = () => {
     return '\n' + this.getDeviceInfo()
-  };
+  }
 
   openEmail = () => {
     Communications.email(
@@ -29,7 +29,7 @@ export default class SupportSection extends React.Component {
       'Support: All About Olaf',
       this.getSupportBody(),
     )
-  };
+  }
 
   render() {
     return (

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -28,7 +28,7 @@ import type {TopLevelViewPropsType} from '../types'
 class BalancesView extends React.Component {
   state = {
     loading: false,
-  };
+  }
 
   props: TopLevelViewPropsType & {
     flex: ?number,
@@ -40,7 +40,7 @@ class BalancesView extends React.Component {
     message: ?string,
 
     updateBalances: () => any,
-  };
+  }
 
   refresh = async () => {
     let start = Date.now()
@@ -53,11 +53,11 @@ class BalancesView extends React.Component {
     await delay(500 - elapsed)
 
     this.setState({loading: false})
-  };
+  }
 
   fetchData = async () => {
     await Promise.all([this.props.updateBalances(true)])
-  };
+  }
 
   openSettings = () => {
     this.props.navigator.push({
@@ -67,7 +67,7 @@ class BalancesView extends React.Component {
       sceneConfig: Navigator.SceneConfigs.FloatFromBottom,
       onDismiss: () => this.props.navigator.pop(),
     })
-  };
+  }
 
   render() {
     let {flex, ole, print, dailyMeals, weeklyMeals} = this.props

--- a/source/views/sis/courses.js
+++ b/source/views/sis/courses.js
@@ -30,16 +30,16 @@ type CoursesViewPropsType = TopLevelViewPropsType & {
   loggedIn: true,
   updateCourses: (force: boolean) => {},
   coursesByTerm: CoursesByTermType,
-};
+}
 
 class CoursesView extends React.Component {
   state: {
     loading: boolean,
   } = {
     loading: false,
-  };
+  }
 
-  props: CoursesViewPropsType;
+  props: CoursesViewPropsType
 
   refresh = async () => {
     let start = Date.now()
@@ -52,15 +52,15 @@ class CoursesView extends React.Component {
     await delay(500 - elapsed)
 
     this.setState({loading: false})
-  };
+  }
 
   renderSectionHeader = (courses: CourseType[], term: string) => {
     return <ListSectionHeader style={styles.rowSectionHeader} title={term} />
-  };
+  }
 
   renderSeparator = (sectionId: string, rowId: string) => {
     return <ListSeparator key={`${sectionId}-${rowId}`} />
-  };
+  }
 
   render() {
     if (this.props.error) {

--- a/source/views/sis/search.js
+++ b/source/views/sis/search.js
@@ -15,7 +15,7 @@ export default class SearchView extends React.Component {
   state = {
     loaded: false,
     error: null,
-  };
+  }
 
   render() {
     if (this.state.error) {

--- a/source/views/streaming/webcams.js
+++ b/source/views/streaming/webcams.js
@@ -44,7 +44,7 @@ class Webcam extends React.PureComponent {
       thumbnail: string,
       accentColor: [number, number, number],
     },
-  };
+  }
 
   render() {
     const {name, thumbnail, streamUrl, pageUrl, accentColor} = this.props.info
@@ -70,7 +70,7 @@ class StreamThumbnail extends React.PureComponent {
     accentColor: [number, number, number],
     textColor: 'white' | 'black',
     thumbnail: any,
-  };
+  }
 
   handlePress = () => {
     const {url, title, infoUrl} = this.props
@@ -79,7 +79,7 @@ class StreamThumbnail extends React.PureComponent {
     } else {
       trackedOpenUrl({url, id: `${title}WebcamView`})
     }
-  };
+  }
 
   render() {
     const {title, thumbnail, accentColor, textColor} = this.props
@@ -103,7 +103,7 @@ class RoundedThumbnail extends React.PureComponent {
     textColor: 'white' | 'black',
     thumbnail: any,
     title: string,
-  };
+  }
 
   render() {
     const {title, thumbnail, accentColor, textColor} = this.props

--- a/source/views/student-orgs/detail-wrapper.js
+++ b/source/views/student-orgs/detail-wrapper.js
@@ -18,7 +18,7 @@ export class StudentOrgsDetailView extends React.Component {
     refreshing: false,
     loaded: false,
     error: false,
-  };
+  }
 
   componentWillMount() {
     this.fetchData()
@@ -26,7 +26,7 @@ export class StudentOrgsDetailView extends React.Component {
 
   props: TopLevelViewPropsType & {
     item: StudentOrgAbridgedType,
-  };
+  }
 
   fetchData = async () => {
     let orgUrl = orgsUrl + '/' + this.props.item.uri
@@ -41,7 +41,7 @@ export class StudentOrgsDetailView extends React.Component {
     }
 
     this.setState({loaded: true})
-  };
+  }
 
   cleanResponseData = (data: StudentOrgInfoType) => {
     let {
@@ -65,7 +65,7 @@ export class StudentOrgsDetailView extends React.Component {
       regularMeetingTime,
       regularMeetingLocation,
     }
-  };
+  }
 
   render() {
     return (

--- a/source/views/student-orgs/detail.android.js
+++ b/source/views/student-orgs/detail.android.js
@@ -41,7 +41,7 @@ export class StudentOrgsDetailRenderView extends React.Component {
     loaded: boolean,
     base: StudentOrgAbridgedType,
     full: ?StudentOrgInfoType,
-  };
+  }
 
   displayContact(contactInfo: string) {
     return (
@@ -109,7 +109,7 @@ export class StudentOrgsDetailRenderView extends React.Component {
         {description ? this.displayDescription(description) : null}
       </View>
     )
-  };
+  }
 
   render() {
     let knownData = this.props.base

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -37,7 +37,7 @@ export class StudentOrgsDetailRenderView extends React.Component {
     loaded: boolean,
     base: StudentOrgAbridgedType,
     full: ?StudentOrgInfoType,
-  };
+  }
 
   displayContact(contactInfo: string) {
     return (
@@ -103,7 +103,7 @@ export class StudentOrgsDetailRenderView extends React.Component {
         {description ? this.displayDescription(description) : null}
       </View>
     )
-  };
+  }
 
   render() {
     let knownData = this.props.base

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -60,7 +60,7 @@ export class StudentOrgsView extends React.Component {
   static propTypes = {
     navigator: React.PropTypes.object.isRequired,
     route: React.PropTypes.object.isRequired,
-  };
+  }
 
   state: {
     orgs: {[key: string]: StudentOrgAbridgedType[]},
@@ -72,7 +72,7 @@ export class StudentOrgsView extends React.Component {
     refreshing: false,
     loaded: false,
     error: false,
-  };
+  }
 
   componentWillMount() {
     this.refresh()
@@ -104,7 +104,7 @@ export class StudentOrgsView extends React.Component {
     }
 
     this.setState({loaded: true})
-  };
+  }
 
   refresh = async () => {
     let start = Date.now()
@@ -118,7 +118,7 @@ export class StudentOrgsView extends React.Component {
       await delay(500 - elapsed)
     }
     this.setState(() => ({refreshing: false}))
-  };
+  }
 
   renderSectionHeader = ({title}: {title: string}) => {
     return (
@@ -128,11 +128,11 @@ export class StudentOrgsView extends React.Component {
         style={styles.rowSectionHeader}
       />
     )
-  };
+  }
 
   getSectionListTitle = (name: string) => {
     return name === 'New' ? '•' : name
-  };
+  }
 
   renderRow = ({item}: {item: StudentOrgAbridgedType}) => {
     return (
@@ -156,7 +156,7 @@ export class StudentOrgsView extends React.Component {
         </Row>
       </ListRow>
     )
-  };
+  }
 
   renderSeparator = (sectionId: string, rowId: string) => {
     return (
@@ -165,7 +165,7 @@ export class StudentOrgsView extends React.Component {
         spacing={{left: leftSideSpacing}}
       />
     )
-  };
+  }
 
   onPressRow = (data: StudentOrgAbridgedType) => {
     tracker.trackEvent('student-org', data.name)
@@ -176,7 +176,7 @@ export class StudentOrgsView extends React.Component {
       backButtonTitle: 'Orgs',
       props: {item: data},
     })
-  };
+  }
 
   render() {
     if (!this.state.loaded) {

--- a/source/views/student-orgs/types.js
+++ b/source/views/student-orgs/types.js
@@ -14,7 +14,7 @@ export type StudentOrgAbridgedType = {
   photoVersion: string,
   subdomain: string,
   uri: string,
-};
+}
 
 export type StudentOrgInfoType = {
   campusName: string,
@@ -38,4 +38,4 @@ export type StudentOrgInfoType = {
   subdomain: string,
   twitter: string,
   uri: string,
-};
+}

--- a/source/views/transportation/bus/index.js
+++ b/source/views/transportation/bus/index.js
@@ -13,12 +13,12 @@ const TIMEZONE = 'America/Winnipeg'
 export default class BusView extends React.Component {
   static defaultProps = {
     busLines: defaultBusLines,
-  };
+  }
 
   state = {
     intervalId: 0,
     now: moment.tz(TIMEZONE),
-  };
+  }
 
   componentWillMount() {
     // This updates the screen every second, so that the "next bus" times are
@@ -33,11 +33,11 @@ export default class BusView extends React.Component {
   props: {
     busLines: BusLineType[],
     line: string,
-  };
+  }
 
   updateTime = () => {
     this.setState({now: moment.tz(TIMEZONE)})
-  };
+  }
 
   render() {
     let {now} = this.state

--- a/source/views/transportation/bus/types.js
+++ b/source/views/transportation/bus/types.js
@@ -1,20 +1,20 @@
 // @flow
 import type moment from 'moment'
-export type DayOfWeekType = 'Su' | 'Mo' | 'Tu' | 'We' | 'Th' | 'Fr' | 'Sa';
+export type DayOfWeekType = 'Su' | 'Mo' | 'Tu' | 'We' | 'Th' | 'Fr' | 'Sa'
 
 export type BusLineType = {
   line: string,
   schedules: BusScheduleType[],
-};
+}
 
 export type BusScheduleType = {
   days: DayOfWeekType[],
   stops: BusStopType[],
   coordinates?: [number, number][],
   times: PlainBusTimeListType[],
-};
+}
 
-export type BusStopType = string;
+export type BusStopType = string
 
-export type PlainBusTimeListType = Array<string | false>;
-export type FancyBusTimeListType = Array<moment | false>;
+export type PlainBusTimeListType = Array<string | false>
+export type FancyBusTimeListType = Array<moment | false>

--- a/source/views/transportation/types.js
+++ b/source/views/transportation/types.js
@@ -3,4 +3,4 @@ export type OtherModeType = {
   name: string,
   description: string,
   url: string,
-};
+}

--- a/source/views/types.js
+++ b/source/views/types.js
@@ -10,13 +10,13 @@ export type RouteType = {
   onRightButton?: () => any,
   onDismiss?: (r: RouteType, n: Navigator) => any,
   sceneConfig?: Object | 'fromBottom' | string,
-};
+}
 
 export type NavStateType = {
   routeStack: RouteType[],
-};
+}
 
 export type TopLevelViewPropsType = {
   navigator: Navigator,
   route: RouteType,
-};
+}

--- a/source/views/views.js
+++ b/source/views/views.js
@@ -19,7 +19,7 @@ export type ViewType =
       icon: string,
       tint: string,
       gradient?: [string, string],
-    };
+    }
 
 export const allViews: ViewType[] = [
   {


### PR DESCRIPTION
Before: `✨  Done in 10.86s.`
After: `✨  Done in 4.16s.`

---

Prettier@1.0 supports a `--no-semi` option, to prevent printing semicolons. This allows us to quit processing every file twice, which is what we currently do: `prettier | eslint`, where we let eslint remove the semicolons for us.