### PR TITLE
Reorder some fastlane actions

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -68,6 +68,11 @@ Submit a new Beta Build to HockeyApp
 fastlane android ci-run
 ```
 Run the appropriate action on CI
+### android set_version
+```
+fastlane android set_version
+```
+Include the build number in the version string
 
 ----
 
@@ -91,7 +96,7 @@ Go rogue
 ```
 fastlane ios update-match
 ```
-In case match needs to be updated - probably never needs to be run
+In case match needs to be updated - rarely needs to be run
 ### ios build
 ```
 fastlane ios build
@@ -107,6 +112,11 @@ Submit a new Beta Build to HockeyApp
 fastlane ios ci-run
 ```
 Run iOS builds or tests, as appropriate
+### ios set_version
+```
+fastlane ios set_version
+```
+Include the build number in the version string
 
 ----
 

--- a/fastlane/actions/latest_hockeyapp_notes.rb
+++ b/fastlane/actions/latest_hockeyapp_notes.rb
@@ -103,7 +103,6 @@ module Fastlane
                                        default_value: 'master'),
           FastlaneCore::ConfigItem.new(key: :platform,
                                        description: 'The platform to fetch: ios, android, macos, windows_phone, custom',
-                                       default_value: :ios,
                                        type: Symbol,
                                        default_value: lane_context[:PLATFORM_NAME] || :ios),
         ]

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -27,11 +27,11 @@ platform :android do
   private_lane :set_version do |options|
     version = options[:version]
     build = options[:build_number]
-    set_gradle_version_name(version_name: "#{version}.#{build}",
+    set_gradle_version_name(version_name: "#{version}-build.#{build}",
                             gradle_path: 'android/app/build.gradle')
     set_gradle_version_code(version_code: build,
                             gradle_path: './android/app/build.gradle')
-    set_package_data(data: { version: "#{version}.#{build}" })
+    set_package_data(data: { version: "#{version}-build.#{build}" })
   end
 
   desc 'Run the appropriate action on CI'

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -4,9 +4,6 @@ platform :android do
     # make sure we have a copy of the data files
     bundle_data
 
-    set_version(version: current_bundle_version,
-                build_number: current_build_number)
-
     gradle(
       task: 'assemble',
       build_type: 'Release',
@@ -41,6 +38,10 @@ platform :android do
   lane :'ci-run' do
     # prepare for the bright future with signed android betas
     authorize_ci_for_keys
+
+    # bump the app version
+    set_version(version: current_bundle_version,
+                build_number: current_build_number)
 
     # and run
     should_deploy = ENV['run_deploy'] == '1'

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -24,24 +24,13 @@ platform :android do
     )
   end
 
-  private_lane :set_version do |options|
-    version = options[:version]
-    build = options[:build_number]
-    set_gradle_version_name(version_name: "#{version}-build.#{build}",
-                            gradle_path: 'android/app/build.gradle')
-    set_gradle_version_code(version_code: build,
-                            gradle_path: './android/app/build.gradle')
-    set_package_data(data: { version: "#{version}-build.#{build}" })
-  end
-
   desc 'Run the appropriate action on CI'
   lane :'ci-run' do
     # prepare for the bright future with signed android betas
     authorize_ci_for_keys
 
-    # bump the app version
-    set_version(version: current_bundle_version,
-                build_number: current_build_number)
+    # set the app version
+    set_version
 
     # and run
     should_deploy = ENV['run_deploy'] == '1'
@@ -50,5 +39,16 @@ platform :android do
     else
       build
     end
+  end
+
+  desc 'Include the build number in the version string'
+  lane :set_version do |options|
+    version = options[:version] || current_bundle_version
+    build = options[:build_number] || current_build_number
+    set_gradle_version_name(version_name: "#{version}-build.#{build}",
+                            gradle_path: 'android/app/build.gradle')
+    set_gradle_version_code(version_code: build,
+                            gradle_path: './android/app/build.gradle')
+    set_package_data(data: { version: "#{version}-build.#{build}" })
   end
 end

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -65,11 +65,11 @@ platform :ios do
   private_lane :set_version do |options|
     version = options[:version]
     build = options[:build_number]
-    increment_version_number(version_number: "#{version}.#{build}",
+    increment_version_number(version_number: "#{version}-build.#{build}",
                              xcodeproj: './ios/AllAboutOlaf.xcodeproj')
     increment_build_number(build_number: build,
                            xcodeproj: './ios/AllAboutOlaf.xcodeproj')
-    set_package_data(data: { version: "#{version}.#{build}" })
+    set_package_data(data: { version: "#{version}-build.#{build}" })
   end
 
   desc 'Do CI-system keychain setup'

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -28,8 +28,6 @@ platform :ios do
     # (more information: https://codesigning.guide)
     match(readonly: true)
 
-    activate_rogue_team
-
     set_version(version: current_bundle_version,
                 build_number: current_build_number)
 
@@ -52,6 +50,8 @@ platform :ios do
     # set up things so they can run
     authorize_ci_for_keys
     ci_keychains
+    activate_rogue_team
+
 
     # and run
     should_deploy = ENV['run_deploy'] == '1'

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -49,9 +49,8 @@ platform :ios do
     ci_keychains
     activate_rogue_team
 
-    # bump the app version
-    set_version(version: current_bundle_version,
-                build_number: current_build_number)
+    # set the app version
+    set_version
 
     # and run
     should_deploy = ENV['run_deploy'] == '1'
@@ -62,9 +61,10 @@ platform :ios do
     end
   end
 
-  private_lane :set_version do |options|
-    version = options[:version]
-    build = options[:build_number]
+  desc 'Include the build number in the version string'
+  lane :set_version do |options|
+    version = options[:version] || current_bundle_version
+    build = options[:build_number] || current_build_number
     increment_version_number(version_number: "#{version}-build.#{build}",
                              xcodeproj: './ios/AllAboutOlaf.xcodeproj')
     increment_build_number(build_number: build,

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -28,9 +28,6 @@ platform :ios do
     # (more information: https://codesigning.guide)
     match(readonly: true)
 
-    set_version(version: current_bundle_version,
-                build_number: current_build_number)
-
     # Build the app
     gym
   end
@@ -52,6 +49,9 @@ platform :ios do
     ci_keychains
     activate_rogue_team
 
+    # bump the app version
+    set_version(version: current_bundle_version,
+                build_number: current_build_number)
 
     # and run
     should_deploy = ENV['run_deploy'] == '1'


### PR DESCRIPTION
Almost done with these…

The main change here is that I moved `go rogue` out of the `ios build` lane and into the `ci-run` lane.

Drew and I already call `fastlane ios go-rogue` manually, so this just allows Eli / official build people to run their builds through fastlane, too.