### PR TITLE
Fix detail calendar title

### DIFF
--- a/source/views/calendar/event-detail.android.js
+++ b/source/views/calendar/event-detail.android.js
@@ -106,7 +106,7 @@ export class EventDetail extends React.PureComponent {
   static navigationOptions = ({navigation}) => {
     const {event} = navigation.state.params
     return {
-      title: event.summary,
+      title: event.title,
       headerRight: <ShareButton onPress={() => shareItem(event)} />,
     }
   }

--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -74,7 +74,7 @@ export class EventDetail extends React.PureComponent {
   static navigationOptions = ({navigation}) => {
     const {event} = navigation.state.params
     return {
-      title: event.summary,
+      title: event.title,
       headerRight: <ShareButton onPress={() => shareItem(event)} />,
     }
   }


### PR DESCRIPTION
When switching EventDetail from a function to a class, I set the navigation options as soon as the class loaded and forgot to change over to use the title prop that comes with a CleanedEventType.

This PR provides a fix by not using `event.summary` and using `event.title` instead.

Closes #1526