### PR TITLE
Add a Moodle shortcut

### DIFF
--- a/source/views/views.js
+++ b/source/views/views.js
@@ -120,6 +120,15 @@ export const allViews: ViewType[] = [
     tint: c.periwinkle,
     gradient: c.lightBlueToBlueDark,
   },
+  {
+    type: 'url',
+    url: 'https://moodle.stolaf.edu/',
+    view: 'MoodleView',
+    title: 'Moodle',
+    icon: 'graduation-cap',
+    tint: c.cantaloupe,
+    gradient: c.yellowToGoldDark,
+  },
   //   {
   //     type: 'view',
   //     view: 'HelpView',


### PR DESCRIPTION
&nbsp; | &nbsp;
--- | ---
<img width="431" alt="screen shot 2017-09-15 at 10 19 58 am" src="https://user-images.githubusercontent.com/464441/30490451-93bd3e0c-99ff-11e7-85ac-ce514614624e.png"> | <img width="431" alt="screen shot 2017-09-15 at 10 20 12 am" src="https://user-images.githubusercontent.com/464441/30490450-93a431d2-99ff-11e7-9a30-3578768e4c90.png">

---

I could go either way on this.

One the one hand, I want to build a somewhat-limited native Moodle view, using the Moodle apis – they exist, and they're enabled. This leads to the question: given that said native view would be more limited than the web moodle, should we ship the web version if we'll ship a less featured native one later?

On another hand, will anyone actually use this view?

---

Thoughts? Especially @rye and @OmarShehata and @elijahverdoorn.