### PR TITLE
Fixes to KSTO

### DIFF
--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -269,7 +269,7 @@ class StreamPlayer extends React.PureComponent<void, StreamPlayerProps, void> {
 
     <title>KSTO Stream</title>
 
-    <audio id="player" webkit-playsinline>
+    <audio id="player" webkit-playsinline playsinline>
       <source src="${url}" />
     </audio>
 


### PR DESCRIPTION
Closes #1805 

I'm going to document cleanups and fixes to the KSTO player here.

So far:

- Android is not working
- Added the unprefixed `playsinline` attribute to the audio tag, which is now part of HTML