### PR TITLE
Centralize Moment timezones and fix the default rounding

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -6,6 +6,7 @@
 
 // Tweak the global fetch
 import './globalize-fetch'
+import './setup-moment'
 import {tracker} from './analytics'
 import OneSignal from 'react-native-onesignal'
 

--- a/source/setup-moment.js
+++ b/source/setup-moment.js
@@ -1,0 +1,20 @@
+// @flow
+import moment from 'moment-timezone'
+
+// Set our default timezone to "central time"
+moment.tz.setDefault('America/Winnipeg')
+
+// These next values made possible by
+// http://stackoverflow.com/questions/42513276
+
+// Tell Moment to round up, so that Moment will always report the
+// time until something else in a way that matches the clock time.
+// That is, at 5:22pm, Moment will report "8 minutes until 5:30pm"
+// until the clock ticks over to 5:23pm.
+// If we do Math.floor, we go the other direction: it will report
+// "7 minutes until 5:30pm" as soon as 5:22pm starts.
+moment.relativeTimeRounding(Math.ceil)
+
+// Tell Moment that a minute is 60 seconds, for reporting purposes.
+// It defaults to 45 seconds.
+moment.relativeTimeThreshold('s', 60)

--- a/source/views/building-hours/__tests__/moment.helper.js
+++ b/source/views/building-hours/__tests__/moment.helper.js
@@ -2,7 +2,8 @@
 import moment from 'moment-timezone'
 export {moment}
 
+moment.tz.setDefault('America/Winnipeg')
+
 export const dayMoment = (time: string, format: ?string = 'ddd h:mma') =>
-  moment.tz(time, format, false, 'America/Winnipeg')
-export const hourMoment = (time: string) =>
-  moment.tz(time, 'h:mma', false, 'America/Winnipeg')
+  moment(time, format, false)
+export const hourMoment = (time: string) => moment(time, 'h:mma', false)

--- a/source/views/building-hours/building-hours-helpers.js
+++ b/source/views/building-hours/building-hours-helpers.js
@@ -1,6 +1,5 @@
 // @flow
 import moment from 'moment-timezone'
-const CENTRAL_TZ = 'America/Winnipeg'
 const TIME_FORMAT = 'h:mma'
 const RESULT_FORMAT = 'h:mma'
 
@@ -29,10 +28,10 @@ export function parseHours(
     dayOfYear -= 1
   }
 
-  let open = moment.tz(fromTime, TIME_FORMAT, true, CENTRAL_TZ)
+  let open = moment(fromTime, TIME_FORMAT, true)
   open.dayOfYear(dayOfYear)
 
-  let close = moment.tz(toTime, TIME_FORMAT, true, CENTRAL_TZ)
+  let close = moment(toTime, TIME_FORMAT, true)
   close.dayOfYear(dayOfYear)
 
   if (close.isBefore(open)) {

--- a/source/views/building-hours/detail.android.js
+++ b/source/views/building-hours/detail.android.js
@@ -22,8 +22,6 @@ import {
 
 const transparentPixel = require('../../../images/transparent.png')
 
-const CENTRAL_TZ = 'America/Winnipeg'
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -86,8 +84,8 @@ const styles = StyleSheet.create({
 export class BuildingHoursDetailView extends React.Component {
   state: {intervalId: number, now: momentT} = {
     intervalId: 0,
-    // now: moment.tz('Wed 7:25pm', 'ddd h:mma', null, CENTRAL_TZ),
-    now: moment.tz(CENTRAL_TZ),
+    // now: moment('Wed 7:25pm', 'ddd h:mma', null),
+    now: moment(),
   }
 
   componentWillMount() {
@@ -103,7 +101,7 @@ export class BuildingHoursDetailView extends React.Component {
   props: BuildingType
 
   updateTime = () => {
-    this.setState({now: moment.tz(CENTRAL_TZ)})
+    this.setState({now: moment()})
   }
 
   render() {

--- a/source/views/building-hours/detail.ios.js
+++ b/source/views/building-hours/detail.ios.js
@@ -17,7 +17,6 @@ import {
   isBuildingOpenAtMoment,
 } from './building-hours-helpers'
 
-const CENTRAL_TZ = 'America/Winnipeg'
 const transparentPixel = require('../../../images/transparent.png')
 
 const styles = StyleSheet.create({
@@ -61,8 +60,8 @@ const styles = StyleSheet.create({
 export class BuildingHoursDetailView extends React.Component {
   state: {intervalId: number, now: momentT} = {
     intervalId: 0,
-    // now: moment.tz('Wed 7:25pm', 'ddd h:mma', null, CENTRAL_TZ),
-    now: moment.tz(CENTRAL_TZ),
+    // now: moment('Wed 7:25pm', 'ddd h:mma', null),
+    now: moment(),
   }
 
   componentWillMount() {
@@ -78,7 +77,7 @@ export class BuildingHoursDetailView extends React.Component {
   props: BuildingType
 
   updateTime = () => {
-    this.setState({now: moment.tz(CENTRAL_TZ)})
+    this.setState({now: moment()})
   }
 
   render() {

--- a/source/views/building-hours/index.js
+++ b/source/views/building-hours/index.js
@@ -18,7 +18,6 @@ import {data as fallbackBuildingHours} from '../../../docs/building-hours'
 import groupBy from 'lodash/groupBy'
 
 import moment from 'moment-timezone'
-const CENTRAL_TZ = 'America/Winnipeg'
 
 export {BuildingHoursDetailView} from './detail'
 
@@ -37,8 +36,8 @@ export class BuildingHoursView extends React.Component {
   } = {
     error: null,
     loading: true,
-    // now: moment.tz('Wed 7:25pm', 'ddd h:mma', null, CENTRAL_TZ),
-    now: moment.tz(CENTRAL_TZ),
+    // now: moment('Wed 7:25pm', 'ddd h:mma', null),
+    now: moment(),
     buildings: groupBuildings(fallbackBuildingHours),
     intervalId: 0,
   }
@@ -58,7 +57,7 @@ export class BuildingHoursView extends React.Component {
   props: TopLevelViewPropsType
 
   updateTime = () => {
-    this.setState({now: moment.tz(CENTRAL_TZ)})
+    this.setState({now: moment()})
   }
 
   fetchData = async () => {
@@ -83,7 +82,7 @@ export class BuildingHoursView extends React.Component {
     this.setState({
       loading: false,
       buildings: groupBuildings(buildings),
-      now: moment.tz(CENTRAL_TZ),
+      now: moment(),
     })
   }
 

--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -14,7 +14,6 @@ import delay from 'delay'
 import LoadingView from '../components/loading'
 import qs from 'querystring'
 import {GOOGLE_CALENDAR_API_KEY} from '../../lib/config'
-const TIMEZONE = 'America/Winnipeg'
 
 export class GoogleCalendarView extends React.Component {
   state: {
@@ -28,7 +27,7 @@ export class GoogleCalendarView extends React.Component {
     loaded: false,
     refreshing: true,
     error: null,
-    now: moment.tz(TIMEZONE),
+    now: moment(),
   }
 
   componentWillMount() {
@@ -67,7 +66,7 @@ export class GoogleCalendarView extends React.Component {
     })
   }
 
-  getEvents = async (now: moment = moment.tz(TIMEZONE)) => {
+  getEvents = async (now: moment = moment()) => {
     let url = this.buildCalendarUrl(this.props.calendarId)
 
     let data: GoogleEventType[] = []

--- a/source/views/menus/lib/__tests__/find-menu.test.js
+++ b/source/views/menus/lib/__tests__/find-menu.test.js
@@ -2,7 +2,7 @@
 // @flow
 import {findMenu} from '../find-menu'
 import moment from 'moment-timezone'
-const CENTRAL_TZ = 'America/Winnipeg'
+moment.tz.setDefault('America/Winnipeg')
 import type {DayPartsCollectionType} from '../../types'
 import uniqueId from 'lodash/uniqueId'
 
@@ -21,20 +21,20 @@ const generateDayparts: (
 }
 
 it('should return `undefined` if no menus are given', () => {
-  const now = moment.tz('13:30', 'H:mm', true, CENTRAL_TZ)
+  const now = moment('13:30', 'H:mm', true)
   const dayparts = generateDayparts()
   expect(findMenu(dayparts, now)).toBeFalsy()
 })
 
 it('should return the station list if only one is given', () => {
-  const now = moment.tz('8:30', 'H:mm', true, CENTRAL_TZ)
+  const now = moment('8:30', 'H:mm', true)
   const dayparts = generateDayparts({start: '13:00', end: '14:00'})
 
   expect(findMenu(dayparts, now)).toBe(dayparts[0][0])
 })
 
 it('should return the first menu, if `now` is before any open', () => {
-  const now = moment.tz('8:00', 'H:mm', true, CENTRAL_TZ)
+  const now = moment('8:00', 'H:mm', true)
   const dayparts = generateDayparts(
     {start: '10:00', end: '11:00'},
     {start: '12:00', end: '13:00'},
@@ -44,7 +44,7 @@ it('should return the first menu, if `now` is before any open', () => {
 })
 
 it('should return the last menu, if `now` is after all close', () => {
-  const now = moment.tz('18:00', 'H:mm', true, CENTRAL_TZ)
+  const now = moment('18:00', 'H:mm', true)
   const dayparts = generateDayparts(
     {start: '10:00', end: '11:00'},
     {start: '12:00', end: '13:00'},
@@ -54,7 +54,7 @@ it('should return the last menu, if `now` is after all close', () => {
 })
 
 it('should return the menu that is open at the given time', () => {
-  const now = moment.tz('12:30', 'H:mm', true, CENTRAL_TZ)
+  const now = moment('12:30', 'H:mm', true)
   const dayparts = generateDayparts(
     {start: '10:00', end: '11:00'},
     {start: '12:00', end: '13:00'},
@@ -65,7 +65,7 @@ it('should return the menu that is open at the given time', () => {
 })
 
 it('should return the next menu if `now` is between two times', () => {
-  const now = moment.tz('11:30', 'H:mm', true, CENTRAL_TZ)
+  const now = moment('11:30', 'H:mm', true)
   const dayparts = generateDayparts(
     {start: '10:00', end: '11:00'},
     {start: '12:00', end: '13:00'},

--- a/source/views/menus/lib/find-menu.js
+++ b/source/views/menus/lib/find-menu.js
@@ -7,7 +7,6 @@ import type {
   DayPartsCollectionType,
   ProcessedMealType,
 } from '../types'
-const CENTRAL_TZ = 'America/Winnipeg'
 
 export function findMenu(
   dayparts: DayPartsCollectionType,
@@ -61,12 +60,8 @@ function findMenuIndex(dayparts: DayPartMenuType[], now: momentT): number {
   // can query times relative to `now`. Also make sure to set dayOfYear to
   // `now`, so that we don't have our days wandering all over the place.
   const times = dayparts.map(({starttime, endtime}) => ({
-    start: moment
-      .tz(starttime, 'H:mm', true, CENTRAL_TZ)
-      .dayOfYear(now.dayOfYear()),
-    end: moment
-      .tz(endtime, 'H:mm', true, CENTRAL_TZ)
-      .dayOfYear(now.dayOfYear()),
+    start: moment(starttime, 'H:mm', true).dayOfYear(now.dayOfYear()),
+    end: moment(endtime, 'H:mm', true).dayOfYear(now.dayOfYear()),
   }))
 
   // We grab the first meal that ends sometime after `now`. The only time

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -25,7 +25,6 @@ import {AllHtmlEntities} from 'html-entities'
 import {toLaxTitleCase} from 'titlecase'
 import {tracker} from '../../analytics'
 import bugsnag from '../../bugsnag'
-const CENTRAL_TZ = 'America/Winnipeg'
 
 const bonappMenuBaseUrl = 'http://legacy.cafebonappetit.com/api/2/menus'
 const bonappCafeBaseUrl = 'http://legacy.cafebonappetit.com/api/2/cafes'
@@ -50,7 +49,7 @@ export class BonAppHostedMenu extends React.Component {
   } = {
     error: null,
     loading: true,
-    now: moment.tz(CENTRAL_TZ),
+    now: moment(),
     cafeMenu: null,
     cafeInfo: null,
   }
@@ -88,7 +87,7 @@ export class BonAppHostedMenu extends React.Component {
       loading: false,
       cafeMenu,
       cafeInfo,
-      now: moment.tz(CENTRAL_TZ),
+      now: moment(),
     })
   }
 

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -20,7 +20,6 @@ import {upgradeMenuItem, upgradeStation} from './lib/process-menu-shorthands'
 import {data as fallbackMenu} from '../../../docs/pause-menu.json'
 import {tracker} from '../../analytics'
 import bugsnag from '../../bugsnag'
-const CENTRAL_TZ = 'America/Winnipeg'
 
 const githubMenuBaseUrl = 'https://stodevx.github.io/AAO-React-Native'
 
@@ -35,7 +34,7 @@ export class GitHubHostedMenu extends React.Component {
   } = {
     error: null,
     loading: true,
-    now: moment.tz(CENTRAL_TZ),
+    now: moment(),
     foodItems: {},
     corIcons: {},
     meals: [],
@@ -99,7 +98,7 @@ export class GitHubHostedMenu extends React.Component {
           endtime: '23:59',
         },
       ],
-      now: moment.tz(CENTRAL_TZ),
+      now: moment(),
     })
   }
 

--- a/source/views/transportation/bus/bus-line.js
+++ b/source/views/transportation/bus/bus-line.js
@@ -15,7 +15,6 @@ import {ListRow} from '../../components/list'
 import {ListSectionHeader} from '../../components/list'
 
 const TIME_FORMAT = 'h:mma'
-const TIMEZONE = 'America/Winnipeg'
 
 const styles = StyleSheet.create({
   separator: {
@@ -73,11 +72,8 @@ export function BusLine({line, now}: {line: BusLineType, now: moment}) {
           time === false
             ? // either pass `false` through or return a parsed time
               false
-            : moment
-                // interpret in Central time
-                .tz(time, TIME_FORMAT, true, TIMEZONE)
-                // and set the date to today
-                .dayOfYear(now.dayOfYear()),
+            : // set the date to today
+              moment(time, TIME_FORMAT, true).dayOfYear(now.dayOfYear()),
       )
     },
   )

--- a/source/views/transportation/bus/index.js
+++ b/source/views/transportation/bus/index.js
@@ -8,8 +8,6 @@ import {NoticeView} from '../../components/notice'
 
 import {data as defaultBusLines} from '../../../../docs/bus-times.json'
 
-const TIMEZONE = 'America/Winnipeg'
-
 export default class BusView extends React.Component {
   static defaultProps = {
     busLines: defaultBusLines,
@@ -17,7 +15,7 @@ export default class BusView extends React.Component {
 
   state = {
     intervalId: 0,
-    now: moment.tz(TIMEZONE),
+    now: moment(),
   }
 
   componentWillMount() {
@@ -36,12 +34,12 @@ export default class BusView extends React.Component {
   }
 
   updateTime = () => {
-    this.setState({now: moment.tz(TIMEZONE)})
+    this.setState({now: moment()})
   }
 
   render() {
     let {now} = this.state
-    // now = moment.tz('Fri 8:13pm', 'ddd h:mma', true, TIMEZONE)
+    // now = moment('Fri 8:13pm', 'ddd h:mma', true)
     const busLines = this.props.busLines
     const activeBusLine = busLines.find(({line}) => line === this.props.line)
 


### PR DESCRIPTION
This PR does two things:

1. It centralizes all the `moment.tz(CENTRAL_TZ)` stuff that we had scattered _everywhere_ into a central file that the entry point includes
2. It tells Moment to quit rounding minutes, so there are (for example) always 9 minutes between 5:21pm and 5:30pm
    - By default, it changes minutes at the 45-second mark

Closes #807
Appeases @drewvolz 