### PR TITLE
Use proper semver notation for build metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,10 +92,8 @@ before_install:
     fi
 
   # make sure to use ruby 2.3
-  - if [[ $ANDROID || $IOS ]]; then
-      rvm use 2.3 --install --binary --fuzzy;
-      gem install bundler;
-    fi
+  - rvm use 2.3 --install --binary --fuzzy
+  - gem install bundler
 
   # only deploy from the once-daily cron-triggered jobs
   - if [[ $CAN_DEPLOY = yes && $TRAVIS_EVENT_TYPE = cron ]]; then run_deploy=1; fi

--- a/fastlane/platforms/agnostic.rb
+++ b/fastlane/platforms/agnostic.rb
@@ -24,6 +24,24 @@ lane :bump do |options|
   set_package_data(data: { version: new_version })
 end
 
+desc 'Set the build number without changing the version'
+lane :'set-build' do |options|
+  old_version = get_package_key(key: :version)
+  UI.message("Current version: #{old_version}")
+  build = options[:build] || UI.input('Build number to set: ').strip
+  new_version = "#{old_version}+#{build}"
+  UI.message("Setting build number to #{new_version}")
+
+  # update iOS version
+  increment_version_number(version_number: new_version,
+                           xcodeproj: ENV['GYM_PROJECT'])
+  # update Android version
+  set_gradle_version_name(version_name: new_version,
+                          gradle_path: lane_context[:GRADLE_FILE])
+  # update package.json version
+  set_package_data(data: { version: new_version })
+end
+
 desc 'Build the release notes: branch, commit hash, changelog'
 lane :release_notes do |options|
   notes = <<~END

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -39,10 +39,10 @@ platform :android do
   lane :set_version do |options|
     version = options[:version] || current_bundle_version
     build = options[:build_number] || current_build_number
-    set_gradle_version_name(version_name: "#{version}-build.#{build}",
+    set_gradle_version_name(version_name: "#{version}+#{build}",
                             gradle_path: lane_context[:GRADLE_FILE])
     set_gradle_version_code(version_code: build,
                             gradle_path: lane_context[:GRADLE_FILE])
-    set_package_data(data: { version: "#{version}-build.#{build}" })
+    set_package_data(data: { version: "#{version}+#{build}" })
   end
 end

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -70,11 +70,11 @@ platform :ios do
   lane :set_version do |options|
     version = options[:version] || current_bundle_version
     build = options[:build_number] || current_build_number
-    increment_version_number(version_number: "#{version}-build.#{build}",
+    increment_version_number(version_number: "#{version}+#{build}",
                              xcodeproj: ENV['GYM_PROJECT'])
     increment_build_number(build_number: build,
                            xcodeproj: ENV['GYM_PROJECT'])
-    set_package_data(data: { version: "#{version}-build.#{build}" })
+    set_package_data(data: { version: "#{version}+#{build}" })
   end
 
   desc 'Do CI-system keychain setup'

--- a/scripts/travis/deploy-codepush.sh
+++ b/scripts/travis/deploy-codepush.sh
@@ -2,6 +2,7 @@
 set -ev
 set -o pipefail
 
+bundle exec fastlane set-build "build:$TRAVIS_BUILD_NUMBER"
 target_version="~2.1"
 
 echo "releasing codepush for ios"

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -11,6 +11,4 @@ if [[ $JS ]]; then
 fi
 
 # install fastlane
-if [[ $ANDROID || $IOS ]]; then
-  bundle install --deployment
-fi
+bundle install --deployment


### PR DESCRIPTION
> Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version. Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]. Identifiers MUST NOT be empty. Build metadata SHOULD be ignored when determining version precedence. Thus two versions that differ only in the build metadata, have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85.

TL;DR: changing from `v2.1.2-build.234` to `v2.1.2+234`. This allows semver queries to work correctly against our app versions, which Codepush was having a hard time with (it's tricky to match `version-name` semver identifiers.)