### PR TITLE
Title-cased job types

### DIFF
--- a/source/views/contacts/data.js
+++ b/source/views/contacts/data.js
@@ -1,7 +1,6 @@
 // @flow
 import {data} from '../../../docs/contact-info.json'
 import type {CardType} from './types'
-
 ;(data: Array<CardType>)
 
 export {data}

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -20,7 +20,6 @@ import delay from 'delay'
 import size from 'lodash/size'
 import orderBy from 'lodash/orderBy'
 import groupBy from 'lodash/groupBy'
-import map from 'lodash/map'
 import {toLaxTitleCase as titleCase} from 'titlecase'
 import {JobRow} from './job-row'
 import type {JobType} from './types'
@@ -61,10 +60,10 @@ export default class StudentWorkView extends React.Component {
 
   fetchData = async () => {
     try {
-      const data: {[key: string]: JobType[]} = await fetchJson(jobsUrl)
+      const data: Array<JobType> = await fetchJson(jobsUrl)
 
       // force title-case on the job types, to prevent not-actually-duplicate headings
-      const processed = map(data, job => ({...job, type: titleCase(job.type)}))
+      const processed = data.map(job => ({...job, type: titleCase(job.type)}))
 
       // Turns out that, for our data, we really just want to sort the categories
       // _backwards_ - that is, On-Campus Work Study should come before

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -20,6 +20,7 @@ import delay from 'delay'
 import size from 'lodash/size'
 import orderBy from 'lodash/orderBy'
 import groupBy from 'lodash/groupBy'
+import map from 'lodash/map'
 import {toLaxTitleCase as titleCase} from 'titlecase'
 import {JobRow} from './job-row'
 import type {JobType} from './types'
@@ -63,7 +64,7 @@ export default class StudentWorkView extends React.Component {
       const data: {[key: string]: JobType[]} = await fetchJson(jobsUrl)
 
       // force title-case on the job types, to prevent not-actually-duplicate headings
-      const processed = data.map(job => ({...job, type: titleCase(job.type)}))
+      const processed = map(data, job => ({...job, type: titleCase(job.type)}))
 
       // Turns out that, for our data, we really just want to sort the categories
       // _backwards_ - that is, On-Campus Work Study should come before

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -18,7 +18,7 @@ import {NoticeView} from '../../components/notice'
 import LoadingView from '../../components/loading'
 import delay from 'delay'
 import size from 'lodash/size'
-import sortBy from 'lodash/sortBy'
+import orderBy from 'lodash/orderBy'
 import groupBy from 'lodash/groupBy'
 import {toLaxTitleCase as titleCase} from 'titlecase'
 import {JobRow} from './job-row'
@@ -26,13 +26,6 @@ import type {JobType} from './types'
 
 const jobsUrl =
   'https://www.stolaf.edu/apps/stuwork/index.cfm?fuseaction=getall&nostructure=1'
-
-const jobSort = new Map([
-  ['On-campus Work Study', 1],
-  ['Off-campus Community Service Work Study', 2],
-  ['On-campus Summer Employment', 3],
-  ['Off-campus Summer Employment', 4],
-])
 
 const styles = StyleSheet.create({
   listContainer: {
@@ -72,13 +65,16 @@ export default class StudentWorkView extends React.Component {
       // force title-case on the job types, to prevent not-actually-duplicate headings
       const processed = data.map(job => ({...job, type: titleCase(job.type)}))
 
-      // We have predefined orders for some job types, but we want all
-      // unknown types to show up at the end of the view, so we make
-      // them sort as Infinity
-      const sorted = sortBy(data, [
-        j => jobSort.get(j.type) || Infinity, // apply predefined group orderings
+      // Turns out that, for our data, we really just want to sort the categories
+      // _backwards_ - that is, On-Campus Work Study should come before 
+      // Off-Campus Work Study, and the Work Studies should come before the 
+      // Summer Employments
+      const sorted = orderBy(data, [
         j => j.type, // sort any groups with the same sort index alphabetically
         j => j.lastModified, // sort all jobs by date-last-modified
+      ], [
+        'desc',
+        'asc',
       ])
 
       this.setState(() => ({jobs: groupBy(sorted, j => j.type)}))

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -70,7 +70,7 @@ export default class StudentWorkView extends React.Component {
       // Off-Campus Work Study, and the Work Studies should come before the
       // Summer Employments
       const sorted = orderBy(
-        data,
+        processed,
         [
           j => j.type, // sort any groups with the same sort index alphabetically
           j => j.lastModified, // sort all jobs by date-last-modified

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -66,16 +66,17 @@ export default class StudentWorkView extends React.Component {
       const processed = data.map(job => ({...job, type: titleCase(job.type)}))
 
       // Turns out that, for our data, we really just want to sort the categories
-      // _backwards_ - that is, On-Campus Work Study should come before 
-      // Off-Campus Work Study, and the Work Studies should come before the 
+      // _backwards_ - that is, On-Campus Work Study should come before
+      // Off-Campus Work Study, and the Work Studies should come before the
       // Summer Employments
-      const sorted = orderBy(data, [
-        j => j.type, // sort any groups with the same sort index alphabetically
-        j => j.lastModified, // sort all jobs by date-last-modified
-      ], [
-        'desc',
-        'asc',
-      ])
+      const sorted = orderBy(
+        data,
+        [
+          j => j.type, // sort any groups with the same sort index alphabetically
+          j => j.lastModified, // sort all jobs by date-last-modified
+        ],
+        ['desc', 'asc'],
+      )
 
       this.setState(() => ({jobs: groupBy(sorted, j => j.type)}))
     } catch (err) {

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -70,7 +70,7 @@ export default class StudentWorkView extends React.Component {
       const data: {[key: string]: JobType[]} = await fetchJson(jobsUrl)
 
       // force title-case on the job types, to prevent not-actually-duplicate headings
-      const processed = data.map(job => ({...job, type: titleCase(job.type)})
+      const processed = data.map(job => ({...job, type: titleCase(job.type)}))
 
       // We have predefined orders for some job types, but we want all
       // unknown types to show up at the end of the view, so we make

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -20,6 +20,7 @@ import delay from 'delay'
 import size from 'lodash/size'
 import sortBy from 'lodash/sortBy'
 import groupBy from 'lodash/groupBy'
+import {toLaxTitleCase as titleCase} from 'titlecase'
 import {JobRow} from './job-row'
 import type {JobType} from './types'
 
@@ -67,6 +68,9 @@ export default class StudentWorkView extends React.Component {
   fetchData = async () => {
     try {
       const data: {[key: string]: JobType[]} = await fetchJson(jobsUrl)
+
+      // force title-case on the job types, to prevent not-actually-duplicate headings
+      const processed = data.map(job => ({...job, type: titleCase(job.type)})
 
       // We have predefined orders for some job types, but we want all
       // unknown types to show up at the end of the view, so we make


### PR DESCRIPTION
Turns 'on-campus non-work study' into 'On-Campus Non-Work Study'

I also updated the job-type sorting algorithm – it turns out that, for our data, we really just want to sort the categories _backwards_ - that is, "On-Campus Work Study" should come before "Off-Campus Work Study", and the "Work Studies" should come before the "Summer Employments".

Closes https://github.com/StoDevX/AAO-React-Native/issues/1343.