### PR TITLE
Make homescreen buttons be buttons

### DIFF
--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -6,10 +6,20 @@ platform :ios do
 
   desc 'Take screenshots'
   lane :screenshot do
-    snapshot(devices: ['iPhone 7 Plus', 'iPhone 6', 'iPhone 5s'],
+    devices = [
+      'iPhone 7 Plus',
+      'iPhone 6',
+      'iPhone 5s',
+      # 'iPhone 4s',
+      'iPad Pro (9.7-inch)',
+      'iPad Pro (12.9-inch)',
+   ]
+    snapshot(devices: devices,
              languages: ['en-US'],
              scheme: ENV['GYM_SCHEME'],
-             project: ENV['GYM_PROJECT'])
+             project: ENV['GYM_PROJECT'],
+             # concurrent_simulators: false,
+             number_of_retries: 0)
   end
 
   desc 'Builds the app'

--- a/ios/AllAboutOlafUITests/AllAboutOlafUITests.swift
+++ b/ios/AllAboutOlafUITests/AllAboutOlafUITests.swift
@@ -39,80 +39,81 @@ class AllAboutOlafUITests: XCTestCase {
     }
 
     func testOpenMenusScreen() {
-        app.otherElements["   Menus"].tap()
+        app.buttons["Menus"].tap()
         sleep(5)
         snapshot("01MenusScreenStavMenu")
     }
 
     func testOpenSisScreen() {
-        app.otherElements["   SIS"].tap()
+        app.buttons["SIS"].tap()
         sleep(1)
         snapshot("02SisScreen")
     }
 
     func testOpenBuildingHoursScreen() {
-        app.otherElements["   Building Hours"].tap()
+        app.buttons["Building Hours"].tap()
         sleep(1)
         snapshot("03BuildingHoursScreen")
     }
 
     func testOpenWebcamsScreen() {
-        app.otherElements["   Streaming Media"].tap()
-        app.tabBars.buttons["Webcams"].tap()
+        app.buttons["Streaming Media"].tap()
+        app.otherElements["  Webcams"].tap()
         sleep(1)
         snapshot("04WebcamsScreen")
     }
 
     func testOpenCalendarScreen() {
-        app.otherElements["   Calendar"].tap()
+        app.buttons["Calendar"].tap()
         sleep(5)
         snapshot("05CalendarScreen")
     }
 
     func testOpenDirectoryScreen() {
-        app.otherElements["   Directory"].tap()
+        app.buttons["Directory"].tap()
         sleep(5)
         snapshot("06DirectoryScreen")
     }
 
     func testOpenStreamingMediaScreen() {
-        app.otherElements["   Streaming Media"].tap()
+        app.buttons["Streaming Media"].tap()
         sleep(1)
         snapshot("07StreamingMediaScreen")
     }
 
     func testOpenNewsScreen() {
-        app.otherElements["   News"].tap()
+        app.buttons["News"].tap()
         sleep(5)
         snapshot("08NewsScreen")
     }
 
     func testOpenCampusMapScreen() {
-        app.otherElements["   Campus Map"].tap()
+        app.buttons["Campus Map"].tap()
+                
         sleep(5)
         snapshot("09CampusMapScreen")
     }
 
     func testOpenImportantContactsScreen() {
-        app.otherElements["   Important Contacts"].tap()
+        app.buttons["Important Contacts"].tap()
         sleep(1)
         snapshot("10ImportantContactsScreen")
     }
 
     func testOpenTransportationScreen() {
-        app.otherElements["   Transportation"].tap()
+        app.buttons["Transportation"].tap()
         sleep(1)
         snapshot("11TransportationScreen")
     }
 
     func testOpenCampusDictionaryScreen() {
-        app.otherElements["   Campus Dictionary"].tap()
+        app.buttons["Campus Dictionary"].tap()
         sleep(1)
         snapshot("12CampusDictionaryScreen")
     }
 
     func testOpenStudentOrgsScreen() {
-        app.otherElements["   Student Orgs"].tap()
+        app.buttons["Student Orgs"].tap()
         sleep(5)
         snapshot("13StudentOrgsScreen")
     }

--- a/source/views/home/button.js
+++ b/source/views/home/button.js
@@ -7,13 +7,12 @@ import type {ViewType} from '../views'
 import {Touchable} from '../components/touchable'
 import * as c from '../components/colors'
 
-export function HomeScreenButton({
-  view,
-  onPress,
-}: {
+type Props = {
   view: ViewType,
   onPress: () => any,
-}) {
+}
+
+export function HomeScreenButton({view, onPress}: Props) {
   const style = {backgroundColor: view.tint}
 
   return (
@@ -21,6 +20,9 @@ export function HomeScreenButton({
       highlight={false}
       onPress={onPress}
       style={[styles.rectangle, style]}
+      accessibilityLabel={view.title}
+      accessibilityTraits="button"
+      accessibilityComponentType="button"
     >
       <Icon name={view.icon} size={32} style={styles.rectangleButtonIcon} />
       <Text style={styles.rectangleButtonText}>{view.title}</Text>


### PR DESCRIPTION
This PR makes the homescreen buttons report themselves as buttons for accessibility purposes.

I referenced https://facebook.github.io/react-native/docs/accessibility.html and https://code.facebook.com/posts/435862739941212/making-react-native-apps-accessible/.

This PR also updates Fastlane to work with the screenshot tool again.