### PR TITLE
Resolve moment errors in detail android hours

### DIFF
--- a/source/views/building-hours/detail/schedule-row.android.js
+++ b/source/views/building-hours/detail/schedule-row.android.js
@@ -6,6 +6,7 @@
 
 import React from 'react'
 import {View, Text, StyleSheet} from 'react-native'
+import moment from 'moment-timezone'
 import type {SingleBuildingScheduleType} from '../types'
 
 import {formatBuildingTimes, summarizeDays} from '../lib'

--- a/source/views/building-hours/detail/schedule-table.android.js
+++ b/source/views/building-hours/detail/schedule-table.android.js
@@ -40,7 +40,7 @@ export class ScheduleTable extends React.PureComponent {
                 isActive={
                   schedule.isPhysicallyOpen !== false &&
                   set.days.includes(dayOfWeek) &&
-                  isScheduleOpenAtMoment(set, this.state.now)
+                  isScheduleOpenAtMoment(set, now)
                 }
               />,
             )}


### PR DESCRIPTION
This PR resolves a crash in android building hours. 

Brings the android `detail/schedule-row` and `detail/schedule-table` in-line with the functioning iOS files.

Closes #1375