### PR TITLE
Only install codepush for deploy builds

### DIFF
--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -4,8 +4,8 @@ set -e -v
 # install packages
 npm install
 
-# install code-push
-if [[ $IOS || $ANDROID ]]; then
+# install code-push, if we're going to use it
+if [[ ( $IOS || $ANDROID ) && $run_deploy == 1 ]]; then
   npm install -g code-push-cli@latest
   code-push login --accessKey "$CODEPUSH_TOKEN"
 fi


### PR DESCRIPTION
This will buy us some time by making the CI pass again, but it's not as ideal as #1134.

We'll still fail when we try to release a new version or beta.