### PR TITLE
Rename "Green Bikes" to "Ole Bikes"

### DIFF
--- a/data/dictionary/green-bikes.yaml
+++ b/data/dictionary/green-bikes.yaml
@@ -1,3 +1,0 @@
-word: Green Bikes
-definition: |
-  The Green Bikes Mechanics team maintains bicycles for use by anyone in the St. Olaf community as part of the campus transportation infrastructure. These 19 bikes are available for speeding you to class on time, down to Northfield and Carleton or further out of town for fun and exercise. Check one out at Rølvaag Library!

--- a/data/dictionary/ole-bikes.yaml
+++ b/data/dictionary/ole-bikes.yaml
@@ -1,0 +1,3 @@
+word: Ole Bikes
+definition: |
+  The Ole Bikes Mechanics team maintains bicycles for use by anyone in the St. Olaf community as part of the campus transportation infrastructure. These 19 bikes are available for speeding you to class on time, down to Northfield and Carleton or further out of town for fun and exercise. Check one out at Rølvaag Library!

--- a/data/dictionary/ole-bikes.yaml
+++ b/data/dictionary/ole-bikes.yaml
@@ -1,3 +1,3 @@
 word: Ole Bikes
 definition: |
-  The Ole Bikes Mechanics team maintains bicycles for use by anyone in the St. Olaf community as part of the campus transportation infrastructure. These 19 bikes are available for speeding you to class on time, down to Northfield and Carleton or further out of town for fun and exercise. Check one out at Rølvaag Library!
+  The Ole Bikes Mechanics team maintains bicycles for use by anyone in the St. Olaf community as part of the campus transportation infrastructure. These 30 bikes are available for speeding you to class on time, down to Northfield and Carleton or further out of town for fun and exercise. Check one out at Rølvaag Library!

--- a/data/transportation/ole-bikes.yaml
+++ b/data/transportation/ole-bikes.yaml
@@ -1,4 +1,4 @@
 name: Ole Bikes
-url: https://wp.stolaf.edu/sa/transportation/greenbikes/
+url: https://www.stolaf.edu/library/libinfo/bikes.cfm
 description: >-
   Great green alternative, available for check-out through Rølvaag Library.

--- a/data/transportation/ole-bikes.yaml
+++ b/data/transportation/ole-bikes.yaml
@@ -1,4 +1,4 @@
-name: Green Bikes
+name: Ole Bikes
 url: https://wp.stolaf.edu/sa/transportation/greenbikes/
 description: >-
   Great green alternative, available for check-out through Rølvaag Library.


### PR DESCRIPTION
This PR is basically just `s/Green/Ole/g` in the locations (only two files) where we mention the bikes outside Rølvaag.

Updates the following locations:

 - Transportation - Other Modes
 - Campus Dictionary

Closes #1683.