### PR TITLE
Enable Nightlies

### DIFF
--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -69,7 +69,11 @@ def auto_beta
   # beta # if last_commit != current_commit
 
   if ENV['run_deploy'] == '1'
+    if ENV['TRAVIS_EVENT_TYPE'] == 'cron'
+      nightly
+    else
       beta
+    end
   else
     build
   end

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -57,14 +57,20 @@ end
 # smart enough to call the appropriate platform's "beta" lane. So, let's make
 # a beta build if there have been new commits since the last beta.
 def auto_beta
-  #last_commit = hockeyapp_version_commit
-  #current_commit = last_git_commit[:commit_hash]
+  # last_commit = hockeyapp_version_commit
+  # current_commit = last_git_commit[:commit_hash]
 
-  #UI.message 'In faux-git terms:'
-  #UI.message "origin/hockeyapp: #{last_commit}"
-  #UI.message "HEAD: #{current_commit}"
-  #will_beta = last_commit != current_commit ? 'yes' : 'no'
-  #UI.message "Thus, will we beta? #{will_beta}"
+  # UI.message 'In faux-git terms:'
+  # UI.message "origin/hockeyapp: #{last_commit}"
+  # UI.message "HEAD: #{current_commit}"
+  # will_beta = last_commit != current_commit ? 'yes' : 'no'
+  # UI.message "Thus, will we beta? #{will_beta}"
 
-  beta #if last_commit != current_commit
+  # beta # if last_commit != current_commit
+
+  if ENV['run_deploy'] == '1'
+      beta
+  else
+    build
+  end
 end

--- a/fastlane/platforms/agnostic.rb
+++ b/fastlane/platforms/agnostic.rb
@@ -20,7 +20,7 @@ desc 'Copy the package.json version into the other version locations'
 lane :'propagate-version' do |options|
   version = get_package_key(key: :version)
   UI.message "Propagating version: #{version}"
-  UI.message "into the Info.plist and build.gradle files" 
+  UI.message "into the Info.plist and build.gradle files"
 
   # update iOS version
   # we're splitting here because iTC can't handle versions with dashes in them
@@ -31,7 +31,7 @@ lane :'propagate-version' do |options|
   # update Android version
   set_gradle_version_name(version_name: version,
                           gradle_path: lane_context[:GRADLE_FILE])
-  
+
   current_version_code = get_gradle_version_code(gradle_path: lane_context[:GRADLE_FILE])
   set_gradle_version_code(version_code: current_version_code + 1,
                           gradle_path: lane_context[:GRADLE_FILE])

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 platform :android do
   desc 'Makes a build'
   lane :build do
@@ -22,6 +23,18 @@ platform :android do
       end
 
     supply(track: 'beta')
+  end
+
+  desc 'Submit a new nightly Build to Google Play'
+  lane :nightly do
+    build
+
+    lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] =
+      lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].select do |apk|
+        apk.end_with? '-release.apk'
+      end
+
+    supply(track: 'alpha')
   end
 
   desc 'Run the appropriate action on CI'

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -16,8 +16,10 @@ platform :android do
   lane :beta do
     build
 
-    lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] =
-      lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].select{ |apk| apk.end_with? "-release.apk" }
+      lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] =
+      lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].select do |apk|
+        apk.end_with? '-release.apk'
+      end
 
     supply(track: 'beta')
   end

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -32,12 +32,7 @@ platform :android do
     set_version
 
     # and run
-    should_deploy = ENV['run_deploy'] == '1'
-    if should_deploy
-      auto_beta
-    else
-      build
-    end
+    auto_beta
   end
 
   desc 'Include the build number in the version string'

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -28,6 +28,15 @@ platform :ios do
     testflight
   end
 
+  desc 'Submit a new nightly Beta Build to Testflight'
+  lane :nightly do
+    match(type: 'appstore', readonly: true)
+
+    build
+
+    testflight(distribute_external: false)
+  end
+
   desc 'Upload dYSM symbols to Bugsnag from Apple'
   lane :refresh_dsyms do
     download_dsyms

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -45,12 +45,7 @@ platform :ios do
     set_version
 
     # and run
-    should_deploy = ENV['run_deploy'] == '1'
-    if should_deploy
-      auto_beta
-    else
-      build
-    end
+    auto_beta
   end
 
   desc 'Include the build number in the version string'


### PR DESCRIPTION
This _should_ allow @drewvolz and I (and others at their behest) to use new builds of master on a nightly basis.

That's … the primary way that we get annoyed by things and fix them. And it's been turned off ever since we switched away from Hockeyapp.

This should turn it back on; we'll know tonight.

I think I have it set up not to distribute these builds to the normal beta teams, hopefully, so you all won't get spammed with notifications.