### PR TITLE
Add "College" after the colleges on the Express schedule

### DIFF
--- a/data/bus-times/express.yaml
+++ b/data/bus-times/express.yaml
@@ -14,8 +14,8 @@ schedules:
       - [44.460719, -93.155794]
       - [44.462210, -93.183026]
     stops:
-      - St. Olaf
-      - Carleton
+      - St. Olaf College
+      - Carleton College
       - Food Co-op
       - Papa Murphy's
       - Cub/Target
@@ -23,8 +23,8 @@ schedules:
       - Jesse James Lanes
       - El Tequila
       - Food Co-op
-      - Carleton
-      - St. Olaf
+      - Carleton College
+      - St. Olaf College
     times:
       - ['4:15pm',  '4:23pm',  '4:27pm',  '4:32pm',  '4:35pm',  '4:37pm',  '4:39pm',  '4:42pm',  '4:45pm',  '4:48pm',   '4:55pm']
       - ['5:00pm',  '5:08pm',  '5:12pm',  '5:17pm',  '5:20pm',  '5:22pm',  '5:24pm',  '5:27pm',  '5:30pm',  '5:33pm',   '5:40pm']
@@ -50,8 +50,8 @@ schedules:
       - [44.460719, -93.155794]
       - [44.462210, -93.183026]
     stops:
-      - St. Olaf
-      - Carleton
+      - St. Olaf College
+      - Carleton College
       - Food Co-op
       - Papa Murphy's
       - Cub/Target
@@ -59,8 +59,8 @@ schedules:
       - Jesse James Lanes
       - El Tequila
       - Food Co-op
-      - Carleton
-      - St. Olaf
+      - Carleton College
+      - St. Olaf College
     times:
       - ['3:00pm',  '3:08pm',  '3:12pm',   '3:17pm',   '3:20pm',   '3:22pm',   '3:24pm',   '3:27pm',   '3:30pm',  '3:33pm',   '3:40pm']
       - ['3:45pm',  '3:53pm',  '3:57pm',   '3:57pm',   '4:05pm',   '4:07pm',   '4:09pm',   '4:12pm',   '4:15pm',  '4:18pm',   '4:25pm']


### PR DESCRIPTION
I don't think there's a reason why we shouldn't do this.  It's this way on the Blue schedule, so I figured I'd make this somewhat consistent.  I could also go the other way. (drop "College" from both)