### PR TITLE
Background audio and vibrate/silent switch

### DIFF
--- a/ios/AllAboutOlaf/AppDelegate.m
+++ b/ios/AllAboutOlaf/AppDelegate.m
@@ -9,6 +9,7 @@
 
 #import "AppDelegate.h"
 #import <BugsnagReactNative/BugsnagReactNative.h>
+#import <AVFoundation/AVFoundation.h>
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
@@ -54,6 +55,9 @@
                                                        diskCapacity:20 * 1024 * 1024  // 20 MiB
                                                            diskPath:nil];
   [NSURLCache setSharedURLCache:URLCache];
+
+  // ignore vibrate/silent switch when playing audio
+  [[AVAudioSession sharedInstance] setCategory: AVAudioSessionCategoryPlayback error: nil];
 
   return YES;
 }


### PR DESCRIPTION
Closes #1754

This PR accomplishes two things with setting the `AVAudioSession` as a shared instance:

1. Background audio streaming (KSTO was our primary target)
2. Sound plays without the vibrate/silent switch toggled on iOS