### PR TITLE
Markdown styles to `Other Modes` cards

### DIFF
--- a/source/views/transportation/other-modes.js
+++ b/source/views/transportation/other-modes.js
@@ -1,32 +1,28 @@
 // @flow
 import React from 'react'
-import {StyleSheet, Text, View, FlatList} from 'react-native'
+import {FlatList} from 'react-native'
 import {TabBarIcon} from '../components/tabbar-icon'
 import type {OtherModeType} from './types'
 import {data as modes} from '../../../docs/transportation.json'
 import * as c from '../components/colors'
 import {Button} from '../components/button'
 import {trackedOpenUrl} from '../components/open-url'
+import {Markdown} from '../components/markdown'
+import glamorous from 'glamorous-native'
 
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: c.white,
-  },
-  title: {
-    fontSize: 30,
-    alignSelf: 'center',
-    marginTop: 10,
-  },
-  content: {
-    marginBottom: 5,
-    marginLeft: 10,
-    marginRight: 10,
-  },
-  mode: {
-    borderWidth: 5,
-    borderTopWidth: 1,
-    borderColor: c.iosLightBackground,
-  },
+const Title = glamorous.text({
+  fontSize: 30,
+  alignSelf: 'center',
+  marginTop: 10,
+})
+
+const Container = glamorous.view({
+  backgroundColor: c.white,
+  paddingHorizontal: 10,
+
+  borderWidth: 5,
+  borderTopWidth: 1,
+  borderColor: c.iosLightBackground,
 })
 
 class OtherModeCard extends React.PureComponent {
@@ -34,7 +30,7 @@ class OtherModeCard extends React.PureComponent {
     data: OtherModeType,
   }
 
-  _onPress = () => {
+  onPress = () => {
     const {data} = this.props
     const modeName = data.name.replace(' ', '')
     return trackedOpenUrl({
@@ -46,15 +42,11 @@ class OtherModeCard extends React.PureComponent {
   render() {
     const {data} = this.props
     return (
-      <View style={styles.mode}>
-        <Text selectable={true} style={styles.title}>
-          {data.name}
-        </Text>
-        <Text selectable={true} style={styles.content}>
-          {data.description}
-        </Text>
-        <Button onPress={this._onPress} title="More info" />
-      </View>
+      <Container>
+        <Title selectable={true}>{data.name}</Title>
+        <Markdown source={data.description} />
+        <Button onPress={this.onPress} title="More Info" />
+      </Container>
     )
   }
 }
@@ -72,7 +64,6 @@ export default class OtherModesView extends React.PureComponent {
   render() {
     return (
       <FlatList
-        contentContainerStyle={styles.container}
         keyExtractor={this.keyExtractor}
         renderItem={this.renderItem}
         data={modes}


### PR DESCRIPTION
This PR adds markdown to the "other modes" transportation cards. I first noticed that those cards do not support markdown in the CARLS project. I've also added a little bit of a buffer to the detail text.

Before | After
--|--
<img width="375" alt="before" src="https://user-images.githubusercontent.com/5240843/29903358-75985ca2-8dd1-11e7-8a07-8ffbfb0d3789.png"> | <img width="375" alt="after" src="https://user-images.githubusercontent.com/5240843/29903357-7596a97a-8dd1-11e7-9ee2-94e1b8926b2e.png">