### PR TITLE
Increase height of calendar row

### DIFF
--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -55,7 +55,7 @@ export default class EventRow extends React.PureComponent {
         fullWidth={true}
         onPress={this._onPress}
       >
-        <Row>
+        <Row minHeight={46}>
           <CalendarTimes event={event} style={styles.timeContainer} />
 
           <Bar style={styles.bar} />


### PR DESCRIPTION
This PR brings calendar rows with single times and titles into line with a minimum height for each row. This makes it much more accessible.

Before | After
--|--
<img width="375" alt="1" src="https://user-images.githubusercontent.com/5240843/29902478-71ffb50e-8dcc-11e7-8b3e-a105107b4ff9.png"> | <img width="375" alt="2" src="https://user-images.githubusercontent.com/5240843/29902477-71f25116-8dcc-11e7-8d12-1a8cbf139c25.png"> 