### PR TITLE
Hide keyboard in dictionary search and scroll

### DIFF
--- a/source/views/components/searchbar/index.ios.js
+++ b/source/views/components/searchbar/index.ios.js
@@ -17,6 +17,7 @@ type PropsType = {
   style?: any,
   placeholder?: string,
   onChangeText: string => any,
+  onSearchButtonPress: string => any,
 }
 
 export const SearchBar = (props: PropsType) => (
@@ -26,5 +27,6 @@ export const SearchBar = (props: PropsType) => (
     hideBackground={true}
     placeholder={props.placeholder || 'Search'}
     onChangeText={props.onChangeText || null}
+    onSearchButtonPress={props.onSearchButtonPress || null}
   />
 )

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -130,6 +130,7 @@ export class DictionaryView extends React.Component {
         <SearchBar
           getRef={ref => (this.searchBar = ref)}
           onChangeText={this.performSearch}
+          // if we don't use the arrow function here, searchBar ref is null...
           onSearchButtonPress={() => this.searchBar.unFocus()}
         />
         <StyledAlphabetListView

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -130,6 +130,7 @@ export class DictionaryView extends React.Component {
         <SearchBar
           getRef={ref => (this.searchBar = ref)}
           onChangeText={this.performSearch}
+          onSearchButtonPress={() => this.searchBar.unFocus()}
         />
         <StyledAlphabetListView
           data={groupBy(this.state.results, item => head(item.word))}
@@ -143,6 +144,8 @@ export class DictionaryView extends React.Component {
           sectionHeaderHeight={headerHeight}
           showsVerticalScrollIndicator={false}
           renderSeparator={this.renderSeparator}
+          keyboardDismissMode="on-drag"
+          keyboardShouldPersistTaps="never"
         />
       </View>
     )


### PR DESCRIPTION
Tweaked the dictionary searching on iOS for a smoother experience.

* Hide the iOS keyboard when hitting the "Search" button
* Dismiss the keyboard when scrolling the search results