### PR TITLE
Remove extraneous newlines from yaml descriptions

### DIFF
--- a/data/contact-info/0-pubsafe.yaml
+++ b/data/contact-info/0-pubsafe.yaml
@@ -2,7 +2,7 @@ title: St. Olaf Public Safety
 phoneNumber: '5077863666'
 buttonText: Call Public Safety
 image: pubsafe.png
-text: >
+text: >-
   24-Hour Public Safety Dispatch. Public safety is availiable 24 hours a day,
   most days of the year. Call public safety in many situations, but there is
   always the option of calling the police as well.

--- a/data/contact-info/2-sarn.yaml
+++ b/data/contact-info/2-sarn.yaml
@@ -2,7 +2,7 @@ title: SARN
 phoneNumber: '5077863777'
 buttonText: Call SARN
 image: sarn.jpg
-text: >
+text: >-
   SARN, the Sexual Assault Resource Network, is a confidential resource
   availiable to all students. Calls to SARN will be picked up by a trained
   advocate to provide services to students struggling with issues of sexual

--- a/data/dictionary/aac.yaml
+++ b/data/dictionary/aac.yaml
@@ -1,5 +1,5 @@
 word: AAC
-definition: >
+definition: >-
   The Academic Advising Center provides support in exploring academic goals
   within the context of possible career and life-long goals. The Center
   supports both faculty advisors and their advisees in providing the necessary

--- a/data/dictionary/ace.yaml
+++ b/data/dictionary/ace.yaml
@@ -1,5 +1,5 @@
 word: ACE
-definition: >
+definition: >-
   Academic Civic Engagement is an approach to teaching and learning that
   encourages students to learn in community contexts. Students consider
   community-based experiences in relation to classroom learning and apply

--- a/data/dictionary/acm.yaml
+++ b/data/dictionary/acm.yaml
@@ -1,5 +1,5 @@
 word: ACM
-definition: >
+definition: >-
   The Association for Computing Machinery is an international organization
   supporting the field of Computer Science. The recently accredited student
   chapter at St. Olaf aims to foster the computing community on campus through

--- a/data/dictionary/adc.yaml
+++ b/data/dictionary/adc.yaml
@@ -1,5 +1,5 @@
 word: ADC
-definition: >
+definition: >-
   ADC stands for the After Dark Committee. As part of the Student Government
   Association, ADC is responsible for planning events for the student body. As
   the name describes, the committee handles events after dark. They plan

--- a/data/dictionary/admissions.yaml
+++ b/data/dictionary/admissions.yaml
@@ -1,4 +1,4 @@
 word: Admissions
-definition: >
+definition: >-
   This is where the St. Olaf journey begins. The Admissions Office guides
   future Ole prospects to see all the good in St. Olaf.

--- a/data/dictionary/agnes-a-cappella.yaml
+++ b/data/dictionary/agnes-a-cappella.yaml
@@ -1,5 +1,5 @@
 word: Agnes A Cappella
-definition: >
+definition: >-
   The female student a cappella group on campus. This is a very competitive
   group to become a part of because they are so highly liked by all of campus.
   The group holds concerts open to the public throughout the year. The campus

--- a/data/dictionary/alias.yaml
+++ b/data/dictionary/alias.yaml
@@ -1,5 +1,5 @@
 word: Alias
-definition: >
+definition: >-
   The term for a group of email addresses made for an easier way to mass
   email. Professors use aliases for easy communication with their classes and
   students use aliases for easy communications with student organizations they

--- a/data/dictionary/amcon.yaml
+++ b/data/dictionary/amcon.yaml
@@ -1,5 +1,5 @@
 word: AmCon
-definition: >
+definition: >-
   Short for American Conversations, an interdisciplinary General Education
   program and learning community in which students analyze America’s history
   and culture. Over four successive semesters in their first and sophomore

--- a/data/dictionary/arms.yaml
+++ b/data/dictionary/arms.yaml
@@ -1,5 +1,5 @@
 word: ARMS
-definition: >
+definition: >-
   “American Racial and Multicultural Studies” is a program committed to the
   study of racial and cultural diversity within the United States. The major
   introduces students to the cultures, histories, and experiences of African

--- a/data/dictionary/asc.yaml
+++ b/data/dictionary/asc.yaml
@@ -1,5 +1,5 @@
 word: ASC
-definition: >
+definition: >-
   The professional and student staff in the Academic Support Center is
   committed to working with students to help facilitate an understanding of
   what it means to fully participate in the academic experience at St. Olaf.

--- a/data/dictionary/asian-conversations.yaml
+++ b/data/dictionary/asian-conversations.yaml
@@ -1,5 +1,5 @@
 word: AsianCon
-definition: >
+definition: >-
   Asian Conversations offers you a dynamic cultural exploration that
   begins with two semesters of Chinese or Japanese language study
   during your first year on campus. During sophomore year you continue

--- a/data/dictionary/basics.yaml
+++ b/data/dictionary/basics.yaml
@@ -1,5 +1,5 @@
 word: BASICS
-definition: >
+definition: >-
   BASICS is a “drinker’s checkup” that helps you examine your use, identify
   changes that could work for you and reduce your risk of future problems.
   It’s not therapy or substance abuse treatment. Any student who’s concerned

--- a/data/dictionary/big-ole.yaml
+++ b/data/dictionary/big-ole.yaml
@@ -1,5 +1,5 @@
 word: Big Ole
-definition: >
+definition: >-
   In 2005 we became the first liberal arts college in the nation to construct
   a utility-grade wind turbine for the sole purpose of providing energy to the
   campus (Carleton College was the first to construct a turbine, but the

--- a/data/dictionary/black-and-gold-gala.yaml
+++ b/data/dictionary/black-and-gold-gala.yaml
@@ -1,5 +1,5 @@
 word: Black and Gold Gala
-definition: >
+definition: >-
   The Alumni Board hosts this annual opportunity for alumni, parents, and
   friends of St. Olaf College to enjoy an evening of dinner and dancing while
   supporting current students. The event also features a silent auction in

--- a/data/dictionary/board-of-regents.yaml
+++ b/data/dictionary/board-of-regents.yaml
@@ -1,5 +1,5 @@
 word: Board of Regents
-definition: >
+definition: >-
   The St. Olaf Board of Regents manages and directs the business and affairs
   of the college. Among its many responsibilities, the board ultimately
   oversees the academic integrity of the college by appointing the president,

--- a/data/dictionary/boe-chapel.yaml
+++ b/data/dictionary/boe-chapel.yaml
@@ -1,5 +1,5 @@
 word: Boe Chapel
-definition: >
+definition: >-
   Dedicated in 1954, Boe is meant to be a place for worship, music, edifying
   convocations, college ceremonies, the arts and private meditation. Daily
   Chapel takes place here during a break from classes.

--- a/data/dictionary/boe-house.yaml
+++ b/data/dictionary/boe-house.yaml
@@ -1,5 +1,5 @@
 word: Boe House
-definition: >
+definition: >-
   Boe House houses the Counseling Center, which was established by St. Olaf
   College to enhance the personal growth and development of its students. The
   Center supports students in their academic pursuits and facilitates personal

--- a/data/dictionary/book.yaml
+++ b/data/dictionary/book.yaml
@@ -1,5 +1,5 @@
 word: Book
-definition: >
+definition: >-
   The official student planner of St. Olaf College. The Book contains college
   policies, schedules, and information related to student life, academic and
   non-academic, at St. Olaf in addition to being a full year, calendar

--- a/data/dictionary/bookstore.yaml
+++ b/data/dictionary/bookstore.yaml
@@ -1,4 +1,4 @@
 word: Bookstore
-definition: >
+definition: >-
   Home to all textbooks, Ole gear, school supplies, and more, the Bookstore is
   conveniently located on the first floor of Buntrock Commons.

--- a/data/dictionary/borsc.yaml
+++ b/data/dictionary/borsc.yaml
@@ -1,5 +1,5 @@
 word: BORSC
-definition: >
+definition: >-
   As a branch of the Student Government Association, the Board of Regents
   Student Committee facilitates communication between the student body and the
   Board of Regents of the college. A primary responsibility of BORSC is to

--- a/data/dictionary/buntrock-commons.yaml
+++ b/data/dictionary/buntrock-commons.yaml
@@ -1,5 +1,5 @@
 word: Buntrock Commons
-definition: >
+definition: >-
   The student center of St. Olaf College. Opened in 1999, it is the central
   gathering place for students. Students get their mail, eat, buy books, meet,
   get involved, host events, and just hang-out here. Check out the “Hi-Mom

--- a/data/dictionary/caf-date.yaml
+++ b/data/dictionary/caf-date.yaml
@@ -1,4 +1,4 @@
 word: Caf Date
-definition: >
+definition: >-
   One of the most common “dates” on campus. Couples can cozy up in the window
   booths or sit in the middle of the Caf for everyone to see!

--- a/data/dictionary/caf.yaml
+++ b/data/dictionary/caf.yaml
@@ -1,5 +1,5 @@
 word: Caf
-definition: >
+definition: >-
   The shortened version of “Cafeteria,” Stav Hall is located on the third
   floor of Buntrock Commons. Students get to dine with the best food in the
   nation.

--- a/data/dictionary/cage.yaml
+++ b/data/dictionary/cage.yaml
@@ -1,5 +1,5 @@
 word: Cage
-definition: >
+definition: >-
   In the center of Buntrock Commons, the campus coffee shop and grill offers
   all-day breakfast, hot and cold sandwiches and plate-sized cookies in a
   lively setting. It’s the perfect place to meet friends or a study group!

--- a/data/dictionary/career-networks-for-oles.yaml
+++ b/data/dictionary/career-networks-for-oles.yaml
@@ -1,5 +1,5 @@
 word: Career Networks for Oles
-definition: >
+definition: >-
   Designed by the Piper Center for Vocation and Career in conjunction with
   President David R. Anderson ’74 and the Office of Alumni and Parent
   Relations. The program connects St. Olaf juniors and seniors with the

--- a/data/dictionary/center-for-arts-and-dance.yaml
+++ b/data/dictionary/center-for-arts-and-dance.yaml
@@ -1,6 +1,6 @@
 word: Center for Arts and Dance
-definition: >
-  Before Buntrock Commons was built, the Center for Arts and Dance housed the 
-  student center. By adding more natural lighting with strategic window placement, 
-  the Center is now home to the Studio Art, Art History and Dance departments. The 
+definition: >-
+  Before Buntrock Commons was built, the Center for Arts and Dance housed the
+  student center. By adding more natural lighting with strategic window placement,
+  the Center is now home to the Studio Art, Art History and Dance departments. The
   building also houses the Flaten Art Museum.

--- a/data/dictionary/christiansen-hall-of-music.yaml
+++ b/data/dictionary/christiansen-hall-of-music.yaml
@@ -1,5 +1,5 @@
 word: Christiansen Hall of Music
-definition: >
+definition: >-
   Christiansen (pronounced kris-tee-AHN-sen) Hall of Music is home to the
   Music Department and the Music Organizations staff that supports concerts
   and tours by the ensembles. Named after St. Olaf Choir founder F. Melius

--- a/data/dictionary/christmas-festival.yaml
+++ b/data/dictionary/christmas-festival.yaml
@@ -1,5 +1,5 @@
 word: Christmas Festival
-definition: >
+definition: >-
   As one of the oldest musical celebrations of Christmas in the United States,
   Christmas Fest was started in 1912 by F. Melius Christiansen, founder of the
   St. Olaf College Music Department. The festival features more than 500

--- a/data/dictionary/club-sports.yaml
+++ b/data/dictionary/club-sports.yaml
@@ -1,5 +1,5 @@
 word: Club Sports
-definition: >
+definition: >-
   An opportunity for athletes to participate in a variety of sports and
   recreational activities that are not a part of the program of NCAA
   intercollegiate sports administered by the St. Olaf Athletics Department.

--- a/data/dictionary/companydance.yaml
+++ b/data/dictionary/companydance.yaml
@@ -1,5 +1,5 @@
 word: Companydance
-definition: >
+definition: >-
   A project-based student dance company that offers a range of performing
   opportunities and is open by audition to all students. The company’s primary
   aesthetic is grounded in the modern dance tradition, but is by no means

--- a/data/dictionary/conversation-tables.yaml
+++ b/data/dictionary/conversation-tables.yaml
@@ -1,4 +1,4 @@
 word: Conversation Tables
-definition: >
+definition: >-
   As part of the Foreign Language GE, students attend weekly dinner tables to
   work on their “conversation” skills in the language they are studying.

--- a/data/dictionary/dac.yaml
+++ b/data/dictionary/dac.yaml
@@ -1,5 +1,5 @@
 word: DAC
-definition: >
+definition: >-
   The Disability and Access Center is located in the ASC and gives students an
   opportunity to access academics differently and work with professional staff
   to establish accommodations with respect to disabilities ranging from

--- a/data/dictionary/daily-chapel.yaml
+++ b/data/dictionary/daily-chapel.yaml
@@ -1,5 +1,5 @@
 word: Daily Chapel
-definition: >
+definition: >-
   With different speakers every day, daily chapel is a time of inspiration for
   body, mind and spirit; a quiet harbor in a busy day; worship. Students,
   faculty and staff witness to their faith and invite the community to join

--- a/data/dictionary/dcc.yaml
+++ b/data/dictionary/dcc.yaml
@@ -1,5 +1,5 @@
 word: DCC
-definition: >
+definition: >-
   The Diversity Celebrations Committee is a branch of the Student Government
   Association (SGA) that provides entertaining and educational experiences
   that support St. Olaf College’s commitment to integrate diverse

--- a/data/dictionary/dean-of-students.yaml
+++ b/data/dictionary/dean-of-students.yaml
@@ -1,5 +1,5 @@
 word: Dean of Students
-definition: >
+definition: >-
   The deans coordinate and direct services and programs designed to assist
   students in taking full advantage of their St. Olaf experience, both in and
   out of the classroom. The Dean of Students Office Suite is home to the Vice

--- a/data/dictionary/deep-end.yaml
+++ b/data/dictionary/deep-end.yaml
@@ -1,5 +1,5 @@
 word: Deep End
-definition: >
+definition: >-
   The two-pronged theater production and student service organization is
   dedicated to providing acting, directing, writing, and technical
   opportunities for students who are not involved in theater department

--- a/data/dictionary/den.yaml
+++ b/data/dictionary/den.yaml
@@ -1,5 +1,5 @@
 word: Den
-definition: >
+definition: >-
   Home to the Lion’s Pause Pool table and Sports Center vibe, the Den is
   located in Buntrock Commons in the Pause where students go to relax, eat,
   and catch the game on TV.

--- a/data/dictionary/dinner-debate.yaml
+++ b/data/dictionary/dinner-debate.yaml
@@ -1,5 +1,5 @@
 word: Dinner Debate
-definition: >
+definition: >-
   The Political Awareness Committee (PAC) plans and hosts dinner debates in
   which students can bring their caf trays and go, listen, and participate in
   debates on a variety of issues on campus.

--- a/data/dictionary/drag-ball.yaml
+++ b/data/dictionary/drag-ball.yaml
@@ -1,5 +1,5 @@
 word: Drag Ball
-definition: >
+definition: >-
   For one night every year, the Drag Ball gives students a chance to abandon
   dress codes, gender roles and inhibitions in celebration of cross-dressing.
   This popular event is hosted in the Pause Mane Stage!

--- a/data/dictionary/e-check-up-to-go.yaml
+++ b/data/dictionary/e-check-up-to-go.yaml
@@ -1,5 +1,5 @@
 word: E-Check Up to Go
-definition: >
+definition: >-
   This is an interactive web survey that allows college and university
   students to enter information about their drinking patterns and receive
   feedback about their use of alcohol. The confidential assessment takes about

--- a/data/dictionary/e-toke.yaml
+++ b/data/dictionary/e-toke.yaml
@@ -1,5 +1,5 @@
 word: E-Toke
-definition: >
+definition: >-
   This is an interactive web survey that allows college and university
   students to enter information about their marijuana habits and receive
   feedback about their use of marijuana. The confidential assessment takes

--- a/data/dictionary/early-music-singers.yaml
+++ b/data/dictionary/early-music-singers.yaml
@@ -1,5 +1,5 @@
 word: Early Music Singers
-definition: >
+definition: >-
   Consists of 14-20 singers and focuses primarily on music of the Medieval,
   Renaissance, and Baroque eras. The choir performs a concert each semester in
   collaboration with the St. Olaf Collegium Musicum, St. Olaf’s early

--- a/data/dictionary/elections.yaml
+++ b/data/dictionary/elections.yaml
@@ -1,4 +1,4 @@
 word: Elections
-definition: >
+definition: >-
   Every fall and spring, the Student Government Association hold elections for
   positions within SGA and Student Senate. Check out Oleville for more info!

--- a/data/dictionary/ellingson.yaml
+++ b/data/dictionary/ellingson.yaml
@@ -1,4 +1,4 @@
 word: Ellingson
-definition: >
+definition: >-
   As a four-story first-year residence hall, Ellingson houses 198 students.
   Spacious lounges enable students to study and relax at ease.

--- a/data/dictionary/encon.yaml
+++ b/data/dictionary/encon.yaml
@@ -1,5 +1,5 @@
 word: EnCon
-definition: >
+definition: >-
   In a world needing to tackle climate change and other
   ecological crises, environmental concerns have become
   relevant for everyone. As such, St. Olaf is proud to

--- a/data/dictionary/fall-concert.yaml
+++ b/data/dictionary/fall-concert.yaml
@@ -1,5 +1,5 @@
 word: Fall Concert
-definition: >
+definition: >-
   Each fall, the Music Entertainment Committee (MEC) hosts an up and coming
   talent concert. Recent fall concerts have been Girl Talk, OK Go, The Hold
   Steady, and Brother Ali.

--- a/data/dictionary/fco.yaml
+++ b/data/dictionary/fco.yaml
@@ -1,5 +1,5 @@
 word: FCO
-definition: >
+definition: >-
   Fellowship of Christian Oles (FCO) is a group of people who gather once a
   week to discuss ideas, worship together, and share in the joy of Christ-
   centered relationships. We are a community striving to live as Christ calls

--- a/data/dictionary/fireside.yaml
+++ b/data/dictionary/fireside.yaml
@@ -1,5 +1,5 @@
 word: Fireside
-definition: >
+definition: >-
   Located on the second floor of Buntrock Commons, it is a place to lounge,
   study, and enjoy yourself. During the winter months, fires can be made in
   the fireplace!

--- a/data/dictionary/fram-fram.yaml
+++ b/data/dictionary/fram-fram.yaml
@@ -1,4 +1,4 @@
 word: Fram! Fram!
-definition: >
+definition: >-
   King Olav’s (Olaf’s) battle cry, “Fram, Fram, Kristmenn, Krossmen” can be
   found on the St. Olaf College crest.

--- a/data/dictionary/fresh-faces.yaml
+++ b/data/dictionary/fresh-faces.yaml
@@ -1,5 +1,5 @@
 word: Fresh Faces
-definition: >
+definition: >-
   A Deep End production for first-years. Fresh Faces is an opportunity to be
   in all first-years cabaret featuring acting scenes, dance numbers, musical
   pieces from popular theater.

--- a/data/dictionary/friday-flowers.yaml
+++ b/data/dictionary/friday-flowers.yaml
@@ -1,5 +1,5 @@
 word: Friday Flowers
-definition: >
+definition: >-
   One of the most popular traditions for students! Each Friday, a local
   florist sells single flowers for students to buy and put in each other’s
   p.o. boxes. The p.o. boxes are wonderful to walk by to see all the flowers

--- a/data/dictionary/global-semester.yaml
+++ b/data/dictionary/global-semester.yaml
@@ -1,5 +1,5 @@
 word: Global Semester
-definition: >
+definition: >-
   One of the most popular and well known study abroad programs. The Global
   Semester is a five-month academic program offering five courses in different
   parts of the world under the supervision of St. Olaf faculty. In cooperation

--- a/data/dictionary/glow.yaml
+++ b/data/dictionary/glow.yaml
@@ -1,5 +1,5 @@
 word: GLOW!
-definition: >
+definition: >-
   Gay, Lesbian, or Whatever! is a student organization comprised of gay,
   lesbian, bisexual, transgender, and heterosexual persons. GLOW! helps to
   educate, provide resources for and foster acceptance and support for self-

--- a/data/dictionary/gospel-choir.yaml
+++ b/data/dictionary/gospel-choir.yaml
@@ -1,4 +1,4 @@
 word: Gospel Choir
-definition: >
+definition: >-
   A choir open to any student who wants to join! Rehearsals are held once a
   week.

--- a/data/dictionary/graduatibility.yaml
+++ b/data/dictionary/graduatibility.yaml
@@ -1,3 +1,3 @@
 word: Graduatibility
-definition: >
+definition: >-
   The ability for one to be able to graduate.

--- a/data/dictionary/great-con.yaml
+++ b/data/dictionary/great-con.yaml
@@ -1,5 +1,5 @@
 word: Great Con
-definition: >
+definition: >-
   An integrated sequence of five courses taken over two years, the Great
   Conversation (Great Con) introduces students to the major epochs of Western
   tradition through direct encounter with significant works. Beginning with

--- a/data/dictionary/green-bikes.yaml
+++ b/data/dictionary/green-bikes.yaml
@@ -1,5 +1,5 @@
 word: Green Bikes
-definition: >
+definition: >-
   The Green Bikes Mechanics team maintains bicycles for use by anyone in the
   St. Olaf community as part of the campus transportation infrastructure.
   These 19 bikes are available for speeding you to class on time, down to

--- a/data/dictionary/health-services.yaml
+++ b/data/dictionary/health-services.yaml
@@ -1,5 +1,5 @@
 word: Health Services
-definition: >
+definition: >-
   Located on the first floor of Tomson Hall, it is staffed by a certified
   family nurse practitioner and support staff who collaborate as needed with
   physicians at the Northfield Hospital Emergency Department. During the

--- a/data/dictionary/her-campus.yaml
+++ b/data/dictionary/her-campus.yaml
@@ -1,5 +1,5 @@
 word: Her Campus
-definition: >
+definition: >-
   A branch of HerCampus.com, this student organization is a weekly online
   magazine for the women of St. Olaf. The organization covers all topics from
   cuties on campus to cooking on campus to the latest and greatest fashion

--- a/data/dictionary/hill-kitt.yaml
+++ b/data/dictionary/hill-kitt.yaml
@@ -1,4 +1,4 @@
 word: HillKitt
-definition: >
+definition: >-
   Because Hilleboe Hall and Kittelsby Hall are connected by the same entrance,
   the 2 halls have received a joint name as well: Hill/Kitt.

--- a/data/dictionary/hill.yaml
+++ b/data/dictionary/hill.yaml
@@ -1,5 +1,5 @@
 word: Hill
-definition: >
+definition: >-
   St. Olaf College sits above the city of Northfield on a hill, so one can
   often hear the college being referred to as the “Hill.” How are things going
   on the Hill today?

--- a/data/dictionary/hilleboe.yaml
+++ b/data/dictionary/hilleboe.yaml
@@ -1,5 +1,5 @@
 word: Hilleboe
-definition: >
+definition: >-
   Hilleboe houses 123 (upper-class) students while maintaining the largest
   triple rooms on campus. The Hilleboe Chapel, study lounges, computer
   facilities, and recreational lounges all provide students with opportunities

--- a/data/dictionary/holland.yaml
+++ b/data/dictionary/holland.yaml
@@ -1,5 +1,5 @@
 word: Holland
-definition: >
+definition: >-
   Home to the Economics, History, Nursing, Philosophy, Political Science,
   Social Work, and Sociology/Anthropology Department, Holland Hall is a Norman
   Gothic building that serves as an architectural landmark on campus. The

--- a/data/dictionary/homecoming.yaml
+++ b/data/dictionary/homecoming.yaml
@@ -1,5 +1,5 @@
 word: Homecoming
-definition: >
+definition: >-
   Every fall the Student Activities Committee (SAC) plans and hosts events,
   games, and activities for students during the week of Homecoming! The Alumni
   Office plans the festive weekend as the St. Olaf Community gathers for a

--- a/data/dictionary/honor-house.yaml
+++ b/data/dictionary/honor-house.yaml
@@ -1,5 +1,5 @@
 word: Honor House
-definition: >
+definition: >-
   The college maintains campus houses that are available for upper-class
   student housing. These houses provide students with alternative
   opportunities to explore and develop interests and personal relationships

--- a/data/dictionary/hoyme.yaml
+++ b/data/dictionary/hoyme.yaml
@@ -1,5 +1,5 @@
 word: Hoyme
-definition: >
+definition: >-
   Hoyme (pronounced Hoy·me) Hall is a four-story hall housing 210 first-year
   students. The main lounge provides a striking view of the surrounding
   countryside as well as a wonderful space for studying and socializing.

--- a/data/dictionary/interim.yaml
+++ b/data/dictionary/interim.yaml
@@ -1,5 +1,5 @@
 word: Interim
-definition: >
+definition: >-
   The Interim is a four-week period of intensive study in one area. Interim
   provides an opportunity for a professor and his or her students to focus
   their entire attention on one course for a full month, to offer a time of

--- a/data/dictionary/intramurals.yaml
+++ b/data/dictionary/intramurals.yaml
@@ -1,5 +1,5 @@
 word: Intramurals
-definition: >
+definition: >-
   For all students who want to participate in some team sport, but maybe want
   something a little less demanding — Intramurals provide weekly games year
   round. Grab a team, sign-up, and play!

--- a/data/dictionary/iso.yaml
+++ b/data/dictionary/iso.yaml
@@ -1,5 +1,5 @@
 word: ISO
-definition: >
+definition: >-
   The International Student Organization serves to facilitate discussions and
   exchanges on a series of cultural, political and personal topics by a series
   of events such as dinners, dances, International Awareness Week and the

--- a/data/dictionary/it.yaml
+++ b/data/dictionary/it.yaml
@@ -1,5 +1,5 @@
 word: IT
-definition: >
+definition: >-
   For all things technical, The Information and Instructional Technologies
   offers a campus-wide network of computing facilities that includes
   Macintosh, PC-compatibles, and UNIX/Linux-based systems. The Helpdesk in

--- a/data/dictionary/jc.yaml
+++ b/data/dictionary/jc.yaml
@@ -1,5 +1,5 @@
 word: JC
-definition: >
+definition: >-
   A Junior Counselor (JC) is an upper-class student who works in a pair to
   build community in first-year residence halls. JC’s are responsible for the
   floor they live on in addition to the overall hall camaraderie.

--- a/data/dictionary/jungle.yaml
+++ b/data/dictionary/jungle.yaml
@@ -1,5 +1,5 @@
 word: Jungle
-definition: >
+definition: >-
   This giant, light-filled room in the Lion’s Pause is the perfect place to
   eat your delicious Pause pizza with your friends! The 2 TVs and booths are
   just a bonus.

--- a/data/dictionary/kierkegaard.yaml
+++ b/data/dictionary/kierkegaard.yaml
@@ -1,5 +1,5 @@
 word: Kierkegaard
-definition: >
+definition: >-
   Søren Aabye Kierkegaard (pronounced Kier·ke·gaard) was a 19th-century Danish
   philosopher. In Rolvaag Memorial Library, The Howard V. and Edna H. Hong
   Kierkegaard Library began as the private collection of its founders who used

--- a/data/dictionary/kildahl.yaml
+++ b/data/dictionary/kildahl.yaml
@@ -1,5 +1,5 @@
 word: Kildahl
-definition: >
+definition: >-
   Kildahl (pronounced Kil·dahl) Hall offers a friendly, comfortable atmosphere
   for 168, first-year students. The main lounge serves as the center of
   community, offering many activities and late night conversations around the

--- a/data/dictionary/kitchen-pause.yaml
+++ b/data/dictionary/kitchen-pause.yaml
@@ -1,5 +1,5 @@
 word: Kitchen (Pause)
-definition: >
+definition: >-
   The student-run, full kitchen offers tasty eats at ridiculously low prices.
   Famous pizzas, quesadillas, shakes, and ice cream all made-to-order! The
   kitchen is open late to serve that “late-night” craving! Hours are Sunday -

--- a/data/dictionary/kittelsby.yaml
+++ b/data/dictionary/kittelsby.yaml
@@ -1,5 +1,5 @@
 word: Kittelsby
-definition: >
+definition: >-
   Kittelsby (pronounced Kittels·bee) Hall houses students 238 (first-year)
   students in triple rooms and is connected to Hilleboe Hall. The unique
   connection to Hilleboe Hall is unlike any of the other first-year dorms.

--- a/data/dictionary/ksto.yaml
+++ b/data/dictionary/ksto.yaml
@@ -1,5 +1,5 @@
 word: KSTO
-definition: >
+definition: >-
   KSTO is a student-run radio station that broadcasts over the airwaves on
   campus at 93.1 FM. Listeners can access KSTO through the online stream and
   through their iPhone application.

--- a/data/dictionary/lair.yaml
+++ b/data/dictionary/lair.yaml
@@ -1,4 +1,4 @@
 word: Lair
-definition: >
+definition: >-
   The small, quaint, transformable room in the Lion’s Pause used for studying
   during the day and events at night!

--- a/data/dictionary/larson.yaml
+++ b/data/dictionary/larson.yaml
@@ -1,4 +1,4 @@
 word: Larson
-definition: >
+definition: >-
   Larson Hall houses 307 upper-class students. The circular arrangement of
   each floor creates a strong community atmosphere.

--- a/data/dictionary/late-night-breakfast.yaml
+++ b/data/dictionary/late-night-breakfast.yaml
@@ -1,5 +1,5 @@
 word: Late night breakfast
-definition: >
+definition: >-
   During finals week, each semester, one night is scheduled for breakfast food
   in Stav served by faculty and staff. This is a great break from studying and
   is one of the students favorite traditions!

--- a/data/dictionary/libraries.yaml
+++ b/data/dictionary/libraries.yaml
@@ -1,5 +1,5 @@
 word: Libraries
-definition: >
+definition: >-
   The St. Olaf collection, housed in three separate libraries (Rølvaag
   Memorial Library, Hustad Science Library, and Halvorson Music Library),
   includes approximately 420,000 books, 22,000 media items, 5000 periodical

--- a/data/dictionary/limestones.yaml
+++ b/data/dictionary/limestones.yaml
@@ -1,5 +1,5 @@
 word: Limestones
-definition: >
+definition: >-
   The famous, seven-voice male a cappella group founded in 1989. The
   Limestones have grown over the years, working through an exciting evolution
   of a cappella singing. They have incorporated a more contemporary pop style

--- a/data/dictionary/mane-stage.yaml
+++ b/data/dictionary/mane-stage.yaml
@@ -1,5 +1,5 @@
 word: Mane Stage
-definition: >
+definition: >-
   The Mane Stage is the Pause’s nightclub venue, hosting late-night events for
   the student body. Modeled after the legendary First Avenue in Minneapolis,
   this space hosts dances, concerts, student performances, and comedians on a

--- a/data/dictionary/manitou-messenger.yaml
+++ b/data/dictionary/manitou-messenger.yaml
@@ -1,5 +1,5 @@
 word: Manitou Messenger
-definition: >
+definition: >-
   Founded in 1887, the student newspaper has an intimate staff and a large
   pool of writers that produce a weekly issue of the paper. The different
   sections cover the many topics of life on campus as well as national and

--- a/data/dictionary/manitou-singers.yaml
+++ b/data/dictionary/manitou-singers.yaml
@@ -1,5 +1,5 @@
 word: Manitou Singers
-definition: >
+definition: >-
   Comprised of select women’s voices from the first year class, Manitou
   (pronounced Man·it·toe) is one of the most popular music organizations on
   the St. Olaf College campus. The 100-voice choir sings at the opening

--- a/data/dictionary/mec.yaml
+++ b/data/dictionary/mec.yaml
@@ -1,5 +1,5 @@
 word: MEC
-definition: >
+definition: >-
   The Music Entertainment Committee, a branch of the Student Government
   Association (SGA), devotes its time to organizing diverse concerts, music
   events, and other forms of music entertainment that cater to the varied

--- a/data/dictionary/mellby.yaml
+++ b/data/dictionary/mellby.yaml
@@ -1,5 +1,5 @@
 word: Mellby
-definition: >
+definition: >-
   Housing 192 upper classmen, Mellby (pronounced Mell·bee) is the oldest
   residence hall on campus and its historic appeal truly stands out. It
   features a kitchen, TV lounge, computer facilities and a large, comfortable

--- a/data/dictionary/mohn.yaml
+++ b/data/dictionary/mohn.yaml
@@ -1,5 +1,5 @@
 word: Mohn
-definition: >
+definition: >-
   One of the two towers on campus, Mohn (pronounced Moan) is a ten-story
   residence hall housing 307 students. The hall, which traditionally houses
   first-year and sophomore students by floor, offers a main lounge, a

--- a/data/dictionary/moodle.yaml
+++ b/data/dictionary/moodle.yaml
@@ -1,5 +1,5 @@
 word: Moodle
-definition: >
+definition: >-
   An online program that faculty and students use for classes. Professors can
   upload a syllabus, calendar, notes, readings, assignments, and quizzes for
   students to access at their convenience.

--- a/data/dictionary/multicultural-affairs.yaml
+++ b/data/dictionary/multicultural-affairs.yaml
@@ -1,5 +1,5 @@
 word: Multicultural Affairs
-definition: >
+definition: >-
   Provides services and assistance to Asian American, African American,
   Hispanic/Latino American, and Native American Students. MCA provides
   academic, financial, personal, career, social counseling and support as

--- a/data/dictionary/natural-lands.yaml
+++ b/data/dictionary/natural-lands.yaml
@@ -1,5 +1,5 @@
 word: Natural Lands
-definition: >
+definition: >-
   In addition to a 300-acre campus, the college owns nearly 700 acres of land
   adjacent to the campus. Most of this land was farmland rented out to local
   farmers. The college, principally through the members of the Biology and the

--- a/data/dictionary/norseman-band.yaml
+++ b/data/dictionary/norseman-band.yaml
@@ -1,5 +1,5 @@
 word: Norseman Band
-definition: >
+definition: >-
   One of two symphonic bands at St. Olaf, Norseman (pronounced Norse·man) has
   developed a reputation in recent years as a dynamic and exciting concert
   ensemble. The 85-piece ensemble performs regularly on campus, and has toured

--- a/data/dictionary/norwegian-sweaters.yaml
+++ b/data/dictionary/norwegian-sweaters.yaml
@@ -1,5 +1,5 @@
 word: Norwegian Sweaters
-definition: >
+definition: >-
   During the weekend of Christmas Festival, the number of Norwegian sweaters
   on campus is extraordinary. Oles of all ages embrace the Norwegian heritage
   while keeping warm! Looking for a Norwegian sweater? Find them in the

--- a/data/dictionary/old-main.yaml
+++ b/data/dictionary/old-main.yaml
@@ -1,5 +1,5 @@
 word: Old Main
-definition: >
+definition: >-
   Built in 1877, Old Main was the first — and originally the only — building
   to occupy Manitou Heights, containing classrooms, a library, housing for
   students and faculty, and a dining room. Newly renovated, Old Main is a

--- a/data/dictionary/ole-ave.yaml
+++ b/data/dictionary/ole-ave.yaml
@@ -1,4 +1,4 @@
 word: Ole Ave
-definition: >
+definition: >-
   St. Olaf Avenue, commonly referred to as “Ole Ave”, runs from campus all the
   way to Highway 3 near downtown Northfield.

--- a/data/dictionary/ole-card.yaml
+++ b/data/dictionary/ole-card.yaml
@@ -1,5 +1,5 @@
 word: Ole card
-definition: >
+definition: >-
   The all-in-one I.D. card for all students. The Ole Card is used to eat meals
   in the Caf, buy coffee and snacks at the Cage, get a sweet treat at the
   Pause, purchase school supplies at the Bookstore, print documents for class,

--- a/data/dictionary/ole-cookie.yaml
+++ b/data/dictionary/ole-cookie.yaml
@@ -1,4 +1,4 @@
 word: Ole cookie
-definition: >
+definition: >-
   Similar to a “monster” cookie, The Cage sells delicious cookies with oats,
   peanut butter, and candy pieces all combined into one giant St. Olaf cookie!

--- a/data/dictionary/ole-spring-relief.yaml
+++ b/data/dictionary/ole-spring-relief.yaml
@@ -1,5 +1,5 @@
 word: Ole Spring Relief
-definition: >
+definition: >-
   The annual, large-scale service trip that takes place over the week of
   spring break. All students have the opportunity to sign-up and take part in
   this great trip!

--- a/data/dictionary/ole-the-lion.yaml
+++ b/data/dictionary/ole-the-lion.yaml
@@ -1,3 +1,3 @@
 word: Ole the lion
-definition: >
+definition: >-
   The beloved mascot of St. Olaf.

--- a/data/dictionary/oleville.yaml
+++ b/data/dictionary/oleville.yaml
@@ -1,4 +1,4 @@
 word: Oleville
-definition: >
+definition: >-
   The official website of the Student Government Association (SGA). Oleville
   explains the various branches of SGA.

--- a/data/dictionary/orgs.yaml
+++ b/data/dictionary/orgs.yaml
@@ -1,5 +1,5 @@
 word: Orgs
-definition: >
+definition: >-
   Student Organizations are known around campus just as “orgs.” To become an
   organization, a club must apply to the Student Organizations Committee
   (SOC). Then, SOC is able to provide funding for the organization.

--- a/data/dictionary/pac.yaml
+++ b/data/dictionary/pac.yaml
@@ -1,5 +1,5 @@
 word: PAC
-definition: >
+definition: >-
   The Political Awareness Committee is a branch of the Student Government
   Association (SGA) and is the primary student promoter of political awareness
   and activity on the St. Olaf campus. Committed to nonpartisan political

--- a/data/dictionary/paccon.yaml
+++ b/data/dictionary/paccon.yaml
@@ -1,5 +1,5 @@
 word: PaCon
-definition: >
+definition: >-
   The Public Affairs Conversation (PaCon) engages students
   and faculty in a search to develop an interdisciplinary
   perspective on American public policy. This yearlong

--- a/data/dictionary/pause.yaml
+++ b/data/dictionary/pause.yaml
@@ -1,5 +1,5 @@
 word: Pause
-definition: >
+definition: >-
   The Lion’s Pause, a branch of the Student Government Association (SGA),is
   most commonly shortened to just the Pause. This is a student-run nightclub
   located on the first floor of Buntrock Commons. Students are lucky to have a

--- a/data/dictionary/pda.yaml
+++ b/data/dictionary/pda.yaml
@@ -1,3 +1,3 @@
 word: PDA
-definition: >
+definition: >-
   President David R. Anderson’s (’74) nickname around campus.

--- a/data/dictionary/pep-band.yaml
+++ b/data/dictionary/pep-band.yaml
@@ -1,5 +1,5 @@
 word: Pep band
-definition: >
+definition: >-
   Provides musical entertainment and lead fan enthusiasm at St. Olaf football
   and basketball games. The students involved are dedicated to enhancing team
   support and the spirit of the crowds at games.

--- a/data/dictionary/piper-center.yaml
+++ b/data/dictionary/piper-center.yaml
@@ -1,5 +1,5 @@
 word: Piper Center
-definition: >
+definition: >-
   Located in Tomson Hall, The Piper Center for Vocation and Career provides
   resources and experiences designed to help students leverage their liberal
   arts education to achieve their full potential. The Piper Center

--- a/data/dictionary/po-box.yaml
+++ b/data/dictionary/po-box.yaml
@@ -1,5 +1,5 @@
 word: PO Box
-definition: >
+definition: >-
   All students get a mailbox that is referred to as their “P.O.” Mailboxes are
   not locked because campus is known for being very safe, as all students are
   respectful of each other.

--- a/data/dictionary/presidents-ball.yaml
+++ b/data/dictionary/presidents-ball.yaml
@@ -1,5 +1,5 @@
 word: President's Ball
-definition: >
+definition: >-
   The President's Ball, otherwise known as Prez Ball, is an annual event
   planned by the Student Activities Committee and enjoyed by students,
   faculty, and staff alike. It is a chance to socialize with the President and

--- a/data/dictionary/pub-safe.yaml
+++ b/data/dictionary/pub-safe.yaml
@@ -1,5 +1,5 @@
 word: Pub Safe
-definition: >
+definition: >-
   Provides 24-hour security services, patrol and response throughout the year.
   Public Safety is dedicated to the safety and protection of the entire St.
   Olaf community. Officers are charged with enforcing college policies as well

--- a/data/dictionary/quad.yaml
+++ b/data/dictionary/quad.yaml
@@ -1,5 +1,5 @@
 word: Quad
-definition: >
+definition: >-
   Behind Buntrock Commons and within the space between Rolvaag, Holland,
   Regents, Tomson, Mellby, the Theater, and Boe, is the area known as the
   Quad. On beautiful, sunny days, students gather to talk, eat, play frisbee,

--- a/data/dictionary/quarry.yaml
+++ b/data/dictionary/quarry.yaml
@@ -1,5 +1,5 @@
 word: Quarry
-definition: >
+definition: >-
   The student-edited fine arts journal that publishes the best of St. Olaf
   students’ literary works and visual art. Fiction, creative non-fiction, and
   poetry are all featured alongside photography, paintings, and other forms of

--- a/data/dictionary/quidditch.yaml
+++ b/data/dictionary/quidditch.yaml
@@ -1,5 +1,5 @@
 word: Quidditch
-definition: >
+definition: >-
   Since St. Olaf so closely resembles Hogwarts, it is only fair that we have a
   Quidditch club! The St. Olaf Quidditch Association brings the wonders of
   Quidditch to the St. Olaf campus on a weekly basis. With pick up games every

--- a/data/dictionary/r-25.yaml
+++ b/data/dictionary/r-25.yaml
@@ -1,5 +1,5 @@
 word: R25
-definition: >
+definition: >-
   The “room scheduling” program for all of campus, excluding the Lion’s Pause.
   This is an easy way to reserve rooms/places on campus from the convenience
   of your own computer.

--- a/data/dictionary/ra.yaml
+++ b/data/dictionary/ra.yaml
@@ -1,4 +1,4 @@
 word: RA
-definition: >
+definition: >-
   A Resident Assistant (RA) is an upper class student who builds community in
   upper-class residence halls.

--- a/data/dictionary/race.yaml
+++ b/data/dictionary/race.yaml
@@ -1,5 +1,5 @@
 word: RACE
-definition: >
+definition: >-
   Race and Ethnic Studies is an interdisciplinary program committed to the
   study of people of color, primarily, though not exclusively, in the United
   States. The major acquaints students with the social, cultural, and

--- a/data/dictionary/rand.yaml
+++ b/data/dictionary/rand.yaml
@@ -1,5 +1,5 @@
 word: Rand
-definition: >
+definition: >-
   Nestled into the north face of Manitou Heights, Rand Hall houses 243 upper-
   classmen. A variety of living options are available in Rand including
   single, double, and quad occupancy rooms. Its suites share their own

--- a/data/dictionary/reading-day.yaml
+++ b/data/dictionary/reading-day.yaml
@@ -1,5 +1,5 @@
 word: Reading Day
-definition: >
+definition: >-
   Before finals start, this day is dedicated to studying. This “free” day
   between when classes and and finals begin is a time for students to recover,
   plan, and study.

--- a/data/dictionary/regents.yaml
+++ b/data/dictionary/regents.yaml
@@ -1,5 +1,5 @@
 word: Regents
-definition: >
+definition: >-
   Firmly rooted in a vision that articulates an integrated approach to the
   study of natural sciences and mathematics, Regents Hall is carrying the
   sciences at St. Olaf deep into the 21st century, housed in inspiring and

--- a/data/dictionary/residence-life.yaml
+++ b/data/dictionary/residence-life.yaml
@@ -1,5 +1,5 @@
 word: Residence Life
-definition: >
+definition: >-
   St. Olaf’s beautiful residential campus is a center for academic, social,
   cultural, and recreational activities. The Residence Life Office strives to
   engage, motivate, and challenge students in 11 residence halls and 21 honor

--- a/data/dictionary/rms.yaml
+++ b/data/dictionary/rms.yaml
@@ -1,5 +1,5 @@
 word: RMS
-definition: >
+definition: >-
   The Regents Hall of Mathematical Sciences (RMS) is the 6 floor building
   connected by tunnel between Tomson Hall and the rest of Regents. It is home
   to the offices for the mathematics, statistics, and computer science

--- a/data/dictionary/rolvaag.yaml
+++ b/data/dictionary/rolvaag.yaml
@@ -1,5 +1,5 @@
 word: Rølvaag
-definition: >
+definition: >-
   Named for the Norwegian immigrant, Ole E. Rølvaag (pronounced Røl·vaag)
   (1876-1931), novelist, educator, and St. Olaf graduate, Rølvaag Memorial
   Library was completed in 1942 and is the main library on campus. The many

--- a/data/dictionary/room-draw.yaml
+++ b/data/dictionary/room-draw.yaml
@@ -1,5 +1,5 @@
 word: Room Draw
-definition: >
+definition: >-
   Process in which students sign up for housing for the next year. Towards the
   end of the school year, students receive a room draw “number” in their P.O.
   and that number will determine the order in which they are eligible to

--- a/data/dictionary/sac.yaml
+++ b/data/dictionary/sac.yaml
@@ -1,5 +1,5 @@
 word: SAC
-definition: >
+definition: >-
   The Student Activities Committee branch of SGA organizes diverse events and
   activities that cater to the varied interests of students. SAC provides
   students with unique escapes from their academic responsibilities. SAC

--- a/data/dictionary/sarn.yaml
+++ b/data/dictionary/sarn.yaml
@@ -1,5 +1,5 @@
 word: SARN
-definition: >
+definition: >-
   The Sexual Assault Resource Network takes a stand against sexual assault and
   intimate violence on campus through supporting survivors and raising
   awareness in the college community. SARN is a CONFIDENTIAL source on campus

--- a/data/dictionary/sas.yaml
+++ b/data/dictionary/sas.yaml
@@ -1,5 +1,5 @@
 word: SAS
-definition: >
+definition: >-
   The Student Accessibility Services is located in the ASC and gives students
   an opportunity to access academics differently and work with professional
   staff to establish accommodations with respect to disabilities ranging from

--- a/data/dictionary/scared-scriptless.yaml
+++ b/data/dictionary/scared-scriptless.yaml
@@ -1,5 +1,5 @@
 word: Scared Scriptless
-definition: >
+definition: >-
   The student improv group at St. Olaf. Their mission is to entertain the
   community through improvisational theater. In addition, Scared Scriptless
   gives students the opportunity to perform improv theater regardless of their

--- a/data/dictionary/scicon.yaml
+++ b/data/dictionary/scicon.yaml
@@ -1,5 +1,5 @@
 word: SciCon
-definition: >
+definition: >-
   The Science Conversation (SciCon) is a sequence of
   three linked courses (fall, interim, spring) for
   sophomore students. The program brings together

--- a/data/dictionary/senate.yaml
+++ b/data/dictionary/senate.yaml
@@ -1,5 +1,5 @@
 word: Senate
-definition: >
+definition: >-
   The Student Senate provides a venue where elected representatives — Hall
   Senators, special constituency Senators (like Multicultural and Off-Campus),
   faculty committee student participants, and the members of the SGA Executive

--- a/data/dictionary/sga.yaml
+++ b/data/dictionary/sga.yaml
@@ -1,5 +1,5 @@
 word: SGA
-definition: >
+definition: >-
   The Student Government Association (SGA) is lead by students who want to
   make life on campus an adventure for their fellow peers. The ten branches of
   SGA bring concerts, political speakers, diversity celebrations, late-night

--- a/data/dictionary/sis.yaml
+++ b/data/dictionary/sis.yaml
@@ -1,5 +1,5 @@
 word: SIS
-definition: >
+definition: >-
   The Student Information System (pronounced S.I.S.) is an all-in-one place
   for students to register for classes, look at their degree audit and look
   over their financial statements. You can use SIS on your desktop or in this

--- a/data/dictionary/skoglund.yaml
+++ b/data/dictionary/skoglund.yaml
@@ -1,5 +1,5 @@
 word: Skoglund
-definition: >
+definition: >-
   Skoglund hosts varsity basketball and volleyball games in its 2,008-seat
   arena, and its natatorium is home to the men’s and women’s swimming and
   diving teams. Skoglund also has a field house, racquetball courts, wrestling

--- a/data/dictionary/soc.yaml
+++ b/data/dictionary/soc.yaml
@@ -1,5 +1,5 @@
 word: SOC
-definition: >
+definition: >-
   The Student Organization Committee is the branch of SGA that registers
   clubs, making them official Orgs. Orgs can apply to SOC for funding for
   events, speakers, equipment, etc, and also use the SORC poster room to

--- a/data/dictionary/specialty-shake.yaml
+++ b/data/dictionary/specialty-shake.yaml
@@ -1,5 +1,5 @@
 word: Specialty Shake
-definition: >
+definition: >-
   Throughout the year the Pause Kitchen comes up with new “specialty shakes”
   that usually pertain to the month or season. For example, in the fall the
   pumpkin pie shake is a big hit, and in the spring, the shamrock shake is a

--- a/data/dictionary/spring-concert.yaml
+++ b/data/dictionary/spring-concert.yaml
@@ -1,4 +1,4 @@
 word: Spring Concert
-definition: >
+definition: >-
   Just like the fall concert, this event is planned and hosted by MEC and is
   the big hit of the spring!

--- a/data/dictionary/st-olaf-extra.yaml
+++ b/data/dictionary/st-olaf-extra.yaml
@@ -1,5 +1,5 @@
 word: St. Olaf Extra
-definition: >
+definition: >-
   Of the many email alias’ on the Hill, the stolaf-extra alias has to be the
   most active! This list can be used for announcing issues not directly
   related to St. Olaf such as items for sale, houses for rent, wanted-to-buy

--- a/data/dictionary/stogrow.yaml
+++ b/data/dictionary/stogrow.yaml
@@ -1,5 +1,5 @@
 word: STOGROW
-definition: >
+definition: >-
   The Saint Olaf Garden Research and Organic Works (STOGROW) farm project is a
   student-run community initiative. STOGROW’s goals are to practice
   sustainable farming methods; to provide fresh, local vegetables, fruits,

--- a/data/dictionary/student-activities.yaml
+++ b/data/dictionary/student-activities.yaml
@@ -1,5 +1,5 @@
 word: Student Activities
-definition: >
+definition: >-
   Home to the Student Government Association (SGA), the Office of Student
   Activities is always upbeat and full of energy! In addition to housing SGA,
   the office is responsible for helping over 190 student organizations,

--- a/data/dictionary/study-abroad.yaml
+++ b/data/dictionary/study-abroad.yaml
@@ -1,5 +1,5 @@
 word: Study Abroad
-definition: >
+definition: >-
   We are known for plentiful and diverse study abroad programs. Each year,
   more than 800 students study off-campus! Academic programs take place in
   Europe, Asia, the Middle East, Africa, North, South and Central America and

--- a/data/dictionary/swing-club.yaml
+++ b/data/dictionary/swing-club.yaml
@@ -1,5 +1,5 @@
 word: Swing Club
-definition: >
+definition: >-
   An organization for any and all students to learn and have fun swing
   dancing! The club offers lessons each week as well as open social dance
   time. Guest instructors and trips to the cities are also regular special

--- a/data/dictionary/swiped-events.yaml
+++ b/data/dictionary/swiped-events.yaml
@@ -1,5 +1,5 @@
 word: Swiped Events
-definition: >
+definition: >-
   Every ESAC class (Wellness Center/physical education class) requires that
   students go to informational sessions run by the Wellness Center on a
   variety of topics. The Wellness Center representatives will “swipe” the Ole

--- a/data/dictionary/taiko.yaml
+++ b/data/dictionary/taiko.yaml
@@ -1,5 +1,5 @@
 word: Taiko
-definition: >
+definition: >-
   The student-led, Taiko Group was formed in 2004. Taiko is a form of drumming
   that originated in Japan. It developed from the martial arts and is a unique
   rhythmic experience that requires physical and mental agility.

--- a/data/dictionary/tomson.yaml
+++ b/data/dictionary/tomson.yaml
@@ -1,5 +1,5 @@
 word: Tomson
-definition: >
+definition: >-
   Tomson Hall houses the Education Department and the college’s six language
   departments, plus the World Languages Center. Other building occupants
   include offices that serve students, such as Admissions and Financial Aid,

--- a/data/dictionary/ultimate.yaml
+++ b/data/dictionary/ultimate.yaml
@@ -1,5 +1,5 @@
 word: Ultimate
-definition: >
+definition: >-
   St. Olaf has 4 Ultimate teams, both Men’s and Women’s. The top teams compete
   regularly at the national level, while the developmental teams are a great
   opportunity to learn the game and make awesome friends. These teams are open

--- a/data/dictionary/urness.yaml
+++ b/data/dictionary/urness.yaml
@@ -1,4 +1,4 @@
 word: Urness
-definition: >
+definition: >-
   Opera and musical theater productions are staged in this hall in the
   Christiansen Hall of Music.

--- a/data/dictionary/valhalla.yaml
+++ b/data/dictionary/valhalla.yaml
@@ -1,5 +1,5 @@
 word: Valhalla
-definition: >
+definition: >-
   This student conducted and operated band (pronounced Val·halla) is founded
   on the principles of making music, meeting other students, and having fun.
   Each year, Valhalla will open its doors to any student who wants to be part

--- a/data/dictionary/van-go.yaml
+++ b/data/dictionary/van-go.yaml
@@ -1,5 +1,5 @@
 word: Van-GO!
-definition: >
+definition: >-
   This transportation service allows students to reserve rides for: community
   service sites, off-campus student-work assignments, student teaching,
   classes at Carleton, and medical/dental/therapy appointments in town. Van-

--- a/data/dictionary/vegan-cookies.yaml
+++ b/data/dictionary/vegan-cookies.yaml
@@ -1,5 +1,5 @@
 word: Vegan cookies
-definition: >
+definition: >-
   During the school week, The Cage sells cookies made with bananas, oats, and
   chocolate chips. These cookies go fast, so students rush to The Cage after
   classes to make sure they can get one

--- a/data/dictionary/viking-chorus.yaml
+++ b/data/dictionary/viking-chorus.yaml
@@ -1,5 +1,5 @@
 word: Viking Chorus
-definition: >
+definition: >-
   The men’s first-year chorus is made up of 85+ member, 60% of which are not
   music majors. This chorus performs at Homecoming and Family weekend,
   Christmas Festival, and more!

--- a/data/dictionary/viking-theater.yaml
+++ b/data/dictionary/viking-theater.yaml
@@ -1,5 +1,5 @@
 word: Viking Theater
-definition: >
+definition: >-
   The college’s very own movie theater-style room is located in on the first
   floor of Buntrock. The space is perfect for movie showings, big meetings,
   and presentations.

--- a/data/dictionary/volunteer-network.yaml
+++ b/data/dictionary/volunteer-network.yaml
@@ -1,5 +1,5 @@
 word: Volunteer Network
-definition: >
+definition: >-
   The Volunteer Network (VN) is committed to providing volunteer opportunities
   for students that benefit both St. Olaf and the larger community. As a
   branch of the Student Government Association (SGA) the goal of VN is to make

--- a/data/dictionary/week-one.yaml
+++ b/data/dictionary/week-one.yaml
@@ -1,4 +1,4 @@
 word: Week One
-definition: >
+definition: >-
   This is the week in which first-year students get acquainted with campus
   before all the upper-class students arrive back.

--- a/data/dictionary/wellness-center.yaml
+++ b/data/dictionary/wellness-center.yaml
@@ -1,5 +1,5 @@
 word: Wellness Center
-definition: >
+definition: >-
   Serves as a resource to promote awareness and education on issues relating
   to healthy lifestyles. We provide prevention and intervention services for
   alcohol and other drug use and abuse concerns. Student Peer Educators (PE)

--- a/data/dictionary/wind-chime-memorial.yaml
+++ b/data/dictionary/wind-chime-memorial.yaml
@@ -1,5 +1,5 @@
 word: Wind Chime Memorial
-definition: >
+definition: >-
   In the middle of the Quad, stands a beautiful wind chime. Built by members
   of the St. Olaf community over the summer of 2003, this Scandinavian-style
   wooden tower commemorates the lives of students who have died while enrolled

--- a/data/dictionary/work-study.yaml
+++ b/data/dictionary/work-study.yaml
@@ -1,5 +1,5 @@
 word: Work-study
-definition: >
+definition: >-
   It is very common for students to have an on-campus (or off-campus — CBWS)
   “student work” job. These jobs are also known as work-study positions.
   Students are awarded a certain amount of “work-study” allowance from the

--- a/data/dictionary/ytterboe.yaml
+++ b/data/dictionary/ytterboe.yaml
@@ -1,5 +1,5 @@
 word: Ytterboe
-definition: >
+definition: >-
   Ytterboe (pronounced Itt·er·boe) Hall houses 402 students in suites of four
   to ten residents. Each suite (or pod) consists of single and double rooms
   arranged around a common living area. This hall features a beautiful main

--- a/data/dictionary/zero-week.yaml
+++ b/data/dictionary/zero-week.yaml
@@ -1,4 +1,4 @@
 word: Zero Week
-definition: >
+definition: >-
   One week before first-years arrive, faculty and staff get back into the
   swing of things. Lots to do for the upcoming school year!

--- a/data/dictionary/zoom-yah-yah.yaml
+++ b/data/dictionary/zoom-yah-yah.yaml
@@ -1,5 +1,5 @@
 word: Zoom Yah! Yah!
-definition: >
+definition: >-
   Runners from across the country (13 states and Spain) have competed in this
   unique, indoor, full marathon on the Tostrud Center track. Members of the
   women’s cross country and track and field teams host the event as a

--- a/data/transportation/break-airport-shuttles.yaml
+++ b/data/transportation/break-airport-shuttles.yaml
@@ -1,5 +1,5 @@
 name: Break Airport Shuttles
 url: https://northfield.betterez.com/cart/5787e3b01f39300a1a000085
-description: >
+description: >-
   Northfield Lines shuttle operates only immediately before and after break.
   You must buy tickets 48 hours in advance.

--- a/data/transportation/enterprise-car-share.yaml
+++ b/data/transportation/enterprise-car-share.yaml
@@ -1,4 +1,4 @@
 name: Enterprise CarShare
 url: https://www.enterprisecarshare.com/us/en/programs/university/st-olaf.html
-description: >
+description: >-
   Car sharing program for business, school, or personal use.

--- a/data/transportation/first-choice-shuttle.yaml
+++ b/data/transportation/first-choice-shuttle.yaml
@@ -1,5 +1,5 @@
 name: First Choice Shuttle
 url: http://youarriveontime.com
-description: >
+description: >-
   Shuttle service to and from MSP airports, bus and train depots, local
   shuttle, medical appointments, casinos, and package delivery.

--- a/data/transportation/green-bikes.yaml
+++ b/data/transportation/green-bikes.yaml
@@ -1,4 +1,4 @@
 name: Green Bikes
 url: https://wp.stolaf.edu/sa/transportation/greenbikes/
-description: >
+description: >-
   Great green alternative, available for check-out through Rolvaag Library.

--- a/data/transportation/hiawathaland-transit.yaml
+++ b/data/transportation/hiawathaland-transit.yaml
@@ -1,5 +1,5 @@
 name: Hiawathaland Transit
 url: https://wp.stolaf.edu/sa/transportation/localexpressbus/
-description: >
+description: >-
   Free route bus that stops at both colleges, Division Street, Target/Cub, and
   El Tequila/Culvers.

--- a/data/transportation/ride-board.yaml
+++ b/data/transportation/ride-board.yaml
@@ -1,4 +1,4 @@
 name: Ride Board
 url: https://www.stolaf.edu/apps/rideboard/index.cfm?fuseaction=browse
-description: >
+description: >-
   Post a ride or look for a ride with students.


### PR DESCRIPTION
This change attacks content defined in `yaml` with multiple lines. If the YAML multi-line string was defined with `>` and expanded over multiple lines, a new line was automatically appended. By changing it to `>-`, we prevent the new line from appearing.

I have a few changes to make in a separate PR for the contact-info `yaml` definitions. (autocorrect, please stop insisting that yaml is yams)

I noticed this when working on the searchbar for the dictionary and student orgs... the individual result in the list view for "PDA" had a newline that extended below the line divider. It was strange. This fixes that.

Before | After
--- | ---
<img width="487" alt="screen shot 2017-04-30 at 9 13 02 pm" src="https://cloud.githubusercontent.com/assets/5240843/25569726/4aa5111c-2dea-11e7-9928-290f351df94a.png"> | <img width="487" alt="screen shot 2017-04-30 at 9 15 46 pm" src="https://cloud.githubusercontent.com/assets/5240843/25569727/4ab4875a-2dea-11e7-97dc-d1e46af0fb49.png">
![screen shot 2017-04-30 at 11 03 29 pm](https://cloud.githubusercontent.com/assets/5240843/25571055/4f3d8ca4-2df9-11e7-898d-4f13cc44ac15.png) | ![screen shot 2017-04-30 at 11 02 42 pm](https://cloud.githubusercontent.com/assets/5240843/25571056/4f4bca12-2df9-11e7-8b4c-18ec0c7d97f7.png)
