### PR TITLE
Use "current" query in streams api

### DIFF
--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -78,7 +78,7 @@ export class StreamListView extends React.PureComponent {
         .format('YYYY-MM-DD')
 
       let params = {
-        class: 'upcoming',
+        class: 'current',
         sort: 'ascending',
         // eslint-disable-next-line camelcase
         date_from: dateFrom,


### PR DESCRIPTION
Switches the class from `upcoming` to `current` so that the list shows all streams from today + the upcoming streams.