### PR TITLE
Fix the `fastlane register` command + other things

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -73,6 +73,11 @@ Run the appropriate action on CI
 fastlane android set_version
 ```
 Include the build number in the version string
+### android codepush
+```
+fastlane android codepush
+```
+
 
 ----
 
@@ -102,6 +107,11 @@ Provisions the profiles; bumps the build number; builds the app
 fastlane ios rogue-build
 ```
 Build, but for the rogue devs
+### ios rogue-beta
+```
+fastlane ios rogue-beta
+```
+Make a beta, but for the rogue devs
 ### ios beta
 ```
 fastlane ios beta
@@ -112,6 +122,11 @@ Submit a new Beta Build to HockeyApp
 fastlane ios ci-run
 ```
 Run iOS builds or tests, as appropriate
+### ios codepush
+```
+fastlane ios codepush
+```
+
 ### ios set_version
 ```
 fastlane ios set_version

--- a/fastlane/platforms/agnostic.rb
+++ b/fastlane/platforms/agnostic.rb
@@ -3,8 +3,10 @@ desc 'Adds any unregistered devices to the provisioning profile'
 lane :register do
   id = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
   new_devices = get_unprovisioned_devices_from_hockey(app_bundle_id: id)
+  UI.message new_devices
   register_devices(devices: new_devices)
-  match(force: true)
+  match(type: 'development', force: true)
+  match(type: 'adhoc', force: true)
 end
 
 desc 'Bump the version string to a new version'

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -36,6 +36,14 @@ platform :ios do
     build
   end
 
+  desc 'Build, but for the rogue devs'
+  lane :'rogue-beta' do
+    activate_rogue_team
+    match(type: 'adhoc', readonly: true)
+    set_version
+    beta
+  end
+
   desc 'Submit a new Beta Build to HockeyApp'
   lane :beta do
     build

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -36,7 +36,7 @@ platform :ios do
     build
   end
 
-  desc 'Build, but for the rogue devs'
+  desc 'Make a beta, but for the rogue devs'
   lane :'rogue-beta' do
     activate_rogue_team
     match(type: 'adhoc', readonly: true)

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -319,6 +319,20 @@
 			remoteGlobalIDString = DA5891D81BA9A9FC002B4DB2;
 			remoteInfo = RNDeviceInfo;
 		};
+		67FDA43C1EBD2AA700AF0937 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 71D5CCADA66D45008D9A38F2 /* RNVectorIcons.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A39873CE1EA65EE60051E01A;
+			remoteInfo = "RNVectorIcons-tvOS";
+		};
+		67FDA4401EBD2AA700AF0937 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 43E420DADB24468C9E296F25 /* RNVectorIcons.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A39873CE1EA65EE60051E01A;
+			remoteInfo = "RNVectorIcons-tvOS";
+		};
 		78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */;
@@ -479,6 +493,7 @@
 			isa = PBXGroup;
 			children = (
 				0027B0A71D5C82AA00C2B4FD /* libRNVectorIcons.a */,
+				67FDA43D1EBD2AA700AF0937 /* libRNVectorIcons-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -503,6 +518,7 @@
 			isa = PBXGroup;
 			children = (
 				008413791D5C3AC30034750D /* libRNVectorIcons.a */,
+				67FDA4411EBD2AA700AF0937 /* libRNVectorIcons-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1224,6 +1240,20 @@
 			fileType = archive.ar;
 			path = libRNDeviceInfo.a;
 			remoteRef = 3A9B26581DE3709F00B6A428 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		67FDA43D1EBD2AA700AF0937 /* libRNVectorIcons-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRNVectorIcons-tvOS.a";
+			remoteRef = 67FDA43C1EBD2AA700AF0937 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		67FDA4411EBD2AA700AF0937 /* libRNVectorIcons-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRNVectorIcons-tvOS.a";
+			remoteRef = 67FDA4401EBD2AA700AF0937 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		78C398B91ACF4ADC00677621 /* libRCTLinking.a */ = {


### PR DESCRIPTION
This:

- updates the xcodeproj for the recent rn-vector-icons update
- updates the `fastlane register` lane to a) print out the pending devices and b) recreate both the adhoc and development certificates
- adds a `fastlane ios rogue-beta` lane, to release a beta from a local machine