### PR TITLE
Rearrange streaming view tabs

### DIFF
--- a/source/views/streaming/index.js
+++ b/source/views/streaming/index.js
@@ -13,10 +13,10 @@ import {StreamListView} from './streams'
 
 export default TabNavigator(
   {
+    StreamingView: {screen: StreamListView},
+    LiveWebcamsView: {screen: WebcamsView},
     KSTORadioView: {screen: KSTOView},
     // WeeklyMovieView: {screen: WeeklyMovieView},
-    LiveWebcamsView: {screen: WebcamsView},
-    StreamingView: {screen: StreamListView},
   },
   {
     navigationOptions: {


### PR DESCRIPTION
This rearranges the tabs to show Streaming, Webcams, then KSTO.

Closes #1550 