### PR TITLE
Remove the Pause's calendar

### DIFF
--- a/source/views/calendar/index.js
+++ b/source/views/calendar/index.js
@@ -30,14 +30,6 @@ export default function CalendarPage() {
           ),
         },
         {
-          id: 'PauseCalendarView',
-          title: 'The Pause',
-          icon: 'paw',
-          component: () => (
-            <GoogleCalendarView calendarId="stolaf.edu_qkrej5rm8c8582dlnc28nreboc@group.calendar.google.com" />
-          ),
-        },
-        {
           id: 'NorthfieldCalendarView',
           title: 'Northfield',
           icon: 'pin',


### PR DESCRIPTION
This is their scheduling calendar... it is more for internal use than for our own. It contains times that are relevant to setup/teardown and contains internal gravity forms submissions.

...we also received an app store review saying the times were inaccurate.