### PR TITLE
Activate "submit building hour update" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ios-simulator": "xcrun instruments -s devices | peco --select-1 --query 'Simulator iPhone' --on-cancel error | sed  's~.*\\[\\(.*\\)\\].*~\\1~' | xargs open -n -a Simulator --args -CurrentDeviceUDID",
     "lint": "eslint --cache source/ *.js",
     "prettier": "prettier --write $npm_package_config_prettier_args 'source/**/*.js' '*.js'",
-    "prettier:changed": "FILES=$(git diff --name-only | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES",
+    "prettier:changed": "FILES=$(git status -u --porcelain | cut -c4- | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES",
     "prettier:since-master": "FILES=$(git diff --name-only master | grep '\\.js$'); prettier --write $npm_package_config_prettier_args $FILES",
     "start": "react-native start",
     "test": "jest",

--- a/source/views/building-hours/report/overview.js
+++ b/source/views/building-hours/report/overview.js
@@ -20,6 +20,7 @@ import type {
 } from '../types'
 import type {TopLevelViewPropsType} from '../../types'
 import {summarizeDays, formatBuildingTimes, blankSchedule} from '../lib'
+import {submitReport} from './submit'
 
 const styles = StyleSheet.create({
   helpWrapper: {
@@ -182,6 +183,10 @@ export class BuildingHoursProblemReportView extends React.PureComponent {
 
   submit = () => {
     console.log(JSON.stringify(this.state.building))
+    submitReport(
+      this.props.navigation.state.params.initialBuilding,
+      this.state.building,
+    )
   }
 
   render() {

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -20,7 +20,6 @@ export function submitReport(current: BuildingType, suggestion: BuildingType) {
   )
 }
 
-
 function makeEmailBody(before: string, after: string, title: string): string {
   return dedent`
     Hi! Thanks for letting us know about an hour change.

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -4,6 +4,7 @@ import jsYaml from 'js-yaml'
 import type {BuildingType} from '../types'
 import {email} from 'react-native-communications'
 import dedent from 'dedent'
+import querystring from 'querystring'
 
 export function submitReport(current: BuildingType, suggestion: BuildingType) {
   const before = stringifyBuilding(current)

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -1,0 +1,54 @@
+// @flow
+
+import jsYaml from 'js-yaml'
+import type {BuildingType} from '../types'
+import {GITHUB_TOKEN} from '../../../lib/config.js'
+import {email} from 'react-native-communications'
+import dedent from 'dedent'
+
+export function submitReport(current: BuildingType, suggestion: BuildingType) {
+  const before = stringifyBuilding(current)
+  const after = stringifyBuilding(suggestion)
+
+  const body = makeIssueBody(before, after)
+
+  return email(
+    ['allaboutolaf@stolaf.edu'],
+    [],
+    [],
+    `[building] Suggestion for ${current.name}`,
+    body,
+  )
+}
+
+function makeIssueBody(before: string, after: string): string {
+  return dedent`
+    Please do not change anything below this line.
+
+    ------------
+
+    \`\`\`yaml
+    ${before}
+    \`\`\`
+
+    \`\`\`yaml
+    ${after}
+    \`\`\`
+  `
+}
+
+function stringifyBuilding(building: BuildingType): string {
+  let res = ''
+  let data = jsYaml.safeDump(building, {flowLevel: 4}).split('\n')
+  for (let line of data) {
+    if (['schedule:', 'breakSchedule:'].includes(line)) {
+      res += `\n\n${line}`
+    } else if (line.startsWith('  - title:') && prev !== 'schedule:') {
+      res += `\n\n${line}`
+    } else {
+      res += `\n${line}`
+    }
+    prev = line
+  }
+  return res
+}

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -9,7 +9,7 @@ export function submitReport(current: BuildingType, suggestion: BuildingType) {
   const before = stringifyBuilding(current)
   const after = stringifyBuilding(suggestion)
 
-  const body = makeIssueBody(before, after)
+  const body = makeEmailBody(before, after, current.name)
 
   return email(
     ['allaboutolaf@stolaf.edu'],
@@ -20,20 +20,42 @@ export function submitReport(current: BuildingType, suggestion: BuildingType) {
   )
 }
 
-function makeIssueBody(before: string, after: string): string {
+
+function makeEmailBody(before: string, after: string, title: string): string {
   return dedent`
+    Hi! Thanks for letting us know about an hour change.
+
     Please do not change anything below this line.
 
     ------------
 
+    Project maintainers: ${makeIssueLink(before, after, title)}
+
+    ${makeBody(before, after)}
+  `
+}
+
+function makeBody(before, after) {
+  return dedent`
+    Before:
     \`\`\`yaml
     ${before}
     \`\`\`
 
+    After:
     \`\`\`yaml
     ${after}
     \`\`\`
   `
+}
+
+function makeIssueLink(before: string, after: string, title: string): string {
+  const q = querystring.stringify({
+    'labels[]': 'data/building',
+    title: `Building hours update for ${title}`,
+    body: makeBody(before, after),
+  })
+  return `https://github.com/StoDevX/AAO-React-Native/issues/new?${q}`
 }
 
 function stringifyBuilding(building: BuildingType): string {

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -2,7 +2,6 @@
 
 import jsYaml from 'js-yaml'
 import type {BuildingType} from '../types'
-import {GITHUB_TOKEN} from '../../../lib/config.js'
 import {email} from 'react-native-communications'
 import dedent from 'dedent'
 
@@ -39,6 +38,7 @@ function makeIssueBody(before: string, after: string): string {
 
 function stringifyBuilding(building: BuildingType): string {
   let res = ''
+  let prev = null
   let data = jsYaml.safeDump(building, {flowLevel: 4}).split('\n')
   for (let line of data) {
     if (['schedule:', 'breakSchedule:'].includes(line)) {

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -23,7 +23,7 @@ export function submitReport(current: BuildingType, suggestion: BuildingType) {
 
 function makeEmailBody(before: string, after: string, title: string): string {
   return dedent`
-    Hi! Thanks for letting us know about an hour change.
+    Hi! Thanks for letting us know about a schedule change.
 
     Please do not change anything below this line.
 


### PR DESCRIPTION
So submitting a GitHub issue, while nice, isn't really workable – we'd either need to make our users set up and log in to a github account, or ship our app's private token with the app somehow, which would allow someone to extract it from the app and pretend to be the app (not the end of the world, but not ideal).

So I went with email. `allaboutolaf@stolaf.edu` currently emails @drewvolz, me, and @rye; lmk if you want to be added (or removed).

Closes https://github.com/StoDevX/AAO-React-Native/issues/1189.