### PR TITLE
Continue merging the big fastlane edit incrementally

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,11 +4,11 @@
 # https://github.com/fastlane/fastlane/tree/master/fastlane/docs
 
 # Set a minimum version for fastlane
-fastlane_version "2.19.0"
+fastlane_version '2.19.0'
 
-import "lib/before_all.rb"
-import "lib/util.rb"
+import 'lib/before_all.rb'
+import 'lib/util.rb'
 
-import "platforms/agnostic.rb"
-import "platforms/android.rb"
-import "platforms/ios.rb"
+import 'platforms/agnostic.rb'
+import 'platforms/android.rb'
+import 'platforms/ios.rb'

--- a/fastlane/Gymfile
+++ b/fastlane/Gymfile
@@ -1,10 +1,10 @@
 # For more information about this configuration visit
 # https://github.com/fastlane/fastlane/tree/master/gym#gymfile
 
-project "ios/AllAboutOlaf.xcodeproj"
-scheme "AllAboutOlaf"
+project 'ios/AllAboutOlaf.xcodeproj'
+scheme 'AllAboutOlaf'
 
-export_method "ad-hoc"
+export_method 'ad-hoc'
 
-output_directory "ios/build"
-output_name "AllAboutOlaf"
+output_directory 'ios/build'
+output_name 'AllAboutOlaf'

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,10 +1,10 @@
-git_url "https://github.com/hawkrives/aao-keys"
+git_url 'https://github.com/hawkrives/aao-keys'
 
 # The default type, can be: appstore, adhoc or development
-type "development"
+type 'development'
 
 # Your Apple Developer Portal username
-username "magneticpapergarden@gmail.com"
+username 'magneticpapergarden@gmail.com'
 
 # The app identifiers to get profiles for
-app_identifier ["com.volz.drew.aao.rogue"]
+app_identifier ['com.volz.drew.aao.rogue']

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -3,8 +3,8 @@
 
 # Remove the # in front of the line to enable the option
 
-scheme "AllAboutOlaf"
-workspace "ios/AllAboutOlaf.xcworkspace"
+scheme 'AllAboutOlaf'
+workspace 'ios/AllAboutOlaf.xcworkspace'
 
 # open_report true
 

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,21 +1,14 @@
 # A list of devices you want to take the screenshots from
-devices([
-  "iPhone 7 Plus",
-  "iPhone 6",
-  "iPhone 5s",
-  "iPhone 4s",
-])
+devices(['iPhone 7 Plus', 'iPhone 6', 'iPhone 5s', 'iPhone 4s'])
 
-languages([
-  "en-US",
-])
+languages(['en-US'])
 
 # The name of the scheme which contains the UI Tests
-scheme "AllAboutOlaf"
-workspace "ios/AllAboutOlaf.xcworkspace"
+scheme 'AllAboutOlaf'
+workspace 'ios/AllAboutOlaf.xcworkspace'
 
 # Where should the resulting screenshots be stored?
-output_directory "fastlane/screenshots"
+output_directory 'fastlane/screenshots'
 
-# uncomment to clear all previously generated screenshots before creating new ones
+# uncomment to clear all previously generated screenshots before taking new ones
 # clear_previous_screenshots true

--- a/fastlane/actions/activate_rogue_team.rb
+++ b/fastlane/actions/activate_rogue_team.rb
@@ -34,31 +34,38 @@ module Fastlane
       end
 
       def self.description
-        "Activate the rogue signing team"
+        'Activate the rogue signing team'
       end
 
       def self.details
-        "Activate the rogue signing team"
+        'Activate the rogue signing team'
       end
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :xcodeproj, default_value: "./ios/AllAboutOlaf.xcodeproj"),
-          FastlaneCore::ConfigItem.new(key: :target, default_value: "AllAboutOlaf"),
-          FastlaneCore::ConfigItem.new(key: :team_id, default_value: "NFMTHAZVS"),
-          FastlaneCore::ConfigItem.new(key: :devteam, default_value: "NFMTHAZVS9"),
-          FastlaneCore::ConfigItem.new(key: :bundle_id, default_value: "com.volz.drew.aao.rogue"),
-          FastlaneCore::ConfigItem.new(key: :profile_id, default_value: "41adf2d3-cb22-4a24-80c3-b4fe83539aa1"),
-          FastlaneCore::ConfigItem.new(key: :profile_name, default_value: "match Development com.volz.drew.aao.rogue"),
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                       default_value: './ios/AllAboutOlaf.xcodeproj'),
+          FastlaneCore::ConfigItem.new(key: :target,
+                                       default_value: 'AllAboutOlaf'),
+          FastlaneCore::ConfigItem.new(key: :team_id,
+                                       default_value: 'NFMTHAZVS'),
+          FastlaneCore::ConfigItem.new(key: :devteam,
+                                       default_value: 'NFMTHAZVS9'),
+          FastlaneCore::ConfigItem.new(key: :bundle_id,
+                                       default_value: 'com.volz.drew.aao.rogue'),
+          FastlaneCore::ConfigItem.new(key: :profile_id,
+                                       default_value: '41adf2d3-cb22-4a24-80c3-b4fe83539aa1'),
+          FastlaneCore::ConfigItem.new(key: :profile_name,
+                                       default_value: 'match Development com.volz.drew.aao.rogue'),
         ]
       end
 
       def self.return_value
-        "None"
+        'None'
       end
 
       def self.authors
-        ["Hawken Rives"]
+        ['Hawken Rives']
       end
 
       def self.is_supported?(platform)

--- a/fastlane/actions/get_gradle_version_name.rb
+++ b/fastlane/actions/get_gradle_version_name.rb
@@ -6,34 +6,34 @@ module Fastlane
         version_name = nil
 
         File.foreach(gradle_path) do |line|
-          if line.include? "versionName "
-            components = line.strip.split(" ")
-            version_name = components[1].tr("\"", "")
+          if line.include? 'versionName '
+            components = line.strip.split(' ')
+            version_name = components[1].tr('"', '')
           end
         end
 
-        if version_name == nil
-          UI.user_error!("Impossible to find the version name in the current gradle file #{gradle_path}")
+        if version_name.nil?
+          UI.user_error!("Could not find the version name in #{gradle_path}")
         else
-          UI.success("Version name found: #{version_name}")
+          UI.success("Version name: #{version_name}")
         end
 
         version_name
       end
 
       def self.description
-        "Get the version name of your android project."
+        'Get the version name of your android project.'
       end
 
       def self.authors
-        ["Hawken Rives"]
+        ['Hawken Rives']
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :gradle_path,
-                               description: "The path to the build.gradle file",
-                                      type: String),
+                                       description: 'The path to the build.gradle file',
+                                       type: String),
         ]
       end
 

--- a/fastlane/actions/get_package_key.rb
+++ b/fastlane/actions/get_package_key.rb
@@ -33,7 +33,7 @@ module Fastlane
         ]
       end
 
-      def self.is_supported?
+      def self.is_supported?(platform)
         true
       end
     end

--- a/fastlane/actions/get_package_key.rb
+++ b/fastlane/actions/get_package_key.rb
@@ -8,9 +8,9 @@ module Fastlane
         package_path = params[:package_path]
 
         file = File.read(package_path)
-        data_hash = JSON.parse(file)
+        data_hash = JSON.parse(file, symbolize_names: true)
 
-        data_hash[key]
+        data_hash[key.to_sym]
       end
 
       def self.description
@@ -25,15 +25,15 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :key,
                                        description: 'The key to fetch',
-                                       type: String),
+                                       type: Symbol),
           FastlaneCore::ConfigItem.new(key: :package_path,
                                        description: 'The path to the package.json file',
-                                       type: String,
-                                       default_value: './package.json'),
+                                       default_value: './package.json',
+                                       type: String),
         ]
       end
 
-      def self.is_supported?(platform)
+      def self.is_supported?
         true
       end
     end

--- a/fastlane/actions/get_package_key.rb
+++ b/fastlane/actions/get_package_key.rb
@@ -14,22 +14,22 @@ module Fastlane
       end
 
       def self.description
-        "Retrieve a value from your package.json file."
+        'Retrieve a value from your package.json file.'
       end
 
       def self.authors
-        ["Hawken Rives"]
+        ['Hawken Rives']
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :key,
-                               description: "The key to fetch",
-                                      type: String),
+                                       description: 'The key to fetch',
+                                       type: String),
           FastlaneCore::ConfigItem.new(key: :package_path,
-                               description: "The path to the package.json file",
-                                      type: String,
-                             default_value: "./package.json"),
+                                       description: 'The path to the package.json file',
+                                       type: String,
+                                       default_value: './package.json'),
         ]
       end
 

--- a/fastlane/actions/latest_hockeyapp_notes.rb
+++ b/fastlane/actions/latest_hockeyapp_notes.rb
@@ -8,10 +8,14 @@ module Fastlane
           config.token = params[:api_token]
         end
 
-        UI.message "Fetching latest version of #{params[:app_name]} from HockeyApp"
+        UI.message "Fetching metadata for #{params[:app_name]} from HockeyApp"
         client = HockeyApp.build_client
         apps = client.get_apps
-        app = apps.find { |a| a.title == params[:app_name] && a.platform == params[:platform] && a.release_type == params[:release_type].to_i }
+        app = apps.find do |a|
+          a.title == params[:app_name] &&
+            a.platform == params[:platform] &&
+            a.release_type == params[:release_type].to_i
+        end
 
         if app.nil?
           return {
@@ -57,37 +61,37 @@ module Fastlane
       end
 
       def self.description
-        "Easily fetch the most recent HockeyApp version for your app"
+        'Easily fetch the most recent HockeyApp version for your app'
       end
 
       def self.details
-        "Allows increment_build_number to increment from the latest HockeyApp version"
+        'Allows increment_build_number to increment from the latest HockeyApp version'
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :app_name,
-                                       description: "The app name to use when fetching the version number",
+                                       description: 'The app name to fetch',
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :api_token,
-                                       env_name: "HOCKEYAPP_TOKEN",
-                                       description: "API Token for Hockey Access",
+                                       env_name: 'HOCKEYAPP_TOKEN',
+                                       description: 'API Token for Hockey access',
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :release_type,
-                                       description: "The release type to use when fetching the version number: Beta=0, Store=1, Alpha=2, Enterprise=3",
-                                       default_value: "0"),
+                                       description: 'The release type to fetch: Beta=0, Store=1, Alpha=2, Enterprise=3',
+                                       default_value: '0'),
           FastlaneCore::ConfigItem.new(key: :platform,
-                                       description: "The platform to use when fetching the version number: iOS, Android, Mac OS, Windows Phone, Custom",
-                                       default_value: "iOS")
+                                       description: 'The platform to fetch: iOS, Android, Mac OS, Windows Phone, Custom',
+                                       default_value: 'iOS'),
         ]
       end
 
       def self.return_value
-        "Parsed notes field for the most recent version of the specified app"
+        'Parsed notes field for the most recent version of the specified app'
       end
 
       def self.authors
-        ["Hawken Rives"]
+        ['Hawken Rives']
       end
 
       def self.is_supported?(platform)

--- a/fastlane/actions/latest_hockeyapp_notes.rb
+++ b/fastlane/actions/latest_hockeyapp_notes.rb
@@ -9,9 +9,7 @@ module Fastlane
         end
 
         UI.message "Fetching metadata for #{params[:app_name]} from HockeyApp"
-        client = HockeyApp.build_client
-        apps = client.get_apps
-        app = apps.find do |a|
+        app = HockeyApp.build_client.get_apps.find do |a|
           a.title == params[:app_name] &&
             a.platform == params[:platform] &&
             a.release_type == params[:release_type].to_i

--- a/fastlane/actions/latest_hockeyapp_version_number.rb
+++ b/fastlane/actions/latest_hockeyapp_version_number.rb
@@ -8,16 +8,20 @@ module Fastlane
           config.token = params[:api_token]
         end
 
-        UI.message "Fetching latest version of #{params[:app_name]} from HockeyApp"
+        UI.message "Fetching metadata for #{params[:app_name]} from HockeyApp"
         client = HockeyApp.build_client
         apps = client.get_apps
-        app = apps.find { |a| a.title == params[:app_name] && a.platform == params[:platform] && a.release_type == params[:release_type].to_i }
-
-        if not app
-          version = 1
-        else
-          version = app.versions.first.version.to_i
+        app = apps.find do |a|
+          a.title == params[:app_name] &&
+            a.platform == params[:platform] &&
+            a.release_type == params[:release_type].to_i
         end
+
+        version = if app.nil?
+                    1
+                  else
+                    app.versions.first.version.to_i
+                  end
 
         UI.message "Found version #{version}"
 
@@ -25,46 +29,37 @@ module Fastlane
       end
 
       def self.description
-        "Easily fetch the most recent HockeyApp version number for your app"
+        'Easily fetch the most recent HockeyApp version number for your app'
       end
 
       def self.details
-        "Provides a way to have increment_build_number be based on the latest HockeyApp version"
+        'Provides a way to have increment_build_number be based on the latest HockeyApp version'
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :app_name,
-                                       env_name: "FL_HOCKEY_PUBLIC_IDENTIFIER",
-                                       description: "The app name to use when fetching the version number",
-                                       optional: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("No App Name for LatestHockeyappVersionNumberAction given, pass using `app_name: 'name'`") unless value and !value.empty?
-                                       end),
+                                       description: 'The app name to use when fetching the version number',
+                                       optional: false),
           FastlaneCore::ConfigItem.new(key: :api_token,
-                                       env_name: "FL_HOCKEY_API_TOKEN",
-                                       description: "API Token for Hockey Access",
-                                       optional: false,
-                                       verify_block: proc do |value|
-                                         UI.user_error!("No API token for LatestHockeyappVersionNumberAction given, pass using `api_token: 'token'`") unless value and !value.empty?
-                                       end),
+                                       env_name: 'HOCKEYAPP_TOKEN',
+                                       description: 'API Token for Hockey Access',
+                                       optional: false),
           FastlaneCore::ConfigItem.new(key: :release_type,
-                                       env_name: "FL_HOCKEY_RELEASE_TYPE",
-                                       description: "The release type to use when fetching the version number: Beta=0, Store=1, Alpha=2, Enterprise=3",
-                                       default_value: "0"),
+                                       description: 'The release type to use when fetching the version number: Beta=0, Store=1, Alpha=2, Enterprise=3',
+                                       default_value: '0'),
           FastlaneCore::ConfigItem.new(key: :platform,
-                                       env_name: "FL_LATEST_HOCKEYAPP_VERSION_NUMBER_PLATFORM",
-                                       description: "The platform to use when fetching the version number: iOS, Android, Mac OS, Windows Phone, Custom",
-                                       default_value: "iOS")
+                                       description: 'The platform to use when fetching the version number: iOS, Android, Mac OS, Windows Phone, Custom',
+                                       default_value: 'iOS')
         ]
       end
 
       def self.return_value
-        "The most recent version number for the specified app"
+        'The most recent version number for the specified app'
       end
 
       def self.authors
-        ["Travis Palmer", "Hawken Rives"]
+        ['Travis Palmer', 'Hawken Rives']
       end
 
       def self.is_supported?(platform)

--- a/fastlane/actions/latest_hockeyapp_version_number.rb
+++ b/fastlane/actions/latest_hockeyapp_version_number.rb
@@ -9,9 +9,7 @@ module Fastlane
         end
 
         UI.message "Fetching metadata for #{params[:app_name]} from HockeyApp"
-        client = HockeyApp.build_client
-        apps = client.get_apps
-        app = apps.find do |a|
+        app = HockeyApp.build_client.get_apps.find do |a|
           a.title == params[:app_name] &&
             a.platform == params[:platform] &&
             a.release_type == params[:release_type].to_i

--- a/fastlane/actions/set_gradle_version_code.rb
+++ b/fastlane/actions/set_gradle_version_code.rb
@@ -1,5 +1,5 @@
-require "tempfile"
-require "fileutils"
+require 'tempfile'
+require 'fileutils'
 
 module Fastlane
   module Actions
@@ -7,14 +7,14 @@ module Fastlane
       def self.run(params)
         gradle_path = params[:gradle_path]
 
-        old_version_code = "0"
+        old_version_code = '0'
         new_version_code = params[:version_code]
 
-        temp_file = Tempfile.new("fastlaneIncrementVersionCode")
+        temp_file = Tempfile.new('fastlaneIncrementVersionCode')
 
         File.foreach(gradle_path) do |line|
-          if line.include? "versionCode "
-            old_version_code = line.strip.split(" ")[1]
+          if line.include? 'versionCode '
+            old_version_code = line.strip.split(' ')[1]
             line = line.sub(old_version_code, new_version_code.to_s)
           end
           temp_file.puts line
@@ -25,31 +25,29 @@ module Fastlane
         FileUtils.mv(temp_file.path, gradle_path)
         temp_file.unlink
 
-        if old_version_code == "0" || new_version_code == "1"
-          UI.user_error!("Impossible to find the version code in the current project folder #{app_folder_name}")
+        if old_version_code == '0' || new_version_code == '1'
+          UI.user_error!("Could not find the version code in #{gradle_path}")
         else
-          UI.success("Version code has been changed from #{old_version_code} to #{new_version_code}")
+          UI.success("#{old_version_code} changed to #{new_version_code}")
         end
 
         new_version_code
       end
 
       def self.description
-        "Change the version code of your android project."
+        'Change the version code of your android project.'
       end
 
       def self.authors
-        ["Jérémy TOUDIC", "Hawken Rives"]
+        ['Jérémy TOUDIC', 'Hawken Rives']
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :gradle_path,
-                               description: "The path to the build.gradle file",
-                                      type: String),
+                                       description: 'The path to the build.gradle file'),
           FastlaneCore::ConfigItem.new(key: :version_code,
-                               description: "The version to change to",
-                                      type: Integer)
+                                       description: 'The version to change to'),
         ]
       end
 

--- a/fastlane/actions/set_gradle_version_name.rb
+++ b/fastlane/actions/set_gradle_version_name.rb
@@ -1,5 +1,5 @@
-require "tempfile"
-require "fileutils"
+require 'tempfile'
+require 'fileutils'
 
 module Fastlane
   module Actions
@@ -7,14 +7,14 @@ module Fastlane
       def self.run(params)
         gradle_path = params[:gradle_path]
 
-        old_version_name = "0"
+        old_version_name = '0'
         new_version_name = params[:version_name]
 
-        temp_file = Tempfile.new("fastlaneSetVersionName")
+        temp_file = Tempfile.new('fastlaneSetVersionName')
 
         File.foreach(gradle_path) do |line|
-          if line.include? "versionName "
-            old_version_name = line.strip.split(" ")[1]
+          if line.include? 'versionName '
+            old_version_name = line.strip.split(' ')[1]
             line = line.sub(old_version_name, "\"#{new_version_name}\"")
           end
           temp_file.puts line
@@ -25,31 +25,29 @@ module Fastlane
         FileUtils.mv(temp_file.path, gradle_path)
         temp_file.unlink
 
-        if old_version_name == "0" || new_version_name == "1"
-          UI.user_error!("Impossible to find the version name in the current project folder #{gradle_path}")
+        if old_version_name == '0' || new_version_name == '1'
+          UI.user_error!("Could not find the version name in #{gradle_path}")
         else
-          UI.success("Version name has been changed from #{old_version_name} to #{new_version_name}")
+          UI.success("#{old_version_name} changed to #{new_version_name}")
         end
 
         new_version_name
       end
 
       def self.description
-        "Change the version name of your android project."
+        'Change the version name of your android project.'
       end
 
       def self.authors
-        ["Jérémy TOUDIC", "Hawken Rives"]
+        ['Jérémy TOUDIC', 'Hawken Rives']
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :gradle_path,
-                               description: "The path to the build.gradle file",
-                                      type: String),
+                                       description: 'The path to the build.gradle file'),
           FastlaneCore::ConfigItem.new(key: :version_name,
-                               description: "The version to change to",
-                                      type: String)
+                                       description: 'The version to change to'),
         ]
       end
 

--- a/fastlane/actions/set_package_data.rb
+++ b/fastlane/actions/set_package_data.rb
@@ -15,32 +15,30 @@ module Fastlane
         pretty = JSON.pretty_generate(data_hash) + "\n"
         File.write(package_path, pretty)
 
-        UI.success("package.json data has been updated to include #{data_to_write}")
+        UI.success("#{package_path} has been updated with #{data_to_write}")
 
         data_hash
       end
 
       def self.description
-        "Change data in your package.json file."
+        'Change data in your package.json file.'
       end
 
       def self.authors
-        ["Hawken Rives"]
+        ['Hawken Rives']
       end
 
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :data,
-                               description: "The data to update",
-                                      type: Hash),
+                                       description: 'The data to update'),
           FastlaneCore::ConfigItem.new(key: :package_path,
-                               description: "The path to the package.json file",
-                                      type: String,
-                             default_value: "./package.json"),
+                                       description: 'The path to the package.json file',
+                                       default_value: './package.json'),
         ]
       end
 
-      def self.is_supported?(platform)
+      def self.is_supported?
         true
       end
     end

--- a/fastlane/actions/set_package_data.rb
+++ b/fastlane/actions/set_package_data.rb
@@ -8,7 +8,7 @@ module Fastlane
         package_path = params[:package_path]
 
         file = File.read(package_path)
-        data_hash = JSON.parse(file)
+        data_hash = JSON.parse(file, symbolize_names: true)
 
         data_hash.update(data_to_write)
 
@@ -31,10 +31,12 @@ module Fastlane
       def self.available_options
         [
           FastlaneCore::ConfigItem.new(key: :data,
-                                       description: 'The data to update'),
+                                       description: 'The data to update',
+                                       type: Hash),
           FastlaneCore::ConfigItem.new(key: :package_path,
                                        description: 'The path to the package.json file',
-                                       default_value: './package.json'),
+                                       default_value: './package.json',
+                                       type: String),
         ]
       end
 

--- a/fastlane/actions/set_package_data.rb
+++ b/fastlane/actions/set_package_data.rb
@@ -40,7 +40,7 @@ module Fastlane
         ]
       end
 
-      def self.is_supported?
+      def self.is_supported?(platform)
         true
       end
     end

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -1,35 +1,35 @@
-desc "Add the github token for stodevx-bot to the CI machine"
+desc 'Add the github token for stodevx-bot to the CI machine'
 private_lane :authorize_ci_for_keys do
-  token = ENV["CI_USER_TOKEN"]
+  token = ENV['CI_USER_TOKEN']
 
   # see macoscope.com/blog/simplify-your-life-with-fastlane-match
   # we're allowing the CI access to the keys repo
-  File.open("#{ENV['HOME']}/.netrc", "a+") do |file|
+  File.open("#{ENV['HOME']}/.netrc", 'a+') do |file|
     file << "machine github.com\n  login #{token}"
   end
 end
 
-desc "Get the hockeyapp version"
+desc 'Get the hockeyapp version'
 private_lane :get_hockeyapp_version do |options|
   latest_hockeyapp_version_number(
-    api_token: ENV["HOCKEYAPP_TOKEN"],
-    app_name: "All About Olaf",
-    platform: options[:platform],
+    api_token: ENV['HOCKEYAPP_TOKEN'],
+    app_name: 'All About Olaf',
+    platform: options[:platform]
   )
 end
 
-desc "Get the commit of the latest build on HockeyApp"
+desc 'Get the commit of the latest build on HockeyApp'
 private_lane :get_hockeyapp_version_commit do |options|
   latest_hockeyapp_notes(
-    api_token: ENV["HOCKEYAPP_TOKEN"],
-    app_name: "All About Olaf",
-    platform: options[:platform],
+    api_token: ENV['HOCKEYAPP_TOKEN'],
+    app_name: 'All About Olaf',
+    platform: options[:platform]
   )[:commit_hash]
 end
 
-desc "Gets the version, either from Travis or from Hockey"
+desc 'Gets the version, either from Travis or from Hockey'
 private_lane :get_current_build_number do |options|
-  ENV["TRAVIS_BUILD_NUMBER"] || get_hockeyapp_version(platform: options[:platform]) + 1
+  ENV['TRAVIS_BUILD_NUMBER'] || get_hockeyapp_version(platform: options[:platform]) + 1
 end
 
 private_lane :build_notes do |options|
@@ -41,35 +41,37 @@ end
 
 private_lane :get_current_bundle_version do |options|
   if options[:platform] == 'Android'
-    get_gradle_version_name(gradle_path: "android/app/build.gradle")
+    get_gradle_version_name(gradle_path: 'android/app/build.gradle')
   elsif options[:platform] == 'iOS'
-    get_info_plist_value(path: "ios/AllAboutOlaf/Info.plist", key: "CFBundleShortVersionString")
+    get_info_plist_value(path: 'ios/AllAboutOlaf/Info.plist',
+                         key: 'CFBundleShortVersionString')
   end
 end
 
-desc "Makes a changelog from the timespan passed"
+desc 'Makes a changelog from the timespan passed'
 private_lane :make_changelog do |options|
-  to_ref = ENV["TRAVIS_COMMIT"] || "HEAD"
-  from_ref = get_hockeyapp_version_commit(platform: options[:platform]) || "HEAD~3"
+  to_ref = ENV['TRAVIS_COMMIT'] || 'HEAD'
+  from_ref = get_hockeyapp_version_commit(platform: options[:platform]) || 'HEAD~3'
 
   sh("git log #{from_ref}..#{to_ref} --pretty='%an, %aD (%h)%n> %s%n' | sed 's/^/    /'")
 end
 
 lane :bundle_data do
-  sh("npm run bundle-data")
+  sh('npm run bundle-data')
 end
 
-# It doesn't make sense to duplicate this in both platforms, and fastlane is smart
-# enough to call the appropriate platform's "beta" lane.
-desc "Make a beta build if there have been new commits since the last beta"
+# It doesn't make sense to duplicate this in both platforms, and fastlane is
+# smart enough to call the appropriate platform's "beta" lane.
+desc 'Make a beta build if there have been new commits since the last beta'
 private_lane :auto_beta do |options|
   last_commit = hockeyapp_version_commit(platform: options[:platform])
   current_commit = last_git_commit[:commit_hash]
 
-  UI.message "In faux-git terms:"
+  UI.message 'In faux-git terms:'
   UI.message "origin/hockeyapp: #{last_commit}"
   UI.message "HEAD: #{current_commit}"
-  UI.message "Thus, will we beta? #{last_commit != current_commit ? "yes" : "no"}"
+  will_beta = last_commit != current_commit ? 'yes' : 'no'
+  UI.message "Thus, will we beta? #{will_beta}"
 
   beta if last_commit != current_commit
 end

--- a/fastlane/platforms/agnostic.rb
+++ b/fastlane/platforms/agnostic.rb
@@ -1,5 +1,5 @@
 # These lanes are non-platform-specific
-desc "Adds any unregistered devices to the provisioning profile"
+desc 'Adds any unregistered devices to the provisioning profile'
 lane :register do
   id = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
   new_devices = get_unprovisioned_devices_from_hockey(app_bundle_id: id)
@@ -7,17 +7,19 @@ lane :register do
   match(force: true)
 end
 
-desc "Bump the version string to a new version"
+desc 'Bump the version string to a new version'
 lane :bump do |options|
-  old_version = get_package_key(key: "version")
+  old_version = get_package_key(key: 'version')
   UI.message("Current version: #{old_version}")
-  version = options[:version] || UI.input("New version: ").strip
+  version = options[:version] || UI.input('New version: ').strip
   UI.message("Upgrading from #{old_version} to #{version}")
 
   # update iOS version
-  increment_version_number(version_number: version, xcodeproj: "./ios/AllAboutOlaf.xcodeproj")
+  increment_version_number(version_number: version,
+                           xcodeproj: './ios/AllAboutOlaf.xcodeproj')
   # update Android version
-  set_gradle_version_name(version_name: version, gradle_path: "android/app/build.gradle")
+  set_gradle_version_name(version_name: version,
+                          gradle_path: 'android/app/build.gradle')
   # update package.json version
-  set_package_data(data: {"version" => version})
+  set_package_data(data: { version: version })
 end

--- a/fastlane/platforms/agnostic.rb
+++ b/fastlane/platforms/agnostic.rb
@@ -9,7 +9,7 @@ end
 
 desc 'Bump the version string to a new version'
 lane :bump do |options|
-  old_version = get_package_key(key: 'version')
+  old_version = get_package_key(key: :version)
   UI.message("Current version: #{old_version}")
   version = options[:version] || UI.input('New version: ').strip
   UI.message("Upgrading from #{old_version} to #{version}")

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -1,45 +1,47 @@
 platform :android do
-  desc "Makes a build"
+  desc 'Makes a build'
   lane :build do
     # make sure we have a copy of the data files
     bundle_data
 
-    version = get_current_bundle_version(platform: "Android")
-    build_number = get_current_build_number(platform: "Android")
+    version = get_current_bundle_version(platform: 'Android')
+    build_number = get_current_build_number(platform: 'Android')
 
-    set_gradle_version_name(version_name: "#{version}.#{build_number}", gradle_path: "android/app/build.gradle")
-    set_gradle_version_code(version_code: build_number, gradle_path: "./android/app/build.gradle")
-    set_package_data(data: {"version" => "#{version}.#{build_number}"})
+    set_gradle_version_name(version_name: "#{version}.#{build_number}",
+                            gradle_path: 'android/app/build.gradle')
+    set_gradle_version_code(version_code: build_number,
+                            gradle_path: './android/app/build.gradle')
+    set_package_data(data: { version: "#{version}.#{build_number}" })
 
     gradle(
-      task: "assemble",
-      build_type: "Release",
-      project_dir: "./android",
+      task: 'assemble',
+      build_type: 'Release',
+      project_dir: './android',
       print_command: true,
-      print_command_output: true,
+      print_command_output: true
     )
   end
 
-  desc "Submit a new Beta Build to HockeyApp"
+  desc 'Submit a new Beta Build to HockeyApp'
   lane :beta do
     build
 
     # Upload to HockeyApp
     hockey(
-      api_token: ENV["HOCKEYAPP_TOKEN"],
-      apk: "./android/app/build/outputs/apk/app-release-unsigned.apk",
-      commit_sha: ENV["TRAVIS_COMMIT"],
-      notes: build_notes(platform: 'Android'),
+      api_token: ENV['HOCKEYAPP_TOKEN'],
+      apk: './android/app/build/outputs/apk/app-release-unsigned.apk',
+      commit_sha: ENV['TRAVIS_COMMIT'],
+      notes: build_notes(platform: 'Android')
     )
   end
 
-  desc "Run the appropriate action on CI"
-  lane :"ci-run" do
+  desc 'Run the appropriate action on CI'
+  lane :'ci-run' do
     authorize_ci_for_keys
 
-    should_deploy = ENV["run_deploy"] == "1"
+    should_deploy = ENV['run_deploy'] == '1'
     if should_deploy
-      auto_beta(platform: "Android")
+      auto_beta(platform: 'Android')
     else
       build
     end

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -1,20 +1,20 @@
 platform :ios do
-  desc "Runs all the tests"
+  desc 'Runs all the tests'
   lane :test do
     scan
   end
 
-  desc "Take screenshots"
+  desc 'Take screenshots'
   lane :screenshot do
     snapshot
   end
 
-  desc "Go rogue"
-  lane :"go-rogue" do
+  desc 'Go rogue'
+  lane :'go-rogue' do
     activate_rogue_team
   end
 
-  desc "Provisions the profiles; bumps the build number; builds the app"
+  desc 'Provisions the profiles; bumps the build number; builds the app'
   lane :build do
     # make sure we have a copy of the data files
     bundle_data
@@ -25,38 +25,40 @@ platform :ios do
 
     activate_rogue_team
 
-    version = get_current_bundle_version(platform: "iOS")
-    build_number = get_current_build_number(platform: "iOS")
-    increment_version_number(version_number: "#{version}.#{build_number}", xcodeproj: "./ios/AllAboutOlaf.xcodeproj")
-    increment_build_number(build_number: build_number, xcodeproj: "./ios/AllAboutOlaf.xcodeproj")
-    set_package_data(data: {"version" => "#{version}.#{build_number}"})
+    version = get_current_bundle_version(platform: 'iOS')
+    build_number = get_current_build_number(platform: 'iOS')
+    increment_version_number(version_number: "#{version}.#{build_number}",
+                             xcodeproj: './ios/AllAboutOlaf.xcodeproj')
+    increment_build_number(build_number: build_number,
+                           xcodeproj: './ios/AllAboutOlaf.xcodeproj')
+    set_package_data(data: { version: "#{version}.#{build_number}" })
 
     # Build the app
     gym
   end
 
-  desc "Submit a new Beta Build to HockeyApp"
+  desc 'Submit a new Beta Build to HockeyApp'
   lane :beta do
     build
 
     hockey(
-      api_token: ENV["HOCKEYAPP_TOKEN"],
-      ipa: "./ios/build/AllAboutOlaf.ipa",
-      commit_sha: ENV["TRAVIS_COMMIT"],
-      notes: build_notes(platform: 'iOS'),
+      api_token: ENV['HOCKEYAPP_TOKEN'],
+      ipa: './ios/build/AllAboutOlaf.ipa',
+      commit_sha: ENV['TRAVIS_COMMIT'],
+      notes: build_notes(platform: 'iOS')
     )
   end
 
   # Lanes specifically for the CIs
-  desc "Do CI-system keychain setup"
+  desc 'Do CI-system keychain setup'
   private_lane :ci_keychains do
-    keychain = ENV["MATCH_KEYCHAIN_NAME"]
-    password = ENV["MATCH_KEYCHAIN_PASSWORD"]
+    keychain = ENV['MATCH_KEYCHAIN_NAME']
+    password = ENV['MATCH_KEYCHAIN_PASSWORD']
 
     create_keychain(
       name: keychain,
       password: password,
-      timeout: 3600,
+      timeout: 3600
     )
 
     match(readonly: true)
@@ -64,14 +66,14 @@ platform :ios do
     sh("security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k #{password} #{keychain}")
   end
 
-  desc "Run iOS builds or tests, as appropriate"
+  desc 'Run iOS builds or tests, as appropriate'
   lane :"ci-run" do
     authorize_ci_for_keys
     ci_keychains
 
-    # I'd like to test, instead of just building, but… Xcode's tests keep
+    # I'd like to test, instead of just building, but... Xcode's tests keep
     # failing on us. So, we just build, if we're not deploying.
-    should_deploy = ENV["run_deploy"] == "1"
+    should_deploy = ENV['run_deploy'] == '1'
     if should_deploy
       auto_beta(platform: 'iOS')
     else
@@ -79,7 +81,7 @@ platform :ios do
     end
   end
 
-  desc "In case match needs to be updated - probably never needs to be run"
+  desc 'In case match needs to be updated - probably never needs to be run'
   lane :"update-match" do
     match(readonly: false)
   end


### PR DESCRIPTION
This PR reindents things and changes a bunch of double quotes to single quotes. (aka it makes the  rubocop linter happier.) Something about "only use double-quotes for templated strings".