### PR TITLE
allow the capitalization prop

### DIFF
--- a/source/views/building-hours/report/overview.js
+++ b/source/views/building-hours/report/overview.js
@@ -316,6 +316,7 @@ class EditableSchedule extends React.PureComponent {
 const TitleCell = ({text, onChange = () => {}}) =>
   <CellTextField
     hideLabel={true}
+    autoCapitalize="words"
     returnKeyType="done"
     placeholder="Title"
     value={text}
@@ -327,6 +328,7 @@ const TitleCell = ({text, onChange = () => {}}) =>
 const NotesCell = ({text, onChange}) =>
   <CellTextField
     hideLabel={true}
+    autoCapitalize="sentences"
     returnKeyType="done"
     placeholder="Notes"
     value={text}

--- a/source/views/components/cells/textfield.js
+++ b/source/views/components/cells/textfield.js
@@ -32,6 +32,7 @@ export class CellTextField extends React.Component {
     _ref: () => {},
     returnKeyType: 'default',
     secureTextEntry: false,
+    autoCapitalize: 'none',
   }
 
   props: {
@@ -79,7 +80,7 @@ export class CellTextField extends React.Component {
         cellAccessoryView={
           <TextInput
             ref={this.cacheRef}
-            autoCapitalize={this.props.autoCapitalize || 'none'}
+            autoCapitalize={this.props.autoCapitalize}
             autoCorrect={false}
             clearButtonMode="while-editing"
             disabled={this.props.disabled}

--- a/source/views/components/cells/textfield.js
+++ b/source/views/components/cells/textfield.js
@@ -43,6 +43,7 @@ export class CellTextField extends React.Component {
     placeholder: string,
     returnKeyType: 'done' | 'next' | 'default',
     secureTextEntry: boolean,
+    autoCapitalize: string,
     value: string,
     labelWidth?: number,
   }
@@ -78,7 +79,7 @@ export class CellTextField extends React.Component {
         cellAccessoryView={
           <TextInput
             ref={this.cacheRef}
-            autoCapitalize="none"
+            autoCapitalize={this.props.autoCapitalize || 'none'}
             autoCorrect={false}
             clearButtonMode="while-editing"
             disabled={this.props.disabled}

--- a/source/views/components/cells/textfield.js
+++ b/source/views/components/cells/textfield.js
@@ -44,7 +44,7 @@ export class CellTextField extends React.Component {
     placeholder: string,
     returnKeyType: 'done' | 'next' | 'default',
     secureTextEntry: boolean,
-    autoCapitalize: string,
+    autoCapitalize: 'characters' | 'words' | 'sentences' | 'none',
     value: string,
     labelWidth?: number,
   }


### PR DESCRIPTION
This PR allows for `CellTextField` elements (a wrapper over `Cells` with `TextInputs`) to specify the `autoCapitalization` [prop](https://facebook.github.io/react-native/docs/textinput.html) which was previously set to `none`. This behavior would default to `sentences`, but we override that to `none`. 

This impacts the Building Hours Edit view where the user can submit changes to a schedule's title and notes. I am altering the title to be capitalized with `words` and the notes to be capitalized with `sentences`.

**Possible values:**
`characters`: all characters.
`words`: first letter of each word.
`sentences`: first letter of each sentence.
`none`: don't auto capitalize anything.
 
Closes #1234 