### PR TITLE
Add Title-IX related contact information

### DIFF
--- a/data/contact-info/5-college-pastors.yaml
+++ b/data/contact-info/5-college-pastors.yaml
@@ -1,0 +1,8 @@
+title: College Pastors
+phoneNumber: '5077863092'
+buttonText: Call Pastor's Office
+image: safe ride.jpg
+text: >-
+  College Pastors are confidential resources trained in pastoral care. They
+  are able to speak with students of any faith, or who don’t practice a
+  religious faith, about all aspects of life.

--- a/data/contact-info/6-health-services.yaml
+++ b/data/contact-info/6-health-services.yaml
@@ -1,0 +1,13 @@
+title: Health Services
+phoneNumber: '5077863063'
+buttonText: Call Health Servies
+image: safe ride.jpg
+text: >-
+  St. Olaf Health Services provides free, confidential, on-campus healthcare
+  visits for students. Medications and testing are available to students during
+  their clinic visit, when appropriate, for a minimal out-of-pocket fee.
+
+  Appointments can be made to discuss education and questions regarding birth
+  control and Plan B as well as Sexual Transmitted Infection education and
+  testing, and pregnancy testing.
+

--- a/data/contact-info/7-report-conduct.yaml
+++ b/data/contact-info/7-report-conduct.yaml
@@ -1,0 +1,14 @@
+title: Title IX Office
+phoneNumber: '5077863465'
+buttonText: Call College Administration
+image: safe ride.jpg
+text: >-
+  Any member of the college community who feels they have experienced sexual
+  misconduct  has the option of reporting to the college. Reporting enables
+  the college to take measures to stop the behavior, prevent it from occurring
+  in the future, and provide support, resources, and protection. You can report
+  to the college without initiating a formal investigation or reporting to law
+  enforcement.
+
+  To make a report, contact the Title IX Case Manager or use St.
+  Olaf’s online reporting form, which can be filled out anonymously: https://wp.stolaf.edu/title-ix/report-sexual-violence/.

--- a/data/contact-info/8-hope-center.yaml
+++ b/data/contact-info/8-hope-center.yaml
@@ -1,0 +1,11 @@
+title: HOPE Center
+phoneNumber: '8006072330'
+buttonText: Call 24-Hour Hotline
+image: safe ride.jpg
+text: >-
+  The HOPE Center, located in Faribault, MN, provides free, confidential
+  advocacy services to victims of sexual and domestic violence. Advocates
+  at the HOPE Center provide crisis intervention, support counseling,
+  information, help with protection planning, and referrals. The HOPE Center
+  also provides legal advocacy regarding court procedures, victim rights, and
+  accompaniment to civil and criminal court proceedings.


### PR DESCRIPTION
I was contacted by Kari Hohn, the college Title-IX Coordinator about putting some more information into the app. We've been emailing about it, and settled on what you see here. I'm starting to wonder if there is a need for a dedicated Resources section of the app, as important contacts seems to be a little cluttered (Pause Kitchen feels even more out of place now!). Maybe adding tabs to the Contacts section would fix the problem and let us add a few more in the future without it becoming a massive list?

@erichkauffman I'd encourage you to reach out to the It's On Us chairs for this upcoming year and see what they think about this data change.