### PR TITLE
Minify data files

### DIFF
--- a/scripts/bundle-data-dir.js
+++ b/scripts/bundle-data-dir.js
@@ -38,7 +38,7 @@ function bundleDataDir({fromDir, toFile}) {
     return yaml.safeLoad(contents)
   })
   const dated = {data: loaded}
-  const output = JSON.stringify(dated, null, 2) + '\n'
+  const output = JSON.stringify(dated, null, 0) + '\n'
 
   const outStream =
     toFile === '-' ? process.stdout : fs.createWriteStream(toFile)

--- a/scripts/bundle-data-dir.js
+++ b/scripts/bundle-data-dir.js
@@ -38,7 +38,7 @@ function bundleDataDir({fromDir, toFile}) {
     return yaml.safeLoad(contents)
   })
   const dated = {data: loaded}
-  const output = JSON.stringify(dated, null, 0) + '\n'
+  const output = JSON.stringify(dated) + '\n'
 
   const outStream =
     toFile === '-' ? process.stdout : fs.createWriteStream(toFile)

--- a/scripts/convert-data-file.js
+++ b/scripts/convert-data-file.js
@@ -53,13 +53,13 @@ function convertDataFile({fromFile, toFile, toFileType = 'json'}) {
 
 function processYaml(fileContents) {
   let loaded = yaml.safeLoad(fileContents)
-  return JSON.stringify({data: loaded}, null, 2)
+  return JSON.stringify({data: loaded}, null, 0)
 }
 
 function processMarkdown(fileContents) {
-  return JSON.stringify({text: fileContents}, null, 2)
+  return JSON.stringify({text: fileContents}, null, 0)
 }
 
 function processCSS(fileContents) {
-  return JSON.stringify({css: fileContents}, null, 2)
+  return JSON.stringify({css: fileContents}, null, 0)
 }

--- a/scripts/convert-data-file.js
+++ b/scripts/convert-data-file.js
@@ -53,13 +53,13 @@ function convertDataFile({fromFile, toFile, toFileType = 'json'}) {
 
 function processYaml(fileContents) {
   let loaded = yaml.safeLoad(fileContents)
-  return JSON.stringify({data: loaded}, null, 0)
+  return JSON.stringify({data: loaded})
 }
 
 function processMarkdown(fileContents) {
-  return JSON.stringify({text: fileContents}, null, 0)
+  return JSON.stringify({text: fileContents})
 }
 
 function processCSS(fileContents) {
-  return JSON.stringify({css: fileContents}, null, 0)
+  return JSON.stringify({css: fileContents})
 }


### PR DESCRIPTION
This PR simply minifies our JSON files when we bundle our data.  This will drastically decrease the in-flight time of our data files, as we would no longer use whitespace here.  But, this will make fetching much faster.