### PR TITLE
Update SARN hours

### DIFF
--- a/data/building-hours/7-3-sarn.yaml
+++ b/data/building-hours/7-3-sarn.yaml
@@ -7,7 +7,7 @@ schedule:
     hours:
       - {days: [Mo, We, Fr], from: '10:10am', to: '10:30am'}
       - {days: [Tu], from: '11:10am', to: '11:30am'}
-      - {days: [Th], from: '11:00am', to: '12:35am'}
+      - {days: [Th], from: '11:00am', to: '12:35pm'}
       - {days: [Tu, Su], from: '7:00pm', to: '8:00pm'}
 
   - title: Phone


### PR DESCRIPTION
Community time on Thursday listed SARN being open until 12:35am instead of 12:35pm.