### PR TITLE
Load bus data from Github

### DIFF
--- a/source/lib/report-network-problem.js
+++ b/source/lib/report-network-problem.js
@@ -4,7 +4,7 @@ import {tracker} from '../analytics'
 import bugsnag from '../bugsnag'
 
 export function reportNetworkProblem(err: Error) {
-	tracker.trackException(err.message)
-	bugsnag.notify(err)
-	console.warn(err)
+  tracker.trackException(err.message)
+  bugsnag.notify(err)
+  console.warn(err)
 }

--- a/source/lib/report-network-problem.js
+++ b/source/lib/report-network-problem.js
@@ -1,0 +1,10 @@
+// @flow
+
+import {tracker} from '../analytics'
+import bugsnag from '../bugsnag'
+
+export function reportNetworkProblem(err: Error) {
+	tracker.trackException(err.message)
+	bugsnag.notify(err)
+	console.warn(err)
+}

--- a/source/views/transportation/bus/bus-line.js
+++ b/source/views/transportation/bus/bus-line.js
@@ -103,7 +103,7 @@ export class BusLine extends React.Component<void, Props, State> {
     )
   }
 
-  setStateFromProps(nextProps: Props) {
+  setStateFromProps = (nextProps: Props) => {
     const {line, now} = nextProps
 
     const schedule = getScheduleForNow(line.schedules, now)

--- a/source/views/transportation/bus/bus-stop-row.js
+++ b/source/views/transportation/bus/bus-stop-row.js
@@ -59,14 +59,12 @@ export class BusStopRow extends React.PureComponent {
       <ListRow fullWidth={true} fullHeight={true}>
         <Row>
           <ProgressChunk
-            {...{
-              barColor,
-              afterStop,
-              beforeStop,
-              atStop,
-              skippingStop,
-              currentStopColor,
-            }}
+            barColor={barColor}
+            afterStop={afterStop}
+            beforeStop={beforeStop}
+            atStop={atStop}
+            skippingStop={skippingStop}
+            currentStopColor={currentStopColor}
             isFirstChunk={isFirstRow}
             isLastChunk={isLastRow}
           />
@@ -83,7 +81,7 @@ export class BusStopRow extends React.PureComponent {
               {place}
             </Title>
             <Detail lines={1}>
-              <ScheduleTimes {...{times, skippingStop}} />
+              <ScheduleTimes times={times} skippingStop={skippingStop} />
             </Detail>
           </Column>
         </Row>

--- a/source/views/transportation/bus/bus-view.js
+++ b/source/views/transportation/bus/bus-view.js
@@ -48,9 +48,9 @@ export class BusView extends React.PureComponent {
       return defaultData
     })
 
-    // if (process.env.NODE_ENV === 'development') {
-    //   busLines = defaultData.data
-    // }
+    if (process.env.NODE_ENV === 'development') {
+      busLines = defaultData.data
+    }
 
     this.updateTime()
 

--- a/source/views/transportation/bus/bus-view.js
+++ b/source/views/transportation/bus/bus-view.js
@@ -26,6 +26,7 @@ export class BusView extends React.PureComponent {
     intervalId: 0,
     loading: false,
     now: moment.tz(TIMEZONE),
+    // now: moment.tz('Fri 8:13pm', 'ddd h:mma', true, TIMEZONE),
   }
 
   componentWillMount() {
@@ -91,7 +92,6 @@ export class BusView extends React.PureComponent {
 
   render() {
     let {now} = this.state
-    // now = moment.tz('Fri 8:13pm', 'ddd h:mma', true, TIMEZONE)
     const activeBusLine = this.findLine()
 
     if (!activeBusLine) {

--- a/source/views/transportation/bus/bus-view.js
+++ b/source/views/transportation/bus/bus-view.js
@@ -85,7 +85,7 @@ export class BusView extends React.PureComponent {
   }
 
   findLine = (): ?BusLineType => {
-    let {busLines} = this.state
+    const {busLines} = this.state
     const {line: thisLine} = this.props
     return busLines.find(({line}) => line === thisLine)
   }

--- a/source/views/transportation/bus/bus-view.js
+++ b/source/views/transportation/bus/bus-view.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {ScrollView} from 'react-native'
+import {ScrollView, RefreshControl} from 'react-native'
 import type {BusLineType} from './types'
 import {BusLine} from './bus-line'
 import moment from 'moment-timezone'
@@ -66,6 +66,17 @@ export class BusView extends React.PureComponent {
     this.setState(() => ({now: moment.tz(TIMEZONE)}))
   }
 
+  refreshTime = async () => {
+    const start = Date.now()
+    this.setState(() => ({loading: true}))
+    this.updateTime()
+    const elapsed = start - Date.now()
+    if (elapsed < 500) {
+      await delay(500 - elapsed)
+    }
+    this.setState(() => ({loading: false}))
+  }
+
   openMap = () => {
     const activeBusLine = this.findLine()
     this.props.navigation.navigate('BusMapView', {line: activeBusLine})
@@ -92,7 +103,14 @@ export class BusView extends React.PureComponent {
     }
 
     return (
-      <ScrollView>
+      <ScrollView
+        refreshControl={
+          <RefreshControl
+            onRefresh={this.refreshTime}
+            refreshing={this.state.loading}
+          />
+        }
+      >
         <BusLine line={activeBusLine} now={now} openMap={this.openMap} />
       </ScrollView>
     )

--- a/source/views/transportation/bus/bus-view.js
+++ b/source/views/transportation/bus/bus-view.js
@@ -24,6 +24,7 @@ export class BusView extends React.PureComponent {
   state = {
     busLines: defaultData.data,
     intervalId: 0,
+    loading: false,
     now: moment.tz(TIMEZONE),
   }
 

--- a/source/views/transportation/bus/bus-view.js
+++ b/source/views/transportation/bus/bus-view.js
@@ -53,15 +53,17 @@ export class BusView extends React.PureComponent {
       busLines = defaultData.data
     }
 
-    this.updateTime()
-
     // wait 0.5 seconds – if we let it go at normal speed, it feels broken.
     const elapsed = Date.now() - start
     if (elapsed < 500) {
       await delay(500 - elapsed)
     }
 
-    this.setState(() => ({busLines, loading: false}))
+    this.setState(() => ({
+      busLines,
+      now: moment.tz(TIMEZONE),
+      loading: false,
+    }))
   }
 
   updateTime = () => {

--- a/source/views/transportation/bus/bus-view.js
+++ b/source/views/transportation/bus/bus-view.js
@@ -56,7 +56,7 @@ export class BusView extends React.PureComponent {
     this.updateTime()
 
     // wait 0.5 seconds – if we let it go at normal speed, it feels broken.
-    const elapsed = start - Date.now()
+    const elapsed = Date.now() - start
     if (elapsed < 500) {
       await delay(500 - elapsed)
     }

--- a/source/views/transportation/other-modes.js
+++ b/source/views/transportation/other-modes.js
@@ -27,7 +27,8 @@ const Container = glamorous.view({
   borderColor: c.iosLightBackground,
 })
 
-const GITHUB_URL = 'https://stodevx.github.io/AAO-React-Native/transportation.json'
+const GITHUB_URL =
+  'https://stodevx.github.io/AAO-React-Native/transportation.json'
 
 class OtherModeCard extends React.PureComponent {
   props: {

--- a/source/views/transportation/other-modes.js
+++ b/source/views/transportation/other-modes.js
@@ -1,9 +1,11 @@
 // @flow
 import React from 'react'
 import {FlatList} from 'react-native'
+import delay from 'delay'
+import {reportNetworkProblem} from '../../lib/report-network-problem'
 import {TabBarIcon} from '../components/tabbar-icon'
 import type {OtherModeType} from './types'
-import {data as modes} from '../../../docs/transportation.json'
+import * as defaultData from '../../../docs/transportation.json'
 import * as c from '../components/colors'
 import {Button} from '../components/button'
 import {trackedOpenUrl} from '../components/open-url'
@@ -24,6 +26,8 @@ const Container = glamorous.view({
   borderTopWidth: 1,
   borderColor: c.iosLightBackground,
 })
+
+const GITHUB_URL = 'https://stodevx.github.io/AAO-React-Native/transportation.json'
 
 class OtherModeCard extends React.PureComponent {
   props: {
@@ -57,6 +61,37 @@ export default class OtherModesView extends React.PureComponent {
     tabBarIcon: TabBarIcon('boat'),
   }
 
+  state = {
+    modes: defaultData.data,
+    loading: false,
+  }
+
+  componentWillMount() {
+    this.fetchData()
+  }
+
+  fetchData = async () => {
+    const start = Date.now()
+    this.setState(() => ({loading: true}))
+
+    let {data: modes} = await fetchJson(GITHUB_URL).catch(err => {
+      reportNetworkProblem(err)
+      return defaultData
+    })
+
+    if (process.env.NODE_ENV === 'development') {
+      modes = defaultData.data
+    }
+
+    // wait 0.5 seconds – if we let it go at normal speed, it feels broken.
+    const elapsed = start - Date.now()
+    if (elapsed < 500) {
+      await delay(500 - elapsed)
+    }
+
+    this.setState(() => ({modes, loading: false}))
+  }
+
   renderItem = ({item}: {item: OtherModeType}) => <OtherModeCard data={item} />
 
   keyExtractor = (item: OtherModeType) => item.name
@@ -66,7 +101,9 @@ export default class OtherModesView extends React.PureComponent {
       <FlatList
         keyExtractor={this.keyExtractor}
         renderItem={this.renderItem}
-        data={modes}
+        refreshing={this.state.loading}
+        onRefresh={this.fetchData}
+        data={this.state.modes}
       />
     )
   }


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/1540

- Loads data from Github for both the bus routes and the "other modes" list
- Allows the user to "pull to refresh" the bus route (but it really just updates the time)
- [more of a cleanup than anything] Passes data to BusMap instead of letting it load its own data