### PR TITLE
Remove html from org descriptions

### DIFF
--- a/source/views/student-orgs/clean-org.js
+++ b/source/views/student-orgs/clean-org.js
@@ -23,7 +23,7 @@ export default function cleanOrg(org: StudentOrgType): StudentOrgType {
   const meetings = org.meetings.trim()
   const description = fastGetTrimmedText(org.description)
   let website = org.website.trim()
-  if (website && /^https?:\/\//.test(website)) {
+  if (website && !/^https?:\/\//.test(website)) {
     website = `http://${website}`
   }
 

--- a/source/views/student-orgs/clean-org.js
+++ b/source/views/student-orgs/clean-org.js
@@ -1,5 +1,6 @@
 // @flow
 import type {StudentOrgType} from './types'
+import {fastGetTrimmedText} from '../../lib/html'
 
 export default function cleanOrg(org: StudentOrgType): StudentOrgType {
   const name = org.name.trim()
@@ -20,7 +21,7 @@ export default function cleanOrg(org: StudentOrgType): StudentOrgType {
 
   const category = org.category.trim()
   const meetings = org.meetings.trim()
-  const description = org.description.trim()
+  const description = fastGetTrimmedText(org.description)
   let website = org.website.trim()
   if (website && /^https?:\/\//.test(website)) {
     website = `http://${website}`

--- a/source/views/student-orgs/detail.android.js
+++ b/source/views/student-orgs/detail.android.js
@@ -1,8 +1,7 @@
 // @flow
 import React from 'react'
-import {ScrollView, Text, StyleSheet} from 'react-native'
+import {ScrollView, Text, View, StyleSheet} from 'react-native'
 import moment from 'moment'
-import {HtmlView} from '../components/html-view'
 import {Card} from '../components/card'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
@@ -38,7 +37,9 @@ const styles = StyleSheet.create({
     paddingLeft: 16,
     paddingRight: 16,
     backgroundColor: c.white,
-    height: 200,
+  },
+  descriptionText: {
+    fontSize: 16,
   },
   footer: {
     fontSize: 10,
@@ -136,21 +137,9 @@ export class StudentOrgsDetailView extends React.Component {
 
         {description
           ? <Card header="Description" style={styles.card}>
-              <HtmlView
-                style={styles.description}
-                html={`
-                  <style>
-                    body {
-                      margin: 10px 15px 10px;
-                      font-family: -apple-system;
-                    }
-                    * {
-                      max-width: 100%;
-                    }
-                  </style>
-                  ${description}
-                `}
-              />
+              <View style={styles.description}>
+                <Text style={styles.descriptionText}>{description}</Text>
+              </View>
             </Card>
           : null}
 

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -1,8 +1,7 @@
 // @flow
 import React from 'react'
-import {ScrollView, Text, StyleSheet, Linking} from 'react-native'
+import {ScrollView, Text, View, StyleSheet, Linking} from 'react-native'
 import moment from 'moment'
-import {HtmlView} from '../components/html-view'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
@@ -31,7 +30,9 @@ const styles = StyleSheet.create({
     paddingLeft: 16,
     paddingRight: 16,
     backgroundColor: c.white,
-    height: 200,
+  },
+  descriptionText: {
+    fontSize: 16,
   },
   footer: {
     fontSize: 10,
@@ -127,21 +128,9 @@ export class StudentOrgsDetailView extends React.Component {
 
           {description
             ? <Section header="DESCRIPTION">
-                <HtmlView
-                  style={styles.description}
-                  html={`
-                    <style>
-                      body {
-                        margin: 10px 15px 10px;
-                        font-family: -apple-system;
-                      }
-                      * {
-                        max-width: 100%;
-                      }
-                    </style>
-                    ${description}
-                  `}
-                />
+                <View style={styles.description}>
+                  <Text style={styles.descriptionText}>{description}</Text>
+                </View>
               </Section>
             : null}
 


### PR DESCRIPTION
As far as we can tell, only one org actually uses HTML in their description.

That introduces a ton of complexity, including the inability for us to automatically resize the description field.

It feels weird.