### PR TITLE
Handle blank contacts in org listings

### DIFF
--- a/source/views/student-orgs/detail.android.js
+++ b/source/views/student-orgs/detail.android.js
@@ -5,11 +5,11 @@ import moment from 'moment'
 import {Card} from '../components/card'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
-import type {ContactPersonType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import Communications from 'react-native-communications'
 import openUrl from '../components/open-url'
-import cleanOrg from './clean-org'
+import {cleanOrg} from './util'
+import {showNameOrEmail} from './util'
 
 const styles = StyleSheet.create({
   name: {
@@ -67,14 +67,6 @@ export class StudentOrgsDetailView extends React.Component {
     navigation: {state: {params: {org: StudentOrgType}}},
   }
 
-  showNameOrEmail = ({c}: {c: ContactPersonType}) => {
-    if (!c.firstName.trim() && !c.lastName.trim()) {
-      return `${c.email}`
-    }
-
-    return `${c.firstName} ${c.lastName} (${c.email})`
-  }
-
   // Using Communications because `mailTo` complains about
   // the lack of an available Activity...
   openEmail = (email: string, org: string) => {
@@ -127,7 +119,7 @@ export class StudentOrgsDetailView extends React.Component {
                   onPress={() => this.openEmail(c.email, orgName)}
                 >
                   {c.title ? c.title + ': ' : ''}
-                  {this.showNameOrEmail({c})}
+                  {showNameOrEmail(c)}
                 </Text>,
               )}
             </Card>

--- a/source/views/student-orgs/detail.android.js
+++ b/source/views/student-orgs/detail.android.js
@@ -8,8 +8,7 @@ import type {StudentOrgType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import Communications from 'react-native-communications'
 import openUrl from '../components/open-url'
-import {cleanOrg} from './util'
-import {showNameOrEmail} from './util'
+import {cleanOrg, showNameOrEmail} from './util'
 
 const styles = StyleSheet.create({
   name: {

--- a/source/views/student-orgs/detail.android.js
+++ b/source/views/student-orgs/detail.android.js
@@ -5,6 +5,7 @@ import moment from 'moment'
 import {Card} from '../components/card'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
+import type {ContactPersonType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import Communications from 'react-native-communications'
 import openUrl from '../components/open-url'
@@ -66,6 +67,14 @@ export class StudentOrgsDetailView extends React.Component {
     navigation: {state: {params: {org: StudentOrgType}}},
   }
 
+  showNameOrEmail = ({c}: {c: ContactPersonType}) => {
+    if (!c.firstName.trim() && !c.lastName.trim()) {
+      return `${c.email}`
+    }
+
+    return `${c.firstName} ${c.lastName} (${c.email})`
+  }
+
   // Using Communications because `mailTo` complains about
   // the lack of an available Activity...
   openEmail = (email: string, org: string) => {
@@ -118,7 +127,7 @@ export class StudentOrgsDetailView extends React.Component {
                   onPress={() => this.openEmail(c.email, orgName)}
                 >
                   {c.title ? c.title + ': ' : ''}
-                  {c.firstName} {c.lastName} ({c.email})
+                  {this.showNameOrEmail({c})}
                 </Text>,
               )}
             </Card>

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -5,6 +5,7 @@ import moment from 'moment'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
+import type {ContactPersonType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import openUrl from '../components/open-url'
 import cleanOrg from './clean-org'
@@ -59,6 +60,14 @@ export class StudentOrgsDetailView extends React.Component {
     navigation: {state: {params: {org: StudentOrgType}}},
   }
 
+  showNameOrEmail = ({c}: {c: ContactPersonType}) => {
+    if (!c.firstName.trim() && !c.lastName.trim()) {
+      return `${c.email}`
+    }
+
+    return `${c.firstName} ${c.lastName}`
+  }
+
   render() {
     const {
       name: orgName,
@@ -111,7 +120,7 @@ export class StudentOrgsDetailView extends React.Component {
                     key={i}
                     cellStyle={c.title ? 'Subtitle' : 'Basic'}
                     accessory="DisclosureIndicator"
-                    title={`${c.firstName} ${c.lastName}`}
+                    title={this.showNameOrEmail({c})}
                     detail={c.title}
                     onPress={() => Linking.openURL(`mailto:${c.email}`)}
                   />,

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -5,10 +5,10 @@ import moment from 'moment'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
-import type {ContactPersonType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import openUrl from '../components/open-url'
-import cleanOrg from './clean-org'
+import {cleanOrg} from './util'
+import {showNameOrEmail} from './util'
 
 const styles = StyleSheet.create({
   name: {
@@ -58,14 +58,6 @@ export class StudentOrgsDetailView extends React.Component {
 
   props: TopLevelViewPropsType & {
     navigation: {state: {params: {org: StudentOrgType}}},
-  }
-
-  showNameOrEmail = ({c}: {c: ContactPersonType}) => {
-    if (!c.firstName.trim() && !c.lastName.trim()) {
-      return `${c.email}`
-    }
-
-    return `${c.firstName} ${c.lastName}`
   }
 
   render() {
@@ -120,7 +112,7 @@ export class StudentOrgsDetailView extends React.Component {
                     key={i}
                     cellStyle={c.title ? 'Subtitle' : 'Basic'}
                     accessory="DisclosureIndicator"
-                    title={this.showNameOrEmail({c})}
+                    title={showNameOrEmail(c)}
                     detail={c.title}
                     onPress={() => Linking.openURL(`mailto:${c.email}`)}
                   />,

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -7,8 +7,7 @@ import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import openUrl from '../components/open-url'
-import {cleanOrg} from './util'
-import {showNameOrEmail} from './util'
+import {cleanOrg, showNameOrEmail} from './util'
 
 const styles = StyleSheet.create({
   name: {

--- a/source/views/student-orgs/util.js
+++ b/source/views/student-orgs/util.js
@@ -1,8 +1,9 @@
 // @flow
 import type {StudentOrgType} from './types'
+import type {ContactPersonType} from './types'
 import {fastGetTrimmedText} from '../../lib/html'
 
-export default function cleanOrg(org: StudentOrgType): StudentOrgType {
+export function cleanOrg(org: StudentOrgType): StudentOrgType {
   const name = org.name.trim()
 
   const advisors = org.advisors
@@ -37,4 +38,12 @@ export default function cleanOrg(org: StudentOrgType): StudentOrgType {
     description,
     website,
   }
+}
+
+export function showNameOrEmail(c: ContactPersonType) {
+  if (!c.firstName.trim() && !c.lastName.trim()) {
+    return `${c.email}`
+  }
+
+  return `${c.firstName} ${c.lastName}`
 }


### PR DESCRIPTION
This PR fixes issues in:

- **iOS**: the contact info for a Student Org member was completely blank if no first/last name.
- **Android**: the contact info for a Student Org member contained extra whitespace if no first/last name.

Closes #1388 

~ | Before | After |
-- | -- | -- |
iOS | ![truth-blank](https://user-images.githubusercontent.com/5240843/29296534-e7331fec-8128-11e7-9c06-068fdef2a2f1.png) | <img width="374" alt="truth-filled" src="https://user-images.githubusercontent.com/5240843/29296533-e730f1cc-8128-11e7-9d28-870c572e61bd.png">
Android | ![android-truth-blank](https://user-images.githubusercontent.com/5240843/29296535-ead53c3e-8128-11e7-8b0b-28eac39c9a9d.png) | ![android-truth-filled](https://user-images.githubusercontent.com/5240843/29296536-ead90490-8128-11e7-9b7b-8a8b7d2bb245.png)
