### PR TITLE
clean up calendar times

### DIFF
--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -88,8 +88,8 @@ function CalendarTimes({event, style}: {event: EventType, style: any}) {
     )
   }
 
-  let startTime = event.startTime.format('h:mm A')
-  let endTime = event.endTime.format('h:mm A')
+  let startTimeFormatted = event.startTime.format('h:mm A')
+  let endTimeFormatted = event.endTime.format('h:mm A')
   let midnightTime = '12:00 AM'
 
   let start, end
@@ -99,15 +99,17 @@ function CalendarTimes({event, style}: {event: EventType, style: any}) {
   } else if (multiDay) {
     // 12:00 PM to Jun. 25 3:00pm
     // Midnight to Jun. 25 <-- assuming the end time is also midnight
-    start = event.startTime.format('h:mm A')
-    const endFormat = endTime === midnightTime ? 'MMM. D' : 'MMM. D h:mm A'
+    start = startTimeFormatted
+    const endFormat = endTimeFormatted === midnightTime
+      ? 'MMM. D'
+      : 'MMM. D h:mm A'
     end = `to ${event.endTime.format(endFormat)}`
   } else if (sillyZeroLength) {
-    start = event.startTime.format('h:mm A')
+    start = startTimeFormatted
     end = 'until ???'
   } else {
-    start = event.startTime.format('h:mm A')
-    end = event.endTime.format('h:mm A')
+    start = startTimeFormatted
+    end = endTimeFormatted
   }
 
   start = start === midnightTime ? 'Midnight' : start

--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -40,7 +40,7 @@ export default function EventRow({
   onPress: () => any,
 }) {
   const title = fastGetTrimmedText(event.summary)
-  
+
   const location = event.location && event.location.trim().length
     ? <Detail style={styles.detail}>{event.location}</Detail>
     : null
@@ -57,7 +57,12 @@ export default function EventRow({
 
         <Bar style={styles.bar} />
 
-        <Column flex={1} paddingTop={2} paddingBottom={3} justifyContent="space-between">
+        <Column
+          flex={1}
+          paddingTop={2}
+          paddingBottom={3}
+          justifyContent="space-between"
+        >
           <Title style={styles.title}>{title}</Title>
           {location}
         </Column>
@@ -82,7 +87,7 @@ function CalendarTimes({event, style}: {event: EventType, style: any}) {
       </Column>
     )
   }
-  
+
   let startTime = event.startTime.format('h:mm A')
   let endTime = event.endTime.format('h:mm A')
   let midnightTime = '12:00 AM'
@@ -104,7 +109,7 @@ function CalendarTimes({event, style}: {event: EventType, style: any}) {
     start = event.startTime.format('h:mm A')
     end = event.endTime.format('h:mm A')
   }
-  
+
   start = start === midnightTime ? 'Midnight' : start
   end = end === midnightTime ? 'Midnight' : end
 

--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -95,7 +95,7 @@ function CalendarTimes({event, style}: {event: EventType, style: any}) {
     // 12:00 PM to Jun. 25 3:00pm
     // Midnight to Jun. 25 <-- assuming the end time is also midnight
     start = event.startTime.format('h:mm A')
-    const endFormat = endTime === midnightTime ? 'MMM. D' : 'MMM. D h:mm A''
+    const endFormat = endTime === midnightTime ? 'MMM. D' : 'MMM. D h:mm A'
     end = `to ${event.endTime.format(endFormat)}`
   } else if (sillyZeroLength) {
     start = event.startTime.format('h:mm A')

--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -40,6 +40,10 @@ export default function EventRow({
   onPress: () => any,
 }) {
   const title = fastGetTrimmedText(event.summary)
+  
+  const location = event.location && event.location.trim().length
+    ? <Detail style={styles.detail}>{event.location}</Detail>
+    : null
 
   return (
     <ListRow
@@ -53,9 +57,9 @@ export default function EventRow({
 
         <Bar style={styles.bar} />
 
-        <Column flex={1} paddingTop={2} paddingBottom={3}>
+        <Column flex={1} paddingTop={2} paddingBottom={3} justifyContent="space-between">
           <Title style={styles.title}>{title}</Title>
-          <Detail style={styles.detail}>{event.location}</Detail>
+          {location}
         </Column>
       </Row>
     </ListRow>
@@ -78,14 +82,21 @@ function CalendarTimes({event, style}: {event: EventType, style: any}) {
       </Column>
     )
   }
+  
+  let startTime = event.startTime.format('h:mm A')
+  let endTime = event.endTime.format('h:mm A')
+  let midnightTime = '12:00 AM'
 
   let start, end
   if (event.isOngoing) {
     start = event.startTime.format('MMM. D')
     end = event.endTime.format('MMM. D')
   } else if (multiDay) {
+    // 12:00 PM to Jun. 25 3:00pm
+    // Midnight to Jun. 25 <-- assuming the end time is also midnight
     start = event.startTime.format('h:mm A')
-    end = `to ${event.endTime.format('MMM. D h:mm A')}`
+    const endFormat = endTime === midnightTime ? 'MMM. D' : 'MMM. D h:mm A''
+    end = `to ${event.endTime.format(endFormat)}`
   } else if (sillyZeroLength) {
     start = event.startTime.format('h:mm A')
     end = 'until ???'
@@ -93,6 +104,9 @@ function CalendarTimes({event, style}: {event: EventType, style: any}) {
     start = event.startTime.format('h:mm A')
     end = event.endTime.format('h:mm A')
   }
+  
+  start = start === midnightTime ? 'Midnight' : start
+  end = end === midnightTime ? 'Midnight' : end
 
   return (
     <Column style={style}>


### PR DESCRIPTION
This PR does several things:

1. It hides the "location" row when it's blank; this fixes the case where it looks like there's a bunch of pointless padding under some rows.
2. If the "times" column is taller than the "info" column, `master` currently doesn't align the "location" with the bottom of the row. Now it should.
3. If a time ends or starts at midnight, the text will now read "Midnight".
4. If a multi-day event ends at midnight, it will not report the ending time at all.