### PR TITLE
Rework the job-link-splitter to not attempt to open newlines

### DIFF
--- a/source/views/sis/student-work/clean-job.js
+++ b/source/views/sis/student-work/clean-job.js
@@ -54,7 +54,7 @@ export function getLinksFromJob(job: JobType) {
 }
 
 function parseLinks(data: string) {
-  const allLinks = data.split(' ')
+  const allLinks = data.split(/\s/)
   if (!allLinks.length) {
     return []
   }


### PR DESCRIPTION
Before, the link extraction logic would include newlines as part of the string that it attempted to open, which led to Safari throwing a tantrum.

This PR changes it to stop at any form of whitespace, instead of just spaces.