### PR TITLE
Submit release notes to Testflight

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,12 +47,12 @@ Makes a build
 ```
 fastlane android beta
 ```
-Submit a new Beta Build to Google Play
+Submit a new beta build to Google Play
 ### android nightly
 ```
 fastlane android nightly
 ```
-Submit a new nightly Build to Google Play
+Submit a new nightly build to Google Play
 ### android ci-run
 ```
 fastlane android ci-run

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -64,15 +64,19 @@ def propagate_version(**args)
   end
 end
 
+# last_git_tag returns the most recent tag, chronologically.
+# newest_tag returns the most recent tag *on this branch*.
+def newest_tag
+  # we chomp to remove the newline
+  sh('git describe --tags --abbrev=0').chomp
+end
+
 # Makes a changelog from the timespan passed
 def make_changelog
   to_ref = ENV['TRAVIS_COMMIT'] || 'HEAD'
-  from_ref = hockeyapp_version_commit || 'HEAD~3'
+  from_ref = newest_tag
 
-  sh("git log #{from_ref}..#{to_ref} --pretty='%an, %aD (%h)%n> %s%n'")
-    .lines
-    .map { |line| '    ' + line }
-    .join
+  sh("git log #{from_ref}..#{to_ref} --oneline --graph")
 end
 
 # It doesn't make sense to duplicate this in both platforms, and fastlane is

--- a/fastlane/platforms/agnostic.rb
+++ b/fastlane/platforms/agnostic.rb
@@ -1,16 +1,3 @@
-desc 'Build the release notes: branch, commit hash, changelog'
-private_lane :release_notes do |options|
-  notes = <<~END
-    branch: #{git_branch}
-    git commit: #{last_git_commit[:commit_hash]}
-
-    ## Changelog
-    (empty)
-  END
-  UI.message notes
-  notes
-end
-
 desc 'clone the match repo'
 private_lane :clone_match do
   git_url = 'https://github.com/hawkrives/aao-keys'

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -15,9 +15,9 @@ platform :android do
     UI.message lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS]
   end
 
-  desc 'Submit a new Beta Build to Google Play'
-  lane :beta do |options|
-    track = options[:track] || 'beta'
+  desc 'Submit a new build to Google Play'
+  private_lane :submit do |options|
+    track = options[:track]
     build(track: track)
 
     lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] =
@@ -25,10 +25,16 @@ platform :android do
         apk.end_with? '-release.apk'
       end
 
-    supply(track: track, check_superseded_tracks: true)
+    supply(track: track,
+           check_superseded_tracks: true)
   end
 
-  desc 'Submit a new nightly Build to Google Play'
+  desc 'Submit a new beta build to Google Play'
+  lane :beta do
+    beta(track: 'beta')
+  end
+
+  desc 'Submit a new nightly build to Google Play'
   lane :nightly do
     beta(track: 'alpha')
   end

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -23,7 +23,7 @@ platform :ios do
   desc 'Submit a new Beta Build to Testflight'
   lane :beta do
     build
-    testflight(changelog: make_changelog)
+    testflight
   end
 
   desc 'Submit a new nightly Beta Build to Testflight'

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -23,13 +23,14 @@ platform :ios do
   desc 'Submit a new Beta Build to Testflight'
   lane :beta do
     build
-    testflight
+    testflight(changelog: make_changelog)
   end
 
   desc 'Submit a new nightly Beta Build to Testflight'
   lane :nightly do
     build
-    testflight(distribute_external: false)
+    testflight(changelog: make_changelog,
+               distribute_external: false)
   end
 
   desc 'Upload dYSM symbols to Bugsnag from Apple'


### PR DESCRIPTION
<details><summary>Example output</summary>
<pre>
*   1c0b99e2 Merge pull request #1353 from StoDevX/greenkeeper/eslint-4.4.0
|\
| * 1a5cdfc1 chore(package): update eslint to version 4.4.0
|/
*   e427453d Merge pull request #1352 from StoDevX/greenkeeper/buffer-5.0.7
|\
| * 8cc2119f fix(package): update buffer to version 5.0.7
|/
* 9de3c193 enable check_superseded_tracks on android fastlane
*   97db7c04 Merge pull request #1351 from StoDevX/nix-uplink-check
|\
| * 597226f9 Fixup according to prettier and lint
| * 5f817eb7 Remove uplink status check from KSTO
* |   9b4c2c81 Merge pull request #1350 from StoDevX/bundle-update-2017-08-05-043200
|\ \
| |/
|/|
| * c9740725 Bundle Update on 2017-08-05
* |   2c6d021f Merge pull request #1348 from StoDevX/fix-ksto-urls
|\ \
| |/
|/|
| * 430f6ce2 update ksto stream url
* |   f4935dae Merge pull request #1347 from StoDevX/fix-webcam-urls
|\ \
| * | 11595bfb update webcam URLs for new backend
| |/
* |   0bf9cbdf Merge pull request #1349 from StoDevX/hawkrives-patch-1
|\ \
| |/
|/|
| * 146b4c29 Update faqs.md
|/
*   780bdf1e Merge pull request #1344 from StoDevX/title-cased-job-types
|\
| * 8efe928d Fix type of "data" variable
| * e460e2d9 switch map to avoid type conflicts
| * 27630d3e use processed variable
| * 50f957a6 ran prettier
| * ffb477b5 update job-type sorting algorithm
| * ff4de7c9 fix a missing close-paren
| * 1fd899fb forcibly title-case the job types
* |   cd99b207 Merge pull request #1340 from StoDevX/bundle-update-2017-08-04-003305
|\ \
| |/
|/|
| * a05562b6 Bundle Update on 2017-08-04
* |   9f142684 Merge pull request #1341 from StoDevX/greenkeeper/bugsnag-react-native-2.3.0
|\ \
| * | f3fffa91 fix(package): update bugsnag-react-native to version 2.3.0
| |/
* |   b3a85260 Merge pull request #1339 from StoDevX/greenkeeper/react-native-google-analytics-bridge-5.2.2
|\ \
| * | 9cbda1f4 fix(package): update react-native-google-analytics-bridge to version 5.2.2
| |/
* | b4716e59 run prettier
* | b22c4407 run npm install a second time if the first fails
|/
*   a20b25b4 Merge pull request #1337 from StoDevX/contacts-flatlist
|\
| *   c8a7b256 Merge pull request #1338 from StoDevX/contacts-flatlist-real
| |\
| | * 9e5597a2 tweak the padding on the list footer
| | * 117d9962 remove inappropriate styling from Card – it's been moved to the list
| | * 496dd8ea port Contacts to FlatList
| | * 899941a9 add a data-typing file
| |/
| * 1c453e8b import the new named export
| * 7dcba74e add a type for a Card
| * 17bdff65 create basic ListEmpty and ListFooter components
| * eccae17e clean up the code of the contact card a bit
* |   885ef488 Merge pull request #1336 from StoDevX/travis-fastlane-stuff
|\ \
| |/
|/|
| * 6117dd7a move match into ios :build lane
| * 0bb67fc7 bump the minimum fastlane version
| * 77e75d70 update fastlane to 2.50.1
| * 5d964d2d update fastlane's docs
| * 82596bf2 reset the android/ios project build numbers to 1.0.0
| * b730b91d remove the extra "version" tools from 'npm version'
| * 31b0b7cf remove the now-unneeded "bump" command
| * 1a60b5bf rework the propagate_version action
| * b5cc7d76 remove the old code from auto_beta
| * 80d13c4b allow current_build_number to get the last build from google play
| * 2bb3875d inline the bundle_data action into the android build lane
| * 0588482e make the :release_notes lane private
| * a0924ee2 simplify the android beta/nighty lanes
| * d55a62b9 reformat some bits of the fastlane files
| * b2bcbd10 move the android emulator creation into fastlane
| * d77d451f use the new setup_travis lane instead of ci_keychains
| * 1dfb0d90 remove the env vars that are no longer used from .travis.yml
| * 4dee3ef1 remove the commented-out code from before_install.sh
* |   8b2ae97f Merge pull request #1333 from StoDevX/greenkeeper/react-native-device-info-0.11.0
|\ \
| |/
|/|
| * 74572d74 fix(package): update react-native-device-info to version 0.11.0
|/
*   1a919c29 Merge pull request #1326 from StoDevX/greenkeeper/react-native-vector-icons-4.3.0
|\
| * 856dd118 Add Android 26 to Travis
| * e05fa7d2 fix(package): update react-native-vector-icons to version 4.3.0
* |   7566c956 Merge pull request #1332 from StoDevX/bundle-update-2017-08-02-201501
|\ \
| * | 606252f9 Bundle Update on 2017-08-02
|/ /
* |   b47d78a4 Merge pull request #1331 from StoDevX/greenkeeper/babel-plugin-flow-react-proptypes-4.1.0
|\ \
| * | 18807e6a chore(package): update babel-plugin-flow-react-proptypes to version 4.1.0
|/ /
* |   9d598c3e Merge pull request #1329 from StoDevX/bundle-update-2017-08-01-161315
|\ \
| * | 4b8deeda Bundle Update on 2017-08-01
|/ /
* |   12481f1f Merge pull request #1328 from StoDevX/greenkeeper/babel-plugin-flow-react-proptypes-4.0.0
|\ \
| |/
|/|
| * 1ca602d8 chore(package): update babel-plugin-flow-react-proptypes to version 4.0.0
|/
*   4286f9b2 Merge pull request #1325 from StoDevX/greenkeeper/js-yaml-3.9.1
|\
| * d4ffc6a6 chore(package): update js-yaml to version 3.9.1
* |   c0bb8d9c Merge pull request #1324 from StoDevX/bundle-update-2017-07-30-081203
|\ \
| |/
|/|
| * 55dd22d1 Bundle Update on 2017-07-30
|/
*   1ce03512 Merge pull request #1323 from StoDevX/bundle-update-2017-07-29-041413
|\
| * 780fd91a Bundle Update on 2017-07-29
|/
*   a97d3c0f Merge pull request #1321 from StoDevX/bundle-update-2017-07-28-001431
|\
| * a4b95379 Bundle Update on 2017-07-28
|/
* 2a2b535f update the xcscheme
*   6f78eefc Merge pull request #1319 from StoDevX/greenkeeper/eslint-plugin-babel-4.1.2
|\
| * ac953c4c chore(package): update eslint-plugin-babel to version 4.1.2
|/
*   2da055ae Merge pull request #1316 from StoDevX/align-webcams
|\
| * 2cfcaa53 remove align center to expand webcam images
* |   7cd2bfca Merge pull request #1317 from StoDevX/bundle-update-2017-07-25-161508
|\ \
| |/
|/|
| * 439cd39d Bundle Update on 2017-07-25
|/
*   5b42dc3d Merge pull request #1315 from StoDevX/greenkeeper/eslint-plugin-react-native-3.0.1
|\
| * 1bda3385 chore(package): update eslint-plugin-react-native to version 3.0.1
|/
*   f5cb5634 Merge pull request #1312 from StoDevX/hawkrives-patch-1
|\
| * aac3da7b prettier whitespace
| * 56aca2bc Update submit.js
| * 69b5ed08 remove a trim() that didn't really need to be there
| * 588ab4e3 remove dedent from building-hours/submit
|/
*   0a68016b Merge pull request #1311 from StoDevX/edit-hours-data-label
|\
| * ed9d3edc Update github label for building hours submissions
|/
*   448dd04b Merge pull request #1307 from StoDevX/bundle-update-2017-07-22-043447
|\
| * be0944cd Bundle Update on 2017-07-22
* |   1bf6a091 Merge pull request #1309 from StoDevX/fix-hours-submissions
|\ \
| * | 482d71d9 fix indentation of building hour submissions
|/ /
* |   840791bd Merge pull request #1304 from StoDevX/submit-updates
|\ \
| * | 8d9336c6 fix wording
| * | 667d9698 import querystring
| * | b6bc0041 make prettier happy
| * | 5a5f19c5 add a handy link to create an issue from a report email
| * | 74cecc52 remove an unused import and add a missing variable
| * | aaf89133 add initial support for submitting building issue reports
| * | e156841e update the prettier:changed command
* | |   a385df55 Merge pull request #1306 from StoDevX/nightlies
|\ \ \
| |_|/
|/| |
| * | ee8cceca add "nightly" build tracks, to run builds every night
| * | f24e699f make some cleanups to some fastlane files
| * | e9750de2 move auto-beta logic into auto-beta
| |/
* |   bd670043 Merge pull request #1305 from StoDevX/greenkeeper/eslint-4.3.0
|\ \
| |/
|/|
| * 3df0942f chore(package): update eslint to version 4.3.0
|/
*   9aac6e10 Merge pull request #1303 from StoDevX/greenkeeper/babel-plugin-flow-react-proptypes-3.4.3
|\
| * 028d56d5 chore(package): update babel-plugin-flow-react-proptypes to version 3.4.3
* |   347413f5 Merge pull request #1302 from StoDevX/bundle-update-2017-07-21-003645
|\ \
| |/
|/|
| * 5ebf0e3d Bundle Update on 2017-07-21
|/
*   ae54e519 Merge pull request #1300 from StoDevX/fix-cfbundleidenfitier
|\
| * 156d281f fix :CFBundleIdentifier Not Found error
|/
* 9ecaf02f essentially revert 9692ad6a131802229ec647799712840ce8a55e1a
* 778096cf reorder items in the xcode project
* 4ab420f8 Merge pull request #1285 from StoDevX/ksto
* a78938ea Enable background audio permissions
* edd9035d Merge branch 'master' into ksto
* 0317eca3 xcode did a thing
* 7a76b4b3 update type of state.streamError
* 0f425b2b add more functional setState calls
* 0bc93bbe fix non-bound functions
* be752ae7 update type of player to Video
* efefce4d remove unused import
* c55957b8 remove now-unused dynamic* variables
* 66d21044 extend purecomponent
* 8df05ca8 import tabbaricon
* 8bcb579c reduce the number of functions in the class
* 03a5c27c split into more components
* 325a670b move navigationOptions to be static
* e23a548b add types for react-native-video
* 9692ad6a read proper flow-typed typedefs
* 4668bdc2 properly add react-native-video to package
* c7f3fab6 add streaming radio to ksto
</pre>
</details>

Changelogs are nice.

I'm not sure how to upload them to Google Play, yet, for non-release builds, so I've punted on that for the moment.

What this PR does, then, is (theoretically) upload a changelog to Testflight for the beta / nightly builds.

Because I'm too lazy to summarize things for a changelog, I'm just printing out all the commits since the last tag. I no longer know when the previous release happened, so I can't just print out the stuff from the last day.

We'll have to see if this breaks during tonight's nightly.

I could be convinced to turn this off for the `beta` channel and only enable it for nightly, if we wanted.