### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ The Calendar won't work until you give it a Google Calendar API key. You should 
 ## Todo
 * Bugs! All bugs should have the [`bug`](https://github.com/StoDevX/AAO-React-Native/issues?q=is%3Aopen+is%3Aissue+label%3Abug) label in the issues
 * Enhancements! All ideas for improvement that are not being worked on should be [`closed` and labelled as `discussion`](https://github.com/StoDevX/AAO-React-Native/issues?utf8=%E2%9C%93&q=is%3Aclosed%20is%3Aissue%20label%3Astatus%2Fdiscussion)
-* [3D touch actions](https://github.com/jordanbyron/react-native-quick-actions) for icon and within
-* [Touch-ID](https://github.com/naoufal/react-native-touch-id) for SIS
 
 ## Contributing
 Please see [CONTRIBUTING](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Calendar won't work until you give it a Google Calendar API key. You should 
 2. Insert your API key in place of the `key goes here` text
 
 ## Todo
-* Bugs! All bugs should have the [`bug`](https://github.com/StoDevX/AAO-React-Native/issues?q=is%3Aopen+is%3Aissue+label%3Abug) label in the issues
+* Bugs! All bugs should have the [`bug/general`](https://github.com/StoDevX/AAO-React-Native/labels/bug%2Fgeneral) or [`bug/layout`](https://github.com/StoDevX/AAO-React-Native/labels/bug%2Flayout) label in the issues
 * Enhancements! All ideas for improvement that are not being worked on should be [`closed` and labelled as `discussion`](https://github.com/StoDevX/AAO-React-Native/issues?utf8=%E2%9C%93&q=is%3Aclosed%20is%3Aissue%20label%3Astatus%2Fdiscussion)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ The Calendar won't work until you give it a Google Calendar API key. You should 
 1. Create a copy of the `.env.sample.js` file and rename it to `.env.js`
 2. Insert your API key in place of the `key goes here` text
 
-## Todo
+## Contributing
 * Bugs! All bugs should have the [`bug/general`](https://github.com/StoDevX/AAO-React-Native/labels/bug%2Fgeneral) or [`bug/layout`](https://github.com/StoDevX/AAO-React-Native/labels/bug%2Flayout) label in the issues
 * Enhancements! All ideas for improvement that are not being worked on should be [`closed` and labelled as `discussion`](https://github.com/StoDevX/AAO-React-Native/issues?utf8=%E2%9C%93&q=is%3Aclosed%20is%3Aissue%20label%3Astatus%2Fdiscussion)
 
-## Contributing
-Please see [CONTRIBUTING](CONTRIBUTING.md)
+For full information, see [CONTRIBUTING](CONTRIBUTING.md)


### PR DESCRIPTION
This PR makes a few data changes to the readme.

* Link [`bug/general`](https://github.com/StoDevX/AAO-React-Native/labels/bug%2Fgeneral) and [`bug/layout`](https://github.com/StoDevX/AAO-React-Native/labels/bug%2Flayout) instead of the broken `bug` label
* Move touch-id and 3d-touch notes to the wiki underneath [nifty components](https://github.com/StoDevX/AAO-React-Native/wiki/Reference-Links#nifty-components)