### PR TITLE
Normalize schedule information

### DIFF
--- a/data/building-hours/1-1-cage.yaml
+++ b/data/building-hours/1-1-cage.yaml
@@ -6,10 +6,8 @@ schedule:
   - title: Kitchen
     notes: The kitchen stops cooking at 8 p.m.
     hours:
-      - {days: [Mo, Tu, We, Th], from: '7:30am', to: '8:00pm'}
-      - {days: [Fr], from: '7:30am', to: '8:00pm'}
-      - {days: [Sa], from: '9:00am', to: '8:00pm'}
-      - {days: [Su], from: '9:00am', to: '8:00pm'}
+      - {days: [Mo, Tu, We, Th, Fr], from: '7:30am', to: '8:00pm'}
+      - {days: [Sa, Su], from: '9:00am', to: '8:00pm'}
 
   - title: Late Night
     hours:

--- a/data/building-hours/3-1-post-office.yaml
+++ b/data/building-hours/3-1-post-office.yaml
@@ -17,5 +17,8 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-    - {days: [Fr], from: '7:30am', to: '12:00pm'}
+    - title: Hours
+      closedForChapelTime: true
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
+        - {days: [Fr], from: '7:30am', to: '12:00pm'}

--- a/data/building-hours/3-2-print-center.yaml
+++ b/data/building-hours/3-2-print-center.yaml
@@ -16,5 +16,8 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-    - {days: [Fr], from: '7:30am', to: '12:00pm'}
+    - title: Hours
+      closedForChapelTime: true
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
+        - {days: [Fr], from: '7:30am', to: '12:00pm'}

--- a/data/building-hours/4-3-rølvaag-library.yaml
+++ b/data/building-hours/4-3-rølvaag-library.yaml
@@ -17,5 +17,7 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:45am', to: '4:30pm'}
-    - {days: [Fr], from: '7:45am', to: '12:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:45am', to: '4:30pm'}
+        - {days: [Fr], from: '7:45am', to: '12:00pm'}

--- a/data/building-hours/5-1-it-helpdesk.yaml
+++ b/data/building-hours/5-1-it-helpdesk.yaml
@@ -16,5 +16,7 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-    - {days: [Fr], from: '7:45am', to: '12:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
+        - {days: [Fr], from: '7:45am', to: '12:00pm'}

--- a/data/building-hours/5-2-asc.yaml
+++ b/data/building-hours/5-2-asc.yaml
@@ -16,5 +16,7 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-    - {days: [Fr], from: '7:45am', to: '12:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
+        - {days: [Fr], from: '7:45am', to: '12:00pm'}

--- a/data/building-hours/7-1-wellness-center.yaml
+++ b/data/building-hours/7-1-wellness-center.yaml
@@ -15,6 +15,8 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo], from: '12:00pm', to: '1:00pm'}
-    - {days: [We], from: '12:00pm', to: '1:00pm'}
-    - {days: [Th], from: '4:00pm', to: '5:30am'}
+    - title: Hours
+      hours:
+        - {days: [Mo], from: '12:00pm', to: '1:00pm'}
+        - {days: [We], from: '12:00pm', to: '1:00pm'}
+        - {days: [Th], from: '4:00pm', to: '5:30am'}

--- a/data/building-hours/8-bc.yaml
+++ b/data/building-hours/8-bc.yaml
@@ -17,5 +17,7 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:00am', to: '10:00pm'}
-    - {days: [Fr, Sa, Su], from: '7:00am', to: '7:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:00am', to: '10:00pm'}
+        - {days: [Fr, Sa, Su], from: '7:00am', to: '7:00pm'}

--- a/data/building-hours/8-rns.yaml
+++ b/data/building-hours/8-rns.yaml
@@ -10,31 +10,45 @@ schedule:
 
 breakSchedule:
   fall:
-    - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '12:00am'}
-    - {days: [Sa, Su], from: '8:00am', to: '12:00am'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '12:00am'}
+        - {days: [Sa, Su], from: '8:00am', to: '12:00am'}
 
   thanksgiving:
-    - {days: [Tu, We], from: '7:00am', to: '10:00pm'}
-    - {days: [Sa], from: '8:00pm', to: '5:00pm'}
-    - {days: [Su], from: '8:00am', to: '12:00am'}
+    - title: Hours
+      hours:
+        - {days: [Tu, We], from: '7:00am', to: '10:00pm'}
+        - {days: [Sa], from: '8:00pm', to: '5:00pm'}
+        - {days: [Su], from: '8:00am', to: '12:00am'}
 
   winter:
-    - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '8:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '8:00pm'}
 
   interim:
-    - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
 
   spring:
-    - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
-    - {days: [Sa], from: '8:00pm', to: '5:00pm'}
-    - {days: [Su], from: '8:00am', to: '12:00am'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
+        - {days: [Sa], from: '8:00pm', to: '5:00pm'}
+        - {days: [Su], from: '8:00am', to: '12:00am'}
 
   easter:
-    - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
-    - {days: [Sa], from: '8:00pm', to: '5:00pm'}
-    - {days: [Su], from: '8:00am', to: '12:00am'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
+        - {days: [Sa], from: '8:00pm', to: '5:00pm'}
+        - {days: [Su], from: '8:00am', to: '12:00am'}
 
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:00am', to: '10:00pm'}
-    - {days: [Fr], from: '7:00am', to: '8:00pm'}
-    - {days: [Sa, Su], from: '10:00am', to: '10:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:00am', to: '10:00pm'}
+        - {days: [Fr], from: '7:00am', to: '8:00pm'}
+        - {days: [Sa, Su], from: '10:00am', to: '10:00pm'}

--- a/data/building-hours/9-admissions.yaml
+++ b/data/building-hours/9-admissions.yaml
@@ -15,4 +15,6 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th, Fr], from: '7:30am', to: '4:30pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th, Fr], from: '7:30am', to: '4:30pm'}

--- a/data/building-hours/9-business-office.yaml
+++ b/data/building-hours/9-business-office.yaml
@@ -14,5 +14,7 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:00pm'}
-    - {days: [Fr], from: '7:30am', to: '12:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:00pm'}
+        - {days: [Fr], from: '7:30am', to: '12:00pm'}

--- a/data/building-hours/9-financial-aid.yaml
+++ b/data/building-hours/9-financial-aid.yaml
@@ -14,5 +14,7 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-    - {days: [Fr], from: '7:30am', to: '12:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
+        - {days: [Fr], from: '7:30am', to: '12:00pm'}

--- a/data/building-hours/9-registrar.yaml
+++ b/data/building-hours/9-registrar.yaml
@@ -14,5 +14,7 @@ breakSchedule:
   spring: []
   easter: []
   summer:
-    - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-    - {days: [Fr], from: '7:30am', to: '12:00pm'}
+    - title: Hours
+      hours:
+        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
+        - {days: [Fr], from: '7:30am', to: '12:00pm'}

--- a/source/views/building-hours/building-hours-helpers.js
+++ b/source/views/building-hours/building-hours-helpers.js
@@ -146,7 +146,7 @@ export function getDetailedBuildingStatus(
 
   let dayOfWeek = getDayOfWeek(m)
 
-  let schedules = normalizeBuildingSchedule(info)
+  let schedules = info.schedule || []
   if (!schedules.length) {
     return [{isActive: false, label: null, status: 'Hours unknown'}]
   }
@@ -186,7 +186,7 @@ export function getDetailedBuildingStatus(
 export function getShortBuildingStatus(info: BuildingType, m: momentT): string {
   let dayOfWeek = getDayOfWeek(m)
 
-  let schedules = normalizeBuildingSchedule(info)
+  let schedules = info.schedule || []
   if (!schedules.length) {
     return 'Closed'
   }
@@ -218,7 +218,7 @@ export function getShortBuildingStatus(info: BuildingType, m: momentT): string {
 export function isBuildingOpen(info: BuildingType, m: momentT): boolean {
   let dayOfWeek = getDayOfWeek(m)
 
-  let schedules = normalizeBuildingSchedule(info)
+  let schedules = info.schedule || []
   if (!schedules.length) {
     return false
   }
@@ -299,15 +299,4 @@ export function summarizeDays(days: DayOfWeekEnumType[]): string {
   let end = moment(endDay, 'dd').format('ddd')
 
   return `${start} — ${end}`
-}
-
-export function normalizeBuildingSchedule(
-  info: BuildingType,
-): NamedBuildingScheduleType[] {
-  let schedules = info.schedule
-  if (!schedules) {
-    return []
-  }
-
-  return schedules
 }

--- a/source/views/building-hours/building-hours-helpers.js
+++ b/source/views/building-hours/building-hours-helpers.js
@@ -6,7 +6,6 @@ const RESULT_FORMAT = 'h:mma'
 
 import type {
   BuildingType,
-  NamedBuildingScheduleType,
   SingleBuildingScheduleType,
   DayOfWeekEnumType,
 } from './types'

--- a/source/views/building-hours/detail.android.js
+++ b/source/views/building-hours/detail.android.js
@@ -13,7 +13,6 @@ import ParallaxView from 'react-native-parallax-view'
 import moment from 'moment-timezone'
 import * as c from '../components/colors'
 import {
-  normalizeBuildingSchedule,
   formatBuildingTimes,
   summarizeDays,
   getShortBuildingStatus,
@@ -116,7 +115,7 @@ export class BuildingHoursDetailView extends React.Component {
       ? buildingImages[this.props.image]
       : transparentPixel
     const openStatus = getShortBuildingStatus(this.props, this.state.now)
-    const schedules = normalizeBuildingSchedule(this.props, this.state.now)
+    const schedules = this.props.schedule || []
     const dayOfWeek = ((this.state.now.format('dd'): any): DayOfWeekEnumType)
 
     const abbr = this.props.abbreviation

--- a/source/views/building-hours/detail.ios.js
+++ b/source/views/building-hours/detail.ios.js
@@ -10,7 +10,6 @@ import {TableView, Section, Cell} from 'react-native-tableview-simple'
 import ParallaxView from 'react-native-parallax-view'
 import * as c from '../components/colors'
 import {
-  normalizeBuildingSchedule,
   formatBuildingTimes,
   summarizeDays,
   getShortBuildingStatus,
@@ -91,7 +90,7 @@ export class BuildingHoursDetailView extends React.Component {
       ? buildingImages[this.props.image]
       : transparentPixel
     const openStatus = getShortBuildingStatus(this.props, this.state.now)
-    const schedules = normalizeBuildingSchedule(this.props, this.state.now)
+    const schedules = this.props.schedule || []
     const dayOfWeek = ((this.state.now.format('dd'): any): DayOfWeekEnumType)
 
     const abbr = this.props.abbreviation

--- a/source/views/building-hours/types.js
+++ b/source/views/building-hours/types.js
@@ -34,7 +34,7 @@ export type NamedBuildingScheduleType = {|
 |}
 
 export type BreakScheduleContainerType = {
-  [key: BreakNameEnumType]: SingleBuildingScheduleType[],
+  [key: BreakNameEnumType]: NamedBuildingScheduleType[],
 }
 
 export type BuildingType = {|


### PR DESCRIPTION
This is part of #1164.

> Make all break schedules use the "full" schedule format and remove normalizeBuildingHours