### PR TITLE
Replace sortable listview?

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7642,11 +7642,10 @@
       "resolved": "https://registry.npmjs.org/react-native-search-bar/-/react-native-search-bar-3.0.0.tgz",
       "integrity": "sha1-lzs4J20G4XMe1SEh6U9Uua7Sv6s="
     },
-    "react-native-sortable-list": {
-      "version": "github:hawkrives/react-native-sortable-list#7b72cc8e16cc71751836b49b3ea4bbc9e8e9cb99",
-      "requires": {
-        "prop-types": "15.5.10"
-      }
+    "react-native-sortable-listview": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/react-native-sortable-listview/-/react-native-sortable-listview-0.2.6.tgz",
+      "integrity": "sha1-0e1rtVL6UZCZTlB8A95aKSFojKY="
     },
     "react-native-tab-view": {
       "version": "0.0.65",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "react-native-restart": "0.0.3",
     "react-native-safari-view": "2.0.0",
     "react-native-search-bar": "3.0.0",
-    "react-native-sortable-list": "github:hawkrives/react-native-sortable-list#7b72cc8e16cc71751836b49b3ea4bbc9e8e9cb99",
+    "react-native-sortable-listview": "0.2.6",
     "react-native-tableview-simple": "0.16.11",
     "react-native-vector-icons": "4.4.0",
     "react-navigation": "1.0.0-beta.11",

--- a/source/views/home/edit.js
+++ b/source/views/home/edit.js
@@ -89,6 +89,7 @@ type RowProps = {
   data: ViewType,
   active: boolean,
   width: number,
+  sortHandlers?: any,
 }
 
 type RowState = {
@@ -209,7 +210,7 @@ class Row extends React.Component<void, RowProps, RowState> {
 
 type Props = {
   onSaveOrder: (ViewType[]) => any,
-  order: string[],
+  order: ViewType[],
 }
 type State = {
   width: number,

--- a/source/views/home/edit.js
+++ b/source/views/home/edit.js
@@ -21,7 +21,8 @@ import fromPairs from 'lodash/fromPairs'
 
 import EntypoIcon from 'react-native-vector-icons/Entypo'
 import IonIcon from 'react-native-vector-icons/Ionicons'
-import SortableList from 'react-native-sortable-list'
+import {Touchable} from '../components/touchable'
+import SortableListView from 'react-native-sortable-listview'
 
 import type {ViewType} from '../views'
 import {allViews} from '../views'
@@ -38,8 +39,6 @@ const styles = StyleSheet.create({
     alignItems: 'stretch',
   },
   row: {
-    flex: 1,
-
     flexDirection: 'row',
     alignItems: 'center',
 
@@ -200,7 +199,9 @@ class Row extends React.Component<void, RowProps, RowState> {
         <Text style={[styles.text, {color: this.props.data.tint}]}>
           {this.props.data.title}
         </Text>
-        {reorderIcon}
+        <Touchable highlight={false} {...this.props.sortHandlers}>
+          {reorderIcon}
+        </Touchable>
       </Animated.View>
     )
   }
@@ -212,6 +213,7 @@ type Props = {
 }
 type State = {
   width: number,
+  activeRowView: string,
 }
 
 class EditHomeView extends React.PureComponent<void, Props, State> {
@@ -221,6 +223,7 @@ class EditHomeView extends React.PureComponent<void, Props, State> {
 
   state = {
     width: Dimensions.get('window').width,
+    activeRowView: '',
   }
 
   componentWillMount() {
@@ -235,18 +238,35 @@ class EditHomeView extends React.PureComponent<void, Props, State> {
     this.setState(() => ({width: event.window.width}))
   }
 
+  onRowActive = event => {
+    this.setState(() => ({activeRowView: event.rowData.index}))
+  }
+
+  onRowMoved = event => {
+    this.setState(() => ({activeRowView: ''}))
+    let order = [...this.props.order]
+    order.splice(event.to, 0, order.splice(event.from, 1)[0])
+    this.props.onSaveOrder(order)
+  }
+
   render() {
     return (
-      <SortableList
+      <SortableListView
         contentContainerStyle={[
           styles.contentContainer,
           {width: this.state.width},
         ]}
         data={objViews}
         order={this.props.order}
-        onChangeOrder={(order: ViewType[]) => this.props.onSaveOrder(order)}
-        renderRow={({data, active}: {data: ViewType, active: boolean}) =>
-          <Row data={data} active={active} width={this.state.width} />}
+        activeOpacity={0.5}
+        onRowActive={this.onRowActive}
+        onRowMoved={this.onRowMoved}
+        renderRow={(view: ViewType) =>
+          <Row
+            data={view}
+            active={this.state.activeRowView === view.view}
+            width={this.state.width}
+          />}
       />
     )
   }

--- a/source/views/home/edit.js
+++ b/source/views/home/edit.js
@@ -240,7 +240,7 @@ class EditHomeView extends React.PureComponent<void, Props, State> {
   }
 
   onRowActive = event => {
-    this.setState(() => ({activeRowView: event.rowData.index}))
+    this.setState(() => ({activeRowView: event.rowData.data.view}))
   }
 
   onRowMoved = event => {

--- a/source/views/home/edit.js
+++ b/source/views/home/edit.js
@@ -243,10 +243,13 @@ class EditHomeView extends React.PureComponent<void, Props, State> {
   }
 
   onRowMoved = event => {
-    this.setState(() => ({activeRowView: ''}))
     let order = [...this.props.order]
     order.splice(event.to, 0, order.splice(event.from, 1)[0])
     this.props.onSaveOrder(order)
+  }
+
+  onMoveEnd = () => {
+    this.setState(() => ({activeRowView: ''}))
   }
 
   render() {
@@ -261,6 +264,7 @@ class EditHomeView extends React.PureComponent<void, Props, State> {
         activeOpacity={0.5}
         onRowActive={this.onRowActive}
         onRowMoved={this.onRowMoved}
+        onMoveEnd={this.onMoveEnd}
         renderRow={(view: ViewType) =>
           <Row
             data={view}


### PR DESCRIPTION
#### Background
The sortable list view that we use from [gitim/react-native-sortable-list](https://github.com/gitim/react-native-sortable-list) works _okay_. We have some frustrations with it due to Android. This PR explores replacing it with [deanmcpherson/react-native-sortable-listview](https://github.com/deanmcpherson/react-native-sortable-listview).

#### Summary
I **do not** think this PR serves as a good replacement. If anything, we will lose some functionality by switching to this component. I don't think switching will get us what we want.
<hr> 

**What we have**

Action | iOS | Android
--|--|--
Press and drag | ✅ |  ✅
Reload new order | ✅ |  ✅
Scrolling on large list | ✅ |  ✅
Rotation resizing | ✅ |  ✅

**What this proposes**

Action | iOS | Android
--|--|--
Press and drag | ✅ |  ✅
Reload new order | ✅ |  ✅
Scrolling on large list | ❌ | ❌
Rotation resizing | ❌ | ❌

<hr>

#### Issue with rotation

Rotating in the `proposed` switch doesn't seem to work correctly. Glancing at the internals, resizing for rotation doesn't seem to be taken into consideration. It appears to resize when a row is pressed.

![problems](https://user-images.githubusercontent.com/5240843/30783904-0034367e-a119-11e7-8c19-0bee315d5123.gif)