### PR TITLE
clean up the ksto error message display

### DIFF
--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -188,7 +188,6 @@ export default class KSTOView extends React.PureComponent<void, Props, State> {
   }
 }
 
-
 type ActionButtonProps = {
   icon: string,
   text: string,

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -160,9 +160,17 @@ export default class KSTOView extends React.PureComponent<void, Props, State> {
         </View>
 
         <View style={styles.container}>
-          <Title />
+          <View style={styles.titleWrapper}>
+            <Text selectable={true} style={styles.heading}>
+              St. Olaf College Radio
+            </Text>
+            <Text selectable={true} style={styles.subHeading}>
+              KSTO 93.1 FM
+            </Text>
 
-          {error}
+            {error}
+          </View>
+
           {button}
 
           {this.state.playState === 'playing'
@@ -180,15 +188,6 @@ export default class KSTOView extends React.PureComponent<void, Props, State> {
   }
 }
 
-const Title = () =>
-  <View style={styles.titleWrapper}>
-    <Text selectable={true} style={styles.heading}>
-      St. Olaf College Radio
-    </Text>
-    <Text selectable={true} style={styles.subHeading}>
-      KSTO 93.1 FM
-    </Text>
-  </View>
 
 type ActionButtonProps = {
   icon: string,
@@ -246,10 +245,12 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   status: {
-    paddingTop: 10,
     fontWeight: '400',
-    fontSize: 24,
+    fontSize: 18,
+    textAlign: 'center',
     color: c.grapefruit,
+    marginTop: 15,
+    marginBottom: 5,
   },
 })
 


### PR DESCRIPTION
Make the KSTO error messages look nicer.

Before | After
--- | ---
<img width=375 src="https://user-images.githubusercontent.com/5240843/30516202-a7447dda-9b05-11e7-832a-9fdd439a51e1.png"> | <img width="375" alt="screen shot 2017-09-16 at 7 28 46 pm" src="https://user-images.githubusercontent.com/464441/30517341-c1b54070-9b21-11e7-9635-5daa6d648838.png">