### PR TITLE
Trim the log that's sent to testflight to a max of 4,000 chars

### DIFF
--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -71,12 +71,32 @@ def newest_tag
   sh('git describe --tags --abbrev=0').chomp
 end
 
-# Makes a changelog from the timespan passed
-def make_changelog
+def git_changelog
   to_ref = ENV['TRAVIS_COMMIT'] || 'HEAD'
   from_ref = newest_tag
 
-  sh("git log #{from_ref}..#{to_ref} --oneline --graph")
+  graph = sh("git log #{from_ref}..#{to_ref} --oneline --graph")
+
+  # make sure to trim off whitespace from the graph lines
+  # to keep the character count down
+  graph
+    .lines
+    .map { |line| line.chomp }
+    .join "\n"
+end
+
+# Makes a changelog from the timespan passed
+def make_changelog
+  log = git_changelog
+
+  limit = 4_000
+  ending = '…'
+
+  if log.length <= limit
+    log
+  else
+    log[0, log.rindex(/\s/, limit - ending.length)].rstrip + ending
+  end
 end
 
 # It doesn't make sense to duplicate this in both platforms, and fastlane is


### PR DESCRIPTION
TestFlight will reject changelogs over 4,000 chars, so this PR will truncate our new git graph to a max of 4,000 chars.

I used https://stackoverflow.com/a/39907261/2347774 as a reference, so I think it's actually fancy and won't truncate within a word.