### PR TITLE
Fix calendar crash

### DIFF
--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -59,8 +59,8 @@ export class GoogleCalendarView extends React.Component {
       return {
         startTime,
         endTime,
-        summary: event.summary,
-        location: event.location,
+        summary: event.summary || '',
+        location: event.location || '',
         isOngoing: startTime.isBefore(now, 'day'),
         extra: {type: 'google', data: event},
       }

--- a/source/views/calendar/types.js
+++ b/source/views/calendar/types.js
@@ -5,10 +5,10 @@ type GoogleTimeType = {
   dateTime: string,
 }
 export type GoogleEventType = {
-  summary: string,
+  summary?: string,
   start: GoogleTimeType,
   end: GoogleTimeType,
-  location: string,
+  location?: string,
 }
 
 type EmbeddedEventDetailType =

--- a/source/views/calendar/types.js
+++ b/source/views/calendar/types.js
@@ -11,8 +11,7 @@ export type GoogleEventType = {
   location?: string,
 }
 
-type EmbeddedEventDetailType =
-  | {type: 'google', data: GoogleEventType}
+type EmbeddedEventDetailType = {type: 'google', data: GoogleEventType}
 
 export type EventType = {
   summary: string,

--- a/source/views/calendar/types.js
+++ b/source/views/calendar/types.js
@@ -11,27 +11,8 @@ export type GoogleEventType = {
   location: string,
 }
 
-export type PresenceEventType = {
-  uri: string,
-  eventName: string,
-  organizationName: string,
-  organizationUri: string,
-  description: string,
-  location: string,
-  rsvpLink?: string,
-  contactName?: string,
-  contactEmail?: string,
-  hasCoverImage?: boolean,
-  photoType: 'upload' | 'search',
-  photoUriWithVersion: string,
-  startDateTimeUtc: string,
-  endDateTimeUtc: string,
-  tags: string[],
-}
-
 type EmbeddedEventDetailType =
   | {type: 'google', data: GoogleEventType}
-  | {type: 'presence', data: PresenceEventType}
 
 export type EventType = {
   summary: string,


### PR DESCRIPTION
Some Pause event today didn't have a title (what the code calls a "summary".)

So it crashed.

I wonder how many production crashes we've gotten from that so far?

This PR fixes the assumption that we will always have a summary, and removes the `PresenceEvent` types.

Closes #1000.