### PR TITLE
Disable KSTO url handler error handling

### DIFF
--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -24,18 +24,23 @@ const kstoAppStoreLink = 'itms://itunes.apple.com/us/app/ksto/id953916647'
 const kstoWebPage = 'https://www.stolaf.edu/multimedia/play/embed/ksto.html'
 const image = require('../../../images/streaming/ksto/ksto-logo.png')
 
+/*
+ * I disabled the ga/bugsnag tracking here because dismissing the dialogs
+ * causes us to get an error... and I can't really see how these would fail?
+ */
+
 function kstoWebsite() {
   Linking.openURL(kstoWebPage).catch(err => {
-    tracker.trackException(`opening Android KSTO url: ${err.message}`)
-    bugsnag.notify(err)
+    //tracker.trackException(`opening Android KSTO url: ${err.message}`)
+    //bugsnag.notify(err)
     console.warn('An error occurred opening the Android KSTO url', err)
   })
 }
 
 function iosKstoAppDownload() {
   Linking.openURL(kstoAppStoreLink).catch(err => {
-    tracker.trackException(`opening KSTO download url: ${err.message}`)
-    bugsnag.notify(err)
+    //tracker.trackException(`opening KSTO download url: ${err.message}`)
+    //bugsnag.notify(err)
     console.warn('An error occurred opening the KSTO download url', err)
   })
 }
@@ -50,8 +55,8 @@ function iosKstoApp() {
       return Linking.openURL(kstoProtocol)
     })
     .catch(err => {
-      tracker.trackException(`opening iOS KSTO url: ${err.message}`)
-      bugsnag.notify(err)
+      //tracker.trackException(`opening iOS KSTO url: ${err.message}`)
+      //bugsnag.notify(err)
       console.warn('An error occurred opening the iOS KSTO url', err)
     })
 }

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -16,8 +16,8 @@ import {
 } from 'react-native'
 import {Button} from '../components/button'
 import * as c from '../components/colors'
-import {tracker} from '../../analytics'
-import bugsnag from '../../bugsnag'
+//import {tracker} from '../../analytics'
+//import bugsnag from '../../bugsnag'
 
 const kstoProtocol = 'KSTORadio://'
 const kstoAppStoreLink = 'itms://itunes.apple.com/us/app/ksto/id953916647'


### PR DESCRIPTION
I disabled the ga/bugsnag tracking here because dismissing the dialogs causes us to get an error... and I can't really see how these would fail?

Like… yeah. There's no good way to differentiate between cancelled and other failures, which is (sadly) how things should be – this prevents bad actors from continually presenting you with the [Open URL] box if you cancel it.

Closes #1051