### PR TITLE
Update npm to 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ before_install:
   - npm config set spin=false
   - npm config set progress=false
 
-  - npm install -g npm@5.3
+  - npm install -g npm@5.4
   - if [[ $JS ]]; then npm install -g greenkeeper-lockfile@1; fi
 
 install:


### PR DESCRIPTION
As of https://github.com/npm/npm/blob/latest/CHANGELOG.md#v541-2017-09-06 (npm@5.4.1), the permissions bugs we were seeing with 5.4.0 should be resolved.

I'm going to update npm to new feature releases manually for a bit, though.