### PR TITLE
Scroll webcams to where the player is showing

### DIFF
--- a/data/webcams/0-alumni-hall-west.yaml
+++ b/data/webcams/0-alumni-hall-west.yaml
@@ -1,5 +1,5 @@
 name: Alumni Hall West
-pageUrl: https://www.stolaf.edu/multimedia/webcams?cam=alumniwest
+pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=alumniwest#fold
 streamUrl: https://cdn.stobcm.com/webcams/alumniwest.stream/master.m3u8
 thumbnail: alumniwest
 tagline: A view of the Ytterboe Hall and the wind turbine

--- a/data/webcams/1-buntrock-plaza.yaml
+++ b/data/webcams/1-buntrock-plaza.yaml
@@ -1,5 +1,5 @@
 name: Buntrock Plaza
-pageUrl: https://www.stolaf.edu/multimedia/webcams?cam=bcplaza
+pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=bcplaza#fold
 streamUrl: https://cdn.stobcm.com/webcams/bcplaza.stream/master.m3u8
 thumbnail: bcplaza
 tagline: Looking out to the plaza and campus green

--- a/data/webcams/2-east-quad.yaml
+++ b/data/webcams/2-east-quad.yaml
@@ -1,5 +1,5 @@
 name: East Quad
-pageUrl: https://www.stolaf.edu/multimedia/webcams?cam=eastquad
+pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=eastquad#fold
 streamUrl: https://cdn.stobcm.com/webcams/eastquad.stream/master.m3u8
 thumbnail: eastquad
 tagline: Looking out to Regents, Holland Hall, and Old Main

--- a/data/webcams/3-hi-mom.yaml
+++ b/data/webcams/3-hi-mom.yaml
@@ -1,5 +1,5 @@
 name: Hi Mom
-pageUrl: https://www.stolaf.edu/multimedia/webcams?cam=himom
+pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=himom#fold
 streamUrl: https://cdn.stobcm.com/webcams/himom.stream/master.m3u8
 thumbnail: himom
 tagline: Located in the Crossroads inside Buntrock Commons

--- a/data/webcams/4-tomson-east-lantern.yaml
+++ b/data/webcams/4-tomson-east-lantern.yaml
@@ -1,5 +1,5 @@
 name: Tomson East Lantern
-pageUrl: https://www.stolaf.edu/multimedia/webcams?cam=tomsoneast
+pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=tomsoneast#fold
 streamUrl: https://cdn.stobcm.com/webcams/tomsoneast.stream/master.m3u8
 thumbnail: tomsoneast
 tagline: A view of the campus green and Wind Chime Memorial

--- a/data/webcams/5-tomson-west-lantern.yaml
+++ b/data/webcams/5-tomson-west-lantern.yaml
@@ -1,5 +1,5 @@
 name: Tomson West Lantern
-pageUrl: https://www.stolaf.edu/multimedia/webcams?cam=tomsonwest
+pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=tomsonwest#fold
 streamUrl: https://cdn.stobcm.com/webcams/tomsonwest.stream/master.m3u8
 thumbnail: tomsonwest
 tagline: Looking out to Mellby Hall and the Theater Building


### PR DESCRIPTION
Use the anchor `#fold` to load the page scrolled down to the point where just the title & player are showing (moving the site header & etc off the screen).

Before | After
--|--
<img width="375" alt="before" src="https://user-images.githubusercontent.com/5240843/31831724-6f02ec16-b592-11e7-848d-e8ec54fa5ba1.png"> | <img width="375" alt="after" src="https://user-images.githubusercontent.com/5240843/31831723-6ef317be-b592-11e7-82d1-e1217606b487.png">