### PR TITLE
Update faqs

### DIFF
--- a/data/faqs.md
+++ b/data/faqs.md
@@ -18,6 +18,4 @@ p {
 </style>
 
 # Known Issues
-- SIS: we're working on a way to have you log into the sis for more than 15 minutes at a time.
 - Building Hours: It reports the 2am buildings as open too often; for instance, the Pause is open on Saturday at 2am, continuing from Friday, but the app reports it as being open on Friday at 2am, as well. This is incorrect.
-- The Cage menu only shows specials: that's a limitation of the data we get from BonApp. SGA is talking with them about providing the rest of the Cage menu. One day, it'll suddenly work!


### PR DESCRIPTION
Removing FAQs about SIS login session and BonApp specials. This should be merged *after* the release of 2.2.3.