### PR TITLE
Port News to FlatList

### DIFF
--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -23,7 +23,7 @@ export class NewsList extends React.Component {
     embedFeaturedImage: ?boolean,
   }
 
-  onPressNews = (title: string, story: StoryType) => {
+  onPressNews = (story: StoryType) => {
     this.props.navigation.navigate('NewsItemView', {
       story,
       embedFeaturedImage: this.props.embedFeaturedImage,

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -1,8 +1,7 @@
 // @flow
 import React from 'react'
-import {StyleSheet} from 'react-native'
+import {StyleSheet, FlatList} from 'react-native'
 import * as c from '../components/colors'
-import SimpleListView from '../components/listview'
 import type {StoryType} from './types'
 import {ListSeparator} from '../components/list'
 import {NoticeView} from '../components/notice'
@@ -15,19 +14,13 @@ const styles = StyleSheet.create({
   },
 })
 
-type NewsListPropsType = TopLevelViewPropsType & {
-  name: string,
-  onRefresh: () => any,
-  entries: StoryType[],
-  loading: boolean,
-  embedFeaturedImage: ?boolean,
-}
-
 export class NewsList extends React.Component {
-  props: NewsListPropsType
-
-  renderSeparator = (sectionId: string, rowId: string) => {
-    return <ListSeparator key={`${sectionId}-${rowId}`} />
+  props: TopLevelViewPropsType & {
+    name: string,
+    onRefresh: () => any,
+    entries: StoryType[],
+    loading: boolean,
+    embedFeaturedImage: ?boolean,
   }
 
   onPressNews = (title: string, story: StoryType) => {
@@ -37,6 +30,11 @@ export class NewsList extends React.Component {
     })
   }
 
+  renderItem = ({item}: {item: StoryType}) =>
+    <NewsRow onPress={this.onPressNews} story={item} />
+
+  keyExtractor = (item: StoryType) => item.title
+
   render() {
     // remove all entries with blank excerpts
     // remove all entries with a <form from the list
@@ -44,24 +42,17 @@ export class NewsList extends React.Component {
       .filter(entry => entry.excerpt.trim() !== '')
       .filter(entry => !entry.content.includes('<form'))
 
-    if (!entries.length) {
-      return <NoticeView text="No news." />
-    }
-
     return (
-      <SimpleListView
+      <FlatList
+        ItemSeparatorComponent={ListSeparator}
+        ListEmptyComponent={<NoticeView text="No news." />}
+        keyExtractor={this.keyExtractor}
         style={styles.listContainer}
         data={entries}
-        renderSeparator={this.renderSeparator}
         refreshing={this.props.loading}
         onRefresh={this.props.onRefresh}
-      >
-        {(story: StoryType) =>
-          <NewsRow
-            onPress={() => this.onPressNews(story.title, story)}
-            story={story}
-          />}
-      </SimpleListView>
+        renderItem={this.renderItem}
+      />
     )
   }
 }

--- a/source/views/news/news-row.js
+++ b/source/views/news/news-row.js
@@ -6,25 +6,33 @@ import {Column, Row} from '../components/layout'
 import {ListRow, Detail, Title} from '../components/list'
 import type {StoryType} from './types'
 
-type NewsRowPropsType = {
-  onPress: () => any,
-  story: StoryType,
-}
+export class NewsRow extends React.PureComponent {
+  props: {
+    onPress: (string, StoryType) => any,
+    story: StoryType,
+  }
 
-export function NewsRow({onPress, story}: NewsRowPropsType) {
-  return (
-    <ListRow onPress={onPress} arrowPosition="top">
-      <Row alignItems="center">
-        <Column flex={1}>
-          <Title lines={1}>{story.title}</Title>
-          <Detail lines={2}>{story.excerpt}</Detail>
-        </Column>
-        {story.featuredImage
-          ? <Image source={{uri: story.featuredImage}} style={styles.image} />
-          : null}
-      </Row>
-    </ListRow>
-  )
+  _onPress = () => {
+    this.props.onPress(this.props.story.title, this.props.story)
+  }
+
+  render() {
+    const {story} = this.props
+
+    return (
+      <ListRow onPress={this._onPress} arrowPosition="top">
+        <Row alignItems="center">
+          <Column flex={1}>
+            <Title lines={1}>{story.title}</Title>
+            <Detail lines={2}>{story.excerpt}</Detail>
+          </Column>
+          {story.featuredImage
+            ? <Image source={{uri: story.featuredImage}} style={styles.image} />
+            : null}
+        </Row>
+      </ListRow>
+    )
+  }
 }
 
 const styles = StyleSheet.create({

--- a/source/views/news/news-row.js
+++ b/source/views/news/news-row.js
@@ -8,13 +8,11 @@ import type {StoryType} from './types'
 
 export class NewsRow extends React.PureComponent {
   props: {
-    onPress: (string, StoryType) => any,
+    onPress: StoryType => any,
     story: StoryType,
   }
 
-  _onPress = () => {
-    this.props.onPress(this.props.story.title, this.props.story)
-  }
+  _onPress = () => this.props.onPress(this.props.story)
 
   render() {
     const {story} = this.props


### PR DESCRIPTION
• | Before | After
--- | --- | ---
St. Olaf | <img width="375" alt="screen shot 2017-08-05 at 10 11 34 pm" src="https://user-images.githubusercontent.com/464441/29000241-20620e4a-7a2b-11e7-9e31-4a244a4c71bf.png">|<img width="375" alt="screen shot 2017-08-05 at 10 11 21 pm" src="https://user-images.githubusercontent.com/464441/29000243-23136e68-7a2b-11e7-87d5-095921bc0fbc.png">
PoliticOle | <img width="375" alt="screen shot 2017-08-05 at 10 11 37 pm" src="https://user-images.githubusercontent.com/464441/29000244-26602b1a-7a2b-11e7-86dd-4b7cbdf14175.png">|<img width="375" alt="screen shot 2017-08-05 at 10 11 23 pm" src="https://user-images.githubusercontent.com/464441/29000245-2838bf2e-7a2b-11e7-8eb6-84217e9850c4.png">

As you can see, FlatList doesn't render the separator at the bottom of the list.

That might be configurable. We might prefer it. I haven't checked what Mail does.