### PR TITLE
Upload source maps to Bugsnag for actual line-based error numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ before_install:
   - nvm install "$TRAVIS_NODE_VERSION"
   - nvm use "$TRAVIS_NODE_VERSION"
   - echo "node -v is now $(node -v)"
-  
+
   # travis doesn't install yarn automatically on osx
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then brew install yarn --without-node; fi
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.0)
-    fastlane (2.62.0)
+    fastlane (2.64.0)
       CFPropertyList (>= 2.3, < 3.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -104,7 +104,7 @@ GEM
     httparty (0.15.6)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
-    i18n (0.9.0)
+    i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     jwt (2.1.0)
@@ -131,7 +131,7 @@ GEM
     public_suffix (2.0.5)
     rainbow (2.2.2)
       rake
-    rake (12.1.0)
+    rake (12.2.1)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -175,8 +175,8 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
-    tty-screen (0.5.0)
-    tzinfo (1.2.3)
+    tty-screen (0.5.1)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uber (0.1.0)
     unf (0.1.4)
@@ -184,14 +184,14 @@ GEM
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
     word_wrap (1.0.0)
-    xcodeproj (1.5.2)
+    xcodeproj (1.5.3)
       CFPropertyList (~> 2.3.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.2.3)
     xcpretty (0.2.8)
       rouge (~> 2.0.7)
-    xcpretty-travis-formatter (0.0.4)
+    xcpretty-travis-formatter (1.0.0)
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
@@ -205,6 +205,5 @@ DEPENDENCIES
   rubocop (= 0.46)
   xcodeproj
 
-
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -12,9 +12,9 @@ xcode-select --install
 
 <table width="100%" >
 <tr>
-<th width="33%"><a href="http://brew.sh">Homebrew</a></td>
-<th width="33%">Installer Script</td>
-<th width="33%">Rubygems</td>
+<th width="33%"><a href="http://brew.sh">Homebrew</a></th>
+<th width="33%">Installer Script</th>
+<th width="33%">RubyGems</th>
 </tr>
 <tr>
 <td width="33%" align="center">macOS</td>
@@ -53,6 +53,11 @@ Submit a new beta build to Google Play
 fastlane android nightly
 ```
 Submit a new nightly build to Google Play
+### android sourcemap
+```
+fastlane android sourcemap
+```
+Bundle an Android sourcemap
 ### android ci-run
 ```
 fastlane android ci-run
@@ -97,6 +102,11 @@ Submit a new Beta Build to Testflight
 fastlane ios nightly
 ```
 Submit a new nightly Beta Build to Testflight
+### ios sourcemap
+```
+fastlane ios sourcemap
+```
+Bundle an iOS sourcemap
 ### ios refresh_dsyms
 ```
 fastlane ios refresh_dsyms

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -64,6 +64,70 @@ def propagate_version(**args)
   end
 end
 
+# Generate argument values for the generate_sourcemap and upload_sourcemap_to_bugsnag lanes
+def get_sourcemap_args
+  # The cwd is /fastlane. I don't know why entry_file doesn't need to be ../, but
+  # I believe that watchman finds the project root and automatically looks there
+  case lane_context[:PLATFORM_NAME]
+  when :android
+    platform = 'android'
+    entry_file = 'index.android.js'
+    bundle_output = '../android-release.bundle'
+    sourcemap_output = '../android-release.bundle.map'
+    bundle_url = 'index.android.bundle'
+  when :ios
+    platform = 'ios'
+    entry_file = 'index.ios.js'
+    bundle_output = '../ios-release.bundle'
+    sourcemap_output = '../ios-release.bundle.map'
+    bundle_url = 'main.jsbundle'
+  end
+
+  {
+    platform: platform,
+    entry_file: entry_file,
+    bundle_output: bundle_output,
+    sourcemap_output: sourcemap_output,
+    bundle_url: bundle_url,
+  }
+end
+
+# Use react-native cli to generate the source map
+def generate_sourcemap
+  args = get_sourcemap_args
+
+  cmd = [
+    'npx react-native bundle',
+    '--dev false',
+    "--platform '#{args[:platform]}'",
+    "--entry-file '#{args[:entry_file]}'",
+    "--bundle-output '#{args[:bundle_output]}'",
+    "--sourcemap-output '#{args[:sourcemap_output]}'",
+  ].join ' '
+
+  FastlaneCore::CommandExecutor.execute(command: cmd,
+                                        print_all: true,
+                                        print_command: true)
+end
+
+# Upload source map to Bugsnag
+def upload_sourcemap_to_bugsnag
+  args = get_sourcemap_args
+
+  cmd = [
+    'npx bugsnag-sourcemaps upload',
+    "--api-key '#{ENV['BUGSNAG_KEY']}'",
+    "--minified-file '#{args[:bundle_output]}'",
+    "--source-map '#{args[:sourcemap_output]}'",
+    "--minified-url '#{args[:bundle_url]}'",
+    '--upload-sources',
+  ].join ' '
+
+  FastlaneCore::CommandExecutor.execute(command: cmd,
+                                        print_all: true,
+                                        print_command: true)
+end
+
 # last_git_tag returns the most recent tag, chronologically.
 # newest_tag returns the most recent tag *on this branch*.
 def newest_tag

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -49,7 +49,8 @@ def propagate_version(**args)
   UI.message "Propagating version: #{version}"
   UI.message 'into the Info.plist and build.gradle files'
 
-  # encode build number into js-land
+  # encode build number into js-land – we've already fetched it, so we'll
+  # never set the "+" into the binaries
   set_package_data(data: { version: "#{version}+#{build}" })
 
   case lane_context[:PLATFORM_NAME]

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -39,6 +39,11 @@ platform :android do
     submit(track: 'alpha')
   end
 
+  desc 'Bundle an Android sourcemap'
+  lane :sourcemap do
+    generate_sourcemap
+  end
+
   desc 'Run the appropriate action on CI'
   lane :'ci-run' do
     # prepare for the bright future with signed android betas

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -27,6 +27,9 @@ platform :android do
 
     supply(track: track,
            check_superseded_tracks: true)
+
+    generate_sourcemap
+    upload_sourcemaps_to_bugsnag
   end
 
   desc 'Submit a new beta build to Google Play'

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -13,7 +13,7 @@ platform :ios do
       # 'iPhone 4s',
       'iPad Pro (9.7-inch)',
       'iPad Pro (12.9-inch)',
-   ]
+    ]
     snapshot(devices: devices,
              languages: ['en-US'],
              scheme: ENV['GYM_SCHEME'],

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -47,6 +47,8 @@ platform :ios do
       puts 'Changelog failed to upload:'
       puts error
     end
+    generate_sourcemap
+    upload_sourcemaps_to_bugsnag
   end
 
   desc 'Bundle an iOS sourcemap'

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -49,6 +49,11 @@ platform :ios do
     end
   end
 
+  desc 'Bundle an iOS sourcemap'
+  lane :sourcemap do
+    generate_sourcemap
+  end
+
   desc 'Upload dYSM symbols to Bugsnag from Apple'
   lane :refresh_dsyms do
     download_dsyms

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "babel-jest": "21.2.0",
     "babel-plugin-flow-react-proptypes": "9.0.0",
     "babel-preset-react-native": "3.0.1",
+    "bugsnag-sourcemaps": "1.0.1",
     "danger": "2.0.1",
     "eslint": "4.10.0",
     "eslint-config-prettier": "2.7.0",

--- a/source/bugsnag.js
+++ b/source/bugsnag.js
@@ -6,7 +6,6 @@ const PRODUCTION = process.env.NODE_ENV === 'production'
 
 const config = new Configuration()
 config.autoNotify = PRODUCTION
-config.codeBundleId = pkg.version
 if (!PRODUCTION) {
   // disable bugsnag in dev builds
   config.beforeSendCallbacks.push(() => false)

--- a/source/bugsnag.js
+++ b/source/bugsnag.js
@@ -2,11 +2,11 @@
 import {Client, Configuration} from 'bugsnag-react-native'
 import pkg from '../package.json'
 
-const PRODUCTION = process.env.NODE_ENV === 'production'
+const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 
 const config = new Configuration()
-config.autoNotify = PRODUCTION
-if (!PRODUCTION) {
+config.autoNotify = IS_PRODUCTION
+if (!IS_PRODUCTION) {
   // disable bugsnag in dev builds
   config.beforeSendCallbacks.push(() => false)
 }

--- a/source/bugsnag.js
+++ b/source/bugsnag.js
@@ -1,6 +1,5 @@
 // @flow
 import {Client, Configuration} from 'bugsnag-react-native'
-import pkg from '../package.json'
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,7 +156,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.1.0:
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -237,6 +237,10 @@ array-equal@^1.0.0:
 array-filter@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
+
+array-find-index@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
 
 array-includes@^3.0.3:
   version "3.0.3"
@@ -1137,6 +1141,17 @@ bugsnag-react-native@2.6.0:
   dependencies:
     prop-types "^15.6.0"
 
+bugsnag-sourcemaps@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bugsnag-sourcemaps/-/bugsnag-sourcemaps-1.0.1.tgz#9c8c74c79a35eae735067f9e2bf54cb66ab58b5d"
+  dependencies:
+    graceful-fs "^4.1.11"
+    listr "^0.12.0"
+    meow "^3.7.0"
+    rc "^1.2.1"
+    read-pkg-up "^2.0.0"
+    request "^2.79.0"
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -1163,9 +1178,20 @@ callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
 
+camelcase-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-2.1.0.tgz#308beeaffdf28119051efa1d932213c91b8f92e7"
+  dependencies:
+    camelcase "^2.0.0"
+    map-obj "^1.0.0"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+
+camelcase@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 camelcase@^3.0.0:
   version "3.0.0"
@@ -1216,7 +1242,7 @@ clamp@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/clamp/-/clamp-1.0.1.tgz#66a0e64011816e37196828fdc8c8c147312c8634"
 
-cli-cursor@^1.0.1:
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
@@ -1227,6 +1253,17 @@ cli-cursor@^2.1.0:
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
     restore-cursor "^2.0.0"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -1492,6 +1529,12 @@ csurf@~1.8.3:
     csrf "~3.0.0"
     http-errors "~1.3.1"
 
+currently-unhandled@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
+  dependencies:
+    array-find-index "^1.0.1"
+
 danger@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/danger/-/danger-2.0.1.tgz#d3b303162c1132cb0a5471eb79f041f1941f9de2"
@@ -1524,6 +1567,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.27.2:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
+
 dateformat@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
@@ -1546,7 +1593,7 @@ debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
-decamelize@^1.0.0, decamelize@^1.1.1:
+decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -1685,6 +1732,10 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 emitter-component@^1.1.1:
   version "1.1.1"
@@ -2035,7 +2086,7 @@ fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.4, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-figures@^1.3.5:
+figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -2224,6 +2275,10 @@ gauge@~2.7.3:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-stdin@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
 get-stdin@^5.0.1:
   version "5.0.1"
@@ -2516,6 +2571,16 @@ imurmurhash@^0.1.4:
 in-publish@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/in-publish/-/in-publish-2.0.0.tgz#e20ff5e3a2afc2690320b6dc552682a9c7fadf51"
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -3229,6 +3294,53 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#8206f4cf6d52ddc5827e5fd14989e0e965933a35"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    p-map "^1.1.1"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3411,6 +3523,19 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -3420,6 +3545,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loud-rejection@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.0"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -3433,6 +3565,10 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+map-obj@^1.0.0, map-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
 marked@0.3.6:
   version "0.3.6"
@@ -3451,6 +3587,21 @@ mem@^1.1.0:
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
     mimic-fn "^1.0.0"
+
+meow@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
+  dependencies:
+    camelcase-keys "^2.0.0"
+    decamelize "^1.1.2"
+    loud-rejection "^1.0.0"
+    map-obj "^1.0.1"
+    minimist "^1.1.3"
+    normalize-package-data "^2.3.4"
+    object-assign "^4.0.1"
+    read-pkg-up "^1.0.1"
+    redent "^1.0.0"
+    trim-newlines "^1.0.0"
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -3541,7 +3692,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
+minimist@1.2.0, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -3669,7 +3820,7 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.2:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
@@ -3807,6 +3958,15 @@ options@>=0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
 
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
@@ -3857,6 +4017,10 @@ p-locate@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
   dependencies:
     p-limit "^1.1.0"
+
+p-map@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 parse-diff@^0.4.0:
   version "0.4.0"
@@ -4111,7 +4275,7 @@ raw-body@~2.1.2:
     iconv-lite "0.4.13"
     unpipe "1.0.0"
 
-rc@^1.1.7:
+rc@^1.1.7, rc@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
   dependencies:
@@ -4458,6 +4622,13 @@ rebound@^0.0.13:
   version "0.0.13"
   resolved "https://registry.yarnpkg.com/rebound/-/rebound-0.0.13.tgz#4a225254caf7da756797b19c5817bf7a7941fac1"
 
+redent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
+  dependencies:
+    indent-string "^2.1.0"
+    strip-indent "^1.0.1"
+
 redux-logger@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
@@ -4678,6 +4849,12 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+rxjs@^5.0.0-beta.11:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.2.tgz#28d403f0071121967f18ad665563255d54236ac3"
+  dependencies:
+    symbol-observable "^1.0.1"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -4832,6 +5009,10 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+
 slice-ansi@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
@@ -4932,6 +5113,10 @@ stream-counter@~0.2.0:
   dependencies:
     readable-stream "~1.1.8"
 
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
+
 stream@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/stream/-/stream-0.0.2.tgz#7f5363f057f6592c5595f00bc80a27f5cec1f0ef"
@@ -5012,6 +5197,12 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
+strip-indent@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
+  dependencies:
+    get-stdin "^4.0.1"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -5032,7 +5223,7 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-symbol-observable@^1.0.3:
+symbol-observable@^1.0.1, symbol-observable@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
@@ -5161,6 +5352,10 @@ tough-cookie@^2.3.2, tough-cookie@~2.3.3:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+
+trim-newlines@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
 trim-right@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/1864

Docs: https://docs.bugsnag.com/platforms/react-native/showing-full-stacktraces/#uploading-source-maps

---

React-Native apps run off of minified JS bundles, to optimize for filesize and thus memory usage.

That's great for users, but not so great for debugging, especially through Bugsnag.

Luckily, Bugsnag lets us upload source maps that tell it what line/column the code actually came from, and they recently released a `bugsnag-sourcemaps` tool that uploads for us.

I know that in #1864 I asked for another build in parallel with the native machines, but I've walked back on that. If I generate and upload the source maps after the native machines, then I'll never try to upload a source map for a build that doesn't exist. I also don't have to install ruby on the third machine just to run `propagate_version`, and I won't have to worry about somehow generating the wrong version number to send to Bugsnag, because I'll be using the same version that we uploaded to Testflight/Play Store.

The source maps will only be built and uploaded on nightly / beta / release builds, not on every Travis build.

I also:
- updated fastlane to 2.56 (I think deppbot is broken again)
- fixed a ruby indentation issue
- removed some whitespace from .travis.yml
- cleaned up a bit of code in the JS-side bugsnag integration