### PR TITLE
Fix KSTO logo sizing and add a landscape layout

### DIFF
--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -27,6 +27,8 @@ type Viewport = {
   height: number,
 }
 
+type Props = {}
+
 type State = {
   refreshing: boolean,
   paused: boolean,
@@ -34,7 +36,7 @@ type State = {
   viewport: Viewport,
 }
 
-export default class KSTOView extends React.PureComponent<void, void, State> {
+export default class KSTOView extends React.PureComponent<void, Props, State> {
   static navigationOptions = {
     tabBarLabel: 'KSTO',
     tabBarIcon: TabBarIcon('radio'),

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -95,11 +95,12 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
         </View>
 
         <View style={[styles.container, sideways && landscape.container]}>
+          <Title />
+
           <PlayPauseButton
             onPress={this.changeControl}
             paused={this.state.paused}
           />
-          <Title />
 
           {!this.state.paused
             ? <Video

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -70,10 +70,31 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
   }
 
   render() {
+    const sideways = this.state.viewport.width > this.state.viewport.height
+
+    const logoWidth = Math.min(
+      this.state.viewport.width / 1.5,
+      this.state.viewport.height / 1.75,
+    )
+
+    const logoSize = {
+      width: logoWidth,
+      height: logoWidth,
+    }
+
     return (
-      <ScrollView>
-        <View style={styles.container}>
-          <Logo />
+      <ScrollView
+        contentContainerStyle={[styles.root, sideways && landscape.root]}
+      >
+        <View style={[styles.logoWrapper, sideways && landscape.logoWrapper]}>
+          <Image
+            source={image}
+            style={[styles.logo, logoSize]}
+            resizeMode="contain"
+          />
+        </View>
+
+        <View style={[styles.container, sideways && landscape.container]}>
           <PlayPauseButton
             onPress={this.changeControl}
             paused={this.state.paused}
@@ -93,19 +114,6 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
       </ScrollView>
     )
   }
-}
-
-const Logo = () => {
-  const viewport = Dimensions.get('window')
-  const style = {
-    maxWidth: viewport.width / 1.2,
-    maxHeight: viewport.height / 2.0,
-  }
-  return (
-    <View style={styles.wrapper}>
-      <Image source={image} style={style} />
-    </View>
-  )
 }
 
 const Title = () => {
@@ -151,11 +159,20 @@ class PlayPauseButton extends React.PureComponent {
 }
 
 const styles = StyleSheet.create({
+  root: {
+  },
   container: {
     alignItems: 'center',
   },
-  wrapper: {
-    padding: 10,
+  logoWrapper: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
+  },
+  logo: {
+    borderRadius: 6,
+    borderColor: c.kstoSecondaryDark,
+    borderWidth: 3,
   },
   heading: {
     marginTop: 10,

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -118,13 +118,12 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
 }
 
 const Title = () => {
-  const style = {fontSize: Dimensions.get('window').height / 30}
   return (
-    <View style={styles.container}>
-      <Text selectable={true} style={[styles.heading, style]}>
+    <View style={styles.titleWrapper}>
+      <Text selectable={true} style={styles.heading}>
         St. Olaf College Radio
       </Text>
-      <Text selectable={true} style={[styles.subHeading, style]}>
+      <Text selectable={true} style={styles.subHeading}>
         KSTO 93.1 FM
       </Text>
     </View>
@@ -175,16 +174,22 @@ const styles = StyleSheet.create({
     borderColor: c.kstoSecondaryDark,
     borderWidth: 3,
   },
+  titleWrapper: {
+    alignItems: 'center',
+    marginBottom: 20,
+  },
   heading: {
-    marginTop: 10,
     color: c.kstoPrimaryDark,
-    fontWeight: '500',
+    fontWeight: '600',
+    fontSize: 28,
+    textAlign: 'center',
   },
   subHeading: {
     marginTop: 5,
-    marginBottom: 10,
     color: c.kstoPrimaryDark,
     fontWeight: '300',
+    fontSize: 28,
+    textAlign: 'center',
   },
 })
 

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -162,9 +162,16 @@ class PlayPauseButton extends React.PureComponent {
 
 const styles = StyleSheet.create({
   root: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    justifyContent: 'space-between',
+    padding: 20,
   },
   container: {
     alignItems: 'center',
+    flex: 1,
+    marginTop: 20,
+    marginBottom: 20,
   },
   logoWrapper: {
     alignItems: 'center',

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -22,11 +22,16 @@ import {TabBarIcon} from '../components/tabbar-icon'
 const kstoStream = 'https://cdn.stobcm.com/radio/ksto1.stream/master.m3u8'
 const image = require('../../../images/streaming/ksto/ksto-logo.png')
 
+type Viewport = {
+  width: number,
+  height: number,
+}
+
 type State = {
   refreshing: boolean,
   paused: boolean,
   streamError: ?Object,
-  metadata: Object[],
+  viewport: Viewport,
 }
 
 export default class KSTOView extends React.PureComponent<void, void, State> {
@@ -39,7 +44,19 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
     refreshing: false,
     paused: true,
     streamError: null,
-    metadata: [],
+    viewport: Dimensions.get('window'),
+  }
+
+  componentWillMount() {
+    Dimensions.addEventListener('change', this.handleResizeEvent)
+  }
+
+  componentWillUnmount() {
+    Dimensions.removeEventListener('change', this.handleResizeEvent)
+  }
+
+  handleResizeEvent = (event: {window: {width: number}}) => {
+    this.setState(() => ({viewport: event.window}))
   }
 
   changeControl = () => {

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -153,6 +153,20 @@ const styles = StyleSheet.create({
   },
 })
 
+const landscape = StyleSheet.create({
+  root: {
+    flex: 1,
+    padding: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  container: {
+  },
+  logoWrapper: {
+    flex: 0,
+  },
+})
+
 const buttonStyles = StyleSheet.create({
   button: {
     alignItems: 'center',

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -22,7 +22,14 @@ import {TabBarIcon} from '../components/tabbar-icon'
 const kstoStream = 'https://cdn.stobcm.com/radio/ksto1.stream/master.m3u8'
 const image = require('../../../images/streaming/ksto/ksto-logo.png')
 
-export default class KSTOView extends React.PureComponent {
+type State = {
+  refreshing: boolean,
+  paused: boolean,
+  streamError: ?Object,
+  metadata: Object[],
+}
+
+export default class KSTOView extends React.PureComponent<void, void, State> {
   static navigationOptions = {
     tabBarLabel: 'KSTO',
     tabBarIcon: TabBarIcon('radio'),
@@ -30,12 +37,7 @@ export default class KSTOView extends React.PureComponent {
 
   player: Video
 
-  state: {
-    refreshing: boolean,
-    paused: boolean,
-    streamError: ?Object,
-    metadata: Object[],
-  } = {
+  state = {
     refreshing: false,
     paused: true,
     streamError: null,

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -35,8 +35,6 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
     tabBarIcon: TabBarIcon('radio'),
   }
 
-  player: Video
-
   state = {
     refreshing: false,
     paused: true,
@@ -67,7 +65,6 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
 
           {!this.state.paused
             ? <Video
-                ref={ref => (this.player = ref)}
                 source={{uri: kstoStream}}
                 playInBackground={true}
                 playWhenInactive={true}

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -48,12 +48,6 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
     this.setState(state => ({paused: !state.paused}))
   }
 
-  // callback when HLS ID3 tags change
-  onTimedMetadata = (data: any) => {
-    this.setState(() => ({metadata: data}))
-    console.log(data)
-  }
-
   // error from react-native-video
   onError = (e: any) => {
     this.setState(() => ({streamError: e, paused: true}))
@@ -78,7 +72,6 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
                 playInBackground={true}
                 playWhenInactive={true}
                 paused={this.state.paused}
-                onTimedMetadata={this.onTimedMetadata}
                 onError={this.onError}
               />
             : null}

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -67,7 +67,6 @@ export default class KSTOView extends React.PureComponent {
             onPress={this.changeControl}
             paused={this.state.paused}
           />
-          {/*<Song />*/}
           <Title />
 
           {!this.state.paused
@@ -113,10 +112,6 @@ const Title = () => {
     </View>
   )
 }
-
-// const song = this.state.metadata.length
-//     ? <Metadata song={this.state.metadata.CHANGEME} />
-//     : null
 
 class PlayPauseButton extends React.PureComponent {
   props: {
@@ -164,18 +159,6 @@ const styles = StyleSheet.create({
     color: c.kstoPrimaryDark,
     fontWeight: '300',
   },
-  // nowPlaying: {
-  //   paddingTop: 10,
-  //   fontSize: Dimensions.get('window').height / 40,
-  //   fontWeight: '500',
-  //   color: c.red,
-  // },
-  // metadata: {
-  //   fontSize: Dimensions.get('window').height / 40,
-  //   paddingHorizontal: 13,
-  //   paddingTop: 5,
-  //   color: c.red,
-  // },
 })
 
 const buttonStyles = StyleSheet.create({

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -94,7 +94,7 @@ export default class KSTOView extends React.PureComponent<void, void, State> {
           />
         </View>
 
-        <View style={[styles.container, sideways && landscape.container]}>
+        <View style={styles.container}>
           <Title />
 
           <PlayPauseButton
@@ -199,8 +199,6 @@ const landscape = StyleSheet.create({
     padding: 20,
     flexDirection: 'row',
     alignItems: 'center',
-  },
-  container: {
   },
   logoWrapper: {
     flex: 0,


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/1600

This PR fixes the KSTO logo sizing when you rotate.

It also adds a landscape-specific layout, and makes some layout tweaks to the existing portrait layout.

I also added a border around the logo.

iPhone 4s | Before | After
--- | --- | ---
Portrait | <img width="504" alt="4s before p" src="https://user-images.githubusercontent.com/464441/30513892-da5ea7a2-9ad0-11e7-9a21-13abd76cc223.png"> | <img width="504" alt="4s after p top" src="https://user-images.githubusercontent.com/464441/30513887-d9af9c1c-9ad0-11e7-836b-c05588e59913.png">
Landscape | <img width="794" alt="4s before l top" src="https://user-images.githubusercontent.com/464441/30513890-da57dcec-9ad0-11e7-9d47-bec540fcce00.png"> | <img width="794" alt="4s after l" src="https://user-images.githubusercontent.com/464441/30513891-da595946-9ad0-11e7-9f60-89d26db9065f.png">

iPhone 6 | Before | After
--- | --- | ---
Portrait | <img width="559" alt="6 before p" src="https://user-images.githubusercontent.com/464441/30513894-da6bbf82-9ad0-11e7-9d27-6d1e00ef21b1.png"> | <img width="559" alt="6 after p" src="https://user-images.githubusercontent.com/464441/30513893-da622648-9ad0-11e7-8800-1ec38051f610.png">
Landscape | <img width="981" alt="6 before l" src="https://user-images.githubusercontent.com/464441/30513888-d9c4f418-9ad0-11e7-9402-e63a5129bc5d.png"> | <img width="981" alt="6 after l" src="https://user-images.githubusercontent.com/464441/30513889-d9cac816-9ad0-11e7-9ed3-ed3d4c70f9c5.png">

