### PR TITLE
Make urls accessible in calendar detail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1798,6 +1798,11 @@
       "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
+    "get-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-urls/-/get-urls-7.0.0.tgz",
+      "integrity": "sha1-xICtx9TGzFy7ZLUxgj3GO5nsHlo="
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -2078,6 +2083,11 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
+    "ip-regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
+      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2180,6 +2190,11 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -3422,6 +3437,11 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true
     },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw="
+    },
     "npmlog": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
@@ -3707,6 +3727,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -3783,6 +3808,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
       "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc="
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s="
     },
     "querystring": {
       "version": "0.2.0",
@@ -4467,6 +4497,11 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
     },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0="
+    },
     "source-map": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
@@ -4562,6 +4597,11 @@
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string_decoder": {
       "version": "1.0.2",
@@ -4696,6 +4736,11 @@
       "resolved": "https://registry.npmjs.org/titlecase/-/titlecase-1.1.2.tgz",
       "integrity": "sha1-eBE9EQgIa4MmMxoyR96o9aSeqFM="
     },
+    "tlds": {
+      "version": "1.189.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.189.0.tgz",
+      "integrity": "sha1-uMtG6nbcL0oB1FuNkHvxmmbp9yk="
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -4810,6 +4855,23 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
+    "url-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-4.1.1.tgz",
+      "integrity": "sha512-ViSDgDPNKkrQHI81GLCjdDN+Rsk3tAW/uLXlBOJxtcHzWZjta58Z0APXhfXzS89YszsheMnEvXeDXsWUB53wwA=="
     },
     "user-home": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "dedent": "0.7.0",
     "delay": "2.0.0",
     "events": "1.1.1",
+    "get-urls": "7.0.0",
     "html-entities": "1.2.1",
     "htmlparser2": "3.9.2",
     "lodash": "4.17.4",
@@ -96,6 +97,7 @@
     "stream": "0.0.2",
     "timers": "0.1.1",
     "titlecase": "1.1.2",
+    "url": "0.11.0",
     "xml2js": "0.4.17"
   },
   "devDependencies": {

--- a/source/views/calendar/event-detail.js
+++ b/source/views/calendar/event-detail.js
@@ -80,7 +80,7 @@ export function EventDetail(props: {
   const {event} = props.navigation.state.params
   const title = fastGetTrimmedText(event.summary || '')
   const summary = event.extra.data.description || ''
-  const trimmedSummary = cleanDescription(event.extra.data.description || '')
+  const rawSummary = cleanDescription(event.extra.data.description || '')
   const location = fastGetTrimmedText(event.location || '')
   const times = getTimes(event)
 
@@ -90,7 +90,7 @@ export function EventDetail(props: {
         <MaybeSection header="EVENT" content={title} />
         <MaybeSection header="TIME" content={times} />
         <MaybeSection header="LOCATION" content={location} />
-        <MaybeSection header="DESCRIPTION" content={trimmedSummary} />
+        <MaybeSection header="DESCRIPTION" content={rawSummary} />
         <Links header="LINKS" content={summary} />
       </TableView>
     </ScrollView>

--- a/source/views/calendar/event-detail.js
+++ b/source/views/calendar/event-detail.js
@@ -37,8 +37,7 @@ function MaybeSection({header, content}: {header: string, content: string}) {
 }
 
 function Links({header, content}: {header: string, content: string}) {
-  const rawUrls = getUrls(content)
-  const links = Array.from(rawUrls)
+  const links = Array.from(getUrls(content))
 
   return links.length
     ? <Section header={header}>

--- a/source/views/calendar/event-detail.js
+++ b/source/views/calendar/event-detail.js
@@ -5,6 +5,8 @@ import {fastGetTrimmedText} from '../../lib/html'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import type {EventType} from './types'
 import {ShareButton} from '../components/nav-buttons'
+import getUrls from 'get-urls'
+import openUrl from '../components/open-url'
 import {times} from './times'
 
 const styles = StyleSheet.create({
@@ -34,6 +36,34 @@ function MaybeSection({header, content}: {header: string, content: string}) {
     : null
 }
 
+function Links({header, content}: {header: string, content: string}) {
+  const rawUrls = getUrls(content)
+  const links = Array.from(rawUrls)
+
+  return links.length
+    ? <Section header={header}>
+        {links.map(url =>
+          <Cell
+            key={url}
+            cellStyle="Title"
+            title={url}
+            accessory="DisclosureIndicator"
+            onPress={() => openUrl(url)}
+          />,
+        )}
+      </Section>
+    : null
+}
+
+function cleanDescription(desc: string) {
+  const description = fastGetTrimmedText(desc || '')
+  if (description == 'See more details') {
+    return ''
+  }
+
+  return description
+}
+
 function getTimes(event: EventType) {
   const {allDay, start, end} = times(event)
 
@@ -49,7 +79,8 @@ export function EventDetail(props: {
 }) {
   const {event} = props.navigation.state.params
   const title = fastGetTrimmedText(event.summary || '')
-  const summary = fastGetTrimmedText(event.extra.data.description || '')
+  const summary = event.extra.data.description || ''
+  const trimmedSummary = cleanDescription(event.extra.data.description || '')
   const location = fastGetTrimmedText(event.location || '')
   const times = getTimes(event)
 
@@ -59,7 +90,8 @@ export function EventDetail(props: {
         <MaybeSection header="EVENT" content={title} />
         <MaybeSection header="TIME" content={times} />
         <MaybeSection header="LOCATION" content={location} />
-        <MaybeSection header="DESCRIPTION" content={summary} />
+        <MaybeSection header="DESCRIPTION" content={trimmedSummary} />
+        <Links header="LINKS" content={summary} />
       </TableView>
     </ScrollView>
   )


### PR DESCRIPTION
This PR adds the `get-urls` and `url` packages to handle parsing for links within strings. I will file another PR to do the same thing in the student work detail view.

Closes #1198

Before | After
-- | --
<img width="487" alt="screen shot 2017-06-16 at 6 40 22 pm" src="https://user-images.githubusercontent.com/5240843/27255673-51780f10-5371-11e7-8a2d-001061258d1b.png"> | <img width="487" alt="screen shot 2017-06-16 at 6 38 43 pm" src="https://user-images.githubusercontent.com/5240843/27255672-51265c88-5371-11e7-8e82-c6468dcb53b5.png">