### PR TITLE
fix bug in calendar; remove extra delay on first load

### DIFF
--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -35,7 +35,7 @@ export class GoogleCalendarView extends React.Component {
   }
 
   componentWillMount() {
-    this.refresh()
+    this.getEvent()
   }
 
   buildCalendarUrl(calendarId: string) {
@@ -96,17 +96,17 @@ export class GoogleCalendarView extends React.Component {
 
   refresh = async () => {
     let start = Date.now()
-    this.setState({refreshing: true})
+    this.setState(() => ({refreshing: true}))
 
     await this.getEvents()
 
     // wait 0.5 seconds – if we let it go at normal speed, it feels broken.
-    let elapsed = start - Date.now()
+    let elapsed = Date.now() - start
     if (elapsed < 500) {
       await delay(500 - elapsed)
     }
 
-    this.setState({refreshing: false})
+    this.setState(() => ({refreshing: false}))
   }
 
   render() {

--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -35,7 +35,7 @@ export class GoogleCalendarView extends React.Component {
   }
 
   componentWillMount() {
-    this.getEvent()
+    this.getEvents()
   }
 
   buildCalendarUrl(calendarId: string) {


### PR DESCRIPTION
- I fixed the "start - Date.now()" bug.
- I removed an accidental extra delay in the first load of calendar
- I switched to functional setState calls