### PR TITLE
set the bus view refresh rate to 1 second

### DIFF
--- a/source/views/transportation/bus/bus-view.js
+++ b/source/views/transportation/bus/bus-view.js
@@ -31,9 +31,9 @@ export class BusView extends React.PureComponent {
 
   componentWillMount() {
     this.fetchData()
-    // This updates the screen every five seconds, so that the "next bus"
-    // times are updated without needing to leave and come back.
-    this.setState(() => ({intervalId: setInterval(this.updateTime, 5000)}))
+    // This updates the screen every second, so that the "next bus" times
+    // are updated without needing to leave and come back.
+    this.setState(() => ({intervalId: setInterval(this.updateTime, 1000)}))
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
We discovered in https://github.com/StoDevX/AAO-React-Native/pull/1546 and https://github.com/StoDevX/AAO-React-Native/pull/1542 that our setInterval calls only seem to work if we run on an interval of around 1000ms.

When I was testing https://github.com/StoDevX/AAO-React-Native/pull/1542, I set it to 1000; however, as I was cleaning up my changes, I appear to have reverted that before I made the PR.

This PR sets the BusView refresh interval to 1000 ms.

Closes https://github.com/StoDevX/AAO-React-Native/issues/1563