### PR TITLE
Format the header in hours reporting

### DIFF
--- a/source/views/building-hours/report/overview.js
+++ b/source/views/building-hours/report/overview.js
@@ -5,12 +5,13 @@
  */
 
 import React from 'react'
-import {ScrollView, View, Text} from 'react-native'
+import {ScrollView, View, StyleSheet, Text} from 'react-native'
 import moment from 'moment-timezone'
 import {CellTextField} from '../../components/cells/textfield'
 import {CellToggle} from '../../components/cells/toggle'
 import {DeleteButtonCell} from '../../components/cells/delete-button'
 import {ButtonCell} from '../../components/cells/button'
+import * as c from '../../components/colors'
 import {TableView, Section, Cell} from 'react-native-tableview-simple'
 import type {
   BuildingType,
@@ -19,6 +20,27 @@ import type {
 } from '../types'
 import type {TopLevelViewPropsType} from '../../types'
 import {summarizeDays, formatBuildingTimes, blankSchedule} from '../lib'
+
+const styles = StyleSheet.create({
+  helpWrapper: {
+    backgroundColor: c.white,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#ebebeb',
+    marginBottom: 10,
+  },
+  helpTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    paddingTop: 15,
+    paddingHorizontal: 15,
+  },
+  helpDescription: {
+    fontSize: 14,
+    paddingTop: 5,
+    paddingBottom: 15,
+    paddingHorizontal: 15,
+  },
+})
 
 export class BuildingHoursProblemReportView extends React.PureComponent {
   static navigationOptions = {
@@ -166,10 +188,13 @@ export class BuildingHoursProblemReportView extends React.PureComponent {
 
     return (
       <ScrollView>
-        <Text>
-          Thanks for spotting a problem! If you could tell us what the new times
-          are, we&rsquo;d greatly appreciate it.
-        </Text>
+        <View style={styles.helpWrapper}>
+          <Text style={styles.helpTitle}>Thanks for spotting a problem!</Text>
+          <Text style={styles.helpDescription}>
+            If you could tell us what the new times are, we&rsquo;d greatly
+            appreciate it.
+          </Text>
+        </View>
 
         <TableView>
           {schedules.map((s, i) =>
@@ -192,7 +217,7 @@ export class BuildingHoursProblemReportView extends React.PureComponent {
             />
           </Section>
 
-          <Section footer="Thanks for reporting!">
+          <Section>
             <ButtonCell title="Submit Report" onPress={this.submit} />
           </Section>
         </TableView>

--- a/source/views/building-hours/report/overview.js
+++ b/source/views/building-hours/report/overview.js
@@ -218,7 +218,7 @@ export class BuildingHoursProblemReportView extends React.PureComponent {
             />
           </Section>
 
-          <Section>
+          <Section footer="Thanks for reporting!">
             <ButtonCell title="Submit Report" onPress={this.submit} />
           </Section>
         </TableView>

--- a/source/views/building-hours/report/overview.js
+++ b/source/views/building-hours/report/overview.js
@@ -25,7 +25,8 @@ const styles = StyleSheet.create({
   helpWrapper: {
     backgroundColor: c.white,
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: '#ebebeb',
+    borderTopColor: c.iosHeaderTopBorder,
+    borderBottomColor: c.iosHeaderBottomBorder,
     marginBottom: 10,
   },
   helpTitle: {


### PR DESCRIPTION
This throws a few styles on the header for the building hours report view. I've also nixed the footer on the submit button.

A piece of #1158

Before | After
--|--
<img width="375" alt="unformatted" src="https://user-images.githubusercontent.com/5240843/27256036-9903c368-5378-11e7-9818-1b2bb82ce8c9.png"> | <img width="373" alt="formatted" src="https://user-images.githubusercontent.com/5240843/27256035-98fcd9ae-5378-11e7-8a2a-12f04fe0b795.png">