### PR TITLE
Update bugsnag-react-native to v2.6.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,9 @@ allprojects {
             // react-native-custom-tabs requires this maven repository
             url "https://jitpack.io"
         }
+        maven {
+            // currently used for bugsnag-react-native
+            url 'https://maven.google.com'
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@hawkrives/react-native-alphabetlistview": "1.0.0",
     "@hawkrives/react-native-sortable-list": "1.0.1",
     "buffer": "5.0.8",
-    "bugsnag-react-native": "2.5.1",
+    "bugsnag-react-native": "2.6.0",
     "css-select": "1.2.0",
     "dedent": "0.7.0",
     "delay": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,9 +1125,9 @@ buffer@5.0.8:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-bugsnag-react-native@2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/bugsnag-react-native/-/bugsnag-react-native-2.5.1.tgz#d7617febd8ae692c5f92ce6d06890c6c0a2def12"
+bugsnag-react-native@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/bugsnag-react-native/-/bugsnag-react-native-2.6.0.tgz#cc5e882890c612e69bb447ff9d1a237960f1eca7"
   dependencies:
     prop-types "^15.6.0"
 
@@ -5313,7 +5313,7 @@ vinyl@^0.5.0:
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
 
-"vm2@github:patriksimek/vm2#custom_files":
+vm2@patriksimek/vm2#custom_files:
   version "3.5.0"
   resolved "https://codeload.github.com/patriksimek/vm2/tar.gz/7e82f90ac705fc44fad044147cb0df09b4c79a57"
 


### PR DESCRIPTION
Closes #1837 

<details>
<summary>Release Notes</summary>
<strong>v2.6.0</strong>

<h4>IMPORTANT UPGRADE NOTE:</h4>
<p>Please ensure that Google's maven repository is specified in your <code>android/build.gradle</code>:</p>
<pre><code>allprojects {
    repositories {
        maven { url 'https://maven.google.com' }
    }
}
</code></pre>
<ul>
<li>(Android) Compile annotations dependency as api rather than implementation</li>
<li>(Android) <a href="https://urls.greenkeeper.io/bugsnag/bugsnag-android/pull/208">Support missing case in handled/unhandled tracker</a></li>
</ul>
</details>

<details>
<summary>Commits</summary>
<p>The new version differs by 4 commits.</p>
<ul>
<li><a href="https://urls.greenkeeper.io/bugsnag/bugsnag-react-native/commit/06ce6633695a3a9b4d0a8b7ad7ae675b49bd349f"><code>06ce663</code></a> <code>v2.6.0</code></li>
<li><a href="https://urls.greenkeeper.io/bugsnag/bugsnag-react-native/commit/30e5177375a90684303644a8b9ca92dc8769ccd3"><code>30e5177</code></a> <code>Merge pull request #179 from bugsnag/google-maven-updates</code></li>
<li><a href="https://urls.greenkeeper.io/bugsnag/bugsnag-react-native/commit/f2b3c7681ee60ac18d8b6cd4f03eb4fe97e41f33"><code>f2b3c76</code></a> <code>reword changelog</code></li>
<li><a href="https://urls.greenkeeper.io/bugsnag/bugsnag-react-native/commit/31f73fee96f98a5477e1022d303412895a2a2dc2"><code>31f73fe</code></a> <code>update for google maven repo</code></li>
</ul>
<p>See the <a href="https://urls.greenkeeper.io/bugsnag/bugsnag-react-native/compare/0252b7a9372167eeb0ea72b09034dbaf09c0f960...06ce6633695a3a9b4d0a8b7ad7ae675b49bd349f">full diff</a></p>
</details>