### PR TITLE
Check the current minute in BusLine's shouldComponentUpdate call

### DIFF
--- a/source/views/transportation/bus/bus-line.js
+++ b/source/views/transportation/bus/bus-line.js
@@ -6,7 +6,6 @@ import {getScheduleForNow, getSetOfStopsForNow} from './lib'
 import get from 'lodash/get'
 import zip from 'lodash/zip'
 import head from 'lodash/head'
-import isEqual from 'lodash/isEqual'
 import last from 'lodash/last'
 import moment from 'moment-timezone'
 import * as c from '../../components/colors'
@@ -108,8 +107,7 @@ export class BusLine extends React.Component<void, Props, State> {
     return (
       this.props.now.isSame(nextProps.now, 'minute') ||
       this.props.line !== nextProps.line ||
-      this.props.openMap !== nextProps.openMap ||
-      !isEqual(this.state.currentMoments, nextState.currentMoments)
+      this.props.openMap !== nextProps.openMap
     )
   }
 

--- a/source/views/transportation/bus/bus-line.js
+++ b/source/views/transportation/bus/bus-line.js
@@ -73,33 +73,10 @@ type Props = {
   line: BusLineType,
   now: moment,
   openMap: () => any,
-}
+};
 
-type State = {
-  schedule: ?BusScheduleType,
-  scheduledMoments: Array<FancyBusTimeListType>,
-  currentMoments: FancyBusTimeListType,
-  stopTitleTimePairs: Array<[string, moment]>,
-}
-
-export class BusLine extends React.Component<void, Props, State> {
-  state = {
-    schedule: null,
-    scheduledMoments: [],
-    currentMoments: [],
-    stopTitleTimePairs: [],
-    firstUpdate: true,
-  }
-
-  componentWillMount() {
-    this.setStateFromProps(this.props)
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    this.setStateFromProps(nextProps)
-  }
-
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
+export class BusLine extends React.Component<void, Props, void> {
+  shouldComponentUpdate(nextProps: Props) {
     // We won't check the time in shouldComponentUpdate, because we really
     // only care if the bus information has changed, and this is called after
     // setStateFromProps runs.
@@ -111,21 +88,7 @@ export class BusLine extends React.Component<void, Props, State> {
     )
   }
 
-  setStateFromProps = (nextProps: Props) => {
-    if (
-      this.props.now.isSame(nextProps.now, 'minute') &&
-      !this.state.firstUpdate
-    ) {
-      return
-    }
-
-    const {line, now} = nextProps
-
-    const schedule = getScheduleForNow(line.schedules, now)
-    if (!schedule) {
-      return
-    }
-
+  generateScheduleInfo = (schedules: Array<BusScheduleType>, now: moment) => {
     const parseTimes = timeset => timeset.map(parseTime(now))
     const scheduledMoments: Array<FancyBusTimeListType> = schedule.times.map(
       parseTimes,
@@ -141,23 +104,17 @@ export class BusLine extends React.Component<void, Props, State> {
       currentMoments,
     )
 
-    this.setState(() => ({
-      schedule,
+    return {
       scheduledMoments,
       currentMoments,
       stopTitleTimePairs,
-      firstUpdate: false,
-    }))
+    }
   }
 
   render() {
     const {line, now} = this.props
-    const {
-      schedule,
-      scheduledMoments,
-      currentMoments,
-      stopTitleTimePairs,
-    } = this.state
+
+    const schedule = getScheduleForNow(line.schedules, now)
 
     // grab the colors (with fallbacks) via _.get
     const barColor = get(barColors, line.line, c.black)
@@ -174,6 +131,12 @@ export class BusLine extends React.Component<void, Props, State> {
         </View>
       )
     }
+
+    const {
+      scheduledMoments,
+      currentMoments,
+      stopTitleTimePairs,
+    } = this.generateScheduleInfo(schedule, now)
 
     const timesIndex = scheduledMoments.indexOf(currentMoments)
     const isLastBus = timesIndex === scheduledMoments.length - 1

--- a/source/views/transportation/bus/bus-line.js
+++ b/source/views/transportation/bus/bus-line.js
@@ -106,6 +106,7 @@ export class BusLine extends React.Component<void, Props, State> {
     // setStateFromProps runs.
 
     return (
+      this.props.now.isSame(nextProps.now, 'minute') ||
       this.props.line !== nextProps.line ||
       this.props.openMap !== nextProps.openMap ||
       !isEqual(this.state.currentMoments, nextState.currentMoments)

--- a/source/views/transportation/bus/bus-line.js
+++ b/source/views/transportation/bus/bus-line.js
@@ -73,7 +73,7 @@ type Props = {
   line: BusLineType,
   now: moment,
   openMap: () => any,
-};
+}
 
 export class BusLine extends React.Component<void, Props, void> {
   shouldComponentUpdate(nextProps: Props) {
@@ -88,7 +88,7 @@ export class BusLine extends React.Component<void, Props, void> {
     )
   }
 
-  generateScheduleInfo = (schedules: Array<BusScheduleType>, now: moment) => {
+  generateScheduleInfo = (schedule: BusScheduleType, now: moment) => {
     const parseTimes = timeset => timeset.map(parseTime(now))
     const scheduledMoments: Array<FancyBusTimeListType> = schedule.times.map(
       parseTimes,


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/1563

I was trying to be smart and not cause another render unless we really needed one, so I checked the minimal set of properties that might change.

I checked two of the `props` – "line" and "openMap" – because they're simple pointer comparisons.

I only checked "currentMoments" from `state`, because it's the simplest data structure that will be generated as part of the state. You really don't want to replace a render bottleneck with a giant datastructure comparison bottleneck. 

What I forgot is that "currentMoments" will only change when the bus wraps around its route, because "currentMoments" is what's used to render the next stop times.

So, I added the third and final prop to the sCU check: `now.minute`. We definitely want to re-render every minute, because the bus dot can move once a minute. I also removed the "currentMoments" check, because currentMoments is a (mathematical) function of `this.props.now` and `this.props.line` – given the same line info, and the same time, it will always produce the same data.

I'm not checking any of the state things, because in order for them to change, the schedule stored in `this.props.line` will change (it's immutable, so any changes will result in a new object, and it'll get a new memory address) and because all of our functions are pure, this component's state only depends on the input props.

---

I've actually made a pretty big change in this PR – I essentially moved all the data generation back into `render`, and I removed all `state` storage. I did this because we'll only call render when the data might have changed, and we're not checking any of the cached data in sCU anymore anyway, so "caching" it's just going to lead to bugs and obscured data flows.

---

I'm not going to make a similar PR to remove data from Building Hours' row state, because it has a lot more rows to potentially re-render and thus re-generate data for, so it makes sense to check the building status and hours shown in sCU there and thus we have to cache them.