### PR TITLE
Make statusbar text visible and light

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -99,7 +99,9 @@
 		<string>armv7</string>
 	</array>
 	<key>UIStatusBarHidden</key>
-	<true/>
+	<false/>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
This PR adjusts the visibility and style of the screen status bar text on the launch image. The status bar text was hidden and set to dark text. This allows for it to appear on launch and have a light text color.

<img width="378" alt="screen shot 2017-06-18 at 8 30 18 pm" src="https://user-images.githubusercontent.com/5240843/27265509-2509f7aa-5465-11e7-9623-212f1326b521.png">