### PR TITLE
Port Contacts to FlatList

### DIFF
--- a/source/views/components/list/list-footer.js
+++ b/source/views/components/list/list-footer.js
@@ -8,9 +8,8 @@ const styles = StyleSheet.create({
     fontSize: 10,
     color: c.iosDisabledText,
     textAlign: 'center',
-  },
-  poweredBy: {
-    paddingBottom: 20,
+    paddingVertical: 20,
+    paddingBottom: 25,
   },
 })
 
@@ -23,7 +22,7 @@ export class ListFooter extends React.PureComponent {
   render() {
     const {title} = this.props
     return (
-      <Text selectable={true} style={[styles.footer, styles.poweredBy]}>
+      <Text selectable={true} style={[styles.footer]}>
         {title}
       </Text>
     )

--- a/source/views/contacts/card.js
+++ b/source/views/contacts/card.js
@@ -11,9 +11,6 @@ import * as c from '../components/colors'
 
 const styles = StyleSheet.create({
   container: {
-    marginLeft: 5,
-    marginRight: 5,
-    marginBottom: 5,
     backgroundColor: c.white,
   },
   title: {
@@ -22,10 +19,7 @@ const styles = StyleSheet.create({
     marginTop: 10,
   },
   content: {
-    marginTop: 5,
-    marginBottom: 5,
-    marginLeft: 10,
-    marginRight: 10,
+    marginHorizontal: 10,
   },
 })
 

--- a/source/views/contacts/contacts.js
+++ b/source/views/contacts/contacts.js
@@ -5,24 +5,58 @@
  */
 
 import React from 'react'
-import SimpleListView from '../components/listview'
-import {data as numbers} from '../../../docs/contact-info.json'
+import {FlatList, View, StyleSheet} from 'react-native'
+import {ListEmpty, ListFooter} from '../components/list'
 import {ContactCard} from './card'
+import {data} from './data'
+import type {CardType} from './types'
 
-export default function ContactView() {
-  return (
-    <SimpleListView data={numbers}>
-      {data =>
-        <ContactCard
-          title={data.title}
-          text={data.text}
-          phoneNumber={data.phoneNumber}
-          buttonText={data.buttonText}
-        />}
-    </SimpleListView>
-  )
-}
-ContactView.navigationOptions = {
-  title: 'Important Contacts',
-  headerBackTitle: 'Contacts',
+const AAO_URL = 'https://github.com/StoDevX/AAO-React-Native/issues/new'
+
+const styles = StyleSheet.create({
+  list: {
+    paddingTop: 5,
+    marginHorizontal: 5,
+  },
+  separator: {
+    height: 5,
+  },
+})
+
+const ContactsSeparator = () => <View style={styles.separator} />
+
+export default class ContactView extends React.PureComponent {
+  static navigationOptions = {
+    title: 'Important Contacts',
+    headerBackTitle: 'Contacts',
+  }
+
+  keyExtractor = (item: CardType) => {
+    return item.title
+  }
+
+  render() {
+    return (
+      <FlatList
+        ItemSeparatorComponent={ContactsSeparator}
+        ListEmptyComponent={<ListEmpty mode="bug" />}
+        ListFooterComponent={
+          <ListFooter
+            title="Collected by the humans of All About Olaf"
+            href={AAO_URL}
+          />
+        }
+        style={styles.list}
+        data={data}
+        keyExtractor={this.keyExtractor}
+        renderItem={({item}: {item: CardType}) =>
+          <ContactCard
+            title={item.title}
+            text={item.text}
+            phoneNumber={item.phoneNumber}
+            buttonText={item.buttonText}
+          />}
+      />
+    )
+  }
 }

--- a/source/views/contacts/data.js
+++ b/source/views/contacts/data.js
@@ -1,0 +1,7 @@
+// @flow
+import {data} from '../../../docs/contact-info.json'
+import type {CardType} from './types'
+
+(data: Array<CardType>);
+
+export {data}


### PR DESCRIPTION
Things to note:

FlatList expects either data with a `key` property, or a `keyExtractor` function that facilitates getting a unique-per-list key. I'm using the `title` property as the key here.

You'll notice that I didn't update the SimpleListView wrapper for this – I think that FlatList and SectionList will prove simple enough that we won't need SimpleListView anymore.

Before | After
--- | ---
<img width="375" alt="screen shot 2017-08-02 at 7 20 57 pm" src="https://user-images.githubusercontent.com/464441/28900571-c80206d0-77b7-11e7-861a-5bc71ea05612.png"> | <img width="375" alt="screen shot 2017-08-02 at 7 20 41 pm" src="https://user-images.githubusercontent.com/464441/28900574-ce2ab548-77b7-11e7-98e9-fd02906dfc4a.png">
<img width="375" alt="screen shot 2017-08-02 at 7 21 02 pm" src="https://user-images.githubusercontent.com/464441/28900585-eb0f90c0-77b7-11e7-800e-0b934b803b6a.png"> | <img width="375" alt="screen shot 2017-08-02 at 7 20 44 pm" src="https://user-images.githubusercontent.com/464441/28900589-edf18046-77b7-11e7-9333-beaff1ea6648.png">


… I seem to have reduced the spacing under the card titles. I don't care either way, really, but I'd rather not put it back.