### PR TITLE
expand calendar detail views to multiple lines

### DIFF
--- a/source/views/calendar/event-detail.js
+++ b/source/views/calendar/event-detail.js
@@ -24,7 +24,7 @@ function MaybeSection({header, content}: {header: string, content: string}) {
   return content.trim()
     ? <Section header={header}>
         <Cell
-          title={
+          cellContentView={
             <Text selectable={true} style={styles.chunk}>
               {content}
             </Text>


### PR DESCRIPTION
The calendar detail view's descriptions did not expand to multiple lines.

Closes #1192 

Before | After
---|---
<img width="487" alt="screen shot 2017-06-16 at 4 29 28 pm" src="https://user-images.githubusercontent.com/5240843/27243795-9fd6ea8e-52b1-11e7-9ee4-fbb70e74e157.png"> | <img width="487" alt="screen shot 2017-06-16 at 4 28 59 pm" src="https://user-images.githubusercontent.com/5240843/27243796-9fea0b46-52b1-11e7-9c96-580dab40f9a9.png"> 