### PR TITLE
fix lookups for flex/meal plan balances

### DIFF
--- a/source/lib/financials/balances.js
+++ b/source/lib/financials/balances.js
@@ -96,11 +96,11 @@ function parseBalancesFromDom(dom: mixed): BalancesOrErrorType {
 }
 
 const lookupHash: Map<RegExp, string> = new Map([
-  [/ flex /i, 'flex'],
-  [/ ole /i, 'ole'],
-  [/ print/i, 'print'],
-  [/daily/i, 'daily'],
-  [/weekly/i, 'weekly'],
+  [/flex/i, 'flex'],
+  [/ole/i, 'ole'],
+  [/print/i, 'print'],
+  [/meals.*day/i, 'daily'],
+  [/meals.*week/i, 'weekly'],
 ])
 
 function rowIntoNamedAmount(row: string): ?[string, string] {


### PR DESCRIPTION
Turns out the the flex dollars row doesn't have a space after the word "flex".

I also updated the daily/weekly meals one to work properly.