### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ before_install:
     fi
 
   # make sure to use ruby 2.3
-  - rvm use ruby-2.4.1 --install --binary --create
+  - rvm use ruby-2.3.1 --install --binary --create
   - gem install bundler
 
   # only deploy from:

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ before_install:
     fi
 
   # make sure to use ruby 2.3
-  - rvm use 2.3 --install --binary --fuzzy
+  - rvm use ruby-2.4.1 --install --binary
   - gem install bundler
 
   # only deploy from:

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ before_install:
     fi
 
   # make sure to use ruby 2.3
-  - rvm use ruby-2.4.1 --install --binary
+  - rvm use ruby-2.4.1 --install --binary --create
   - gem install bundler
 
   # only deploy from:

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -15,4 +15,4 @@ if [[ $TRAVIS_OS_NAME == "osx" ]]; then
 fi
 
 # install fastlane
-bundle install --deployment
+bundle install


### PR DESCRIPTION
4 days ago, in https://github.com/StoDevX/AAO-React-Native/pull/1113, our builds suddenly started failing.

After having no idea what could have changed in the build, since none of the travis-level dependencies had changed, I finally noticed that a previous "good" build was built with Ruby 2.3.4, but the failing builds were using 2.3.4-clang.

<details>
<summary>see screenshots</summary>

<table>
<tr><td><img alt="a screenshot of the good build log" src="https://cloud.githubusercontent.com/assets/464441/26559161/8f35fb9e-4473-11e7-8757-8f25bd685f35.jpg"></td></tr>
<tr><td>a screenshot of the good build log</td></tr>
</table>

<table>
<tr><td><img alt="a screenshot of the bad build log" src="https://cloud.githubusercontent.com/assets/464441/26559164/92327e9e-4473-11e7-8e51-bcd7fb172f49.jpg"></td></tr>
<tr><td>a screenshot of the bad build log</td></tr>
</table>
</details>

Given that, and given that the error message in question involved compiler flags, I assumed that I just needed to force rvm to install the non-clang ruby.

<details>
<summary>see snipped log</summary>

```text
compiling unf.cc
cc1plus: warning: command line option ‘-Wdeclaration-after-statement’ is valid
for C/ObjC but not for C++ [enabled by default]
cc1plus: error: unrecognized command line option ‘-Wshorten-64-to-32’
cc1plus: warning: command line option ‘-Wimplicit-function-declaration’ is valid
for C/ObjC but not for C++ [enabled by default]
cc1plus: error: unrecognized command line option ‘-Wdivision-by-zero’
cc1plus: error: unrecognized command line option ‘-Wextra-tokens’
make: *** [unf.o] Error 1
make failed, exit code 2
```
</details>

I think the magic was removing the `--fuzzy` argument.

Then our Android builds worked!

But… the iOS builds quit working. "Add `--create`," they said. So I added `--create`.

Then I specified the exact ruby version that's preinstalled on the JS machines, so that they don't have to go install it themselves.

Then… somehow, the iOS builds decided to install the gems into a ruby/2.3.0 folder, instead of 2.3.1!

My notes about that debugging read

> this … apparently changes where the gems are installed? My understanding from the docs is that --deployment installs the gems into the project folder, inside vendor/, but removing that flag seems to have allowed fastlane to run again … so idk. Anyway.

So. TL;DR: builds work again. Yay.