### PR TITLE
Makes android homescreen buttons not stretch, like iOS does

### DIFF
--- a/source/views/home/button.js
+++ b/source/views/home/button.js
@@ -37,8 +37,6 @@ const cellHorizontalPadding = 4
 const styles = StyleSheet.create({
   // Main buttons for actions on home screen
   rectangle: {
-    flex: 1,
-
     alignItems: 'center',
     justifyContent: 'center',
 


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/1645

Before | After
--- | ---
![a-before](https://user-images.githubusercontent.com/464441/30527302-a9e8e4b2-9bec-11e7-8de8-4ac5a93533b1.png) | ![a-after](https://user-images.githubusercontent.com/464441/30527307-b3631f1c-9bec-11e7-9fda-82cb3ffa402c.png)
<img width="375" alt="i-before" src="https://user-images.githubusercontent.com/464441/30527303-a9ee1b08-9bec-11e7-9a63-0d0d95446c35.png"> | <img width="375" alt="i-after" src="https://user-images.githubusercontent.com/464441/30527309-b3bb36e8-9bec-11e7-95b5-987e7ec1ea31.png">


