### PR TITLE
Bump version to 2.4.2-pre

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "all-about-olaf",
-  "version": "2.4.1",
+  "version": "2.4.2-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "all-about-olaf",
-  "version": "2.4.1",
+  "version": "2.4.2-pre",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This is what @hawkrives accidentally did in #1802 and reverted in #1804.

I wonder if we should just use 2.4-pre or something like that.