### PR TITLE
Move greenkeeper-lockfile-upload to after_script, not after_success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,6 +147,9 @@ script:
   # even if another task in script.sh fails.
   - if [[ $JS ]]; then npm run danger; fi
 
+after_script:
+  - if [[ $JS ]]; then greenkeeper-lockfile-upload; fi
+
 after_success:
   - bash scripts/travis/after_success.sh
 

--- a/scripts/travis/after_success.sh
+++ b/scripts/travis/after_success.sh
@@ -12,7 +12,3 @@ if [[ $JS ]]; then
   npm install coveralls
   ./node_modules/.bin/coveralls < ./coverage/lcov.info
 fi
-
-if [[ $JS ]]; then
-  greenkeeper-lockfile-upload
-fi


### PR DESCRIPTION
This is in accordance with their spec, and also will allow us to see if there are any errors with how we're doing things.