### PR TITLE
Prevent Student Work from refreshing right after the initial load

### DIFF
--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -54,7 +54,7 @@ export default class StudentWorkView extends React.PureComponent {
   }
 
   componentWillMount() {
-    this.refresh()
+    this.fetchData()
   }
 
   fetchData = async () => {


### PR DESCRIPTION
We want to call `fetchData` because it

- (a) doesn't incur a 500ms delay penalty on first load, and
- (b) doesn't spin the spinner right after the loading screen hides.