### PR TITLE
Update Fastlane

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,8 +121,6 @@ install:
   # install fastlane (if at first you don't succeed, try once more)
   - bundle install || bundle install
 
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install imagemagick; fi
-
 before_script:
   - if [[ $JS ]]; then greenkeeper-lockfile-update; fi
   # Fire up the Android emulator

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source "https://rubygems.org"
 
-gem "badge"
 gem "fastlane"
 gem "hockeyapp"
 gem "json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,18 +13,12 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     babosa (1.0.2)
-    badge (0.8.5)
-      curb (~> 0.9)
-      fastimage (>= 1.6)
-      fastlane (>= 2.0)
-      mini_magick (>= 4.5)
     claide (1.0.2)
     colored (1.2)
     colored2 (3.1.2)
     commander-fastlane (4.4.5)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
-    curb (0.9.4)
     declarative (0.0.10)
     declarative-option (0.1.0)
     diff-lcs (1.3)
@@ -190,7 +184,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  badge
   fastlane
   fastlane-plugin-bugsnag
   hockeyapp

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,14 +25,14 @@ GEM
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
     curb (0.9.4)
-    declarative (0.0.9)
+    declarative (0.0.10)
     declarative-option (0.1.0)
     diff-lcs (1.3)
     docile (1.1.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.2.1)
-    excon (0.58.0)
+    excon (0.59.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -41,7 +41,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.0)
-    fastlane (2.55.0)
+    fastlane (2.56.0)
       CFPropertyList (>= 2.3, < 3.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -76,7 +76,7 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-bugsnag (1.1.0)
     gh_inspector (1.0.3)
-    google-api-client (0.13.4)
+    google-api-client (0.13.6)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.5)
       httpclient (>= 2.8.1, < 3.0)
@@ -123,7 +123,7 @@ GEM
     mimemagic (0.3.2)
     mini_magick (4.5.1)
     minitest (5.10.3)
-    multi_json (1.12.1)
+    multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nanaimo (0.2.3)
@@ -196,7 +196,6 @@ DEPENDENCIES
   hockeyapp
   json
   xcodeproj
-
 
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
I think our gem-updater bot quit working.

I also removed the "badge" ruby dependency, since we don't use it anymore.

(We used `badge` once upon a time to generate a different icon for betas.)

This removal allowed me to remove the "imagemagick" dependency on macOS builds, which should save around 20 seconds per build.