### PR TITLE
Put run_deploy logic into fastlane/lib/util

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
     - TRAVIS_NODE_VERSION=8
     # set the ruby version up top
     - TRAVIS_RUBY_VERSION=ruby-2.4.2
-    # always set run_deploy
-    - run_deploy=0
     # GH_TOKEN:
     # - used by greenkeeper to update package-lock.json
     - secure: s2HicpDrioxVuS/1KyDMgFkgbM3eVxp1FVF1R922oKeUGhtNFERufXp+nXaG98trqmJhfjfx243i7qP8oEX1DoGtFAHAuILBG0KTXoY1HZG/ZlVpc2pjRQmfCt3tJCs8Trovv2q2yM21JtTKXJ6wZ+XUGK0zqXbd4IH7k30Q649CIZ+l/pcU4cVqoLojekFWMQuW9onPOiTGtBckdPngmJ9GgAGDQesYjZ/p5RTaggCleD4oFmgkUdPZtityr+6TYe6cU9fFIVHyxe5F4JsiXB2aKk0qbX86tXUdlneOTYAw0YsxzVbpjtjVeedG3lm+UDAABznaqyuj4EI2+ERIXEMXtDzG+knQuQIF1P9E5ZWRanuSbfwFRJecPXyw03AtT+lBEHls1klRFep0yYzSKPunuqyeFZG+QFFtiegPnk7C4R2KfJhghB8kr8Ysgwg1YJXP77AaTBET0YsEvhMNNqEGK0LsXhZJUCWUnZfINFwp8ggEB8ZHWqWmTD2SxufqWXCzcMBnNdyuoDAH8//myA/09UcxzRpQwBqy3wH/Nlb47n+RydQxxiSmpTw0xAa5f9/qRjy0DrIT0PowDN1VGLgy6wQIqzAN6Ex4Y7AIyaTZrga7cbpfHE7lKee8XTTfDJnfGywJ1+3CqpZpA1jQhRzeGQbxPfghaOxzI46i4p4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,16 +159,6 @@ before_install:
   - echo "ruby -v is now $(ruby -v)"
   - gem install bundler
 
-  # only deploy from:
-  # - cron-triggered jobs
-  # - tagged commits
-  # - commits whose messages contain the string [ci run beta]
-  - if [[
-      $TRAVIS_EVENT_TYPE == "cron" ||
-      $TRAVIS_TAG != "" ||
-      $TRAVIS_COMMIT_MESSAGE == *"[ci run beta]"*
-    ]]; then run_deploy=1; fi
-
   # force a consistent node version
   - echo "Using node $TRAVIS_NODE_VERSION (node -v says $(node -v))"
   - nvm install "$TRAVIS_NODE_VERSION"

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -118,3 +118,13 @@ def auto_beta
     build
   end
 end
+
+def should_deploy?
+	cron? ||
+		!ENV['TRAVIS_TAG'].empty? ||
+		ENV['TRAVIS_COMMIT_MESSAGE'] =~ /\[ci run beta\]/
+end
+
+def cron?
+	ENV['TRAVIS_EVENT_TYPE'] == 'cron'
+end

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -105,7 +105,7 @@ end
 def auto_beta
   UI.message "TRAVIS_EVENT_TYPE: #{ENV['TRAVIS_EVENT_TYPE']}"
   if should_deploy?
-	  if cron?
+    if cron?
       UI.message 'building nightly'
       nightly
     else
@@ -119,11 +119,11 @@ def auto_beta
 end
 
 def should_deploy?
-	cron? ||
-		!ENV['TRAVIS_TAG'].empty? ||
-		ENV['TRAVIS_COMMIT_MESSAGE'] =~ /\[ci run beta\]/
+  cron? ||
+    !ENV['TRAVIS_TAG'].empty? ||
+    ENV['TRAVIS_COMMIT_MESSAGE'] =~ /\[ci run beta\]/
 end
 
 def cron?
-	ENV['TRAVIS_EVENT_TYPE'] == 'cron'
+  ENV['TRAVIS_EVENT_TYPE'] == 'cron'
 end

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -103,18 +103,17 @@ end
 # smart enough to call the appropriate platform's "beta" lane. So, let's make
 # a beta build if there have been new commits since the last beta.
 def auto_beta
-  UI.message "run_deploy: #{ENV['run_deploy']}"
   UI.message "TRAVIS_EVENT_TYPE: #{ENV['TRAVIS_EVENT_TYPE']}"
-  if ENV['run_deploy'] == '1'
-    if ENV['TRAVIS_EVENT_TYPE'] == 'cron'
-      UI.message 'nightly'
+  if should_deploy?
+	  if cron?
+      UI.message 'building nightly'
       nightly
     else
-      UI.message 'beta'
+      UI.message 'building beta'
       beta
     end
   else
-    UI.message 'just build'
+    UI.message 'just building'
     build
   end
 end


### PR DESCRIPTION
I don't know how to feel about this.  For one, it consolidates the logic into the same place it's used, but it does introduce concern about Travis into Fastlane, and if we want the two to be decoupled, (I can't think of a reason why) that might work.

However, we know that this should work, unless something is wrong in the logic itself.

I'd say this is PR is mutually exclusive with #1831 unless that fails to fix #1830, in which case I'd want that reverted.  I'll be offline for the next ~6 hours so if someone decides they want to merge this instead of #1831, feel free, just keep in mind that both shouldn't be there.

*Closes #1830.*