### PR TITLE
Remove auto-play of ksto audio

### DIFF
--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -340,11 +340,6 @@ class StreamPlayer extends React.PureComponent<void, StreamPlayerProps, void> {
 
       // "error" is fired when an error occurs.
       player.addEventListener('error', error)
-
-      /////
-      /////
-
-      player.play()
     </script>`
 
   render() {


### PR DESCRIPTION
This is a remnant of a previous iteration of the KSTO webview player, when I would unmount and remount the WebView when the audio paused.

Closes https://github.com/StoDevX/AAO-React-Native/issues/1643