### PR TITLE
Mark flow-typed/npm as vendored in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.pbxproj -text
+flow-typed/npm/* linguist-vendored


### PR DESCRIPTION
This helps GitHub's language comprehension engine, [linguist](https://github.com/github/linguist), understand what's going on.

Read more about this feature on the [Linguist README](https://github.com/github/linguist/blob/4166f2e89d3e0d0d21e67ac5677a56a4efaa8221/README.md#vendored-code).