### PR TITLE
Email allaboutolaf@ instead of odt@

### DIFF
--- a/source/views/settings/sections/support.js
+++ b/source/views/settings/sections/support.js
@@ -27,7 +27,7 @@ export default class SupportSection extends React.Component {
 
   openEmail = () => {
     Communications.email(
-      ['odt@stolaf.edu'],
+      ['allaboutolaf@stolaf.edu'],
       null,
       null,
       'Support: All About Olaf',


### PR DESCRIPTION
This way, (a) I see the support emails as well and (b) it doesn't overload the odt any more than they need to be. 

I asked @elijahverdoorn about this before PRing it.  