### PR TITLE
Reconfigure the innards of FancyMenu

### DIFF
--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {View, StyleSheet, SectionList} from 'react-native'
+import {StyleSheet, SectionList} from 'react-native'
 import * as c from '../../components/colors'
 import {connect} from 'react-redux'
 import {updateMenuFilters} from '../../../flux'
@@ -12,6 +12,7 @@ import type {
   MasterCorIconMapType,
   ProcessedMealType,
   MenuItemContainerType,
+  StationMenuType,
 } from '../types'
 import size from 'lodash/size'
 import values from 'lodash/values'
@@ -19,27 +20,26 @@ import {ListSeparator, ListSectionHeader} from '../../components/list'
 import type {FilterType} from '../../components/filter'
 import {applyFiltersToItem} from '../../components/filter'
 import {NoticeView} from '../../components/notice'
-import {FilterMenuToolbar} from './filter-menu-toolbar'
+import {FilterMenuToolbar as FilterToolbar} from './filter-menu-toolbar'
 import {FoodItemRow} from './food-item-row'
 import {chooseMeal} from '../lib/choose-meal'
 import {buildFilters} from '../lib/build-filters'
 
-type FancyMenuPropsType = TopLevelViewPropsType & {
+type Props = TopLevelViewPropsType & {
   applyFilters: (filters: FilterType[], item: MenuItemType) => boolean,
-  now: momentT,
-  name: string,
+  cafeMessage?: ?string,
   filters: FilterType[],
   foodItems: MenuItemContainerType,
   meals: ProcessedMealType[],
   menuCorIcons: MasterCorIconMapType,
+  name: string,
+  now: momentT,
   onFiltersChange: (f: FilterType[]) => any,
+  onRefresh?: ?() => any,
+  refreshing?: ?boolean,
 }
 
-const leftSideSpacing = 28
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
   inner: {
     backgroundColor: c.white,
   },
@@ -48,30 +48,39 @@ const styles = StyleSheet.create({
   },
 })
 
-const CustomSeparator = () => (
-  <ListSeparator spacing={{left: leftSideSpacing}} />
-)
+class FancyMenu extends React.PureComponent<any, Props, void> {
+  static leftSideSpacing = 28
+  static separator = () => (
+    <ListSeparator spacing={{left: FancyMenu.leftSideSpacing}} />
+  )
 
-class FancyMenuView extends React.PureComponent {
   static defaultProps = {
     applyFilters: applyFiltersToItem,
   }
 
-  props: FancyMenuPropsType
-
   componentWillMount() {
-    let {foodItems, menuCorIcons, filters, meals, now} = this.props
+    this.updateFilters(this.props)
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    this.updateFilters(nextProps)
+  }
+
+  updateFilters = (props: Props) => {
+    const {foodItems, menuCorIcons, filters, meals, now} = props
 
     // prevent ourselves from overwriting the filters from redux on mount
     if (filters.length) {
       return
     }
 
-    const foodItemsArray = values(foodItems)
-    this.props.onFiltersChange(
-      buildFilters(foodItemsArray, menuCorIcons, meals, now),
-    )
+    const newFilters = buildFilters(values(foodItems), menuCorIcons, meals, now)
+    props.onFiltersChange(newFilters)
   }
+
+  areSpecialsFiltered = filters => Boolean(filters.find(this.isSpecialsFilter))
+  isSpecialsFilter = f =>
+    f.enabled && f.type === 'toggle' && f.spec.label === 'Only Show Specials'
 
   openFilterView = () => {
     this.props.navigation.navigate('FilterView', {
@@ -81,17 +90,50 @@ class FancyMenuView extends React.PureComponent {
     })
   }
 
+  groupMenuData = (props: Props, stations: Array<StationMenuType>) => {
+    const {applyFilters, filters, foodItems} = props
+
+    const derefrenceMenuItems = menu =>
+      menu.items
+        // Dereference each menu item
+        .map(id => foodItems[id])
+        // Ensure that the referenced menu items exist,
+        // and apply the selected filters to the items in the menu
+        .filter(item => item && applyFilters(filters, item))
+
+    const menusWithItems = stations
+      // We're grouping the menu items in a [label, Array<items>] tuple.
+      .map(menu => [menu.label, derefrenceMenuItems(menu)])
+      // We only want to show stations with at least one item in them
+      .filter(([_, items]) => items.length)
+      // We need to map the tuples into objects for SectionList
+      .map(([title, data]) => ({title, data}))
+
+    return menusWithItems
+  }
+
   renderSectionHeader = ({section: {title}}: any) => {
     const {filters, now, meals} = this.props
     const {stations} = chooseMeal(meals, filters, now)
     const menu = stations.find(m => m.label === title)
-    const note = menu ? menu.note : ''
 
     return (
       <ListSectionHeader
         title={title}
-        subtitle={note}
-        spacing={{left: leftSideSpacing}}
+        subtitle={menu ? menu.note : ''}
+        spacing={{left: FancyMenu.leftSideSpacing}}
+      />
+    )
+  }
+
+  renderItem = ({item}: {item: MenuItemType}) => {
+    const specialsFilterEnabled = this.areSpecialsFiltered(this.props.filters)
+    return (
+      <FoodItemRow
+        data={item}
+        corIcons={this.props.menuCorIcons}
+        badgeSpecials={!specialsFilterEnabled}
+        spacing={{left: FancyMenu.leftSideSpacing}}
       />
     )
   }
@@ -99,102 +141,59 @@ class FancyMenuView extends React.PureComponent {
   keyExtractor = (item, index) => index.toString()
 
   render() {
-    const {applyFilters, filters, foodItems, now, meals} = this.props
+    const {filters, now, meals, cafeMessage} = this.props
 
-    const {label: mealName, stations: stationMenus} = chooseMeal(
-      meals,
-      filters,
-      now,
-    )
-
-    const filteredByMenu = stationMenus
-      .map(menu => [
-        // we're grouping the menu items in a [label, Array<items>] tuple.
-        menu.label,
-        // dereference each menu item
-        menu.items
-          .map(id => foodItems[id])
-          // ensure that the referenced menu items exist
-          // and apply the selected filters to the items in the menu
-          .filter(item => item && applyFilters(filters, item)),
-      ])
-      // we only want to show stations with at least one item in them
-      .filter(([_, items]) => items.length)
-
-    // map the tuples into objects for SectionList
-    const grouped = filteredByMenu.map(([title, data]) => ({title, data}))
-
+    const {label: mealName, stations} = chooseMeal(meals, filters, now)
     const anyFiltersEnabled = filters.some(f => f.enabled)
-    const specialsFilterEnabled = Boolean(
-      filters.find(
-        f =>
-          f.enabled &&
-          f.type === 'toggle' &&
-          f.spec.label === 'Only Show Specials',
-      ),
-    )
+    const specialsFilterEnabled = this.areSpecialsFiltered(filters)
+    const groupedMenuData = this.groupMenuData(this.props, stations)
 
-    let messageView = (
-      <NoticeView style={styles.message} text="No items to show." />
-    )
-    if (specialsFilterEnabled && stationMenus.length === 0) {
-      messageView = (
-        <NoticeView
-          style={styles.message}
-          text="No items to show. There may be no specials today. Try changing the filters."
-        />
-      )
-    } else if (anyFiltersEnabled && !size(grouped)) {
-      messageView = (
-        <NoticeView
-          style={styles.message}
-          text="No items to show. Try changing the filters."
-        />
-      )
+    let message = 'No items to show.'
+    if (cafeMessage) {
+      message = cafeMessage
+    } else if (specialsFilterEnabled && stations.length === 0) {
+      message =
+        'No items to show. There may be no specials today. Try changing the filters.'
+    } else if (anyFiltersEnabled && !size(groupedMenuData)) {
+      message = 'No items to show. Try changing the filters.'
     }
 
+    const messageView = <NoticeView style={styles.message} text={message} />
+
+    const header = (
+      <FilterToolbar
+        date={now}
+        title={mealName}
+        filters={filters}
+        onPress={this.openFilterView}
+      />
+    )
+
     return (
-      <View style={styles.container}>
-        <FilterMenuToolbar
-          date={now}
-          title={mealName}
-          filters={filters}
-          onPress={this.openFilterView}
-        />
-        <SectionList
-          ItemSeparatorComponent={CustomSeparator}
-          ListEmptyComponent={messageView}
-          keyExtractor={this.keyExtractor}
-          style={styles.inner}
-          sections={grouped}
-          renderSectionHeader={this.renderSectionHeader}
-          renderItem={({item}: {item: MenuItemType}) => (
-            <FoodItemRow
-              data={item}
-              corIcons={this.props.menuCorIcons}
-              badgeSpecials={!specialsFilterEnabled}
-              spacing={{left: leftSideSpacing}}
-            />
-          )}
-        />
-      </View>
+      <SectionList
+        ItemSeparatorComponent={FancyMenu.separator}
+        ListEmptyComponent={messageView}
+        ListHeaderComponent={header}
+        data={filters}
+        keyExtractor={this.keyExtractor}
+        onRefresh={this.props.onRefresh}
+        refreshing={this.props.refreshing}
+        renderItem={this.renderItem}
+        renderSectionHeader={this.renderSectionHeader}
+        sections={(groupedMenuData: any)}
+        style={styles.inner}
+      />
     )
   }
 }
 
-function mapStateToProps(state, actualProps: FancyMenuPropsType) {
-  return {
-    filters: state.menus[actualProps.name] || [],
-  }
-}
+const mapState = (state, actualProps: Props) => ({
+  filters: state.menus[actualProps.name] || [],
+})
 
-function mapDispatchToProps(dispatch, actualProps: FancyMenuPropsType) {
-  return {
-    onFiltersChange: (filters: FilterType[]) =>
-      dispatch(updateMenuFilters(actualProps.name, filters)),
-  }
-}
+const mapDispatch = (dispatch, actualProps: Props) => ({
+  onFiltersChange: (filters: FilterType[]) =>
+    dispatch(updateMenuFilters(actualProps.name, filters)),
+})
 
-export const FancyMenu = connect(mapStateToProps, mapDispatchToProps)(
-  FancyMenuView,
-)
+export const ConnectedFancyMenu = connect(mapState, mapDispatch)(FancyMenu)

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -48,12 +48,10 @@ const styles = StyleSheet.create({
   },
 })
 
-class FancyMenu extends React.PureComponent<any, Props, void> {
-  static leftSideSpacing = 28
-  static separator = () => (
-    <ListSeparator spacing={{left: FancyMenu.leftSideSpacing}} />
-  )
+const LEFT_MARGIN = 28
+const Separator = () => <ListSeparator spacing={{left: LEFT_MARGIN}} />
 
+class FancyMenu extends React.PureComponent<any, Props, void> {
   static defaultProps = {
     applyFilters: applyFiltersToItem,
   }
@@ -121,7 +119,7 @@ class FancyMenu extends React.PureComponent<any, Props, void> {
       <ListSectionHeader
         title={title}
         subtitle={menu ? menu.note : ''}
-        spacing={{left: FancyMenu.leftSideSpacing}}
+        spacing={{left: LEFT_MARGIN}}
       />
     )
   }
@@ -133,7 +131,7 @@ class FancyMenu extends React.PureComponent<any, Props, void> {
         data={item}
         corIcons={this.props.menuCorIcons}
         badgeSpecials={!specialsFilterEnabled}
-        spacing={{left: FancyMenu.leftSideSpacing}}
+        spacing={{left: LEFT_MARGIN}}
       />
     )
   }
@@ -171,7 +169,7 @@ class FancyMenu extends React.PureComponent<any, Props, void> {
 
     return (
       <SectionList
-        ItemSeparatorComponent={FancyMenu.separator}
+        ItemSeparatorComponent={Separator}
         ListEmptyComponent={messageView}
         ListHeaderComponent={header}
         data={filters}

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -27,6 +27,7 @@ import {AllHtmlEntities} from 'html-entities'
 import {toLaxTitleCase} from 'titlecase'
 import {tracker} from '../../analytics'
 import bugsnag from '../../bugsnag'
+import delay from 'delay'
 const CENTRAL_TZ = 'America/Winnipeg'
 
 const bonappMenuBaseUrl = 'http://legacy.cafebonappetit.com/api/2/menus'
@@ -102,9 +103,16 @@ export class BonAppHostedMenu extends React.Component<void, Props, State> {
   }
 
   refresh = async () => {
+    const start = Date.now()
     this.setState(() => ({refreshing: true}))
 
     await this.fetchData(this.props)
+
+    // wait 0.5 seconds – if we let it go at normal speed, it feels broken.
+    const elapsed = Date.now() - start
+    if (elapsed < 500) {
+      await delay(500 - elapsed)
+    }
 
     this.setState(() => ({refreshing: false}))
   }

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -5,18 +5,20 @@ import LoadingView from '../components/loading'
 import qs from 'querystring'
 import {NoticeView} from '../components/notice'
 import type {TopLevelViewPropsType} from '../types'
-import {FancyMenu} from './components/fancy-menu'
+import {ConnectedFancyMenu as FancyMenu} from './components/fancy-menu'
 import type {
-  BonAppMenuInfoType,
-  BonAppCafeInfoType,
+  BonAppMenuInfoType as MenuInfoType,
+  BonAppCafeInfoType as CafeInfoType,
   StationMenuType,
   ProcessedMealType,
   DayPartMenuType,
   MenuItemContainerType,
+  MenuItemType,
 } from './types'
 import sample from 'lodash/sample'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
+import toPairs from 'lodash/toPairs'
 import type momentT from 'moment'
 import moment from 'moment-timezone'
 import {trimStationName, trimItemLabel} from './lib/trim-names'
@@ -33,77 +35,89 @@ const fetchJsonQuery = (url, query) =>
   fetchJson(`${url}?${qs.stringify(query)}`)
 const entities = new AllHtmlEntities()
 
-type BonAppPropsType = TopLevelViewPropsType & {
+const DEFAULT_MENU = [
+  {
+    label: 'Menu',
+    starttime: '0:00',
+    endtime: '23:59',
+    id: 'na',
+    abbreviation: 'M',
+    stations: [],
+  },
+]
+
+type Props = TopLevelViewPropsType & {
   cafeId: string,
   ignoreProvidedMenus?: boolean,
   loadingMessage: string[],
   name: string,
 }
+type State = {
+  error: ?Error,
+  loading: boolean,
+  refreshing: boolean,
+  now: momentT,
+  cafeInfo: ?CafeInfoType,
+  cafeMenu: ?MenuInfoType,
+}
 
-export class BonAppHostedMenu extends React.Component {
-  props: BonAppPropsType
-
-  state: {
-    error: ?Error,
-    loading: boolean,
-    now: momentT,
-    cafeInfo: ?BonAppCafeInfoType,
-    cafeMenu: ?BonAppMenuInfoType,
-  } = {
+export class BonAppHostedMenu extends React.Component<void, Props, State> {
+  state = {
     error: null,
     loading: true,
+    refreshing: false,
     now: moment.tz(CENTRAL_TZ),
     cafeMenu: null,
     cafeInfo: null,
   }
 
   componentWillMount() {
-    this.fetchData(this.props)
-  }
-
-  componentWillReceiveProps(newProps: BonAppPropsType) {
-    this.props.cafeId !== newProps.cafeId && this.fetchData(newProps)
-  }
-
-  fetchData = async (props: BonAppPropsType) => {
-    this.setState({loading: true})
-
-    let cafeMenu = null
-    let cafeInfo = null
-
-    try {
-      let requests = await Promise.all([
-        fetchJsonQuery(bonappMenuBaseUrl, {cafe: props.cafeId}),
-        fetchJsonQuery(bonappCafeBaseUrl, {cafe: props.cafeId}),
-      ])
-      cafeMenu = (requests[0]: BonAppMenuInfoType)
-      cafeInfo = (requests[1]: BonAppCafeInfoType)
-    } catch (err) {
-      tracker.trackException(err.message)
-      bugsnag.notify(err)
-      this.setState({error: err})
-    }
-
-    this.setState({
-      loading: false,
-      cafeMenu,
-      cafeInfo,
-      now: moment.tz(CENTRAL_TZ),
+    this.fetchData(this.props).then(() => {
+      this.setState(() => ({loading: false}))
     })
   }
 
-  findCafeMessage = (
-    cafeId: string,
-    cafeInfo: BonAppCafeInfoType,
-    now: momentT,
-  ) => {
-    let actualCafeInfo = cafeInfo.cafes[cafeId]
+  componentWillReceiveProps(newProps: Props) {
+    if (this.props.cafeId !== newProps.cafeId) {
+      this.fetchData(newProps)
+    }
+  }
+
+  fetchData = async (props: Props) => {
+    let cafeMenu: ?MenuInfoType = null
+    let cafeInfo: ?CafeInfoType = null
+
+    try {
+      ;[cafeMenu, cafeInfo] = await Promise.all([
+        fetchJsonQuery(bonappMenuBaseUrl, {cafe: props.cafeId}),
+        fetchJsonQuery(bonappCafeBaseUrl, {cafe: props.cafeId}),
+      ])
+    } catch (error) {
+      tracker.trackException(error.message)
+      bugsnag.notify(error)
+      this.setState(() => ({error}))
+    }
+
+    this.setState(() => ({cafeMenu, cafeInfo, now: moment.tz(CENTRAL_TZ)}))
+  }
+
+  refresh = async () => {
+    this.setState(() => ({refreshing: true}))
+
+    await this.fetchData(this.props)
+
+    this.setState(() => ({refreshing: false}))
+  }
+
+  findCafeMessage(cafeId: string, cafeInfo: CafeInfoType, now: momentT) {
+    const actualCafeInfo = cafeInfo.cafes[cafeId]
     if (!actualCafeInfo) {
       return 'BonApp did not return a menu for that café'
     }
 
     const todayDate = now.format('YYYY-MM-DD')
-    let todayMenu = actualCafeInfo.days.find(({date}) => date === todayDate)
+    const todayMenu = actualCafeInfo.days.find(({date}) => date === todayDate)
+
     if (!todayMenu) {
       return 'Closed today'
     } else if (todayMenu.status === 'closed') {
@@ -111,6 +125,32 @@ export class BonAppHostedMenu extends React.Component {
     }
 
     return null
+  }
+
+  buildCustomStationMenu(foodItems: MenuItemContainerType) {
+    const groupByStation = (grouped, item: MenuItemType) => {
+      if (item.station in grouped) {
+        grouped[item.station].push(item.id)
+      } else {
+        grouped[item.station] = [item.id]
+      }
+      return grouped
+    }
+
+    // go over the list of all food items, turning it into a mapping
+    // of {StationName: Array<FoodItemId>}
+    const idsGroupedByStation = reduce(foodItems, groupByStation, {})
+
+    // then we make our own StationMenus list
+    return toPairs(idsGroupedByStation).map(([name, items], i) => ({
+      order_id: String(i),
+      id: String(i),
+      label: name,
+      price: '',
+      note: '',
+      soup: false,
+      items: items,
+    }))
   }
 
   prepareSingleMenu(
@@ -121,38 +161,12 @@ export class BonAppHostedMenu extends React.Component {
     let stationMenus: StationMenuType[] = mealInfo ? mealInfo.stations : []
 
     if (ignoreProvidedMenus) {
-      // go over the list of all food items, turning it into a mapping
-      // of {StationName: Array<FoodItemId>}
-      const idsGroupedByStation = reduce(
-        foodItems,
-        (grouped, item) => {
-          if (item.station in grouped) {
-            grouped[item.station].push(item.id)
-          } else {
-            grouped[item.station] = [item.id]
-          }
-          return grouped
-        },
-        {},
-      )
-
-      // then we make our own StationMenus list
-      stationMenus = Object.keys(idsGroupedByStation).map((name, i) => ({
-        order_id: String(i),
-        id: String(i),
-        label: name,
-        price: '',
-        note: '',
-        soup: false,
-        items: idsGroupedByStation[name],
-      }))
+      stationMenus = this.buildCustomStationMenu(foodItems)
     }
 
     // Make sure to titlecase the station menus list, too, so the sort works
-    stationMenus = stationMenus.map(s => ({
-      ...s,
-      label: toLaxTitleCase(s.label),
-    }))
+    const titleCaseLabels = s => ({...s, label: toLaxTitleCase(s.label)})
+    stationMenus = stationMenus.map(titleCaseLabels)
 
     return {
       stations: stationMenus,
@@ -160,6 +174,37 @@ export class BonAppHostedMenu extends React.Component {
       starttime: mealInfo.starttime || '0:00',
       endtime: mealInfo.endtime || '23:59',
     }
+  }
+
+  getMeals(args: {
+    cafeMenu: MenuInfoType,
+    cafeId: string,
+    ignoreProvidedMenus: boolean,
+    foodItems: MenuItemContainerType,
+  }) {
+    const {cafeMenu, cafeId, ignoreProvidedMenus, foodItems} = args
+
+    // We hard-code to the first day returned because we're only requesting
+    // one day. `cafes` is a map of cafe ids to cafes, but we only request one
+    // cafe at a time, so we just grab the one we requested.
+    const dayparts = cafeMenu.days[0].cafes[cafeId].dayparts
+
+    // either use the meals as provided by bonapp, or make our own
+    const mealInfoItems = dayparts[0].length ? dayparts[0] : DEFAULT_MENU
+
+    const ignoreMenus = dayparts[0].length ? ignoreProvidedMenus : true
+    return mealInfoItems.map(mealInfo =>
+      this.prepareSingleMenu(mealInfo, foodItems, ignoreMenus),
+    )
+  }
+
+  prepareFood(cafeMenu: MenuInfoType) {
+    return mapValues(cafeMenu.items, item => ({
+      ...item, // we want to edit the item, not replace it
+      station: entities.decode(toLaxTitleCase(trimStationName(item.station))), // <b>@station names</b> are a mess
+      label: entities.decode(trimItemLabel(item.label)), // clean up the titles
+      description: getTrimmedTextWithSpaces(parseHtml(item.description || '')), // clean up the descriptions
+    }))
   }
 
   render() {
@@ -172,7 +217,7 @@ export class BonAppHostedMenu extends React.Component {
     }
 
     if (!this.state.cafeMenu || !this.state.cafeInfo) {
-      let err = new Error(
+      const err = new Error(
         `Something went wrong loading BonApp cafe ${this.props.cafeId}`,
       )
       tracker.trackException(err)
@@ -182,57 +227,34 @@ export class BonAppHostedMenu extends React.Component {
       )
     }
 
-    let {cafeId, ignoreProvidedMenus = false} = this.props
-    let {now, cafeMenu, cafeInfo} = this.state
+    const {cafeId, ignoreProvidedMenus = false} = this.props
+    const {now, cafeMenu, cafeInfo} = this.state
 
     // We grab the "today" info from here because BonApp returns special
     // messages in this response, like "Closed for Christmas Break"
-    // TODO: Figure out how to pass this down to FancyMenu, so we can render
-    //       the filterbar to let people change meals if a meal/day isn't available.
-    let specialMessage = this.findCafeMessage(cafeId, cafeInfo, now)
-    if (specialMessage) {
-      return <NoticeView text={specialMessage} />
-    }
+    const specialMessage = this.findCafeMessage(cafeId, cafeInfo, now)
 
     // prepare all food items from bonapp for rendering
-    const foodItems = mapValues(cafeMenu.items, item => ({
-      ...item, // we want to edit the item, not replace it
-      station: entities.decode(toLaxTitleCase(trimStationName(item.station))), // <b>@station names</b> are a mess
-      label: entities.decode(trimItemLabel(item.label)), // clean up the titles
-      description: getTrimmedTextWithSpaces(parseHtml(item.description || '')), // clean up the descriptions
-    }))
+    const foodItems = this.prepareFood(cafeMenu)
 
-    // We hard-code to the first day returned because we're only requesting
-    // one day. `cafes` is a map of cafe ids to cafes, but we only request one
-    // cafe at a time, so we just grab the one we requested.
-    const dayparts = cafeMenu.days[0].cafes[cafeId].dayparts
-
-    // either use the meals as provided by bonapp, or make our own custom meal info
-    const mealInfoItems = dayparts[0].length
-      ? dayparts[0]
-      : [
-          {
-            label: 'Menu',
-            starttime: '0:00',
-            endtime: '23:59',
-            id: 'na',
-            abbreviation: 'M',
-            stations: [],
-          },
-        ]
-    const ignoreMenus = dayparts[0].length ? ignoreProvidedMenus : true
-    const allMeals = mealInfoItems.map(mealInfo =>
-      this.prepareSingleMenu(mealInfo, foodItems, ignoreMenus),
-    )
+    const meals = this.getMeals({
+      foodItems,
+      ignoreProvidedMenus,
+      cafeId,
+      cafeMenu,
+    })
 
     return (
       <FancyMenu
-        navigation={this.props.navigation}
+        cafeMessage={specialMessage}
         foodItems={foodItems}
+        meals={meals}
         menuCorIcons={cafeMenu.cor_icons}
-        meals={allMeals}
-        now={now}
         name={this.props.name}
+        navigation={this.props.navigation}
+        now={now}
+        onRefresh={this.refresh}
+        refreshing={this.state.refreshing}
       />
     )
   }

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import LoadingView from '../components/loading'
 import {NoticeView} from '../components/notice'
-import {FancyMenu} from './components/fancy-menu'
+import {ConnectedFancyMenu as FancyMenu} from './components/fancy-menu'
 import type {TopLevelViewPropsType} from '../types'
 import type momentT from 'moment'
 import moment from 'moment-timezone'


### PR DESCRIPTION
Firstly, I'd like to apologize for this PR: this whole component over here is a bit of a mess. I hope that it's a bit easier to follow after this.

So. Things that this PR does:

- Uses `ListHeaderComponent` on `<SectionList />` to render the Filter toolbar, thus allowing it to move with the list
  - Removes a level of nesting, and removes a now-unneeded stylesheet
- Adds Pull-To-Refresh capabilities on the menus, which, when coupled with the aforementioned ListHeaderComponent, works like you would expect
  - on iOS, the PTR is above the filter bar, and on Android, it comes over the top (because the filter bar is part of the list)
- [bugfix] It properly calls updateFilters on componentWillMount in FancyMenu
- It pulls out and names a number of routines that were hiding inside of `render()` or some other area, hopefully making the code easier to follow overall
  - I still can't shake the feeling that this can be dissected into separate components somehow (this = the whole menu structure) but I'll keep letting my subconscious stew on that
- It renders the Café's message inside of the list, allowing you to switch menus (and eventually days)
  - This actually resolves a TODO that was in the code: 
      ```
      // TODO: Figure out how to pass this down to FancyMenu, so we can render
      //       the filterbar to let people change meals if a meal/day isn't available.
      ```
  - I switched FancyMenu to use ListEmptyComponent to render the messages pretty recently (https://github.com/StoDevX/AAO-React-Native/commit/1adf7dab27e36c7eead5d44c5327becd3a086299)
  - Then I just took advantage of that, and of the ListHeaderComponent, to be able to pass a message down from BonAppMenu to FancyMenu

I think that's about it.