### PR TITLE
Add settings to left button in new nav

### DIFF
--- a/source/views/components/nav-buttons/open-settings.js
+++ b/source/views/components/nav-buttons/open-settings.js
@@ -22,7 +22,7 @@ export function OpenSettingsButton({
       borderless
       highlight={false}
       style={[styles.button, buttonStyle]}
-      onPress={() => navigation.push('SettingsView')}
+      onPress={() => navigation.navigate('SettingsView')}
     >
       <Icon style={styles.icon} name="ios-settings" />
     </Touchable>

--- a/source/views/home/home.js
+++ b/source/views/home/home.js
@@ -15,8 +15,7 @@ import type {ViewType} from '../views'
 import {allViews} from '../views'
 import {HomeScreenButton, CELL_MARGIN} from './button'
 import {trackedOpenUrl} from '../components/open-url'
-import {EditHomeButton} from '../components/nav-buttons'
-import {OpenSettingsButton} from '../components/nav-buttons'
+import {EditHomeButton, OpenSettingsButton} from '../components/nav-buttons'
 
 function HomePage({
   navigation,
@@ -55,8 +54,8 @@ HomePage.navigationOptions = ({navigation}) => {
   return {
     title: 'All About Olaf',
     headerBackTitle: 'Home',
-    headerRight: <EditHomeButton navigation={navigation} />,
     headerLeft: <OpenSettingsButton navigation={navigation} />,
+    headerRight: <EditHomeButton navigation={navigation} />,
   }
 }
 

--- a/source/views/home/home.js
+++ b/source/views/home/home.js
@@ -16,6 +16,7 @@ import {allViews} from '../views'
 import {HomeScreenButton, CELL_MARGIN} from './button'
 import {trackedOpenUrl} from '../components/open-url'
 import {EditHomeButton} from '../components/nav-buttons'
+import {OpenSettingsButton} from '../components/nav-buttons'
 
 function HomePage({
   navigation,
@@ -55,6 +56,7 @@ HomePage.navigationOptions = ({navigation}) => {
     title: 'All About Olaf',
     headerBackTitle: 'Home',
     headerRight: <EditHomeButton navigation={navigation} />,
+    headerLeft: <OpenSettingsButton navigation={navigation} />,
   }
 }
 


### PR DESCRIPTION
This adds the Settings button to open the Settings component in the new navigation.  Proof attached.

Button | Detail
---|---
<img width="374" alt="screen shot 2017-06-11 at 7 31 19 pm" src="https://user-images.githubusercontent.com/5240843/27015507-01d9e476-4edd-11e7-9d45-4afb2bb116dd.png"> | <img width="369" alt="screen shot 2017-06-11 at 7 30 45 pm" src="https://user-images.githubusercontent.com/5240843/27015508-01ebd79e-4edd-11e7-9d45-558bb9982109.png">
