### PR TITLE
Remove nested StackNavigator from Carleton menus

### DIFF
--- a/source/navigation.js
+++ b/source/navigation.js
@@ -9,7 +9,13 @@ import {ContactsView, ContactsDetailView} from './views/contacts'
 import {DictionaryView, DictionaryDetailView} from './views/dictionary'
 import {HomeView, EditHomeView} from './views/home'
 import StreamingView from './views/streaming'
-import {MenusView} from './views/menus'
+import {
+  MenusView,
+  CarletonBurtonMenuScreen,
+  CarletonLDCMenuScreen,
+  CarletonWeitzMenuScreen,
+  CarletonSaylesMenuScreen,
+} from './views/menus'
 import {FilterView} from './views/components/filter'
 import NewsView from './views/news'
 import NewsItemView from './views/news/news-item'
@@ -83,6 +89,10 @@ export const AppNavigator = StackNavigator(
     TransportationView: {screen: TransportationView},
     OtherModesDetailView: {screen: OtherModesDetailView},
     BusMapView: {screen: BusMapView},
+    CarletonBurtonMenuView: {screen: CarletonBurtonMenuScreen},
+    CarletonLDCMenuView: {screen: CarletonLDCMenuScreen},
+    CarletonWeitzMenuView: {screen: CarletonWeitzMenuScreen},
+    CarletonSaylesMenuView: {screen: CarletonSaylesMenuScreen},
   },
   {
     navigationOptions: {

--- a/source/views/menus/index.js
+++ b/source/views/menus/index.js
@@ -5,33 +5,20 @@
  */
 
 import React from 'react'
-import {StackNavigator} from 'react-navigation'
 import {TabNavigator} from '../components/tabbed-view'
 import {TabBarIcon} from '../components/tabbar-icon'
 
 import {BonAppHostedMenu} from './menu-bonapp'
 import {GitHubHostedMenu} from './menu-github'
-import {
-  CarletonCafeIndex,
+import {CarletonCafeIndex} from './carleton-menus'
+// import {BonAppPickerView} from './dev-bonapp-picker'
+
+export {
   CarletonBurtonMenuScreen,
   CarletonLDCMenuScreen,
   CarletonWeitzMenuScreen,
   CarletonSaylesMenuScreen,
 } from './carleton-menus'
-// import {BonAppPickerView} from './dev-bonapp-picker'
-
-const CarletonMenuPicker = StackNavigator(
-  {
-    CarletonCafeIndex: {screen: CarletonCafeIndex},
-    CarletonBurtonMenuView: {screen: CarletonBurtonMenuScreen},
-    CarletonLDCMenuView: {screen: CarletonLDCMenuScreen},
-    CarletonWeitzMenuView: {screen: CarletonWeitzMenuScreen},
-    CarletonSaylesMenuView: {screen: CarletonSaylesMenuScreen},
-  },
-  {
-    headerMode: 'none',
-  },
-)
 
 export const MenusView = TabNavigator(
   {
@@ -100,9 +87,9 @@ export const MenusView = TabNavigator(
     },
 
     CarletonMenuListView: {
-      screen: CarletonMenuPicker,
+      screen: CarletonCafeIndex,
       navigationOptions: {
-        title: 'Carleton',
+        tabBarLabel: 'Carleton',
         tabBarIcon: TabBarIcon('menu'),
       },
     },


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/1695

In the below screenshots, you'll notice that the Carleton Menu detail says "Back to Home". However, pressing it wouldn't take you Home – it'd take you back to the list of menus.

This is the simplest way to fix that. The only downside is that you can't use the tab bar to switch away, but I feel like it was kinda weird before, anyway.

• | Before | After
--- | --- | ---
Index | ![old-list](https://user-images.githubusercontent.com/464441/31057367-2d280eba-a6a7-11e7-8d6d-3eeb62fc8054.png) | ![new-list](https://user-images.githubusercontent.com/464441/31057368-2d2ec9ee-a6a7-11e7-82b8-9e728611f6ad.png)
Menu | ![old-burton](https://user-images.githubusercontent.com/464441/31057366-2d0e1a0a-a6a7-11e7-9ae0-59a05e3ee610.png) | ![new-burton](https://user-images.githubusercontent.com/464441/31057369-2d32da2a-a6a7-11e7-9b58-a571b9facb1c.png)