### PR TITLE
Pull-to-refresh on streams list

### DIFF
--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -97,7 +97,7 @@ export class StreamListView extends React.PureComponent {
       const mapped = toPairs(grouped).map(([title, data]) => ({title, data}))
 
       // wait 0.5 seconds – if we let it go at normal speed, it feels broken.
-      const elapsed = start - Date.now()
+      const elapsed = Date.now() - start
       if (elapsed < 500) {
         await delay(500 - elapsed)
       }

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -62,8 +62,8 @@ export class StreamListView extends React.PureComponent {
 
     // wait 0.5 seconds – if we let it go at normal speed, it feels broken.
     const elapsed = Date.now() - start
-    if (elapsed < 1500) {
-      await delay(1500 - elapsed)
+    if (elapsed < 500) {
+      await delay(500 - elapsed)
     }
 
     this.setState(() => ({refreshing: false}))

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -69,9 +69,8 @@ export class StreamListView extends React.PureComponent {
     this.setState(() => ({refreshing: false}))
   }
 
-  getStreams = async () => {
+  getStreams = async (date: moment = moment.tz(CENTRAL_TZ)) => {
     try {
-      const date = moment.tz(CENTRAL_TZ)
       const dateFrom = date.format('YYYY-MM-DD')
       const dateTo = date.add(1, 'month').format('YYYY-MM-DD')
 


### PR DESCRIPTION
This PR changes what `refreshing` and `onRefresh` listen to. This enables the nice pull-to-refresh logic to get new stream data.