### PR TITLE
Remove giant header comments from source files

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -1,8 +1,4 @@
-/**
- * @flow
- * All About Olaf
- * Index view
- */
+// @flow
 
 import './globalize-fetch'
 import './setup-moment'

--- a/source/views/building-hours/list.js
+++ b/source/views/building-hours/list.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * Building Hours list page
- */
 
 import React from 'react'
 import {StyleSheet, SectionList} from 'react-native'

--- a/source/views/building-hours/row.js
+++ b/source/views/building-hours/row.js
@@ -1,8 +1,5 @@
 // @flow
-/**
- * All About Olaf
- * Building Hours list element
- */
+
 import React from 'react'
 import {View, Text, StyleSheet} from 'react-native'
 import {Badge} from '../components/badge'

--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * Calendar page
- */
 
 import React from 'react'
 import {EventList} from './event-list'

--- a/source/views/calendar/event-list.js
+++ b/source/views/calendar/event-list.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * List of calendar events
- */
 
 import React from 'react'
 import {StyleSheet, SectionList} from 'react-native'

--- a/source/views/calendar/index.js
+++ b/source/views/calendar/index.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * Calendar page
- */
 
 import React from 'react'
 import {TabNavigator} from '../components/tabbed-view'

--- a/source/views/contacts/contact-list.js
+++ b/source/views/contacts/contact-list.js
@@ -1,8 +1,4 @@
-/**
- * @flow
- * All About Olaf
- * Contact page
- */
+// @flow
 
 import React from 'react'
 import {SectionList, StyleSheet} from 'react-native'

--- a/source/views/home/home.js
+++ b/source/views/home/home.js
@@ -1,8 +1,4 @@
-/**
- * @flow
- * All About Olaf
- * iOS Home page
- */
+// @flow
 
 import React from 'react'
 import {ScrollView, StyleSheet, StatusBar} from 'react-native'

--- a/source/views/menus/index.js
+++ b/source/views/menus/index.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * Menus page
- */
 
 import React from 'react'
 import {TabNavigator} from '../components/tabbed-view'

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types, camelcase */
 // @flow
 import React from 'react'
 import LoadingView from '../components/loading'
@@ -151,6 +150,7 @@ export class BonAppHostedMenu extends React.Component<void, Props, State> {
 
     // then we make our own StationMenus list
     return toPairs(idsGroupedByStation).map(([name, items], i) => ({
+      // eslint-disable-next-line camelcase
       order_id: String(i),
       id: String(i),
       label: name,

--- a/source/views/news/index.js
+++ b/source/views/news/index.js
@@ -1,9 +1,5 @@
 /* eslint-disable camelcase */
-/**
- * @flow
- * All About Olaf
- * News page
- */
+// @flow
 
 import React from 'react'
 import {TabNavigator} from '../components/tabbed-view'

--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -1,4 +1,5 @@
 // @flow
+
 import React from 'react'
 import {StyleSheet, ScrollView, Platform} from 'react-native'
 import {TableView} from 'react-native-tableview-simple'
@@ -6,7 +7,6 @@ import type {TopLevelViewPropsType} from '../types'
 import * as c from '../components/colors'
 
 import CredentialsLoginSection from './sections/login-credentials'
-// import TokenLoginSection from './sections/login-token'
 import OddsAndEndsSection from './sections/odds-and-ends'
 import SupportSection from './sections/support'
 

--- a/source/views/sis/index.js
+++ b/source/views/sis/index.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * iOS SIS page
- */
 
 import {TabNavigator} from '../components/tabbed-view'
 

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -1,9 +1,4 @@
-/**
- * @flow
- *
- * All About Olaf
- * Student Work page
- */
+// @flow
 
 import React from 'react'
 import {StyleSheet, Text, SectionList} from 'react-native'

--- a/source/views/streaming/index.js
+++ b/source/views/streaming/index.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * Media page
- */
 
 import {TabNavigator} from '../components/tabbed-view'
 

--- a/source/views/streaming/movie.js
+++ b/source/views/streaming/movie.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * Weekly Movie page
- */
 
 import React from 'react'
 import {StyleSheet, View, Text} from 'react-native'

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * KSTO page
- */
 
 import React from 'react'
 import {

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * Streaming Media page
- */
 
 import React from 'react'
 import {StyleSheet, SectionList} from 'react-native'

--- a/source/views/streaming/webcams.js
+++ b/source/views/streaming/webcams.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * Webcams page
- */
 
 import React from 'react'
 import {

--- a/source/views/transportation/index.js
+++ b/source/views/transportation/index.js
@@ -1,8 +1,4 @@
 // @flow
-/**
- * All About Olaf
- * Transportation page
- */
 
 import React from 'react'
 


### PR DESCRIPTION
```diff
@@ -1,8 +1,4 @@
-/**
- * @flow
- * All About Olaf
- * Index view
- */
+// @flow
```

1. IMHO, they serve no purpose – you know what app you're working on.
2. They're out of date – we haven't kept the name of the view current, and some say "iOS" when they're cross-platform (*cough* home screen *cough*)

I believe that @drewvolz (hi) added them primarily because they're "what you do" in Cocoa-land. I disagree with them there, as well, but that's a different debate. These comments date back to some of the very first code that was written for this project.

I chatted with @drewvolz about removing these, and he seemed positive, so I'm PRing it.