### PR TITLE
Downgrade babel-preset-react-native

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -558,12 +558,6 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
       "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94="
     },
-    "babel-plugin-syntax-dynamic-import": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
-      "dev": true
-    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
@@ -939,16 +933,15 @@
       }
     },
     "babel-preset-react-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-3.0.0.tgz",
-      "integrity": "sha512-T6WWSKJ1g2TWXliYjEq9XAhvQAv8uoCT24Ch1lV/4rugENzWjFrr/KD9Eqe0/0EUcWcrfXE2KzhtIsaYpbX/DQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-2.1.0.tgz",
+      "integrity": "sha1-kBPr2C2hyIECv1iIEP9Z4gnKK4o=",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
         "babel-plugin-react-transform": "2.0.2",
         "babel-plugin-syntax-async-functions": "6.13.0",
         "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
         "babel-plugin-syntax-flow": "6.18.0",
         "babel-plugin-syntax-jsx": "6.18.0",
         "babel-plugin-syntax-trailing-function-commas": "6.22.0",
@@ -973,7 +966,6 @@
         "babel-plugin-transform-react-jsx": "6.24.1",
         "babel-plugin-transform-react-jsx-source": "6.22.0",
         "babel-plugin-transform-regenerator": "6.24.1",
-        "babel-template": "6.25.0",
         "react-transform-hmr": "1.0.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "babel-eslint": "7.2.3",
     "babel-jest": "20.0.3",
     "babel-plugin-flow-react-proptypes": "5.0.0",
-    "babel-preset-react-native": "3.0.0",
+    "babel-preset-react-native": "2.1.0",
     "danger": "2.0.0-alpha.8",
     "eslint": "4.5.0",
     "eslint-config-prettier": "2.3.0",


### PR DESCRIPTION
reverts fdfc07e2b9ae829fa48505c150cd087a716edd26

an attempt at fixing #1436 

because I am really kinda at a loss, but it seems like an update to how js is compiled might silently break the bundling? maybe?