### PR TITLE
Leave BugSnag breadcrumb on navigation

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -70,14 +70,15 @@ export default class App extends React.Component {
     const currentScreen = getCurrentRouteName(currentState)
     const prevScreen = getCurrentRouteName(prevState)
 
+    if (!currentScreen) return
+    
     if (currentScreen !== prevScreen) {
       tracker.trackScreenView(currentScreen)
+      bugsnag.leaveBreadcrumb(currentScreen, {
+        type: 'navigation',
+        previousScreen: prevScreen,
+      })
     }
-
-    bugsnag.leaveBreadcrumb(`Navigated from to ${currentScreen}.`, {
-      type: 'navigation',
-      previousScreen: prevScreen,
-    })
   }
 
   render() {

--- a/source/app.js
+++ b/source/app.js
@@ -71,7 +71,7 @@ export default class App extends React.Component {
     const prevScreen = getCurrentRouteName(prevState)
 
     if (!currentScreen) return
-    
+
     if (currentScreen !== prevScreen) {
       tracker.trackScreenView(currentScreen)
       bugsnag.leaveBreadcrumb(currentScreen, {

--- a/source/app.js
+++ b/source/app.js
@@ -11,6 +11,7 @@ import OneSignal from 'react-native-onesignal'
 import React from 'react'
 import {Provider} from 'react-redux'
 import {store} from './flux'
+import bugsnag from './bugsnag'
 import {tracker} from './analytics'
 import {AppNavigator} from './navigation'
 import type {NavigationState} from 'react-navigation'
@@ -72,6 +73,11 @@ export default class App extends React.Component {
     if (currentScreen !== prevScreen) {
       tracker.trackScreenView(currentScreen)
     }
+
+    bugsnag.leaveBreadcrumb(`Navigated from to ${currentScreen}.`, {
+      type: 'navigation',
+      previousScreen: prevousScreen,
+    })
   }
 
   render() {

--- a/source/app.js
+++ b/source/app.js
@@ -76,7 +76,7 @@ export default class App extends React.Component {
 
     bugsnag.leaveBreadcrumb(`Navigated from to ${currentScreen}.`, {
       type: 'navigation',
-      previousScreen: prevousScreen,
+      previousScreen: prevScreen,
     })
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3495,13 +3495,13 @@ mime-db@~1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.23.0.tgz#a31b4070adaea27d732ea333740a64d0ec9a6659"
 
-mime-types@2.1.11, mime-types@~2.1.6, mime-types@~2.1.9:
+mime-types@2.1.11:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.11.tgz#c259c471bda808a85d6cd193b430a5fae4473b3c"
   dependencies:
     mime-db "~1.23.0"
 
-mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17:
+mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, mime-types@~2.1.6, mime-types@~2.1.9:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
@@ -3531,17 +3531,13 @@ minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 "mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
@@ -4672,13 +4668,13 @@ rx-lite-aggregates@^4.0.8:
   dependencies:
     rx-lite "*"
 
-rx-lite@*, rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
-
-rx-lite@^4.0.8:
+rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
+rx-lite@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -5352,11 +5348,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.19"
 
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-
-whatwg-fetch@^1.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 


### PR DESCRIPTION
This PR causes `trackScreenChanges` to send a breadcrumb of type `navigation` (the only reserved key in the metadata object) and then send the previous screen as well.

*Closes #1800.*

I'm open to tweaking the syntax and stuff or offloading this to a different location.