### PR TITLE
Make iOS open the webcams page (like Android)

### DIFF
--- a/source/views/streaming/webcams.js
+++ b/source/views/streaming/webcams.js
@@ -132,14 +132,8 @@ type ThumbnailProps = {
 
 class StreamThumbnail extends React.PureComponent<void, ThumbnailProps, void> {
   handlePress = () => {
-    const {streamUrl, name, pageUrl} = this.props.webcam
-    if (Platform.OS === 'ios') {
-      trackedOpenUrl({url: streamUrl, id: `${name}WebcamView`})
-    } else if (Platform.OS === 'android') {
-      trackedOpenUrl({url: pageUrl, id: `${name}WebcamView`})
-    } else {
-      trackedOpenUrl({url: pageUrl, id: `${name}WebcamView`})
-    }
+    const {name, pageUrl} = this.props.webcam
+    trackedOpenUrl({url: pageUrl, id: `${name}WebcamView`})
   }
 
   render() {

--- a/source/views/streaming/webcams.js
+++ b/source/views/streaming/webcams.js
@@ -11,7 +11,6 @@ import {
   Text,
   ScrollView,
   Image,
-  Platform,
   Dimensions,
 } from 'react-native'
 import delay from 'delay'


### PR DESCRIPTION
Broadcast Media is hoping to launch their new mobile-friendly theme next week, so let's prepare for that!

BM would like to have the analytics for the page, and the main reason (IIRC) that iOS opens teh stream directly is that the page was hard to navigate on mobile. With a mobile-friendly website, that concern goes away.