### PR TITLE
Refactor share calendar event logic

### DIFF
--- a/source/views/calendar/calendar-util.js
+++ b/source/views/calendar/calendar-util.js
@@ -1,10 +1,21 @@
 // @flow
 
-import {Platform, Alert, Linking} from 'react-native'
+import {Platform, Alert, Linking, Share} from 'react-native'
 import RNCalendarEvents from 'react-native-calendar-events'
 import type {CleanedEventType} from './types'
 import bugsnag from '../../bugsnag'
 import {tracker} from '../../analytics'
+import {getTimes} from './clean-event'
+
+export function shareEvent(event: CleanedEventType): Promise<any> {
+  const title = event.title
+  const times = getTimes(event)
+  const location = event.location
+  const message = `${title}\n\n${times}\n\n${location}`
+  return Share.share({message})
+    .then(result => console.log(result))
+    .catch(error => console.log(error.message))
+}
 
 export function addToCalendar(event: CleanedEventType): Promise<boolean> {
   return RNCalendarEvents.authorizationStatus()

--- a/source/views/calendar/event-detail.android.js
+++ b/source/views/calendar/event-detail.android.js
@@ -1,15 +1,15 @@
 // @flow
 import React from 'react'
-import {Text, ScrollView, StyleSheet, Share} from 'react-native'
+import {Text, ScrollView, StyleSheet} from 'react-native'
 import type {CleanedEventType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {ShareButton} from '../components/nav-buttons'
 import openUrl from '../components/open-url'
 import {Card} from '../components/card'
-import {getTimes, getLinksFromEvent} from './clean-event'
+import {getLinksFromEvent} from './clean-event'
 import * as c from '../components/colors'
 import {ButtonCell} from '../components/cells/button'
-import {addToCalendar} from './calendar-util'
+import {addToCalendar, shareEvent} from './calendar-util'
 import delay from 'delay'
 import {ListFooter} from '../components/list'
 
@@ -97,20 +97,12 @@ const CalendarButton = ({message, disabled, onPress}) => {
   )
 }
 
-const shareItem = (event: CleanedEventType) => {
-  const times = getTimes(event)
-  const message = `${event.summary}\n\n${times}\n\n${event.location}`
-  Share.share({message})
-    .then(result => console.log(result))
-    .catch(error => console.log(error.message))
-}
-
 export class EventDetail extends React.PureComponent {
   static navigationOptions = ({navigation}) => {
     const {event} = navigation.state.params
     return {
       title: event.title,
-      headerRight: <ShareButton onPress={() => shareItem(event)} />,
+      headerRight: <ShareButton onPress={() => shareEvent(event)} />,
     }
   }
 

--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -1,15 +1,15 @@
 // @flow
 import React from 'react'
-import {Text, ScrollView, StyleSheet, Share} from 'react-native'
+import {Text, ScrollView, StyleSheet} from 'react-native'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import type {CleanedEventType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {ShareButton} from '../components/nav-buttons'
 import openUrl from '../components/open-url'
 import {ListFooter} from '../components/list'
-import {getTimes, getLinksFromEvent} from './clean-event'
+import {getLinksFromEvent} from './clean-event'
 import {ButtonCell} from '../components/cells/button'
-import {addToCalendar} from './calendar-util'
+import {addToCalendar, shareEvent} from './calendar-util'
 import delay from 'delay'
 
 const styles = StyleSheet.create({
@@ -19,16 +19,6 @@ const styles = StyleSheet.create({
 })
 
 const STO_CALENDAR_URL = 'https://www.stolaf.edu/calendar'
-
-const shareItem = (event: CleanedEventType) => {
-  const summary = event.summary ? event.summary : ''
-  const times = getTimes(event) ? getTimes(event) : ''
-  const location = event.location ? event.location : ''
-  const message = `${summary}\n\n${times}\n\n${location}`
-  Share.share({message})
-    .then(result => console.log(result))
-    .catch(error => console.log(error.message))
-}
 
 function MaybeSection({header, content}: {header: string, content: string}) {
   return content.trim()
@@ -78,7 +68,7 @@ export class EventDetail extends React.PureComponent {
     const {event} = navigation.state.params
     return {
       title: event.title,
-      headerRight: <ShareButton onPress={() => shareItem(event)} />,
+      headerRight: <ShareButton onPress={() => shareEvent(event)} />,
     }
   }
 


### PR DESCRIPTION
Closes #1647

* Deduplicate share in both files
* Remove ternary checks
* Return the Share.share promise for reusability
* Use event.title instead of event.summary