### PR TITLE
Fix webcam image alignments

### DIFF
--- a/source/views/streaming/webcams.js
+++ b/source/views/streaming/webcams.js
@@ -174,7 +174,6 @@ const styles = StyleSheet.create({
     width: cellWidth,
     height: cellHeight,
     margin: CELL_MARGIN / 2,
-    alignItems: 'center',
     justifyContent: 'center',
 
     elevation: 2,


### PR DESCRIPTION
Remove align center to expand webcam images.

Closes #1301

Before | After
--|--
<img width="318" alt="screen shot 2017-07-25 at 2 01 44 am" src="https://user-images.githubusercontent.com/5240843/28557911-47ed0a20-70dd-11e7-943d-ac94c8269207.png"> | <img width="319" alt="screen shot 2017-07-25 at 2 04 11 am" src="https://user-images.githubusercontent.com/5240843/28557966-99932698-70dd-11e7-8e9e-6a7fb20a34ff.png">
<img width="374" alt="screen shot 2017-07-25 at 2 28 16 am" src="https://user-images.githubusercontent.com/5240843/28558711-19b3f282-70e1-11e7-89cf-32b292e4a3fd.png"> | <img width="376" alt="screen shot 2017-07-25 at 2 27 34 am" src="https://user-images.githubusercontent.com/5240843/28558710-19b3a7b4-70e1-11e7-9a85-56bca03f8ee3.png">