### PR TITLE
Momentary ceiling

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -6,6 +6,7 @@
 
 // Tweak the global fetch
 import './globalize-fetch'
+import './setup-moment'
 import {tracker} from './analytics'
 import OneSignal from 'react-native-onesignal'
 

--- a/source/setup-moment.js
+++ b/source/setup-moment.js
@@ -1,0 +1,17 @@
+// @flow
+import moment from 'moment-timezone'
+
+// These next values made possible by
+// http://stackoverflow.com/questions/42513276
+
+// Tell Moment to round up, so that Moment will always report the
+// time until something else in a way that matches the clock time.
+// That is, at 5:22pm, Moment will report "8 minutes until 5:30pm"
+// until the clock ticks over to 5:23pm.
+// If we do Math.floor, we go the other direction: it will report
+// "7 minutes until 5:30pm" as soon as 5:22pm starts.
+moment.relativeTimeRounding(Math.ceil)
+
+// Tell Moment that a minute is 60 seconds, for reporting purposes.
+// It defaults to 45 seconds.
+moment.relativeTimeThreshold('s', 60)


### PR DESCRIPTION
This PR tells Moment to quit rounding minutes, so there are (for example) always 9 minutes between 5:21pm and 5:30pm.

By default, Moment changes minutes at the 45-second mark.

Appeases @drewvolz 
Closes nothing