### PR TITLE
Add special-case tel: and mailto: handling

### DIFF
--- a/source/views/components/__tests__/open-url.test.js
+++ b/source/views/components/__tests__/open-url.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+
+import {canOpenUrl} from '../open-url'
+
+describe('canOpenUrl', () => {
+    test('opens http:// links', () => {
+        expect(canOpenUrl('http://google.com')).toBe(true)
+    })
+    test('opens https:// links', () => {
+        expect(canOpenUrl('https://google.com')).toBe(true)
+    })
+    test('opens tel: links', () => {
+        expect(canOpenUrl('tel:18001234567')).toBe(true)
+    })
+    test('opens mailto: links', () => {
+        expect(canOpenUrl('mailto:aao@stolaf.edu')).toBe(true)
+    })
+    test('does not open about: links', () => {
+        expect(canOpenUrl('about:blank')).toBe(false)
+        expect(canOpenUrl('about:config')).toBe(false)
+    })
+    test('does not open data: urls', () => {
+        expect(canOpenUrl('data:base64;fab')).toBe(false)
+    })
+})

--- a/source/views/components/__tests__/open-url.test.js
+++ b/source/views/components/__tests__/open-url.test.js
@@ -3,23 +3,23 @@
 import {canOpenUrl} from '../open-url'
 
 describe('canOpenUrl', () => {
-    test('opens http:// links', () => {
-        expect(canOpenUrl('http://google.com')).toBe(true)
-    })
-    test('opens https:// links', () => {
-        expect(canOpenUrl('https://google.com')).toBe(true)
-    })
-    test('opens tel: links', () => {
-        expect(canOpenUrl('tel:18001234567')).toBe(true)
-    })
-    test('opens mailto: links', () => {
-        expect(canOpenUrl('mailto:aao@stolaf.edu')).toBe(true)
-    })
-    test('does not open about: links', () => {
-        expect(canOpenUrl('about:blank')).toBe(false)
-        expect(canOpenUrl('about:config')).toBe(false)
-    })
-    test('does not open data: urls', () => {
-        expect(canOpenUrl('data:base64;fab')).toBe(false)
-    })
+  test('opens http:// links', () => {
+    expect(canOpenUrl('http://google.com')).toBe(true)
+  })
+  test('opens https:// links', () => {
+    expect(canOpenUrl('https://google.com')).toBe(true)
+  })
+  test('opens tel: links', () => {
+    expect(canOpenUrl('tel:18001234567')).toBe(true)
+  })
+  test('opens mailto: links', () => {
+    expect(canOpenUrl('mailto:aao@stolaf.edu')).toBe(true)
+  })
+  test('does not open about: links', () => {
+    expect(canOpenUrl('about:blank')).toBe(false)
+    expect(canOpenUrl('about:config')).toBe(false)
+  })
+  test('does not open data: urls', () => {
+    expect(canOpenUrl('data:base64;fab')).toBe(false)
+  })
 })

--- a/source/views/components/open-url.js
+++ b/source/views/components/open-url.js
@@ -6,18 +6,13 @@ import {tracker} from '../../analytics'
 import SafariView from 'react-native-safari-view'
 import {CustomTabs} from 'react-native-custom-tabs'
 
-let iosOnShowListener = null
-let iosOnDismissListener = null
+let iosOnShowListener = () => StatusBar.setBarStyle('dark-content')
+let iosOnDismissListener = () => StatusBar.setBarStyle('light-content')
 function startStatusBarColorChanger() {
   SafariView.isAvailable()
     .then(() => {
-      iosOnShowListener = SafariView.addEventListener('onShow', () =>
-        StatusBar.setBarStyle('dark-content'),
-      )
-
-      iosOnDismissListener = SafariView.addEventListener('onDismiss', () =>
-        StatusBar.setBarStyle('light-content'),
-      )
+      SafariView.addEventListener('onShow', iosOnShowListener)
+      SafariView.addEventListener('onDismiss', iosOnDismissListener)
     })
     .catch(() => {})
 }

--- a/source/views/components/open-url.js
+++ b/source/views/components/open-url.js
@@ -66,6 +66,19 @@ function androidOpen(url: string) {
 }
 
 export default function openUrl(url: string) {
+  const protocol = /^(.*?):?\/\//.exec(url)
+
+  if (protocol.length) {
+    switch (protocol[1]) {
+      case 'tel':
+        return genericOpen(url)
+      case 'mailto':
+        return genericOpen(url)
+      default:
+        break
+    }
+  }
+
   switch (Platform.OS) {
     case 'android':
       return androidOpen(url)

--- a/source/views/components/open-url.js
+++ b/source/views/components/open-url.js
@@ -61,7 +61,7 @@ function androidOpen(url: string) {
 }
 
 export default function openUrl(url: string) {
-  const protocol = /^(.*?):?\/\//.exec(url)
+  const protocol = /^(.*?):/.exec(url)
 
   if (protocol.length) {
     switch (protocol[1]) {


### PR DESCRIPTION
With this patch, when someone taps a `tel:` or `mailto:` protocol link, SafariWebView won't crash because the RN Linking library will handle it.

This will let us use phone numbers and email addresses in the new Markdown components.