### PR TITLE
Hide refreshing spinners on select views

### DIFF
--- a/source/views/contacts/contact-list.js
+++ b/source/views/contacts/contact-list.js
@@ -9,7 +9,6 @@ import {SectionList, StyleSheet} from 'react-native'
 import {ListSeparator, ListSectionHeader} from '../components/list'
 import {ListEmpty} from '../components/list'
 import {ContactRow} from './contact-row'
-import delay from 'delay'
 import {reportNetworkProblem} from '../../lib/report-network-problem'
 import * as defaultData from '../../../docs/contact-info.json'
 import groupBy from 'lodash/groupBy'
@@ -37,7 +36,6 @@ type Props = TopLevelViewPropsType
 type State = {
   contacts: Array<ContactType>,
   loading: boolean,
-  refreshing: boolean,
 }
 
 export class ContactsListView extends React.PureComponent<void, Props, State> {
@@ -49,27 +47,12 @@ export class ContactsListView extends React.PureComponent<void, Props, State> {
   state = {
     contacts: defaultData.data,
     loading: true,
-    refreshing: false,
   }
 
   componentWillMount() {
     this.fetchData()
   }
 
-  refresh = async () => {
-    const start = Date.now()
-    this.setState(() => ({refreshing: true}))
-
-    await this.fetchData()
-
-    // wait 0.5 seconds – if we let it go at normal speed, it feels broken.
-    const elapsed = Date.now() - start
-    if (elapsed < 500) {
-      await delay(500 - elapsed)
-    }
-
-    this.setState(() => ({refreshing: false}))
-  }
 
   fetchData = async () => {
     this.setState(() => ({loading: true}))
@@ -112,8 +95,6 @@ export class ContactsListView extends React.PureComponent<void, Props, State> {
         keyExtractor={this.keyExtractor}
         renderSectionHeader={this.renderSectionHeader}
         renderItem={this.renderItem}
-        refreshing={this.state.refreshing}
-        onRefresh={this.refresh}
       />
     )
   }

--- a/source/views/contacts/contact-list.js
+++ b/source/views/contacts/contact-list.js
@@ -53,7 +53,6 @@ export class ContactsListView extends React.PureComponent<void, Props, State> {
     this.fetchData()
   }
 
-
   fetchData = async () => {
     this.setState(() => ({loading: true}))
 

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -136,13 +136,6 @@ export class DictionaryView extends React.PureComponent<void, Props, State> {
   }
 
   render() {
-    const refreshControl = (
-      <RefreshControl
-        refreshing={this.state.loading}
-        onRefresh={this.refresh}
-      />
-    )
-
     return (
       <SearchableAlphabetListView
         cell={this.renderRow}
@@ -152,7 +145,6 @@ export class DictionaryView extends React.PureComponent<void, Props, State> {
         }
         data={groupBy(this.state.results, item => head(item.word))}
         onSearch={this.performSearch}
-        refreshControl={refreshControl}
         renderSeparator={this.renderSeparator}
         sectionHeader={this.renderSectionHeader}
         sectionHeaderHeight={SECTION_HEADER_HEIGHT}

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {StyleSheet, RefreshControl, Platform} from 'react-native'
+import {StyleSheet, Platform} from 'react-native'
 import {SearchableAlphabetListView} from '../components/searchable-alphabet-listview'
 import {Column} from '../components/layout'
 import {

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -192,7 +192,7 @@ export class StudentOrgsView extends React.Component {
   }
 
   render() {
-    if (this.state.loading) {
+    if (this.state.loading && !this.state.refreshing) {
       return <LoadingView />
     }
 

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -95,8 +95,6 @@ export class StudentOrgsView extends React.Component {
   }
 
   fetchData = async () => {
-    this.setState(() => ({loading: true}))
-
     const responseData: StudentOrgType[] = await fetchJson(
       orgsUrl,
     ).catch(err => {
@@ -118,9 +116,7 @@ export class StudentOrgsView extends React.Component {
 
     const sorted = sortBy(withSortableNames, '$sortableName')
     const grouped = groupBy(sorted, '$groupableName')
-    this.setState(() => ({orgs: sorted, results: grouped}))
-
-    this.setState(() => ({loading: false}))
+    this.setState(() => ({orgs: sorted, results: grouped, loading: false}))
   }
 
   refresh = async () => {
@@ -192,7 +188,7 @@ export class StudentOrgsView extends React.Component {
   }
 
   render() {
-    if (this.state.loading && !this.state.refreshing) {
+    if (this.state.loading) {
       return <LoadingView />
     }
 

--- a/source/views/transportation/bus/bus-view.js
+++ b/source/views/transportation/bus/bus-view.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {ScrollView, RefreshControl} from 'react-native'
+import {ScrollView} from 'react-native'
 import type {BusLineType} from './types'
 import {BusLine} from './bus-line'
 import moment from 'moment-timezone'
@@ -70,17 +70,6 @@ export class BusView extends React.PureComponent {
     this.setState(() => ({now: moment.tz(TIMEZONE)}))
   }
 
-  refreshTime = async () => {
-    const start = Date.now()
-    this.setState(() => ({loading: true}))
-    this.updateTime()
-    const elapsed = Date.now() - start
-    if (elapsed < 500) {
-      await delay(500 - elapsed)
-    }
-    this.setState(() => ({loading: false}))
-  }
-
   openMap = () => {
     const activeBusLine = this.findLine()
     this.props.navigation.navigate('BusMapView', {line: activeBusLine})
@@ -106,14 +95,7 @@ export class BusView extends React.PureComponent {
     }
 
     return (
-      <ScrollView
-        refreshControl={
-          <RefreshControl
-            onRefresh={this.refreshTime}
-            refreshing={this.state.loading}
-          />
-        }
-      >
+      <ScrollView>
         <BusLine line={activeBusLine} now={now} openMap={this.openMap} />
       </ScrollView>
     )


### PR DESCRIPTION
Closes #1710 
Closes #1711
Closes #1712

- Hide refresh spinner for Important Contacts list
- Hide refresh spinner for Dictionary list
- Hide refresh spinner for Bus schedules
- Hide Loading view on pull-to-refresh for Student Orgs list