### PR TITLE
Remove codepush entirely

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,7 +71,6 @@ project.ext.react = [
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
-apply from: "../../node_modules/react-native-code-push/android/codepush.gradle"
 
 /**
  * Set this to true to create two separate APKs instead of one:
@@ -185,7 +184,6 @@ if (propFile.canRead()) {
 dependencies {
     // please keep this list sorted
     compile project(':bugsnag-react-native')
-    compile project(':react-native-code-push')
     compile project(':react-native-custom-tabs')
     compile project(':react-native-device-info')
     compile project(':react-native-google-analytics-bridge')

--- a/android/app/src/main/java/com/allaboutolaf/MainApplication.java
+++ b/android/app/src/main/java/com/allaboutolaf/MainApplication.java
@@ -19,7 +19,6 @@ import com.geektime.rnonesignalandroid.ReactNativeOneSignalPackage;
 import com.github.droibit.android.reactnative.customtabs.CustomTabsPackage;
 import com.idehub.GoogleAnalyticsBridge.GoogleAnalyticsBridgePackage;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
-import com.microsoft.codepush.react.CodePush;
 import com.oblador.keychain.KeychainPackage;
 import com.oblador.vectoricons.VectorIconsPackage;
 import com.pusherman.networkinfo.RNNetworkInfoPackage;
@@ -34,11 +33,6 @@ public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
-    protected String getJSBundleFile() {
-      return CodePush.getJSBundleFile();
-    }
-
-    @Override
     public boolean getUseDeveloperSupport() {
       return BuildConfig.DEBUG;
     }
@@ -49,7 +43,6 @@ public class MainApplication extends Application implements ReactApplication {
         new MainReactPackage(),
         // please keep these sorted alphabetically
         BugsnagReactNative.getPackage(),
-        new CodePush(getResources().getString(R.string.reactNativeCodePush_androidDeploymentKey), getApplicationContext(), BuildConfig.DEBUG),
         new CustomTabsPackage(),
         new GoogleAnalyticsBridgePackage(),
         new KeychainPackage(),

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
-    <string moduleConfig="true" name="reactNativeCodePush_androidDeploymentKey">5jvlQ5-xBItoSRqf-D-3hqdEsPTLEJN_nzUOz</string>
     <string name="app_name">All About Olaf</string>
 </resources>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,8 +5,6 @@ include ':app'
 include ':bugsnag-react-native'
 project(':bugsnag-react-native').projectDir = new File(rootProject.projectDir, '../node_modules/bugsnag-react-native/android')
 
-include ':react-native-code-push'
-project(':react-native-code-push').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-code-push/android/app')
 
 include ':react-native-custom-tabs'
 project(':react-native-custom-tabs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-custom-tabs/android')

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,7 +5,6 @@ include ':app'
 include ':bugsnag-react-native'
 project(':bugsnag-react-native').projectDir = new File(rootProject.projectDir, '../node_modules/bugsnag-react-native/android')
 
-
 include ':react-native-custom-tabs'
 project(':react-native-custom-tabs').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-custom-tabs/android')
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -78,11 +78,6 @@ Run the appropriate action on CI
 fastlane android set_version
 ```
 Include the build number in the version string
-### android codepush
-```
-fastlane android codepush
-```
-
 ### android matchesque
 ```
 fastlane android matchesque
@@ -122,11 +117,6 @@ Upload dYSM symbols to Bugsnag from Apple
 fastlane ios ci-run
 ```
 Run iOS builds or tests, as appropriate
-### ios codepush
-```
-fastlane ios codepush
-```
-
 ### ios set_version
 ```
 fastlane ios set_version

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -68,11 +68,3 @@ def auto_beta
 
   beta #if last_commit != current_commit
 end
-
-def codepush_cli(app:, channel: 'nightly', install_target: '~2.3 || ~2.3.0-beta')
-  target = "--targetBinaryVersion '#{install_target}'"
-  # `fastlane x` runs in the ./fastlane folder, so we have to go up a level
-  Dir.chdir("..") do
-    sh("code-push release-react '#{app}' ios -d '#{channel}' #{target}")
-  end
-end

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -8,7 +8,7 @@ platform :android do
            build_type: 'Release',
            print_command: true,
            print_command_output: true)
-    
+
     UI.message lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS]
   end
 
@@ -42,7 +42,6 @@ platform :android do
     should_deploy = ENV['run_deploy'] == '1'
     if should_deploy
       auto_beta
-      codepush
     else
       build
     end
@@ -54,10 +53,6 @@ platform :android do
     set_gradle_version_name(version_name: version,
                             gradle_path: lane_context[:GRADLE_FILE])
     set_package_data(data: { version: "#{version}" })
-  end
-
-  lane :codepush do
-    codepush_cli(app: 'AllAboutOlaf-Android')
   end
 
   desc 'extract the android keys from the match repo'

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -55,14 +55,9 @@ platform :ios do
     should_deploy = ENV['run_deploy'] == '1'
     if should_deploy
       auto_beta
-      codepush
     else
       build
     end
-  end
-
-  lane :codepush do
-    codepush_cli(app: 'AllAboutOlaf-iOS')
   end
 
   desc 'Include the build number in the version string'
@@ -84,7 +79,7 @@ platform :ios do
     create_keychain(name: keychain,
                     password: password,
                     timeout: 3600)
-    
+
     # Set up code signing correctly
     # (more information: https://codesigning.guide)
     match(type: 'appstore', readonly: true)

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -41,7 +41,6 @@
 		9304AFEA1BEF4D77A9BE9E47 /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EFDF596D3434455B7F672D3 /* libRNVectorIcons.a */; };
 		9E5D73F8D3CC4F7499359624 /* libRNNetworkInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C476D4877F945308C96FF0F /* libRNNetworkInfo.a */; };
 		A0102781BF874C25BD76AD1D /* libRNDeviceInfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A2D51A8982104BF29657933B /* libRNDeviceInfo.a */; };
-		A3D56267BEA24AB583A6D2A2 /* libCodePush.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E90E6CCE2A464D80BE6D83B2 /* libCodePush.a */; };
 		A90299E6C1BD45C385BBF8F0 /* libDBCustomTabs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D222CA78E6554BBB83448435 /* libDBCustomTabs.a */; };
 		BBDFD91C684046CB9FD0CD55 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 742B362B86E443C09A7F9FD9 /* Entypo.ttf */; };
 /* End PBXBuildFile section */
@@ -257,13 +256,6 @@
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RNSearchBar;
 		};
-		00D67CC91E5005DF00379DD7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = AECB3DDD098E445D8AB3555F /* CodePush.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 134814201AA4EA6300B7C361;
-			remoteInfo = CodePush;
-		};
 		00DE0C341E7C3087005F3CE3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 59C781128E0B476A8826CD12 /* BugsnagReactNative.xcodeproj */;
@@ -392,7 +384,6 @@
 		9C476D4877F945308C96FF0F /* libRNNetworkInfo.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNNetworkInfo.a; sourceTree = "<group>"; };
 		A2D51A8982104BF29657933B /* libRNDeviceInfo.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNDeviceInfo.a; sourceTree = "<group>"; };
 		A91038679F834707B769D282 /* RNKeychain.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNKeychain.xcodeproj; path = "../node_modules/react-native-keychain/RNKeychain.xcodeproj"; sourceTree = "<group>"; };
-		AECB3DDD098E445D8AB3555F /* CodePush.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = CodePush.xcodeproj; path = "../node_modules/react-native-code-push/ios/CodePush.xcodeproj"; sourceTree = "<group>"; };
 		B4920CEFDAA947C8B63B7C8B /* libBugsnagReactNative.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libBugsnagReactNative.a; sourceTree = "<group>"; };
 		BC36B827687E41ADA029DA16 /* libRNSearchBar.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNSearchBar.a; sourceTree = "<group>"; };
 		C1122D5F37D247E09037EE31 /* BVLinearGradient.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = BVLinearGradient.xcodeproj; path = "../node_modules/react-native-linear-gradient/BVLinearGradient.xcodeproj"; sourceTree = "<group>"; };
@@ -403,7 +394,6 @@
 		D530CE76BA714A59B2BECB28 /* libSafariViewManager.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libSafariViewManager.a; sourceTree = "<group>"; };
 		E288E9E30083441F948E40BF /* RNSearchBar.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSearchBar.xcodeproj; path = "../node_modules/react-native-search-bar/RNSearchBar.xcodeproj"; sourceTree = "<group>"; };
 		E6FBE71A05CC43E2B4885180 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
-		E90E6CCE2A464D80BE6D83B2 /* libCodePush.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libCodePush.a; sourceTree = "<group>"; };
 		F803FE6585F04E9F8D3C053F /* libRCTGoogleAnalyticsBridge.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTGoogleAnalyticsBridge.a; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -439,7 +429,6 @@
 				1848577634C04472802C4F91 /* libRCTGoogleAnalyticsBridge.a in Frameworks */,
 				37755BD2F66641FB97979B7E /* libRCTOneSignal.a in Frameworks */,
 				24C1AB28D1424CD095CB8582 /* libRNKeychain.a in Frameworks */,
-				A3D56267BEA24AB583A6D2A2 /* libCodePush.a in Frameworks */,
 				56DC65C1BF07427AA1F84CFC /* libSafariViewManager.a in Frameworks */,
 				A90299E6C1BD45C385BBF8F0 /* libDBCustomTabs.a in Frameworks */,
 				570ACE6B68F941838FFABAA9 /* libRNViewShot.a in Frameworks */,
@@ -595,14 +584,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		00D67CC61E5005DF00379DD7 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				00D67CCA1E5005DF00379DD7 /* libCodePush.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		00DE0C311E7C3087005F3CE3 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -727,7 +708,6 @@
 				36AB9BDB6CF1449E997C6D74 /* AirMaps.xcodeproj */,
 				59C781128E0B476A8826CD12 /* BugsnagReactNative.xcodeproj */,
 				C1122D5F37D247E09037EE31 /* BVLinearGradient.xcodeproj */,
-				AECB3DDD098E445D8AB3555F /* CodePush.xcodeproj */,
 				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
 				3A0CEA711DEA20340036E739 /* RCTAnimation.xcodeproj */,
 				00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */,
@@ -878,10 +858,6 @@
 				{
 					ProductGroup = 00CF91E61E770EF900DD9CBC /* Products */;
 					ProjectRef = C1122D5F37D247E09037EE31 /* BVLinearGradient.xcodeproj */;
-				},
-				{
-					ProductGroup = 00D67CC61E5005DF00379DD7 /* Products */;
-					ProjectRef = AECB3DDD098E445D8AB3555F /* CodePush.xcodeproj */;
 				},
 				{
 					ProductGroup = 00C302A81ABCB8CE00DB3ED1 /* Products */;
@@ -1188,13 +1164,6 @@
 			remoteRef = 00D4C3481EB97C9900733278 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		00D67CCA1E5005DF00379DD7 /* libCodePush.a */ = {
-			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libCodePush.a;
-			remoteRef = 00D67CC91E5005DF00379DD7 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		00DE0C351E7C3087005F3CE3 /* libBugsnagReactNative.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -1423,7 +1392,6 @@
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
 					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
@@ -1469,7 +1437,6 @@
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
 					"$(SRCROOT)/../node_modules/react-native-view-shot/ios",
@@ -1543,7 +1510,6 @@
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
 				);
@@ -1596,7 +1562,6 @@
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",
 					"$(SRCROOT)/../node_modules/react-native-google-analytics-bridge/ios/RCTGoogleAnalyticsBridge/**",
 					"$(SRCROOT)/../node_modules/react-native-onesignal/ios/**",
-					"$(SRCROOT)/../node_modules/react-native-code-push/ios/CodePush/**",
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
 				);

--- a/ios/AllAboutOlaf/AppDelegate.m
+++ b/ios/AllAboutOlaf/AppDelegate.m
@@ -8,7 +8,6 @@
  */
 
 #import "AppDelegate.h"
-#import <CodePush/CodePush.h>
 #import <BugsnagReactNative/BugsnagReactNative.h>
 
 #import <React/RCTBundleURLProvider.h>
@@ -24,13 +23,8 @@
 {
   NSURL *jsCodeLocation;
 
-#ifdef DEBUG
     jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios"
                                                                     fallbackResource:nil];
-#else
-    jsCodeLocation = [CodePush bundleURL];
-#endif
-
 #ifndef DEBUG
   [BugsnagReactNative start];
 #endif

--- a/ios/AllAboutOlaf/AppDelegate.m
+++ b/ios/AllAboutOlaf/AppDelegate.m
@@ -23,7 +23,7 @@
 {
   NSURL *jsCodeLocation;
 
-    jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios"
+  jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios"
                                                                     fallbackResource:nil];
 #ifndef DEBUG
   [BugsnagReactNative start];

--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -35,8 +35,6 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>6</string>
-	<key>CodePushDeploymentKey</key>
-	<string>oSozdf5RtDr2j8T7PFz-oWgNmoBIEJN_nzUOz</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/package.json
+++ b/package.json
@@ -31,18 +31,6 @@
     "validate-data": "node scripts/validate-data.js",
     "version": "bundle exec fastlane propagate-version && git add ios/ android/"
   },
-  "codepush": {
-    "ios": {
-      "release": "oSozdf5RtDr2j8T7PFz-oWgNmoBIEJN_nzUOz",
-      "staging": "wU8CTAoyYARqbOBVPXo6kWm7iq8CEJN_nzUOz",
-      "nightly": "lkDky5WyEEILExg-RWX6ymfrJDn6EJN_nzUOz"
-    },
-    "android": {
-      "release": "5jvlQ5-xBItoSRqf-D-3hqdEsPTLEJN_nzUOz",
-      "staging": "GsN8Ii8enIpe8dVijiFQWZ743lV_EJN_nzUOz",
-      "nightly": "cMzHZZ5aUuk0ILftVFFwJvZLxiycEJN_nzUOz"
-    }
-  },
   "babel": {
     "presets": [
       "react-native"
@@ -85,7 +73,6 @@
     "react-native": "0.42.3",
     "react-native-alphabetlistview": "github:sunnylqm/react-native-alphabetlistview#aea5d61fdd9034c7178d73ce8b2ee104da6941cc",
     "react-native-button": "1.8.2",
-    "react-native-code-push": "1.17.3-beta",
     "react-native-communications": "2.2.1",
     "react-native-custom-tabs": "0.1.4",
     "react-native-device-info": "0.10.2",

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -4,12 +4,6 @@ set -e -v
 # install packages
 npm install
 
-# install code-push
-if [[ $IOS || $ANDROID ]]; then
-  npm install -g code-push-cli@latest
-  code-push login --accessKey "$CODEPUSH_TOKEN"
-fi
-
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
   brew install imagemagick
 fi

--- a/source/lib/refresh.js
+++ b/source/lib/refresh.js
@@ -1,10 +1,8 @@
 // @flow
 import {clearAsyncStorage} from './storage'
-import codePush from 'react-native-code-push'
 import {clearLoginCredentials} from './login'
 
 export async function refreshApp() {
   await clearAsyncStorage()
   await clearLoginCredentials()
-  codePush.restartApp()
 }

--- a/source/root.js
+++ b/source/root.js
@@ -2,25 +2,9 @@
 
 import {AppRegistry} from 'react-native'
 import App from './app'
-import codePush from 'react-native-code-push'
 
 // I'm not importing the exported variable because I just want to initialize
 // the file here.
 import './bugsnag'
 
-let codePushOptions = {
-  checkFrequency: codePush.CheckFrequency.ON_APP_RESUME,
-  installMode: codePush.InstallMode.ON_NEXT_RESTART,
-}
-
-if (process.env.NODE_ENV !== 'production') {
-  // essentially disable codepush on dev mode
-  codePushOptions = {
-    checkFrequency: codePush.CheckFrequency.MANUAL,
-    installMode: codePush.InstallMode.ON_NEXT_RESTART,
-  }
-}
-
-AppRegistry.registerComponent('AllAboutOlaf', () =>
-  codePush(codePushOptions)(App),
-)
+AppRegistry.registerComponent('AllAboutOlaf', () => App)

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -1,9 +1,8 @@
 // @flow
 import React from 'react'
 import {View} from 'react-native'
-import {getVersion} from 'react-native-device-info'
 import {Cell, Section} from 'react-native-tableview-simple'
-import {allaboutolaf} from '../../../../package.json'
+import {version, allaboutolaf} from '../../../../package.json'
 import type {TopLevelViewPropsType} from '../../types'
 import {setFeedbackStatus} from '../../../flux/parts/settings'
 import {connect} from 'react-redux'
@@ -41,8 +40,6 @@ class OddsAndEndsSection extends React.Component {
       ? '[dev] '
       : allaboutolaf.source ? `[${allaboutolaf.source}] ` : ''
 
-    const versionString = getVersion()
-
     return (
       <View>
         <Section header="MISCELLANY">
@@ -59,7 +56,7 @@ class OddsAndEndsSection extends React.Component {
           <Cell
             cellStyle="RightDetail"
             title="Version"
-            detail={`${versionMoniker}${versionString}`}
+            detail={`${versionMoniker}${version}`}
           />
 
           <CellToggle

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -3,7 +3,7 @@ import React from 'react'
 import {View} from 'react-native'
 import {getVersion} from 'react-native-device-info'
 import {Cell, Section} from 'react-native-tableview-simple'
-import {version, allaboutolaf} from '../../../../package.json'
+import {allaboutolaf} from '../../../../package.json'
 import type {TopLevelViewPropsType} from '../../types'
 import {setFeedbackStatus} from '../../../flux/parts/settings'
 import {connect} from 'react-redux'
@@ -41,11 +41,7 @@ class OddsAndEndsSection extends React.Component {
       ? '[dev] '
       : allaboutolaf.source ? `[${allaboutolaf.source}] ` : ''
 
-    //    native (codepush)
-    // eg, 2.1.2 (2.1.2+2957)
-    const versionString = getVersion() === version
-      ? getVersion()
-      : `${getVersion()} (${version})`
+    const versionString = getVersion()
 
     return (
       <View>

--- a/source/views/settings/sections/support.js
+++ b/source/views/settings/sections/support.js
@@ -5,6 +5,7 @@ import {Section} from 'react-native-tableview-simple'
 import type {TopLevelViewPropsType} from '../../types'
 import Communications from 'react-native-communications'
 import DeviceInfo from 'react-native-device-info'
+import {version} from '../../../../package.json'
 import {PushButtonCell} from '../components/push-button'
 import {refreshApp} from '../../../lib/refresh'
 
@@ -24,7 +25,7 @@ export default class SupportSection extends React.Component {
       ----- Please do not edit below here -----
       ${DeviceInfo.getBrand()} ${DeviceInfo.getModel()}
       ${DeviceInfo.getDeviceId()}
-      ${DeviceInfo.getSystemName()} ${DeviceInfo.getSystemVersion()}
+      ${DeviceInfo.getSystemName()} ${version}
       ${DeviceInfo.getReadableVersion()}
     `
 

--- a/source/views/settings/sections/support.js
+++ b/source/views/settings/sections/support.js
@@ -5,7 +5,6 @@ import {Section} from 'react-native-tableview-simple'
 import type {TopLevelViewPropsType} from '../../types'
 import Communications from 'react-native-communications'
 import DeviceInfo from 'react-native-device-info'
-import {version} from '../../../../package.json'
 import {PushButtonCell} from '../components/push-button'
 import {refreshApp} from '../../../lib/refresh'
 
@@ -27,7 +26,6 @@ export default class SupportSection extends React.Component {
       ${DeviceInfo.getDeviceId()}
       ${DeviceInfo.getSystemName()} ${DeviceInfo.getSystemVersion()}
       ${DeviceInfo.getReadableVersion()}
-      Codepush: ${version}
     `
 
   openEmail = () => {


### PR DESCRIPTION
This removes the codepush package from the repository. The app builds and runs on iOS and Android still -- so everything works as it did before. 

We will need to add a way to refresh the app state (something a codepush reset previously did) which will be tracked in https://github.com/StoDevX/AAO-React-Native/issues/1135.

Closes #1131.