### PR TITLE
Revert bugsnag-react-native upgrade to 2.6.0 in #1850

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,9 +30,5 @@ allprojects {
             // react-native-custom-tabs requires this maven repository
             url "https://jitpack.io"
         }
-        maven {
-            // currently used for bugsnag-react-native
-            url 'https://maven.google.com'
-        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@hawkrives/react-native-search-bar": "3.0.0-3",
     "@hawkrives/react-native-sortable-list": "1.0.1",
     "buffer": "5.0.8",
-    "bugsnag-react-native": "2.6.0",
+    "bugsnag-react-native": "2.5.1",
     "css-select": "1.2.0",
     "dedent": "0.7.0",
     "delay": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,9 +1131,9 @@ buffer@5.0.8:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-bugsnag-react-native@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/bugsnag-react-native/-/bugsnag-react-native-2.6.0.tgz#cc5e882890c612e69bb447ff9d1a237960f1eca7"
+bugsnag-react-native@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/bugsnag-react-native/-/bugsnag-react-native-2.5.1.tgz#d7617febd8ae692c5f92ce6d06890c6c0a2def12"
   dependencies:
     prop-types "^15.6.0"
 
@@ -5311,7 +5311,7 @@ vinyl@^0.5.0:
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
 
-vm2@patriksimek/vm2#custom_files:
+"vm2@github:patriksimek/vm2#custom_files":
   version "3.5.0"
   resolved "https://codeload.github.com/patriksimek/vm2/tar.gz/7e82f90ac705fc44fad044147cb0df09b4c79a57"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5311,7 +5311,7 @@ vinyl@^0.5.0:
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
 
-"vm2@github:patriksimek/vm2#custom_files":
+vm2@patriksimek/vm2#custom_files:
   version "3.5.0"
   resolved "https://codeload.github.com/patriksimek/vm2/tar.gz/7e82f90ac705fc44fad044147cb0df09b4c79a57"
 


### PR DESCRIPTION
Closes #1861.

Note that this does not provide a working solution to the upgrade problem, it simply reverts so that we have a working Android app again.

I'd say we should drop another beta release after this, too, just so we don't leave people out if they're on the beta channel.

@hawkrives suggested upgrading to 2.5.2 as being possible, but if we plan on going back and installing 2.6.0 later, I'm fine with just leaving it at 2.5.1.