### PR TITLE
Allow editing building hours on Android

### DIFF
--- a/source/views/building-hours/detail/schedule-table.android.js
+++ b/source/views/building-hours/detail/schedule-table.android.js
@@ -11,6 +11,7 @@ import moment from 'moment-timezone'
 import type {NamedBuildingScheduleType} from '../types'
 import {isScheduleOpenAtMoment, getDayOfWeek} from '../lib'
 import {ScheduleRow} from './schedule-row'
+import {ButtonCell} from '../../components/cells/button'
 
 export class ScheduleTable extends React.PureComponent {
   props: {
@@ -20,7 +21,7 @@ export class ScheduleTable extends React.PureComponent {
   }
 
   render() {
-    const {now, schedules} = this.props
+    const {now, schedules, onProblemReport} = this.props
     const dayOfWeek = getDayOfWeek(now)
 
     return (
@@ -46,6 +47,9 @@ export class ScheduleTable extends React.PureComponent {
             )}
           </Card>,
         )}
+        <Card style={styles.scheduleContainer}>
+          <ButtonCell title="Suggest an Edit" onPress={onProblemReport} />
+        </Card>
       </View>
     )
   }

--- a/source/views/building-hours/report/editor.js
+++ b/source/views/building-hours/report/editor.js
@@ -114,7 +114,7 @@ class WeekTogglesIOS extends React.PureComponent {
     const allDays = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
 
     return (
-      <Row flexDirection="column">
+      <Row justifyContent="center">
         {allDays.map((day, i) =>
           <ToggleButton
             key={day}

--- a/source/views/building-hours/report/editor.js
+++ b/source/views/building-hours/report/editor.js
@@ -6,7 +6,7 @@
 
 import React from 'react'
 import xor from 'lodash/xor'
-import {ScrollView, Text, StyleSheet} from 'react-native'
+import {View, ScrollView, Platform, Text, StyleSheet} from 'react-native'
 import moment from 'moment-timezone'
 import {TableView, Section, Cell} from 'react-native-tableview-simple'
 import type {SingleBuildingScheduleType, DayOfWeekEnumType} from '../types'
@@ -17,6 +17,8 @@ import * as c from '../../components/colors'
 import DatePicker from 'react-native-datepicker'
 import {Touchable} from '../../components/touchable'
 import {DeleteButtonCell} from '../../components/cells/delete-button'
+import {CellToggle} from '../../components/cells/toggle'
+import {ListSeparator} from '../../components/list'
 
 export class BuildingHoursScheduleEditorView extends React.PureComponent {
   static navigationOptions = {
@@ -101,7 +103,7 @@ export class BuildingHoursScheduleEditorView extends React.PureComponent {
   }
 }
 
-class WeekToggles extends React.PureComponent {
+class WeekTogglesIOS extends React.PureComponent {
   props: {days: DayOfWeekEnumType[], onChangeDays: (DayOfWeekEnumType[]) => any}
 
   toggleDay = day => {
@@ -112,7 +114,7 @@ class WeekToggles extends React.PureComponent {
     const allDays = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
 
     return (
-      <Row justifyContent="center">
+      <Row flexDirection="column">
         {allDays.map((day, i) =>
           <ToggleButton
             key={day}
@@ -123,6 +125,36 @@ class WeekToggles extends React.PureComponent {
           />,
         )}
       </Row>
+    )
+  }
+}
+
+class WeekTogglesAndroid extends React.PureComponent {
+  props: {days: DayOfWeekEnumType[], onChangeDays: (DayOfWeekEnumType[]) => any}
+
+  toggleDay = day => {
+    this.props.onChangeDays(xor(this.props.days, [day]))
+  }
+
+  render() {
+    const allDays = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
+
+    return (
+      <View>
+        {allDays.map((day, i) =>
+          <View key={day}>
+            <CellToggle
+              key={day}
+              label={day}
+              value={this.props.days.includes(day)}
+              onChange={() => this.toggleDay(day)}
+            />
+            {i === allDays.length - 1 && styles.finalCell
+              ? null
+              : <ListSeparator force={true} />}
+          </View>,
+        )}
+      </View>
     )
   }
 }
@@ -152,6 +184,8 @@ class ToggleButton extends React.PureComponent {
     )
   }
 }
+
+const WeekToggles = Platform.OS === 'ios' ? WeekTogglesIOS : WeekTogglesAndroid
 
 class DatePickerCell extends React.PureComponent {
   props: {

--- a/source/views/components/list/list-separator.js
+++ b/source/views/components/list/list-separator.js
@@ -13,9 +13,11 @@ type PropsType = {
   styles?: any,
   fullWidth?: boolean,
   spacing?: {left?: number, right?: number},
+  force?: boolean,
 }
+
 export function ListSeparator(props: PropsType) {
-  if (Platform.OS === 'android') {
+  if (Platform.OS === 'android' && !props.force) {
     return null
   }
 


### PR DESCRIPTION
Closes #1628 

Thanks @hawkrives for all the help on this one!

* Adds a button to open hours suggestion view to Android
* Adds schedule editing view to Android
* Use rows and toggles on Android to select days

This last change where we have to use rows and toggles is (most likely?) due to a flexbox layout bug. We tried quite a lot of things, but we could not get the styles to apply to both platforms... so this is the workaround. 