### PR TITLE
Misc fixes in preparation for Flow 56

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -16,6 +16,8 @@ const jsFiles = danger.git.created_files.filter(path => path.endsWith('.js'))
 
 // new js files should have `@flow` at the top
 jsFiles
+  // except for those in /flow-typed
+  .filter(filepath => !filepath.includes('flow-typed'))
   .filter(filepath => {
     const content = readFile(filepath)
     return !content.includes('@flow')

--- a/source/app.js
+++ b/source/app.js
@@ -74,7 +74,9 @@ export default class App extends React.Component {
     const currentScreen = getCurrentRouteName(currentState)
     const prevScreen = getCurrentRouteName(prevState)
 
-    if (!currentScreen) return
+    if (!currentScreen) {
+      return
+    }
 
     if (currentScreen !== prevScreen) {
       tracker.trackScreenView(currentScreen)

--- a/source/app.js
+++ b/source/app.js
@@ -10,6 +10,10 @@ import {store} from './flux'
 import bugsnag from './bugsnag'
 import {tracker} from './analytics'
 import {AppNavigator} from './navigation'
+import {
+  startStatusBarColorChanger,
+  stopStatusBarColorChanger,
+} from './views/components/open-url'
 import type {NavigationState} from 'react-navigation'
 
 // gets the current screen from navigation state
@@ -26,11 +30,13 @@ function getCurrentRouteName(navigationState: NavigationState): ?string {
 }
 
 export default class App extends React.Component {
-  componentDidMount() {
+  componentWillMount() {
     OneSignal.addEventListener('received', this.onReceived)
     OneSignal.addEventListener('opened', this.onOpened)
     OneSignal.addEventListener('registered', this.onRegistered)
     OneSignal.addEventListener('ids', this.onIds)
+
+    startStatusBarColorChanger()
   }
 
   componentWillUnmount() {
@@ -38,6 +44,8 @@ export default class App extends React.Component {
     OneSignal.removeEventListener('opened', this.onOpened)
     OneSignal.removeEventListener('registered', this.onRegistered)
     OneSignal.removeEventListener('ids', this.onIds)
+
+    stopStatusBarColorChanger()
   }
 
   onReceived(notification: any) {

--- a/source/navigation.js
+++ b/source/navigation.js
@@ -20,7 +20,7 @@ import {FilterView} from './views/components/filter'
 import NewsView from './views/news'
 import NewsItemView from './views/news/news-item'
 import SISView from './views/sis'
-import JobDetailView from './views/sis/student-work/detail'
+import {JobDetailView} from './views/sis/student-work/detail'
 import {
   BuildingHoursView,
   BuildingHoursDetailView,

--- a/source/views/building-hours/lib/__tests__/parse-hours.test.js
+++ b/source/views/building-hours/lib/__tests__/parse-hours.test.js
@@ -45,7 +45,9 @@ describe('handles wierd times', () => {
   })
 
   it('handles Saturday at 1:30am', () => {
-    const now = dayMoment('Sat 1:30am')
+    // TODO: report a bug to moment-timezone that tz("Sat 1:30am", "ddd h:mma") is invalid (at least when `moment.now` = 2017-11-09)
+    const saturday = '2017-11-11T01:30:00'
+    const now = plainMoment(saturday, 'YYYY-MM-DD[T]HH:mm:ss')
     const input = {days: [], from: '10:00am', to: '2:00am'}
     const {open, close} = parseHours(input, now)
 

--- a/source/views/calendar/event-detail.android.js
+++ b/source/views/calendar/event-detail.android.js
@@ -122,19 +122,19 @@ export class EventDetail extends React.PureComponent {
       await delay(500 - elapsed)
     }
 
-    await addToCalendar(event).then(result => {
-      if (result) {
-        this.setState({
-          message: 'Event has been added to your calendar',
-          disabled: true,
-        })
-      } else {
-        this.setState({
-          message: 'Could not add event to your calendar',
-          disabled: false,
-        })
-      }
-    })
+    const result = await addToCalendar(event)
+
+    if (result) {
+      this.setState(() => ({
+        message: 'Event has been added to your calendar',
+        disabled: true,
+      }))
+    } else {
+      this.setState(() => ({
+        message: 'Could not add event to your calendar',
+        disabled: false,
+      }))
+    }
   }
 
   onPressButton = () => this.addEvent(this.props.navigation.state.params.event)

--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -94,19 +94,19 @@ export class EventDetail extends React.PureComponent {
       await delay(500 - elapsed)
     }
 
-    await addToCalendar(event).then(result => {
-      if (result) {
-        this.setState({
-          message: 'Event has been added to your calendar',
-          disabled: true,
-        })
-      } else {
-        this.setState({
-          message: 'Could not add event to your calendar',
-          disabled: false,
-        })
-      }
-    })
+    const result = await addToCalendar(event)
+
+    if (result) {
+      this.setState(() => ({
+        message: 'Event has been added to your calendar',
+        disabled: true,
+      }))
+    } else {
+      this.setState(() => ({
+        message: 'Could not add event to your calendar',
+        disabled: false,
+      }))
+    }
   }
 
   onPressButton = () => this.addEvent(this.props.navigation.state.params.event)

--- a/source/views/components/datepicker/datepicker.android.js
+++ b/source/views/components/datepicker/datepicker.android.js
@@ -37,7 +37,7 @@ type TimePickerResponse = {
   minute: number,
 }
 
-export class AndroidDatePicker extends React.PureComponent<any, Props, void> {
+export class DatePicker extends React.PureComponent<any, Props, void> {
   static defaultProps = {
     mode: 'date',
     androidMode: 'default',

--- a/source/views/components/datepicker/datepicker.ios.js
+++ b/source/views/components/datepicker/datepicker.ios.js
@@ -34,7 +34,7 @@ type State = {
   allowPointerEvents: boolean,
 }
 
-export class IosDatePicker extends React.Component<any, Props, State> {
+export class DatePicker extends React.Component<any, Props, State> {
   static defaultProps = {
     mode: 'date',
     height: 259, // 216 (DatePickerIOS) + 1 (borderTop) + 42 (marginTop), iOS only
@@ -125,7 +125,7 @@ type ModalProps = {
   timezone: string,
 }
 
-class DatePickerModal extends React.PureComponent<void, ModalProps, void> {
+class DatePickerModal extends React.PureComponent<any, ModalProps, void> {
   static SUPPORTED_ORIENTATIONS = [
     'portrait',
     'portrait-upside-down',
@@ -202,7 +202,16 @@ class DatePickerModal extends React.PureComponent<void, ModalProps, void> {
   }
 }
 
-const Button = ({style, textStyle, onPress, text}) => (
+type StyleSheetRule = number | Object | Array<StyleSheetRule>
+
+type ButtonProps = {
+  style?: StyleSheetRule,
+  textStyle?: StyleSheetRule,
+  onPress: () => any,
+  text: string,
+}
+
+const Button = ({style, textStyle, onPress, text}: ButtonProps) => (
   <TouchableHighlight
     underlayColor="transparent"
     onPress={onPress}

--- a/source/views/components/datepicker/index.js
+++ b/source/views/components/datepicker/index.js
@@ -1,12 +1,11 @@
 // @flow
 // Copied from https://github.com/xgfe/react-native-datepicker
 
-import React from 'react'
-import {Platform, Keyboard} from 'react-native'
+import * as React from 'react'
+import {Keyboard} from 'react-native'
 import moment from 'moment-timezone'
 
-import {IosDatePicker} from './ios'
-import {AndroidDatePicker} from './android'
+import {DatePicker as ActualDatePicker} from './datepicker'
 
 const FORMATS = {
   date: 'YYYY-MM-DD',
@@ -33,7 +32,7 @@ type State = {
   timezone: string,
 }
 
-export class DatePicker extends React.Component<any, Props, State> {
+export class DatePicker extends React.Component<Props, State> {
   static defaultProps = {
     mode: 'date',
     androidMode: 'default',
@@ -83,34 +82,20 @@ export class DatePicker extends React.Component<any, Props, State> {
   }
 
   render() {
-    const propsToPass = {
-      date: this.state.date,
-      formattedDate: this.formatDate(this.state.date),
-      mode: this.props.mode,
-      onDateChange: this.onDateChange,
-      style: this.props.style,
-      ref: this.setRef,
-    }
-
-    if (Platform.OS === 'ios') {
-      return (
-        <IosDatePicker
-          duration={this.props.duration}
-          height={this.props.height}
-          minuteInterval={this.props.minuteInterval}
-          timezone={this.state.timezone}
-          {...propsToPass}
-        />
-      )
-    } else if (Platform.OS === 'android') {
-      return (
-        <AndroidDatePicker
-          androidMode={this.props.androidMode}
-          {...propsToPass}
-        />
-      )
-    } else {
-      throw new Error(`Platform ${Platform.OS} is not supported!`)
-    }
+    return (
+      <ActualDatePicker
+        ref={this.setRef}
+        androidMode={this.props.androidMode}
+        duration={this.props.duration}
+        height={this.props.height}
+        minuteInterval={this.props.minuteInterval}
+        timezone={this.state.timezone}
+        date={this.state.date}
+        formattedDate={this.formatDate(this.state.date)}
+        mode={this.props.mode}
+        onDateChange={this.onDateChange}
+        style={this.props.style}
+      />
+    )
   }
 }

--- a/source/views/components/datepicker/index.js
+++ b/source/views/components/datepicker/index.js
@@ -32,7 +32,7 @@ type State = {
   timezone: string,
 }
 
-export class DatePicker extends React.Component<Props, State> {
+export class DatePicker extends React.Component<any, Props, State> {
   static defaultProps = {
     mode: 'date',
     androidMode: 'default',

--- a/source/views/components/filter/apply-filters.js
+++ b/source/views/components/filter/apply-filters.js
@@ -2,7 +2,6 @@
 import type {FilterType, ToggleType, ListType, ListItemSpecType} from './types'
 import values from 'lodash/values'
 import difference from 'lodash/difference'
-import isPlainObject from 'lodash/isPlainObject'
 
 export function applyFiltersToItem(filters: FilterType[], item: any): boolean {
   // Given a list of filters, return the result of running all of those
@@ -63,7 +62,7 @@ export function applyAndListFilter(
   itemValue: string[] | {[key: string]: string},
 ): boolean {
   // In case the value is an object, instead of an array, convert it to an array
-  if (isPlainObject(itemValue)) {
+  if (!Array.isArray(itemValue)) {
     itemValue = values(itemValue)
   }
 

--- a/source/views/components/open-url.js
+++ b/source/views/components/open-url.js
@@ -41,14 +41,10 @@ function genericOpen(url: string) {
 }
 
 async function iosOpen(url: string) {
-  await startStatusBarColorChanger()
-  const retval = await SafariView.isAvailable()
-    // if it's around, open in safari
+  // SafariView.isAvailable throws if it's not available
+  return SafariView.isAvailable()
     .then(() => SafariView.show({url}))
-    // fall back to opening in default browser
     .catch(() => genericOpen(url))
-  await stopStatusBarColorChanger()
-  return retval
 }
 
 function androidOpen(url: string) {

--- a/source/views/components/open-url.js
+++ b/source/views/components/open-url.js
@@ -6,21 +6,19 @@ import {tracker} from '../../analytics'
 import SafariView from 'react-native-safari-view'
 import {CustomTabs} from 'react-native-custom-tabs'
 
-let iosOnShowListener = () => StatusBar.setBarStyle('dark-content')
-let iosOnDismissListener = () => StatusBar.setBarStyle('light-content')
-function startStatusBarColorChanger() {
-  SafariView.isAvailable()
+const iosOnShowListener = () => StatusBar.setBarStyle('dark-content')
+const iosOnDismissListener = () => StatusBar.setBarStyle('light-content')
+export function startStatusBarColorChanger() {
+  return SafariView.isAvailable()
     .then(() => {
       SafariView.addEventListener('onShow', iosOnShowListener)
       SafariView.addEventListener('onDismiss', iosOnDismissListener)
     })
     .catch(() => {})
 }
-startStatusBarColorChanger()
 
-// eslint-disable-next-line no-unused-vars
-function stopStatusBarColorChanger() {
-  SafariView.isAvailable()
+export function stopStatusBarColorChanger() {
+  return SafariView.isAvailable()
     .then(() => {
       SafariView.removeEventListener('onShow', iosOnShowListener)
       SafariView.removeEventListener('onDismiss', iosOnDismissListener)
@@ -42,14 +40,15 @@ function genericOpen(url: string) {
     })
 }
 
-function iosOpen(url: string) {
-  return (
-    SafariView.isAvailable()
-      // if it's around, open in safari
-      .then(() => SafariView.show({url}))
-      // fall back to opening in default browser
-      .catch(() => genericOpen(url))
-  )
+async function iosOpen(url: string) {
+  await startStatusBarColorChanger()
+  const retval = await SafariView.isAvailable()
+    // if it's around, open in safari
+    .then(() => SafariView.show({url}))
+    // fall back to opening in default browser
+    .catch(() => genericOpen(url))
+  await stopStatusBarColorChanger()
+  return retval
 }
 
 function androidOpen(url: string) {

--- a/source/views/components/open-url.js
+++ b/source/views/components/open-url.js
@@ -40,7 +40,7 @@ function genericOpen(url: string) {
     })
 }
 
-async function iosOpen(url: string) {
+function iosOpen(url: string) {
   // SafariView.isAvailable throws if it's not available
   return SafariView.isAvailable()
     .then(() => SafariView.show({url}))

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -17,7 +17,6 @@ import type {WordType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {tracker} from '../../analytics'
 import groupBy from 'lodash/groupBy'
-import head from 'lodash/head'
 import uniq from 'lodash/uniq'
 import words from 'lodash/words'
 import deburr from 'lodash/deburr'
@@ -47,7 +46,7 @@ const styles = StyleSheet.create({
 type Props = TopLevelViewPropsType
 
 type State = {
-  results: {[key: string]: Array<WordType>},
+  results: Array<WordType>,
   allTerms: Array<WordType>,
   refreshing: boolean,
 }
@@ -153,7 +152,7 @@ export class DictionaryView extends React.PureComponent<void, Props, State> {
           ROW_HEIGHT +
           (Platform.OS === 'ios' ? 11 / 12 * StyleSheet.hairlineWidth : 0)
         }
-        data={groupBy(this.state.results, item => head(item.word))}
+        data={groupBy(this.state.results, item => item.word[0])}
         onSearch={this.performSearch}
         refreshControl={refreshControl}
         renderSeparator={this.renderSeparator}

--- a/source/views/menus/components/dietary-tags.js
+++ b/source/views/menus/components/dietary-tags.js
@@ -29,7 +29,9 @@ export function DietaryTags({
   style?: any,
 }) {
   // filter the mapping of all icons by just the icons provided by this item
-  let filtered = pick(corIcons, keys(dietary))
+  let filtered = Array.isArray(dietary)
+    ? pick(corIcons, [])
+    : pick(corIcons, keys(dietary))
 
   // turn the remaining items into images
   let tags = map(filtered, (dietaryIcon, key) => (

--- a/source/views/menus/lib/choose-meal.js
+++ b/source/views/menus/lib/choose-meal.js
@@ -2,8 +2,7 @@
 
 import type momentT from 'moment'
 import type {ProcessedMealType} from '../types'
-import type {FilterType, PickerType} from '../../components/filter'
-import find from 'lodash/find'
+import type {FilterType} from '../../components/filter'
 import {findMeal} from './find-menu'
 
 export function chooseMeal(
@@ -11,13 +10,16 @@ export function chooseMeal(
   filters: FilterType[],
   now: momentT,
 ): ProcessedMealType {
-  const mealChooserFilter: ?PickerType = find(
-    filters,
+  const mealChooserFilter: ?FilterType = filters.find(
     f => f.type === 'picker' && f.spec.title === "Today's Menus",
   )
-  let selectedMeal = meals[0]
 
-  if (mealChooserFilter && mealChooserFilter.spec.selected) {
+  let selectedMeal = meals[0]
+  if (
+    mealChooserFilter &&
+    mealChooserFilter.spec.selected &&
+    mealChooserFilter.spec.selected.label
+  ) {
     let label = mealChooserFilter.spec.selected.label
     selectedMeal = meals.find(meal => meal.label === label)
   } else {

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -24,20 +24,22 @@ const CENTRAL_TZ = 'America/Winnipeg'
 
 const githubMenuBaseUrl = 'https://stodevx.github.io/AAO-React-Native'
 
-export class GitHubHostedMenu extends React.Component {
-  props: TopLevelViewPropsType & {
-    name: string,
-    loadingMessage: string[],
-  }
+type Props = TopLevelViewPropsType & {
+  name: string,
+  loadingMessage: string[],
+}
 
-  state: {
-    error: ?Error,
-    loading: boolean,
-    now: momentT,
-    foodItems: MenuItemContainerType,
-    corIcons: MasterCorIconMapType,
-    meals: ProcessedMealType[],
-  } = {
+type State = {
+  error: ?Error,
+  loading: boolean,
+  now: momentT,
+  foodItems: MenuItemContainerType,
+  corIcons: MasterCorIconMapType,
+  meals: ProcessedMealType[],
+}
+
+export class GitHubHostedMenu extends React.PureComponent<any, Props, State> {
+  state = {
     error: null,
     loading: true,
     now: moment.tz(CENTRAL_TZ),
@@ -77,12 +79,12 @@ export class GitHubHostedMenu extends React.Component {
       corIcons = fallbackMenu.corIcons || {}
     }
 
-    foodItems = fromPairs(
+    const upgradedFoodItems = fromPairs(
       foodItems.map(upgradeMenuItem).map(item => [item.id, item]),
     )
     stationMenus = stationMenus.map((menu, index) => ({
       ...upgradeStation(menu, index),
-      items: filter(foodItems, item => item.station === menu.label).map(
+      items: filter(upgradedFoodItems, item => item.station === menu.label).map(
         item => item.id,
       ),
     }))
@@ -90,7 +92,7 @@ export class GitHubHostedMenu extends React.Component {
     this.setState({
       loading: false,
       corIcons,
-      foodItems,
+      foodItems: upgradedFoodItems,
       meals: [
         {
           label: 'Menu',

--- a/source/views/news/fetch-feed.js
+++ b/source/views/news/fetch-feed.js
@@ -19,7 +19,7 @@ const fetchText = url => fetch(url).then(r => r.text())
 
 export async function fetchRssFeed(
   url: string,
-  query?: Object,
+  query: Object = {},
 ): Promise<StoryType[]> {
   const responseText = await fetchText(`${url}?${qs.stringify(query)}`)
   const feed: FeedResponseType = await parseXml(responseText)
@@ -28,7 +28,7 @@ export async function fetchRssFeed(
 
 export async function fetchWpJson(
   url: string,
-  query?: Object,
+  query: Object = {},
 ): Promise<StoryType[]> {
   const feed: WpJsonResponseType = await fetchJson(
     `${url}?${qs.stringify(query)}`,

--- a/source/views/news/news-container.js
+++ b/source/views/news/news-container.js
@@ -10,22 +10,23 @@ import {reportNetworkProblem} from '../../lib/report-network-problem'
 import {NewsList} from './news-list'
 import {fetchRssFeed, fetchWpJson} from './fetch-feed'
 
-export default class NewsContainer extends React.Component {
-  props: TopLevelViewPropsType & {
-    name: string,
-    url: string,
-    query?: Object,
-    embedFeaturedImage?: boolean,
-    mode: 'rss' | 'wp-json',
-    thumbnail: number,
-  }
+type Props = TopLevelViewPropsType & {
+  name: string,
+  url: string,
+  query?: Object,
+  embedFeaturedImage?: boolean,
+  mode: 'rss' | 'wp-json',
+  thumbnail: number,
+}
 
-  state: {
-    entries: StoryType[],
-    loading: boolean,
-    refreshing: boolean,
-    error: ?Error,
-  } = {
+type State = {
+  entries: StoryType[],
+  loading: boolean,
+  refreshing: boolean,
+  error: ?Error,
+}
+export default class NewsContainer extends React.PureComponent<any, Props, State> {
+  state = {
     entries: [],
     loading: true,
     error: null,
@@ -33,12 +34,9 @@ export default class NewsContainer extends React.Component {
   }
 
   componentWillMount() {
-    this.loadInitialData()
-  }
-
-  loadInitialData = async () => {
-    await this.fetchData()
-    this.setState(() => ({loading: false}))
+    this.fetchData().then(() => {
+      this.setState(() => ({loading: false}))
+    })
   }
 
   fetchData = async () => {
@@ -69,7 +67,7 @@ export default class NewsContainer extends React.Component {
     }
   }
 
-  refresh = async () => {
+  refresh = async (): any => {
     let start = Date.now()
     this.setState(() => ({refreshing: true}))
 

--- a/source/views/news/news-container.js
+++ b/source/views/news/news-container.js
@@ -25,7 +25,11 @@ type State = {
   refreshing: boolean,
   error: ?Error,
 }
-export default class NewsContainer extends React.PureComponent<any, Props, State> {
+export default class NewsContainer extends React.PureComponent<
+  any,
+  Props,
+  State,
+> {
   state = {
     entries: [],
     loading: true,

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -14,16 +14,16 @@ const styles = StyleSheet.create({
   },
 })
 
-export class NewsList extends React.Component {
-  props: TopLevelViewPropsType & {
-    name: string,
-    onRefresh: () => any,
-    entries: StoryType[],
-    loading: boolean,
-    embedFeaturedImage: ?boolean,
-    thumbnail: number,
-  }
+type Props = TopLevelViewPropsType & {
+  name: string,
+  onRefresh: () => any,
+  entries: StoryType[],
+  loading: boolean,
+  embedFeaturedImage: ?boolean,
+  thumbnail: number,
+}
 
+export class NewsList extends React.PureComponent<any, Props, void> {
   onPressNews = (story: StoryType) => {
     this.props.navigation.navigate('NewsItemView', {
       story,

--- a/source/views/news/news-row.js
+++ b/source/views/news/news-row.js
@@ -6,13 +6,13 @@ import {Column, Row} from '../components/layout'
 import {ListRow, Detail, Title} from '../components/list'
 import type {StoryType} from './types'
 
-export class NewsRow extends React.PureComponent {
-  props: {
-    onPress: StoryType => any,
-    story: StoryType,
-    thumbnail: number,
-  }
+type Props = {
+  onPress: StoryType => any,
+  story: StoryType,
+  thumbnail: number,
+}
 
+export class NewsRow extends React.PureComponent<any, Props, void> {
   _onPress = () => this.props.onPress(this.props.story)
 
   render() {

--- a/source/views/settings/credits.js
+++ b/source/views/settings/credits.js
@@ -48,9 +48,11 @@ export default function CreditsView() {
   let formattedContributors = credits.contributors
     .map(w => w.replace(' ', ' '))
     .join(' • ')
+
   let formattedAcks = credits.acknowledgements
     .map(w => w.replace(' ', ' '))
     .join(' • ')
+
   return (
     <ScrollView style={styles.container}>
       <Image source={image} style={styles.logo} />

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -23,7 +23,6 @@ class OddsAndEndsSection extends React.Component {
   onCreditsButton = () => this.onPressButton('CreditsView')
   onPrivacyButton = () => this.onPressButton('PrivacyView')
   onLegalButton = () => this.onPressButton('LegalView')
-  onSnapshotsButton = () => this.onPressButton('SnapshotsView')
   onSourceButton = () =>
     trackedOpenUrl({
       url: 'https://github.com/StoDevX/AAO-React-Native',
@@ -54,15 +53,6 @@ class OddsAndEndsSection extends React.Component {
             onChange={val => this.props.onChangeFeedbackToggle(!val)}
           />
         </Section>
-
-        {process.env.NODE_ENV === 'development' ? (
-          <Section header="UTILITIES">
-            <PushButtonCell
-              title="Snapshots"
-              onPress={this.onSnapshotsButton}
-            />
-          </Section>
-        ) : null}
       </View>
     )
   }

--- a/source/views/settings/sections/support.js
+++ b/source/views/settings/sections/support.js
@@ -3,7 +3,7 @@ import React from 'react'
 import {Alert} from 'react-native'
 import {Section} from 'react-native-tableview-simple'
 import type {TopLevelViewPropsType} from '../../types'
-import Communications from 'react-native-communications'
+import {email} from 'react-native-communications'
 import DeviceInfo from 'react-native-device-info'
 import {version} from '../../../../package.json'
 import {PushButtonCell} from '../../components/cells/push-button'
@@ -26,7 +26,7 @@ export default class SupportSection extends React.Component {
     `
 
   openEmail = () => {
-    Communications.email(
+    email(
       ['allaboutolaf@stolaf.edu'],
       null,
       null,

--- a/source/views/sis/student-work/detail.android.js
+++ b/source/views/sis/student-work/detail.android.js
@@ -133,27 +133,32 @@ function LastUpdated({when}: {when: string}) {
   ) : null
 }
 
-export default function JobDetailView(props: {
+type Props = {
   navigation: {state: {params: {job: JobType}}},
-}) {
-  const job = cleanJob(props.navigation.state.params.job)
-
-  return (
-    <ScrollView>
-      <Title job={job} />
-      <Contact job={job} />
-      <Hours job={job} />
-      <Description job={job} />
-      <Skills job={job} />
-      <Comments job={job} />
-      <Links job={job} />
-      <LastUpdated when={job.lastModified} />
-    </ScrollView>
-  )
 }
-JobDetailView.navigationOptions = ({navigation}) => {
-  const {job} = navigation.state.params
-  return {
-    title: job.title,
+
+export class JobDetailView extends React.PureComponent<any, Props, void> {
+  static navigationOptions = ({navigation}) => {
+    const {job} = navigation.state.params
+    return {
+      title: job.title,
+    }
+  }
+
+  render() {
+    const job = cleanJob(this.props.navigation.state.params.job)
+
+    return (
+      <ScrollView>
+        <Title job={job} />
+        <Contact job={job} />
+        <Hours job={job} />
+        <Description job={job} />
+        <Skills job={job} />
+        <Comments job={job} />
+        <Links job={job} />
+        <LastUpdated when={job.lastModified} />
+      </ScrollView>
+    )
   }
 }

--- a/source/views/sis/student-work/detail.ios.js
+++ b/source/views/sis/student-work/detail.ios.js
@@ -126,28 +126,33 @@ function LastUpdated({when}: {when: string}) {
   ) : null
 }
 
-export default function JobDetailView(props: {
+type Props = {
   navigation: {state: {params: {job: JobType}}},
-}) {
-  const job = cleanJob(props.navigation.state.params.job)
-
-  return (
-    <ScrollView>
-      <Title selectable={true}>{job.title}</Title>
-      <TableView>
-        <Information job={job} />
-        <Description job={job} />
-        <Skills job={job} />
-        <Comments job={job} />
-        <Links job={job} />
-      </TableView>
-      <LastUpdated when={job.lastModified} />
-    </ScrollView>
-  )
 }
-JobDetailView.navigationOptions = ({navigation}) => {
-  const {job} = navigation.state.params
-  return {
-    title: job.title,
+
+export class JobDetailView extends React.PureComponent<any, Props, void> {
+  static navigationOptions = ({navigation}) => {
+    const {job} = navigation.state.params
+    return {
+      title: job.title,
+    }
+  }
+
+  render() {
+    const job = cleanJob(this.props.navigation.state.params.job)
+
+    return (
+      <ScrollView>
+        <Title selectable={true}>{job.title}</Title>
+        <TableView>
+          <Information job={job} />
+          <Description job={job} />
+          <Skills job={job} />
+          <Comments job={job} />
+          <Links job={job} />
+        </TableView>
+        <LastUpdated when={job.lastModified} />
+      </ScrollView>
+    )
   }
 }

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -20,7 +20,6 @@ import {reportNetworkProblem} from '../../lib/report-network-problem'
 import size from 'lodash/size'
 import sortBy from 'lodash/sortBy'
 import groupBy from 'lodash/groupBy'
-import head from 'lodash/head'
 import uniq from 'lodash/uniq'
 import words from 'lodash/words'
 import deburr from 'lodash/deburr'
@@ -115,7 +114,7 @@ export class StudentOrgsView extends React.PureComponent<any, Props, State> {
       return {
         ...item,
         $sortableName: sortableName,
-        $groupableName: head(startCase(sortableName)),
+        $groupableName: startCase(sortableName)[0],
       }
     })
 

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -67,23 +67,26 @@ const styles = StyleSheet.create({
   },
 })
 
-export class StudentOrgsView extends React.Component {
+type Props = TopLevelViewPropsType
+
+type State = {
+  orgs: Array<StudentOrgType>,
+  results: {[key: string]: StudentOrgType[]},
+  refreshing: boolean,
+  error: boolean,
+  loading: boolean,
+}
+
+export class StudentOrgsView extends React.PureComponent<any, Props, State> {
   static navigationOptions = {
     title: 'Student Orgs',
     headerBackTitle: 'Orgs',
   }
 
-  props: TopLevelViewPropsType
   searchBar: any
 
-  state: {
-    orgs: {[key: string]: StudentOrgType[]},
-    results: {[key: string]: StudentOrgType[]},
-    refreshing: boolean,
-    error: boolean,
-    loading: boolean,
-  } = {
-    orgs: {},
+  state = {
+    orgs: [],
     results: {},
     refreshing: false,
     loading: true,

--- a/source/views/transportation/bus/lib/__tests__/find-remaining-departures-for-stop.test.js
+++ b/source/views/transportation/bus/lib/__tests__/find-remaining-departures-for-stop.test.js
@@ -30,7 +30,7 @@ function buildBusSchedules(now): Array<BusSchedule> {
   return schedules.map(processBusSchedule(now))
 }
 
-const formatTime = m => m ? m.format('h:mma') : null
+const formatTime = m => (m ? m.format('h:mma') : null)
 
 function makeSchedule(now) {
   const schedule = getScheduleForNow(buildBusSchedules(now), now)
@@ -42,7 +42,11 @@ test('handles a time before the bus runs', () => {
   const now = dayAndTime('Mo 12:00pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[0]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -50,7 +54,11 @@ test('handles a time right when the bus starts', () => {
   const now = dayAndTime('Mo 1:00pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[0]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -58,7 +66,11 @@ test('handles a time between two stops', () => {
   const now = dayAndTime('Mo 1:01pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[1]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -66,7 +78,11 @@ test('handles a time at the second stop', () => {
   const now = dayAndTime('Mo 1:05pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[1]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -74,7 +90,11 @@ test('handles a time at the last stop', () => {
   const now = dayAndTime('Mo 1:10pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[schedule.timetable.length - 1]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -82,7 +102,11 @@ test('handles a time between two iterations', () => {
   const now = dayAndTime('Mo 1:55pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[0]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -90,7 +114,11 @@ test('handles the first stop of the second iteration', () => {
   const now = dayAndTime('Mo 2:00pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[0]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -98,7 +126,11 @@ test('handles the first stop of the last iteration', () => {
   const now = dayAndTime('Mo 3:00pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[0]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -106,7 +138,11 @@ test('handles the last stop of the last iteration', () => {
   const now = dayAndTime('Mo 3:10pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[schedule.timetable.length - 1]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -114,7 +150,11 @@ test('handles a stop that will be skipped', () => {
   const now = dayAndTime('Mo 2:05pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[1]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -122,7 +162,11 @@ test('handles a time after the bus runs', () => {
   const now = dayAndTime('Mo 11:00pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[0]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -130,7 +174,11 @@ test('handles a time on another day', () => {
   const now = dayAndTime('We 12:00pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[0]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })
 
@@ -138,6 +186,10 @@ test('handles a time when the bus is not running', () => {
   const now = dayAndTime('Sa 1:00pm')
   const {schedule, busStatus, departureIndex} = makeSchedule(now)
   const stop = schedule.timetable[0]
-  const actual = findRemainingDeparturesForStop({stop, departureIndex, busStatus})
+  const actual = findRemainingDeparturesForStop({
+    stop,
+    departureIndex,
+    busStatus,
+  })
   expect(actual.map(formatTime)).toMatchSnapshot()
 })

--- a/source/views/transportation/bus/lib/parse-time.js
+++ b/source/views/transportation/bus/lib/parse-time.js
@@ -4,7 +4,9 @@ const TIME_FORMAT = 'h:mma'
 const TIMEZONE = 'America/Winnipeg'
 import moment from 'moment-timezone'
 
-export const parseTime = (now: moment) => (time: string | false): null | moment => {
+export const parseTime = (now: moment) => (
+  time: string | false,
+): null | moment => {
   // either pass `false` through or return a parsed time
   if (time === false) {
     return null

--- a/source/views/transportation/types.js
+++ b/source/views/transportation/types.js
@@ -3,4 +3,5 @@ export type OtherModeType = {
   name: string,
   description: string,
   url: string,
+  category: string,
 }


### PR DESCRIPTION
This PR is all of the miscellaneous changes I made while in the depths of the React-Native v0.49 / v0.50 upgrade.

- 9fe7e6e Like https://github.com/StoDevX/AAO-React-Native/pull/1881 for CodeClimate, this configures `danger` to not worry about `@flow` annotations in `flow-typed/`
- 3367beb There was a property missing in the `OtherModesType` flow type. I added it. (Flow 56 noticed this.)
- `several` Some of these commits are pulling the state/props types out of components and into external types – Flow 56 changes how you specify Props and State.
- 23fd5d9 / 28e65fd Removal of `_.head` from AlphabetListViews. Turns out that `_.head` expects an array, not a string, so I just switched to accessing `str[0]` instead.
- bff938a Hopefully the last time I need to correct an import of `react-native-communications`
- 3199761 I missed this in https://github.com/StoDevX/AAO-React-Native/pull/1859; this removes the "Open Storybook" button from Settings in dev mode
- e4f2241 / 93294f8267e1763300f3f52172344e8e5e1c57df Optimize the openUrl listeners on iOS, I guess
- 34c6d6a It makes more sense to check if something is an array than to check if it's an object – arrays are objects, but the inverse is not true
- c64fc4d rework the datepicker to pick the platform component at compile time (flow 56 doesn't like the original code)
- bd5f752 reduce promises in event-detail adding to calendar logic or something
- 4f2bd32 fix timezone bug in a parse-hours test (I think it's a bug)

That's more-or-less everything.