### PR TITLE
Don't set the calendar to refresh until you refresh

### DIFF
--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -29,7 +29,7 @@ export class GoogleCalendarView extends React.Component {
   } = {
     events: [],
     loaded: false,
-    refreshing: true,
+    refreshing: false,
     error: null,
     now: moment.tz(TIMEZONE),
   }


### PR DESCRIPTION
This is fallout from (that other PR where I switched to call getEvents instead of refresh).

It never stops refreshing, today. 