### PR TITLE
Format the event share message

### DIFF
--- a/source/views/calendar/event-detail.js
+++ b/source/views/calendar/event-detail.js
@@ -14,7 +14,10 @@ const styles = StyleSheet.create({
 })
 
 const shareItem = (event: EventType) => {
-  const message = `${event.summary}: ${event.startTime.toString()} – ${event.endTime.toString()}`
+  const summary = event.summary ? event.summary : ''
+  const times = getTimes(event) ? getTimes(event) : ''
+  const location = event.location ? event.location : ''
+  const message = `${summary}\n\n${times}\n\n${location}`
   Share.share({message})
     .then(result => console.log(result))
     .catch(error => console.log(error.message))


### PR DESCRIPTION
This changes the calendar event share message by:

- formatting the hours to be readable and not computery
- adding event location

## Before
```
Imminent Brewing Grand Opening: Sat Jun 17 2017 12:00:00 GMT-0400 – Sun Jun 18 2017 00:00:00 GMT-0400
```

## After

```
Imminent Brewing Grand Opening
 
12:00 PM — 9:00 PM
 
Imminent Brewing, 519 Division St S #2, Northfield, MN 55057, USA 
```