### PR TITLE
Remove the fixed-width restriction from <Button/>

### DIFF
--- a/source/views/components/__tests__/__snapshots__/button.test.js.snap
+++ b/source/views/components/__tests__/__snapshots__/button.test.js.snap
@@ -58,8 +58,8 @@ exports[`can change the title 1`] = `
         "color": "#FFFFFF",
         "marginVertical": 10,
         "overflow": "hidden",
+        "paddingHorizontal": 20,
         "paddingVertical": 10,
-        "width": 200,
       },
       false,
     ]
@@ -81,8 +81,8 @@ exports[`renders 1`] = `
         "color": "#FFFFFF",
         "marginVertical": 10,
         "overflow": "hidden",
+        "paddingHorizontal": 20,
         "paddingVertical": 10,
-        "width": 200,
       },
       false,
     ]

--- a/source/views/components/button.js
+++ b/source/views/components/button.js
@@ -9,10 +9,10 @@ import * as c from './colors'
 const styles = StyleSheet.create({
   button: {
     backgroundColor: c.denim,
-    width: 200,
     color: c.white,
     alignSelf: 'center',
     paddingVertical: 10,
+    paddingHorizontal: 20,
     marginVertical: 10,
     borderRadius: 6,
     overflow: 'hidden',


### PR DESCRIPTION
As the title says.

Before | After
--- | ---
<img width="375" alt="screen shot 2017-08-05 at 3 56 19 pm" src="https://user-images.githubusercontent.com/464441/28998668-a62947ee-79f6-11e7-8071-47245ade303d.png"> | <img width="375" alt="screen shot 2017-08-05 at 3 56 00 pm" src="https://user-images.githubusercontent.com/464441/28998669-a7cf359a-79f6-11e7-958a-7a706081655c.png">

… ignore the markdown and formatting of the text boxes plz. 😄 
