### PR TITLE
port Calendar to SectionList

### DIFF
--- a/source/views/calendar/event-list.js
+++ b/source/views/calendar/event-list.js
@@ -5,19 +5,21 @@
  */
 
 import React from 'react'
-import {StyleSheet} from 'react-native'
+import {StyleSheet, SectionList} from 'react-native'
 import * as c from '../components/colors'
-import SimpleListView from '../components/listview'
+import toPairs from 'lodash/toPairs'
 import type {TopLevelViewPropsType} from '../types'
 import type {EventType} from './types'
 import groupBy from 'lodash/groupBy'
-import size from 'lodash/size'
 import moment from 'moment-timezone'
 import {ListSeparator, ListSectionHeader} from '../components/list'
 import {NoticeView} from '../components/notice'
 import EventRow from './event-row'
 
-export class EventList extends React.Component {
+const FullWidthSeparator = props =>
+  <ListSeparator fullWidth={true} {...props} />
+
+export class EventList extends React.PureComponent {
   props: TopLevelViewPropsType & {
     events: EventType[],
     message: ?string,
@@ -26,11 +28,9 @@ export class EventList extends React.Component {
     now: moment,
   }
 
-  groupEvents = (
-    events: EventType[],
-    now: moment,
-  ): {[key: string]: EventType[]} => {
-    return groupBy(events, event => {
+  groupEvents = (events: EventType[], now: moment): any => {
+    // the proper return type is $ReadOnlyArray<{title: string, data: $ReadOnlyArray<EventType>}>
+    const grouped = groupBy(events, event => {
       if (event.isOngoing) {
         return 'Ongoing'
       }
@@ -39,49 +39,43 @@ export class EventList extends React.Component {
       }
       return event.startTime.format('ddd  MMM Do') // google returns events in CST
     })
+
+    return toPairs(grouped).map(([key, value]) => ({
+      title: key,
+      data: value,
+    }))
   }
 
   onPressEvent = (title: string, event: EventType) => {
     this.props.navigation.navigate('EventDetailView', {event})
   }
 
-  renderSectionHeader = (
-    sectionData: EventType[],
-    sectionIdentifier: string,
-  ) => {
-    return <ListSectionHeader title={sectionIdentifier} spacing={{left: 10}} />
-  }
+  renderSectionHeader = ({section: {title}}: any) =>
+    // the proper type is ({section: {title}}: {section: {title: string}})
+    <ListSectionHeader title={title} spacing={{left: 10}} />
 
-  renderSeparator = (sectionID: any, rowID: any) => {
-    return <ListSeparator fullWidth={true} key={`${sectionID}-${rowID}`} />
-  }
+  renderItem = ({item}: {item: EventType}) =>
+    <EventRow onPress={this.onPressEvent} event={item} />
+
+  keyExtractor = (item: EventType, index: number) => index.toString()
 
   render() {
     if (this.props.message) {
       return <NoticeView text={this.props.message} />
     }
 
-    if (!size(this.props.events)) {
-      return <NoticeView text="No events." />
-    }
-
-    const events = this.groupEvents(this.props.events, this.props.now)
-
     return (
-      <SimpleListView
+      <SectionList
+        ItemSeparatorComponent={FullWidthSeparator}
+        ListEmptyComponent={<NoticeView text="No events." />}
         style={styles.container}
-        data={events}
-        renderSectionHeader={this.renderSectionHeader}
-        renderSeparator={this.renderSeparator}
+        sections={this.groupEvents(this.props.events, this.props.now)}
+        keyExtractor={this.keyExtractor}
         refreshing={this.props.refreshing}
         onRefresh={this.props.onRefresh}
-      >
-        {(event: EventType) =>
-          <EventRow
-            onPress={() => this.onPressEvent(event.summary, event)}
-            event={event}
-          />}
-      </SimpleListView>
+        renderSectionHeader={this.renderSectionHeader}
+        renderItem={this.renderItem}
+      />
     )
   }
 }

--- a/source/views/calendar/event-list.js
+++ b/source/views/calendar/event-list.js
@@ -46,7 +46,7 @@ export class EventList extends React.PureComponent {
     }))
   }
 
-  onPressEvent = (title: string, event: EventType) => {
+  onPressEvent = (event: EventType) => {
     this.props.navigation.navigate('EventDetailView', {event})
   }
 

--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -32,43 +32,50 @@ const styles = StyleSheet.create({
   },
 })
 
-export default function EventRow({
-  event,
-  onPress,
-}: {
-  event: EventType,
-  onPress: () => any,
-}) {
-  const title = fastGetTrimmedText(event.summary)
+export default class EventRow extends React.PureComponent {
+  props: {
+    event: EventType,
+    onPress: (string, EventType) => any,
+  }
 
-  const location = event.location && event.location.trim().length
-    ? <Detail>{event.location}</Detail>
-    : null
+  _onPress = () => {
+    const {event} = this.props
+    this.props.onPress(event.summary, event)
+  }
 
-  return (
-    <ListRow
-      contentContainerStyle={styles.row}
-      arrowPosition="top"
-      fullWidth={true}
-      onPress={onPress}
-    >
-      <Row>
-        <CalendarTimes event={event} style={styles.timeContainer} />
+  render() {
+    const {event} = this.props
+    const title = fastGetTrimmedText(event.summary)
 
-        <Bar style={styles.bar} />
+    const location = event.location && event.location.trim().length
+      ? <Detail>{event.location}</Detail>
+      : null
 
-        <Column
-          flex={1}
-          paddingTop={2}
-          paddingBottom={3}
-          justifyContent="space-between"
-        >
-          <Title>{title}</Title>
-          {location}
-        </Column>
-      </Row>
-    </ListRow>
-  )
+    return (
+      <ListRow
+        contentContainerStyle={styles.row}
+        arrowPosition="top"
+        fullWidth={true}
+        onPress={this._onPress}
+      >
+        <Row>
+          <CalendarTimes event={event} style={styles.timeContainer} />
+
+          <Bar style={styles.bar} />
+
+          <Column
+            flex={1}
+            paddingTop={2}
+            paddingBottom={3}
+            justifyContent="space-between"
+          >
+            <Title>{title}</Title>
+            {location}
+          </Column>
+        </Row>
+      </ListRow>
+    )
+  }
 }
 
 function CalendarTimes({event, style}: {event: EventType, style: any}) {

--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -35,13 +35,10 @@ const styles = StyleSheet.create({
 export default class EventRow extends React.PureComponent {
   props: {
     event: EventType,
-    onPress: (string, EventType) => any,
+    onPress: EventType => any,
   }
 
-  _onPress = () => {
-    const {event} = this.props
-    this.props.onPress(event.summary, event)
-  }
+  _onPress = () => this.props.onPress(this.props.event)
 
   render() {
     const {event} = this.props


### PR DESCRIPTION
No visual differences on the ListView; empty calendars need some work.

<img width="375" alt="screen shot 2017-08-05 at 9 30 31 pm" src="https://user-images.githubusercontent.com/464441/29000054-520d8e16-7a25-11e7-86de-6b332eb3a59b.png">

---

You will notice two comments along these lines: `// the proper return type is $ReadOnlyArray<{title: string, data: $ReadOnlyArray<EventType>}>`.

That's because I cannot for the _life_ of me convince Flow and SectionList to play nice together.

It's complaining about things like that I didn't annotate the whole object that's being passed in, but I would have expected that to validate as a subset – "I just need something that conforms to this shape" – but whatever.

Except, I went to the [Flow docs](https://flow.org/en/docs/lang/width-subtyping/): 

> "It’s safe to use an object with “extra” properties in a position that is annotated with a specific set of properties."

OK, thanks, flow docs.

For now, I've just annotated those as `any`.