### PR TITLE
Only deploy to gh-pages from JS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,7 @@ deploy:
     local_dir: docs/
     on:
       branch: master
+      condition: $JS
 
 before_cache:
   - rm -f "$HOME/.gradle/caches/modules-2/modules-2.lock"


### PR DESCRIPTION
I just realized that all three builds have been deploying to gh-pages.

There's no real problem there - they all run the same bundle-data script.

It's just unintended.

I've now fixed that.