### PR TITLE
Remove google login and courses

### DIFF
--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -6,7 +6,7 @@ import type {TopLevelViewPropsType} from '../types'
 import * as c from '../components/colors'
 
 import CredentialsLoginSection from './sections/login-credentials'
-import TokenLoginSection from './sections/login-token'
+// import TokenLoginSection from './sections/login-token'
 import OddsAndEndsSection from './sections/odds-and-ends'
 import SupportSection from './sections/support'
 

--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -31,8 +31,6 @@ export default function SettingsView(props: SettingsViewPropsType) {
       <TableView>
         <CredentialsLoginSection />
 
-        <TokenLoginSection navigator={props.navigator} route={props.route} />
-
         <SupportSection />
 
         <OddsAndEndsSection navigator={props.navigator} route={props.route} />

--- a/source/views/sis/index.js
+++ b/source/views/sis/index.js
@@ -9,7 +9,7 @@ import React from 'react'
 import type {TopLevelViewPropsType} from '../types'
 import TabbedView from '../components/tabbed-view'
 import BalancesView from './balances'
-import CoursesView from './courses'
+// import CoursesView from './courses'
 // import SearchView from './search'
 
 export default function SISView({navigator, route}: TopLevelViewPropsType) {
@@ -22,12 +22,12 @@ export default function SISView({navigator, route}: TopLevelViewPropsType) {
           icon: 'card',
           component: () => <BalancesView navigator={navigator} route={route} />,
         },
-        {
-          id: 'CoursesView',
-          title: 'Courses',
-          icon: 'archive',
-          component: () => <CoursesView navigator={navigator} route={route} />,
-        },
+        // {
+        //   id: 'CoursesView',
+        //   title: 'Courses',
+        //   icon: 'archive',
+        //   component: () => <CoursesView navigator={navigator} route={route} />,
+        // },
         // {
         //   id: 'CourseSearchView',
         //   title: 'Search',


### PR DESCRIPTION
This removes the Google Login component in `views/settings/index.js` as well as comments out the courses view in SIS. 

> master no longer uses the SIS for financial info, but we won't be able to fill out the Courses tab once Google disables the in-app browser OAuth login.


Closes #978