### PR TITLE
Add time to streaming events list items

### DIFF
--- a/source/views/streaming/streams/row.js
+++ b/source/views/streaming/streams/row.js
@@ -32,7 +32,7 @@ function Info({item}: {item: StreamType}) {
 function Time({item}: {item: StreamType}) {
   const showTime = item.status != 'archived'
   return showTime
-    ? <Detail>{item.date.format('dddd, MMMM Do, YYYY')}</Detail>
+    ? <Detail>{item.date.format('h:mm A – ddd, MMM. Do, YYYY')}</Detail>
     : null
 }
 


### PR DESCRIPTION
- Adds the start time
- Shortens the day and month
- Removes the year 

Before | After
--|--
<img width="414" alt="screen shot 2017-09-12 at 8 52 16 pm" src="https://user-images.githubusercontent.com/5240843/30354736-5549733e-97fc-11e7-8867-956bbca71147.png"> | <img width="414" alt="screen shot 2017-09-12 at 9 31 23 pm" src="https://user-images.githubusercontent.com/5240843/30355493-c5fc202c-9801-11e7-8445-04cb7edf518b.png">


Closes #1548 