### PR TITLE
Sort data files in natural sort order when bundling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8662,6 +8662,12 @@
         }
       }
     },
+    "string-natural-compare": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-2.0.2.tgz",
+      "integrity": "sha1-xc5OJ4q10SZa5vxVQ1rre3b8sAE=",
+      "dev": true
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "pify": "3.0.0",
     "prettier": "1.4.4",
     "react-native-view-shot": "1.12.0",
-    "react-test-renderer": "16.0.0-alpha.12"
+    "react-test-renderer": "16.0.0-alpha.12",
+    "string-natural-compare": "2.0.2"
   }
 }

--- a/scripts/bundle-data-dir.js
+++ b/scripts/bundle-data-dir.js
@@ -3,6 +3,7 @@ const yaml = require('js-yaml')
 const fs = require('fs')
 const junk = require('junk')
 const path = require('path')
+const natsort = require('string-natural-compare')
 
 // run cli
 if (process.mainModule === module) {
@@ -24,6 +25,9 @@ function bundleDataDir({fromDir, toFile}) {
   if (!files.length) {
     return
   }
+
+  // sort the files so that 9 comes before 10
+  files.sort(natsort)
 
   const loaded = files.map(fpath => {
     console.log(fpath)


### PR DESCRIPTION
We want 10 to come after 9, when we name files to maintain a sort order.

Without this, that 10th category will sort right after the 1st.