### PR TITLE
Update the URL for the directory to remove a redirect

### DIFF
--- a/source/views/views.js
+++ b/source/views/views.js
@@ -56,7 +56,7 @@ export const allViews: ViewType[] = [
   },
   {
     type: 'url',
-    url: 'https://www.stolaf.edu/personal/directory/index.cfm',
+    url: 'https://www.stolaf.edu/personal/index.cfm',
     view: 'DirectoryView',
     title: 'Directory',
     icon: 'v-card',


### PR DESCRIPTION
When I did the Stalkernet redesign, I updated the folder hierarchy too.

There's no more `/directory` folder; everything just lives in `/personal`, now.

The current URL works – I added a `.htaccess` redirect for it – but there's no reason to follow an extra redirect any longer than we have to.