### PR TITLE
Remove the constant passing of :platform in fastlane

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,7 +1,11 @@
-app_identifier "com.volz.drew.aao.rogue" # The bundle identifier of your app
-apple_id "magneticpapergarden@gmail.com" # Your Apple email address
+# The bundle identifier of your app
+app_identifier 'com.volz.drew.aao.rogue'
 
-team_id "NFMTHAZVS9"  # Developer Portal Team ID
+# Your Apple email address
+apple_id 'magneticpapergarden@gmail.com'
+
+# Developer Portal Team ID
+team_id 'NFMTHAZVS9'
 
 # you can even provide different app identifiers, Apple IDs and team names per lane:
 # More information: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -87,6 +87,11 @@ Take screenshots
 fastlane ios go-rogue
 ```
 Go rogue
+### ios update-match
+```
+fastlane ios update-match
+```
+In case match needs to be updated - probably never needs to be run
 ### ios build
 ```
 fastlane ios build
@@ -102,11 +107,6 @@ Submit a new Beta Build to HockeyApp
 fastlane ios ci-run
 ```
 Run iOS builds or tests, as appropriate
-### ios update-match
-```
-fastlane ios update-match
-```
-In case match needs to be updated - probably never needs to be run
 
 ----
 

--- a/fastlane/actions/latest_hockeyapp_notes.rb
+++ b/fastlane/actions/latest_hockeyapp_notes.rb
@@ -104,7 +104,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :platform,
                                        description: 'The platform to fetch: ios, android, macos, windows_phone, custom',
                                        default_value: :ios,
-                                       type: Symbol),
+                                       type: Symbol,
+                                       default_value: lane_context[:PLATFORM_NAME] || :ios),
         ]
       end
 

--- a/fastlane/actions/latest_hockeyapp_version_number.rb
+++ b/fastlane/actions/latest_hockeyapp_version_number.rb
@@ -68,7 +68,7 @@ module Fastlane
                                        type: Symbol),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        description: 'The platform to fetch: ios, android, macos, windows_phone, custom',
-                                       default_value: :ios,
+                                       default_value: lane_context[:PLATFORM_NAME] || :ios,
                                        type: Symbol),
         ]
       end

--- a/fastlane/lib/before_all.rb
+++ b/fastlane/lib/before_all.rb
@@ -1,5 +1,5 @@
 before_all do
   # too lazy to change the name in travis, so we jut copy it here
-  ENV['FL_HOCKEY_API_TOKEN'] = ENV['HOCKEY_TOKEN'] if ENV.key?('HOCKEY_TOKEN')
-  ENV['FL_HOCKEY_COMMIT_SHA'] = ENV['TRAVIS_COMMIT'] if ENV.key?('TRAVIS_COMMIT')
+  ENV['FL_HOCKEY_API_TOKEN'] = ENV['HOCKEY_TOKEN']
+  ENV['FL_HOCKEY_COMMIT_SHA'] = ENV['TRAVIS_COMMIT']
 end

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -32,9 +32,10 @@ end
 
 # Get the current "app bundle" version
 def current_bundle_version
-  if lane_context[:PLATFORM_NAME] == :android
+  case lane_context[:PLATFORM_NAME]
+  when :android
     get_gradle_version_name(gradle_path: 'android/app/build.gradle')
-  elsif lane_context[:PLATFORM_NAME] == :ios
+  when :ios
     get_info_plist_value(path: 'ios/AllAboutOlaf/Info.plist',
                          key: 'CFBundleShortVersionString')
   end

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -39,7 +39,7 @@ def current_bundle_version
     get_info_plist_value(path: 'ios/AllAboutOlaf/Info.plist',
                          key: 'CFBundleShortVersionString')
   else
-    package_get_data(key: :version)
+    get_package_key(key: :version)
   end
 end
 

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -37,10 +37,10 @@ def get_current_build_number(options)
 end
 
 # Get the current "app bundle" version
-def get_current_bundle_version(options)
-  if options[:platform] == :android
+def get_current_bundle_version(_)
+  if lane_context[:PLATFORM_NAME] == :android
     get_gradle_version_name(gradle_path: 'android/app/build.gradle')
-  elsif options[:platform] == :ios
+  elsif lane_context[:PLATFORM_NAME] == :ios
     get_info_plist_value(path: 'ios/AllAboutOlaf/Info.plist',
                          key: 'CFBundleShortVersionString')
   end

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -10,21 +10,21 @@ def authorize_ci_for_keys
 end
 
 # Get the hockeyapp version
-def get_hockeyapp_version(_)
+def get_hockeyapp_version
   latest_hockeyapp_version_number(
     app_name: 'All About Olaf',
   )
 end
 
 # Get the commit of the latest build on HockeyApp
-def get_hockeyapp_version_commit(_)
+def get_hockeyapp_version_commit
   latest_hockeyapp_notes(
     app_name: 'All About Olaf',
   )[:commit_hash]
 end
 
 # Gets the version, either from Travis or from Hockey
-def get_current_build_number(_)
+def get_current_build_number
   ENV['TRAVIS_BUILD_NUMBER'] if ENV.key?('TRAVIS_BUILD_NUMBER')
 
   begin
@@ -35,7 +35,7 @@ def get_current_build_number(_)
 end
 
 # Get the current "app bundle" version
-def get_current_bundle_version(_)
+def get_current_bundle_version
   if lane_context[:PLATFORM_NAME] == :android
     get_gradle_version_name(gradle_path: 'android/app/build.gradle')
   elsif lane_context[:PLATFORM_NAME] == :ios
@@ -45,7 +45,7 @@ def get_current_bundle_version(_)
 end
 
 # Makes a changelog from the timespan passed
-def make_changelog(_)
+def make_changelog
   to_ref = ENV['TRAVIS_COMMIT'] || 'HEAD'
   from_ref = get_hockeyapp_version_commit || 'HEAD~3'
 
@@ -58,7 +58,7 @@ end
 # It doesn't make sense to duplicate this in both platforms, and fastlane is
 # smart enough to call the appropriate platform's "beta" lane. So, let's make
 # a beta build if there have been new commits since the last beta.
-def auto_beta(_)
+def auto_beta
   last_commit = get_hockeyapp_version_commit
   current_commit = last_git_commit[:commit_hash]
 

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -10,27 +10,25 @@ def authorize_ci_for_keys
 end
 
 # Get the hockeyapp version
-def get_hockeyapp_version(options)
+def get_hockeyapp_version(_)
   latest_hockeyapp_version_number(
     app_name: 'All About Olaf',
-    platform: options[:platform]
   )
 end
 
 # Get the commit of the latest build on HockeyApp
-def get_hockeyapp_version_commit(options)
+def get_hockeyapp_version_commit(_)
   latest_hockeyapp_notes(
     app_name: 'All About Olaf',
-    platform: options[:platform]
   )[:commit_hash]
 end
 
 # Gets the version, either from Travis or from Hockey
-def get_current_build_number(options)
+def get_current_build_number(_)
   ENV['TRAVIS_BUILD_NUMBER'] if ENV.key?('TRAVIS_BUILD_NUMBER')
 
   begin
-    (get_hockeyapp_version(platform: options[:platform]) + 1).to_s
+    (get_hockeyapp_version + 1).to_s
   rescue
     '1'
   end
@@ -47,9 +45,9 @@ def get_current_bundle_version(_)
 end
 
 # Makes a changelog from the timespan passed
-def make_changelog(options)
+def make_changelog(_)
   to_ref = ENV['TRAVIS_COMMIT'] || 'HEAD'
-  from_ref = get_hockeyapp_version_commit(platform: options[:platform]) || 'HEAD~3'
+  from_ref = get_hockeyapp_version_commit || 'HEAD~3'
 
   sh("git log #{from_ref}..#{to_ref} --pretty='%an, %aD (%h)%n> %s%n'")
     .lines
@@ -60,8 +58,8 @@ end
 # It doesn't make sense to duplicate this in both platforms, and fastlane is
 # smart enough to call the appropriate platform's "beta" lane. So, let's make
 # a beta build if there have been new commits since the last beta.
-def auto_beta(options)
-  last_commit = get_hockeyapp_version_commit(platform: options[:platform])
+def auto_beta(_)
+  last_commit = get_hockeyapp_version_commit
   current_commit = last_git_commit[:commit_hash]
 
   UI.message 'In faux-git terms:'

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -10,32 +10,28 @@ def authorize_ci_for_keys
 end
 
 # Get the hockeyapp version
-def get_hockeyapp_version
-  latest_hockeyapp_version_number(
-    app_name: 'All About Olaf',
-  )
+def hockeyapp_version
+  latest_hockeyapp_version_number(app_name: 'All About Olaf')
 end
 
 # Get the commit of the latest build on HockeyApp
-def get_hockeyapp_version_commit
-  latest_hockeyapp_notes(
-    app_name: 'All About Olaf',
-  )[:commit_hash]
+def hockeyapp_version_commit
+  latest_hockeyapp_notes(app_name: 'All About Olaf')[:commit_hash]
 end
 
 # Gets the version, either from Travis or from Hockey
-def get_current_build_number
+def current_build_number
   ENV['TRAVIS_BUILD_NUMBER'] if ENV.key?('TRAVIS_BUILD_NUMBER')
 
   begin
-    (get_hockeyapp_version + 1).to_s
+    (hockeyapp_version + 1).to_s
   rescue
     '1'
   end
 end
 
 # Get the current "app bundle" version
-def get_current_bundle_version
+def current_bundle_version
   if lane_context[:PLATFORM_NAME] == :android
     get_gradle_version_name(gradle_path: 'android/app/build.gradle')
   elsif lane_context[:PLATFORM_NAME] == :ios
@@ -47,7 +43,7 @@ end
 # Makes a changelog from the timespan passed
 def make_changelog
   to_ref = ENV['TRAVIS_COMMIT'] || 'HEAD'
-  from_ref = get_hockeyapp_version_commit || 'HEAD~3'
+  from_ref = hockeyapp_version_commit || 'HEAD~3'
 
   sh("git log #{from_ref}..#{to_ref} --pretty='%an, %aD (%h)%n> %s%n'")
     .lines
@@ -59,7 +55,7 @@ end
 # smart enough to call the appropriate platform's "beta" lane. So, let's make
 # a beta build if there have been new commits since the last beta.
 def auto_beta
-  last_commit = get_hockeyapp_version_commit
+  last_commit = hockeyapp_version_commit
   current_commit = last_git_commit[:commit_hash]
 
   UI.message 'In faux-git terms:'

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -38,6 +38,8 @@ def current_bundle_version
   when :ios
     get_info_plist_value(path: 'ios/AllAboutOlaf/Info.plist',
                          key: 'CFBundleShortVersionString')
+  else
+    package_get_data(key: :version)
   end
 end
 

--- a/fastlane/platforms/agnostic.rb
+++ b/fastlane/platforms/agnostic.rb
@@ -31,7 +31,7 @@ lane :release_notes do |options|
     git commit: #{last_git_commit[:commit_hash]}
 
     ## Changelog
-    #{make_changelog(platform: options[:platform])}
+    #{make_changelog}
   END
   UI.message notes
   notes

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -16,16 +16,6 @@ platform :android do
     )
   end
 
-  private_lane :set_version do |options|
-    version = options[:version]
-    build = options[:build_number]
-    set_gradle_version_name(version_name: "#{version}.#{build}",
-                            gradle_path: 'android/app/build.gradle')
-    set_gradle_version_code(version_code: build,
-                            gradle_path: './android/app/build.gradle')
-    set_package_data(data: { version: "#{version}.#{build}" })
-  end
-
   desc 'Submit a new Beta Build to HockeyApp'
   lane :beta do
     build
@@ -35,6 +25,16 @@ platform :android do
       apk: lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH],
       notes: release_notes
     )
+  end
+
+  private_lane :set_version do |options|
+    version = options[:version]
+    build = options[:build_number]
+    set_gradle_version_name(version_name: "#{version}.#{build}",
+                            gradle_path: 'android/app/build.gradle')
+    set_gradle_version_code(version_code: build,
+                            gradle_path: './android/app/build.gradle')
+    set_package_data(data: { version: "#{version}.#{build}" })
   end
 
   desc 'Run the appropriate action on CI'

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -4,8 +4,8 @@ platform :android do
     # make sure we have a copy of the data files
     bundle_data
 
-    version = get_current_bundle_version
-    build_number = get_current_build_number
+    version = current_bundle_version
+    build_number = current_build_number
 
     set_gradle_version_name(version_name: "#{version}.#{build_number}",
                             gradle_path: 'android/app/build.gradle')

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -4,8 +4,8 @@ platform :android do
     # make sure we have a copy of the data files
     bundle_data
 
-    version = get_current_bundle_version(platform: :android)
-    build_number = get_current_build_number(platform: :android)
+    version = get_current_bundle_version
+    build_number = get_current_build_number
 
     set_gradle_version_name(version_name: "#{version}.#{build_number}",
                             gradle_path: 'android/app/build.gradle')
@@ -29,7 +29,7 @@ platform :android do
     # Upload to HockeyApp
     hockey(
       apk: lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH],
-      notes: release_notes(platform: :android)
+      notes: release_notes
     )
   end
 
@@ -39,7 +39,7 @@ platform :android do
 
     should_deploy = ENV['run_deploy'] == '1'
     if should_deploy
-      auto_beta(platform: :android)
+      auto_beta
     else
       build
     end

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -39,8 +39,10 @@ platform :android do
 
   desc 'Run the appropriate action on CI'
   lane :'ci-run' do
+    # prepare for the bright future with signed android betas
     authorize_ci_for_keys
 
+    # and run
     should_deploy = ENV['run_deploy'] == '1'
     if should_deploy
       auto_beta

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -4,14 +4,8 @@ platform :android do
     # make sure we have a copy of the data files
     bundle_data
 
-    version = current_bundle_version
-    build_number = current_build_number
-
-    set_gradle_version_name(version_name: "#{version}.#{build_number}",
-                            gradle_path: 'android/app/build.gradle')
-    set_gradle_version_code(version_code: build_number,
-                            gradle_path: './android/app/build.gradle')
-    set_package_data(data: { version: "#{version}.#{build_number}" })
+    set_version(version: current_bundle_version,
+                build_number: current_build_number)
 
     gradle(
       task: 'assemble',
@@ -20,6 +14,16 @@ platform :android do
       print_command: true,
       print_command_output: true
     )
+  end
+
+  private_lane :set_version do |options|
+    version = options[:version]
+    build = options[:build_number]
+    set_gradle_version_name(version_name: "#{version}.#{build}",
+                            gradle_path: 'android/app/build.gradle')
+    set_gradle_version_code(version_code: build,
+                            gradle_path: './android/app/build.gradle')
+    set_package_data(data: { version: "#{version}.#{build}" })
   end
 
   desc 'Submit a new Beta Build to HockeyApp'

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -25,8 +25,8 @@ platform :ios do
 
     activate_rogue_team
 
-    version = get_current_bundle_version(platform: :ios)
-    build_number = get_current_build_number(platform: :ios)
+    version = current_bundle_version
+    build_number = current_build_number
     increment_version_number(version_number: "#{version}.#{build_number}",
                              xcodeproj: './ios/AllAboutOlaf.xcodeproj')
     increment_build_number(build_number: build_number,
@@ -73,7 +73,7 @@ platform :ios do
     # failing on us. So, we just build, if we're not deploying.
     should_deploy = ENV['run_deploy'] == '1'
     if should_deploy
-      auto_beta(platform: :ios)
+      auto_beta
     else
       build
     end

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -25,13 +25,8 @@ platform :ios do
 
     activate_rogue_team
 
-    version = current_bundle_version
-    build_number = current_build_number
-    increment_version_number(version_number: "#{version}.#{build_number}",
-                             xcodeproj: './ios/AllAboutOlaf.xcodeproj')
-    increment_build_number(build_number: build_number,
-                           xcodeproj: './ios/AllAboutOlaf.xcodeproj')
-    set_package_data(data: { version: "#{version}.#{build_number}" })
+    set_version(version: current_bundle_version,
+                build_number: current_build_number)
 
     # Build the app
     gym
@@ -45,6 +40,16 @@ platform :ios do
       ipa: lane_context[SharedValues::IPA_OUTPUT_PATH],
       notes: release_notes
     )
+  end
+
+  private_lane :set_version do |options|
+    version = options[:version]
+    build = options[:build_number]
+    increment_version_number(version_number: "#{version}.#{build}",
+                             xcodeproj: './ios/AllAboutOlaf.xcodeproj')
+    increment_build_number(build_number: build,
+                           xcodeproj: './ios/AllAboutOlaf.xcodeproj')
+    set_package_data(data: { version: "#{version}.#{build}" })
   end
 
   # Lanes specifically for the CIs

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -14,7 +14,7 @@ platform :ios do
     activate_rogue_team
   end
 
-  desc 'In case match needs to be updated - probably never needs to be run'
+  desc 'In case match needs to be updated - rarely needs to be run'
   lane :"update-match" do
     match(readonly: false)
   end
@@ -48,12 +48,12 @@ platform :ios do
   end
 
   desc 'Run iOS builds or tests, as appropriate'
-  lane :"ci-run" do
+  lane :'ci-run' do
+    # set up things so they can run
     authorize_ci_for_keys
     ci_keychains
 
-    # I'd like to test, instead of just building, but... Xcode's tests keep
-    # failing on us. So, we just build, if we're not deploying.
+    # and run
     should_deploy = ENV['run_deploy'] == '1'
     if should_deploy
       auto_beta

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -43,7 +43,7 @@ platform :ios do
 
     hockey(
       ipa: lane_context[SharedValues::IPA_OUTPUT_PATH],
-      notes: release_notes(platform: :ios)
+      notes: release_notes
     )
   end
 


### PR DESCRIPTION
This allows us to significantly shorten / eliminate arguments to most of the fastlane actions we call. Fastlane sets up `lane_context[:PLATFORM_NAME]` with the current platform's name for us.