### PR TITLE
Ignore errors in the testflight upload process

### DIFF
--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -29,9 +29,14 @@ platform :ios do
   desc 'Submit a new nightly Beta Build to Testflight'
   lane :nightly do
     build
-    # TestFliht is returning 500 errors when we upload changelogs again.
-    testflight(#changelog: make_changelog,
-               distribute_external: false)
+    # TestFlight is returning 500 errors when we upload changelogs again.
+    begin
+      testflight(changelog: make_changelog,
+                 distribute_external: false)
+    rescue => error
+      puts "Changelog failed to upload:"
+      puts error
+    end
   end
 
   desc 'Upload dYSM symbols to Bugsnag from Apple'


### PR DESCRIPTION
TestFlight sometimes doesn't like our nightly changelogs. However, the builds still get uploaded and processed, so we'll just ignore errors raised within TestFlight.

Here's an example travis build that failed to upload to TestFlight: https://travis-ci.org/StoDevX/AAO-React-Native/jobs/269066805#L3603