### PR TITLE
Release v2.4.2 β2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "all-about-olaf",
-  "version": "2.4.2-pre",
+  "version": "2.4.2-beta.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
View [the comparison](https://github.com/StoDevX/AAO-React-Native/compare/v2.4.2...release/v2.4.2-beta.2).

This release is intended to get our hotfix for the Android startup issues introduced in the `bugsnag-react-native` v2.6.0 upgrade step out into the beta channel.

## Checklist
- [x] [Release PR]() successfully builds against `master`
- [x] Signed-off/approved
- [x] [GitHub release](/StoDevX/AAO-React-Native/releases/tag/v2.4.2-beta.2) drafted
- [x] GitHub release created
- [x] [Release PR]() merged to `master`.
- [x] Tag build passes