### PR TITLE
Fix the when-to-show-checkmarks-in-a-filter-list logic

### DIFF
--- a/source/views/components/filter/section-list.js
+++ b/source/views/components/filter/section-list.js
@@ -72,7 +72,7 @@ export function ListSection({filter, onChange}: PropsType) {
       image={
         spec.showImages && <Image style={styles.icon} source={val.image} />
       }
-      accessory={!includes(selected, val) && 'Checkmark'}
+      accessory={includes(selected, val) && 'Checkmark'}
       cellStyle="RightDetail"
       cellContentView={
         <Column style={styles.content}>


### PR DESCRIPTION
Once upon a time, we had [`source/views/components/filter/section-list.js#L83`](https://github.com/StoDevX/AAO-React-Native/blame/a62628001bbe08f2197949338c22006b2b1a6447/source/views/components/filter/section-list.js#L83).

Then, https://github.com/StoDevX/AAO-React-Native/pull/767 happened, because `react-native-tableview-simple` removed their CustomCell support.

As part of that, I changed the first link into this: [`source/views/components/filter/section-list.js#L75`](https://github.com/StoDevX/AAO-React-Native/blame/e803a55cc1b273f049bcd22799e2b414ff4b81d5/source/views/components/filter/section-list.js#L75).

Before #767, the logic was `<Checkmark transparent={!includes(selected, val)} />` – "hide the checkmark if the item is not in the list.".

After #767, the logic morphed into `accessory={!includes(selected, val) && 'Checkmark'}` – "show the checkmark if the item is not in the list".

So… I just need to invert that check.

Closes #908.