### PR TITLE
Update github label for edit building hours

### DIFF
--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -67,7 +67,7 @@ function makeHtmlBody(before, after) {
 
 function makeIssueLink(before: string, after: string, title: string): string {
   const q = querystring.stringify({
-    'labels[]': 'data/building',
+    'labels[]': 'data/hours',
     title: `Building hours update for ${title}`,
     body: makeMarkdownBody(before, after),
   })


### PR DESCRIPTION
This changes the label from data/building to data/hours.