### PR TITLE
Fix webcam onpress highlight

### DIFF
--- a/source/views/streaming/webcams.js
+++ b/source/views/streaming/webcams.js
@@ -161,23 +161,27 @@ class StreamThumbnail extends React.PureComponent<void, ThumbnailProps, void> {
         : transparentPixel
 
     return (
-      <Touchable
-        highlight={true}
-        underlayColor={baseColor}
-        activeOpacity={0.7}
-        onPress={this.handlePress}
-      >
-        <Image source={img} style={[styles.image, {width, height}]}>
-          <View style={styles.titleWrapper}>
-            <LinearGradient
-              colors={[startColor, baseColor]}
-              locations={[0, 0.8]}
-            >
-              <Text style={[styles.titleText, {color: textColor}]}>{name}</Text>
-            </LinearGradient>
-          </View>
-        </Image>
-      </Touchable>
+      <View style={[styles.cell, styles.rounded]}>
+        <Touchable
+          highlight={true}
+          underlayColor={baseColor}
+          activeOpacity={0.7}
+          onPress={this.handlePress}
+        >
+          <Image source={img} style={{width, height}}>
+            <View style={styles.titleWrapper}>
+              <LinearGradient
+                colors={[startColor, baseColor]}
+                locations={[0, 0.8]}
+              >
+                <Text style={[styles.titleText, {color: textColor}]}>
+                  {name}
+                </Text>
+              </LinearGradient>
+            </View>
+          </Image>
+        </Touchable>
+      </View>
     )
   }
 }
@@ -189,13 +193,14 @@ const styles = StyleSheet.create({
     padding: CELL_MARGIN / 2,
     flexDirection: 'row',
   },
+  cell: {
+    overflow: 'hidden',
+    margin: CELL_MARGIN / 2,
+    borderRadius: 6,
+  },
   column: {
     flex: 1,
     alignItems: 'center',
-  },
-  image: {
-    margin: CELL_MARGIN / 2,
-    borderRadius: 6,
   },
   titleWrapper: {
     flex: 1,

--- a/source/views/streaming/webcams.js
+++ b/source/views/streaming/webcams.js
@@ -161,7 +161,7 @@ class StreamThumbnail extends React.PureComponent<void, ThumbnailProps, void> {
         : transparentPixel
 
     return (
-      <View style={[styles.cell, styles.rounded]}>
+      <View style={styles.cell}>
         <Touchable
           highlight={true}
           underlayColor={baseColor}


### PR DESCRIPTION
Closes #1648 

This brings back the parent view wrapper that we applied styles to. We noticed the highlight appearing around the borders of the rounded image on press after the last set of changes. This PR reverts those by bringing back the wrapper and applying styles to it again.