### PR TITLE
Whitelist ListRow's props

### DIFF
--- a/source/views/building-hours/row.js
+++ b/source/views/building-hours/row.js
@@ -66,7 +66,7 @@ export function BuildingRow({info, name, now, onPress}: PropsType) {
   const textaccent = foregroundColors[openStatus] || 'rgb(130, 82, 45)'
 
   return (
-    <ListRow onPress={onPress} arrowPosition="center" direction="column">
+    <ListRow onPress={onPress} arrowPosition="center">
       <Column>
         <Row style={styles.title}>
           <Title lines={1} style={styles.titleText}>

--- a/source/views/components/list/list-row.js
+++ b/source/views/components/list/list-row.js
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
   },
 })
 
-type PropsType = {
+type PropsType = {|
   style?: any,
   contentContainerStyle?: any,
   arrowPosition?: 'center' | 'top' | 'none',
@@ -43,7 +43,7 @@ type PropsType = {
   spacing?: {left?: number, right?: number},
   onPress?: () => any,
   children?: any,
-}
+|}
 export function ListRow(props: PropsType) {
   const {
     style,

--- a/source/views/transportation/bus/bus-line.js
+++ b/source/views/transportation/bus/bus-line.js
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import {View, StyleSheet, Platform} from 'react-native'
+import {View, StyleSheet, Platform, Text} from 'react-native'
 import type {BusLineType, FancyBusTimeListType} from './types'
 import {getScheduleForNow, getSetOfStopsForNow} from './lib'
 import get from 'lodash/get'
@@ -11,8 +11,7 @@ import moment from 'moment-timezone'
 import * as c from '../../components/colors'
 import {Separator} from '../../components/separator'
 import {BusStopRow} from './bus-stop-row'
-import {ListRow} from '../../components/list'
-import {ListSectionHeader} from '../../components/list'
+import {ListRow, ListSectionHeader, Title} from '../../components/list'
 
 const TIME_FORMAT = 'h:mma'
 const TIMEZONE = 'America/Winnipeg'
@@ -61,7 +60,9 @@ export function BusLine({line, now}: {line: BusLineType, now: moment}) {
     return (
       <View>
         <ListSectionHeader title={line.line} titleStyle={androidColor} />
-        <ListRow title="This line is not running today." />
+        <ListRow>
+          <Title><Text>This line is not running today.</Text></Title>
+        </ListRow>
       </View>
     )
   }


### PR DESCRIPTION
I noticed while doing some cleanup on BusView that I was misusing ListRow.

Flow provides an "exact object type", which acts as a property key whitelist.

I changed ListRow's props to use the exact object type, which caught two spots where I was misusing ListRow.