### PR TITLE
Do the Flow v56 / React-Native update 💃

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -23,6 +23,7 @@
 .*/node_modules/.*/__tests?__/.*
 .*/node_modules/.*/examples/.*
 .*/node_modules/react-native-mock/.*
+.*/node_modules/react-native-restart/.*
 ; remove this after rn-linear-gradient updates
 .*/node_modules/react-native-linear-gradient/.*
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -26,6 +26,8 @@
 .*/node_modules/react-native-restart/.*
 ; remove this after rn-linear-gradient updates
 .*/node_modules/react-native-linear-gradient/.*
+; ignore all of react-navigation for now
+.*/node_modules/react-navigation/.*
 
 [include]
 

--- a/source/app.js
+++ b/source/app.js
@@ -4,7 +4,7 @@ import './globalize-fetch'
 import './setup-moment'
 import OneSignal from 'react-native-onesignal'
 
-import React from 'react'
+import * as React from 'react'
 import {Provider} from 'react-redux'
 import {makeStore, initRedux} from './flux'
 import bugsnag from './bugsnag'

--- a/source/app.js
+++ b/source/app.js
@@ -32,7 +32,9 @@ function getCurrentRouteName(navigationState: NavigationState): ?string {
   return route.routeName
 }
 
-export default class App extends React.Component {
+type Props = {}
+
+export default class App extends React.Component<Props> {
   componentWillMount() {
     OneSignal.addEventListener('received', this.onReceived)
     OneSignal.addEventListener('opened', this.onOpened)

--- a/source/flux/init.js
+++ b/source/flux/init.js
@@ -35,7 +35,10 @@ function netInfoIsConnected(store) {
     store.dispatch(updateOnlineStatus(isConnected))
   }
 
-  NetInfo.isConnected.addEventListener('change', updateConnectionStatus)
+  NetInfo.isConnected.addEventListener(
+    'connectionChange',
+    updateConnectionStatus,
+  )
   return NetInfo.isConnected.fetch().then(updateConnectionStatus)
 }
 

--- a/source/views/building-hours/detail/badge.js
+++ b/source/views/building-hours/detail/badge.js
@@ -13,9 +13,9 @@ const BGCOLORS = {
   Closed: c.salmon,
 }
 
-export class Badge extends React.PureComponent {
-  props: {status: string}
+type Props = {status: string}
 
+export class Badge extends React.PureComponent<Props> {
   render() {
     const {status} = this.props
     const bgColor = BGCOLORS[status] || c.goldenrod

--- a/source/views/building-hours/detail/badge.js
+++ b/source/views/building-hours/detail/badge.js
@@ -4,7 +4,7 @@
  * <Badge/> renders the [Open] / [Closed] / [IDK] badge on the detai view
  */
 
-import React from 'react'
+import * as React from 'react'
 import {View, Text, StyleSheet, Platform} from 'react-native'
 import * as c from '../../components/colors'
 

--- a/source/views/building-hours/detail/building.js
+++ b/source/views/building-hours/detail/building.js
@@ -41,7 +41,7 @@ type Props = {
   onProblemReport: () => any,
 }
 
-export class BuildingDetail extends React.Component<void, Props, void> {
+export class BuildingDetail extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props) {
     return (
       !this.props.now.isSame(nextProps.now, 'minute') ||

--- a/source/views/building-hours/detail/building.js
+++ b/source/views/building-hours/detail/building.js
@@ -4,7 +4,7 @@
  * <Building /> controls the structure of the detail view.
  */
 
-import React from 'react'
+import * as React from 'react'
 import {ScrollView, StyleSheet, Platform, Image} from 'react-native'
 import {buildingImages} from '../../../../images/building-images'
 import type {BuildingType} from '../types'

--- a/source/views/building-hours/detail/header.js
+++ b/source/views/building-hours/detail/header.js
@@ -10,9 +10,9 @@ import {View, Text, StyleSheet} from 'react-native'
 import type {BuildingType} from '../types'
 import * as c from '../../components/colors'
 
-export class Header extends React.PureComponent {
-  props: {building: BuildingType}
+type Props = {building: BuildingType}
 
+export class Header extends React.PureComponent<Props> {
   render() {
     const {building} = this.props
 

--- a/source/views/building-hours/detail/header.js
+++ b/source/views/building-hours/detail/header.js
@@ -5,7 +5,7 @@
  * subtitle.
  */
 
-import React from 'react'
+import * as React from 'react'
 import {View, Text, StyleSheet} from 'react-native'
 import type {BuildingType} from '../types'
 import * as c from '../../components/colors'

--- a/source/views/building-hours/detail/index.js
+++ b/source/views/building-hours/detail/index.js
@@ -5,7 +5,7 @@
  * building.
  */
 
-import React from 'react'
+import * as React from 'react'
 import type {BuildingType} from '../types'
 import moment from 'moment-timezone'
 import {BuildingDetail} from './building'

--- a/source/views/building-hours/detail/index.js
+++ b/source/views/building-hours/detail/index.js
@@ -12,18 +12,20 @@ import {BuildingDetail} from './building'
 import {CENTRAL_TZ} from '../lib'
 import type {TopLevelViewPropsType} from '../../types'
 
-export class BuildingHoursDetailView extends React.PureComponent {
+type Props = TopLevelViewPropsType & {
+  navigation: {state: {params: {building: BuildingType}}},
+}
+
+type State = {intervalId: number, now: moment}
+
+export class BuildingHoursDetailView extends React.PureComponent<Props, State> {
   static navigationOptions = ({navigation}) => {
     return {
       title: navigation.state.params.building.name,
     }
   }
 
-  props: TopLevelViewPropsType & {
-    navigation: {state: {params: {building: BuildingType}}},
-  }
-
-  state: {intervalId: number, now: moment} = {
+  state = {
     intervalId: 0,
     // now: moment.tz('Wed 7:25pm', 'ddd h:mma', null, CENTRAL_TZ),
     now: moment.tz(CENTRAL_TZ),

--- a/source/views/building-hours/detail/schedule-row.android.js
+++ b/source/views/building-hours/detail/schedule-row.android.js
@@ -11,13 +11,13 @@ import type {SingleBuildingScheduleType} from '../types'
 
 import {formatBuildingTimes, summarizeDays} from '../lib'
 
-export class ScheduleRow extends React.PureComponent {
-  props: {
-    set: SingleBuildingScheduleType,
-    isActive: boolean,
-    now: moment,
-  }
+type Props = {
+  set: SingleBuildingScheduleType,
+  isActive: boolean,
+  now: moment,
+}
 
+export class ScheduleRow extends React.PureComponent<Props> {
   render() {
     const {set, isActive, now} = this.props
     return (

--- a/source/views/building-hours/detail/schedule-row.android.js
+++ b/source/views/building-hours/detail/schedule-row.android.js
@@ -4,7 +4,7 @@
  * <ScheduleRow/> renders a single row of the schedule information.
  */
 
-import React from 'react'
+import * as React from 'react'
 import {View, Text, StyleSheet} from 'react-native'
 import moment from 'moment-timezone'
 import type {SingleBuildingScheduleType} from '../types'

--- a/source/views/building-hours/detail/schedule-row.ios.js
+++ b/source/views/building-hours/detail/schedule-row.ios.js
@@ -11,13 +11,13 @@ import moment from 'moment-timezone'
 import {Cell} from 'react-native-tableview-simple'
 import {formatBuildingTimes, summarizeDays} from '../lib'
 
-export class ScheduleRow extends React.PureComponent {
-  props: {
-    set: SingleBuildingScheduleType,
-    isActive: boolean,
-    now: moment,
-  }
+type Props = {
+  set: SingleBuildingScheduleType,
+  isActive: boolean,
+  now: moment,
+}
 
+export class ScheduleRow extends React.PureComponent<Props> {
   render() {
     const {set, isActive, now} = this.props
     return (

--- a/source/views/building-hours/detail/schedule-row.ios.js
+++ b/source/views/building-hours/detail/schedule-row.ios.js
@@ -4,7 +4,7 @@
  * <ScheduleRow/> renders a single row of the schedule information.
  */
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import type {SingleBuildingScheduleType} from '../types'
 import moment from 'moment-timezone'

--- a/source/views/building-hours/detail/schedule-table.android.js
+++ b/source/views/building-hours/detail/schedule-table.android.js
@@ -9,13 +9,13 @@ import {isScheduleOpenAtMoment, getDayOfWeek} from '../lib'
 import {ScheduleRow} from './schedule-row'
 import {ButtonCell} from '../../components/cells/button'
 
-export class ScheduleTable extends React.PureComponent {
-  props: {
-    now: moment,
-    schedules: NamedBuildingScheduleType[],
-    onProblemReport: () => any,
-  }
+type Props = {
+  now: moment,
+  schedules: NamedBuildingScheduleType[],
+  onProblemReport: () => any,
+}
 
+export class ScheduleTable extends React.PureComponent<Props> {
   render() {
     const {now, schedules, onProblemReport} = this.props
     const dayOfWeek = getDayOfWeek(now)

--- a/source/views/building-hours/detail/schedule-table.android.js
+++ b/source/views/building-hours/detail/schedule-table.android.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {View, StyleSheet} from 'react-native'
 import {Card} from '../../components/card'
 import moment from 'moment-timezone'

--- a/source/views/building-hours/detail/schedule-table.ios.js
+++ b/source/views/building-hours/detail/schedule-table.ios.js
@@ -11,13 +11,13 @@ import type {NamedBuildingScheduleType} from '../types'
 import {isScheduleOpenAtMoment, getDayOfWeek} from '../lib'
 import {ScheduleRow} from './schedule-row'
 
-export class ScheduleTable extends React.PureComponent {
-  props: {
-    now: moment,
-    schedules: NamedBuildingScheduleType[],
-    onProblemReport: () => any,
-  }
+type Props = {
+  now: moment,
+  schedules: NamedBuildingScheduleType[],
+  onProblemReport: () => any,
+}
 
+export class ScheduleTable extends React.PureComponent<Props> {
   render() {
     const {now, schedules, onProblemReport} = this.props
     const dayOfWeek = getDayOfWeek(now)

--- a/source/views/building-hours/detail/schedule-table.ios.js
+++ b/source/views/building-hours/detail/schedule-table.ios.js
@@ -4,7 +4,7 @@
  * <ScheduleTable/> renders the table of schedules.
  */
 
-import React from 'react'
+import * as React from 'react'
 import {TableView, Section, Cell} from 'react-native-tableview-simple'
 import moment from 'moment-timezone'
 import type {NamedBuildingScheduleType} from '../types'

--- a/source/views/building-hours/list.js
+++ b/source/views/building-hours/list.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, SectionList} from 'react-native'
 import {BuildingRow} from './row'
 import {tracker} from '../../analytics'

--- a/source/views/building-hours/list.js
+++ b/source/views/building-hours/list.js
@@ -20,14 +20,14 @@ const styles = StyleSheet.create({
   },
 })
 
-export class BuildingHoursList extends React.PureComponent {
-  props: TopLevelViewPropsType & {
-    now: momentT,
-    loading: boolean,
-    onRefresh: () => any,
-    buildings: Array<{title: string, data: BuildingType[]}>,
-  }
+type Props = TopLevelViewPropsType & {
+  now: momentT,
+  loading: boolean,
+  onRefresh: () => any,
+  buildings: Array<{title: string, data: BuildingType[]}>,
+}
 
+export class BuildingHoursList extends React.PureComponent<Props> {
   onPressRow = (data: BuildingType) => {
     tracker.trackEvent('building-hours', data.name)
     this.props.navigation.navigate('BuildingHoursDetailView', {building: data})

--- a/source/views/building-hours/report/editor.js
+++ b/source/views/building-hours/report/editor.js
@@ -4,7 +4,7 @@
  * An editor for individual building schedules.
  */
 
-import React from 'react'
+import * as React from 'react'
 import xor from 'lodash/xor'
 import {View, ScrollView, Platform, Text, StyleSheet} from 'react-native'
 import moment from 'moment-timezone'

--- a/source/views/building-hours/report/editor.js
+++ b/source/views/building-hours/report/editor.js
@@ -20,26 +20,31 @@ import {DeleteButtonCell} from '../../components/cells/delete-button'
 import {CellToggle} from '../../components/cells/toggle'
 import {ListSeparator} from '../../components/list'
 
-export class BuildingHoursScheduleEditorView extends React.PureComponent {
+type Props = TopLevelViewPropsType & {
+  navigation: {
+    state: {
+      params: {
+        set: SingleBuildingScheduleType,
+        onEditSet: (set: SingleBuildingScheduleType) => any,
+        onDeleteSet: () => any,
+      },
+    },
+  },
+}
+
+type State = {
+  set: ?SingleBuildingScheduleType,
+}
+
+export class BuildingHoursScheduleEditorView extends React.PureComponent<
+  Props,
+  State,
+> {
   static navigationOptions = {
     title: 'Edit Schedule',
   }
 
-  props: TopLevelViewPropsType & {
-    navigation: {
-      state: {
-        params: {
-          set: SingleBuildingScheduleType,
-          onEditSet: (set: SingleBuildingScheduleType) => any,
-          onDeleteSet: () => any,
-        },
-      },
-    },
-  }
-
-  state: {
-    set: ?SingleBuildingScheduleType,
-  } = {
+  state = {
     set: this.props.navigation.state.params.initialSet,
   }
 
@@ -103,10 +108,13 @@ export class BuildingHoursScheduleEditorView extends React.PureComponent {
   }
 }
 
-class WeekTogglesIOS extends React.PureComponent {
-  props: {days: DayOfWeekEnumType[], onChangeDays: (DayOfWeekEnumType[]) => any}
+type WeekTogglesProps = {
+  days: DayOfWeekEnumType[],
+  onChangeDays: (DayOfWeekEnumType[]) => any,
+}
 
-  toggleDay = day => {
+class WeekTogglesIOS extends React.PureComponent<WeekTogglesProps> {
+  toggleDay = (day: DayOfWeekEnumType) => {
     this.props.onChangeDays(xor(this.props.days, [day]))
   }
 
@@ -128,9 +136,7 @@ class WeekTogglesIOS extends React.PureComponent {
   }
 }
 
-class WeekTogglesAndroid extends React.PureComponent {
-  props: {days: DayOfWeekEnumType[], onChangeDays: (DayOfWeekEnumType[]) => any}
-
+class WeekTogglesAndroid extends React.PureComponent<WeekTogglesProps> {
   toggleDay = day => {
     this.props.onChangeDays(xor(this.props.days, [day]))
   }
@@ -156,13 +162,13 @@ class WeekTogglesAndroid extends React.PureComponent {
   }
 }
 
-class ToggleButton extends React.PureComponent {
-  props: {
-    active: boolean,
-    text: string,
-    onPress: (newState: string) => any,
-  }
+type ToggleButtonProps = {
+  active: boolean,
+  text: DayOfWeekEnumType,
+  onPress: (newState: DayOfWeekEnumType) => any,
+}
 
+class ToggleButton extends React.PureComponent<ToggleButtonProps> {
   onPress = () => this.props.onPress(this.props.text)
 
   render() {
@@ -183,13 +189,13 @@ class ToggleButton extends React.PureComponent {
 
 const WeekToggles = Platform.OS === 'ios' ? WeekTogglesIOS : WeekTogglesAndroid
 
-class DatePickerCell extends React.PureComponent {
-  props: {
-    date: moment,
-    title: string,
-    onChange: (date: moment) => any,
-  }
+type DatePickerCellProps = {
+  date: moment,
+  title: string,
+  onChange: (date: moment) => any,
+}
 
+class DatePickerCell extends React.PureComponent<DatePickerCellProps> {
   _picker: any
   openPicker = () => this._picker.onPressDate()
 

--- a/source/views/building-hours/report/overview.js
+++ b/source/views/building-hours/report/overview.js
@@ -4,7 +4,7 @@
  * Building Hours "report a problem" screen.
  */
 
-import React from 'react'
+import * as React from 'react'
 import {ScrollView, View, StyleSheet, Text} from 'react-native'
 import moment from 'moment-timezone'
 import {CellTextField} from '../../components/cells/textfield'

--- a/source/views/building-hours/report/overview.js
+++ b/source/views/building-hours/report/overview.js
@@ -44,18 +44,23 @@ const styles = StyleSheet.create({
   },
 })
 
-export class BuildingHoursProblemReportView extends React.PureComponent {
+type Props = TopLevelViewPropsType & {
+  navigation: {state: {params: {initialBuilding: BuildingType}}},
+}
+
+type State = {
+  building: BuildingType,
+}
+
+export class BuildingHoursProblemReportView extends React.PureComponent<
+  Props,
+  State,
+> {
   static navigationOptions = {
     title: 'Report a Problem',
   }
 
-  props: TopLevelViewPropsType & {
-    navigation: {state: {params: {initialBuilding: BuildingType}}},
-  }
-
-  state: {
-    building: BuildingType,
-  } = {
+  state = {
     building: this.props.navigation.state.params.initialBuilding,
   }
 
@@ -232,20 +237,20 @@ export class BuildingHoursProblemReportView extends React.PureComponent {
   }
 }
 
-class EditableSchedule extends React.PureComponent {
-  props: {
-    schedule: NamedBuildingScheduleType,
-    scheduleIndex: number,
-    addRow: (idx: number) => any,
-    editRow: (
-      schedIdx: number,
-      setIdx: number,
-      set: SingleBuildingScheduleType,
-    ) => any,
-    onEditSchedule: (idx: number, set: NamedBuildingScheduleType) => any,
-    onDelete: (idx: number) => any,
-  }
+type EditableScheduleProps = {
+  schedule: NamedBuildingScheduleType,
+  scheduleIndex: number,
+  addRow: (idx: number) => any,
+  editRow: (
+    schedIdx: number,
+    setIdx: number,
+    set: SingleBuildingScheduleType,
+  ) => any,
+  onEditSchedule: (idx: number, set: NamedBuildingScheduleType) => any,
+  onDelete: (idx: number) => any,
+}
 
+class EditableSchedule extends React.PureComponent<EditableScheduleProps> {
   onEdit = data => {
     const idx = this.props.scheduleIndex
     this.props.onEditSchedule(idx, {
@@ -285,8 +290,8 @@ class EditableSchedule extends React.PureComponent {
     return (
       <View>
         <Section header="INFORMATION">
-          <TitleCell text={schedule.title} onChange={this.editTitle} />
-          <NotesCell text={schedule.notes} onChange={this.editNotes} />
+          <TitleCell text={schedule.title || ''} onChange={this.editTitle} />
+          <NotesCell text={schedule.notes || ''} onChange={this.editNotes} />
 
           <CellToggle
             label="Closes for Chapel"
@@ -317,8 +322,9 @@ class EditableSchedule extends React.PureComponent {
   }
 }
 
+type TextFieldProps = {text: string, onChange: string => any}
 // "Title" will become a textfield like the login form
-const TitleCell = ({text, onChange = () => {}}) => (
+const TitleCell = ({text, onChange = () => {}}: TextFieldProps) => (
   <CellTextField
     hideLabel={true}
     autoCapitalize="words"
@@ -331,7 +337,7 @@ const TitleCell = ({text, onChange = () => {}}) => (
 )
 
 // "Notes" will become a big textarea
-const NotesCell = ({text, onChange}) => (
+const NotesCell = ({text, onChange}: TextFieldProps) => (
   <CellTextField
     hideLabel={true}
     autoCapitalize="sentences"
@@ -343,14 +349,14 @@ const NotesCell = ({text, onChange}) => (
   />
 )
 
-class TimesCell extends React.PureComponent {
-  props: {
-    set: SingleBuildingScheduleType,
-    setIndex: number,
-    onPress: (setIdx: number, set: SingleBuildingScheduleType) => any,
-    now: moment,
-  }
+type TimesCellProps = {
+  set: SingleBuildingScheduleType,
+  setIndex: number,
+  onPress: (setIdx: number, set: SingleBuildingScheduleType) => any,
+  now: moment,
+}
 
+class TimesCell extends React.PureComponent<TimesCellProps> {
   onPress = () => {
     this.props.onPress(this.props.setIndex, this.props.set)
   }

--- a/source/views/building-hours/row.js
+++ b/source/views/building-hours/row.js
@@ -55,13 +55,14 @@ type Props = {
 }
 
 type State = {
+  firstUpdate: boolean,
   openStatus: string,
   hours: Array<any>,
   accentBg: string,
   accentText: string,
 }
 
-export class BuildingRow extends React.Component<void, Props, State> {
+export class BuildingRow extends React.Component<Props, State> {
   state = {
     openStatus: 'Unknown',
     hours: [],

--- a/source/views/building-hours/row.js
+++ b/source/views/building-hours/row.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {View, Text, StyleSheet} from 'react-native'
 import {Badge} from '../components/badge'
 import isEqual from 'lodash/isEqual'

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -27,21 +27,23 @@ const groupBuildings = (buildings: BuildingType[]) => {
   return toPairs(grouped).map(([key, value]) => ({title: key, data: value}))
 }
 
-export class BuildingHoursView extends React.Component {
+type Props = TopLevelViewPropsType
+
+type State = {
+  error: ?Error,
+  loading: boolean,
+  now: moment,
+  buildings: Array<{title: string, data: BuildingType[]}>,
+  intervalId: number,
+}
+
+export class BuildingHoursView extends React.Component<Props, State> {
   static navigationOptions = {
     title: 'Building Hours',
     headerBackTitle: 'Hours',
   }
 
-  props: TopLevelViewPropsType
-
-  state: {
-    error: ?Error,
-    loading: boolean,
-    now: moment,
-    buildings: Array<{title: string, data: BuildingType[]}>,
-    intervalId: number,
-  } = {
+  state = {
     error: null,
     loading: false,
     // now: moment.tz('Wed 7:25pm', 'ddd h:mma', null, CENTRAL_TZ),
@@ -66,7 +68,7 @@ export class BuildingHoursView extends React.Component {
     this.setState(() => ({now: moment.tz(CENTRAL_TZ)}))
   }
 
-  refresh = async () => {
+  refresh = async (): any => {
     let start = Date.now()
     this.setState(() => ({loading: true}))
 

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -5,7 +5,7 @@
  * the local copy as a fallback, and renders the list of buildings.
  */
 
-import React from 'react'
+import * as React from 'react'
 import {NoticeView} from '../components/notice'
 import {BuildingHoursList} from './list'
 

--- a/source/views/building-hours/types.js
+++ b/source/views/building-hours/types.js
@@ -19,11 +19,11 @@ export type BreakNameEnumType =
   | 'easter'
   | 'summer'
 
-export type SingleBuildingScheduleType = {|
+export type SingleBuildingScheduleType = {
   days: DayOfWeekEnumType[],
   from: string,
   to: string,
-|}
+}
 
 export type NamedBuildingScheduleType = {
   title: 'Hours' | string,
@@ -37,7 +37,7 @@ export type BreakScheduleContainerType = {
   [key: BreakNameEnumType]: NamedBuildingScheduleType[],
 }
 
-export type BuildingType = {|
+export type BuildingType = {
   name: string,
   subtitle?: string,
   abbreviation?: string,
@@ -45,4 +45,4 @@ export type BuildingType = {|
   category: string,
   schedule: NamedBuildingScheduleType[],
   breakSchedule?: BreakScheduleContainerType,
-|}
+}

--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {EventList} from './event-list'
 import bugsnag from '../../bugsnag'
 import {tracker} from '../../analytics'

--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -13,16 +13,18 @@ import qs from 'querystring'
 import {GOOGLE_CALENDAR_API_KEY} from '../../lib/config'
 const TIMEZONE = 'America/Winnipeg'
 
-export class GoogleCalendarView extends React.Component {
-  props: {calendarId: string} & TopLevelViewPropsType
+type Props = {calendarId: string} & TopLevelViewPropsType
 
-  state: {
-    events: EventType[],
-    loading: boolean,
-    refreshing: boolean,
-    error: ?Error,
-    now: moment,
-  } = {
+type State = {
+  events: EventType[],
+  loading: boolean,
+  refreshing: boolean,
+  error: ?Error,
+  now: moment,
+}
+
+export class GoogleCalendarView extends React.Component<Props, State> {
+  state = {
     events: [],
     loading: true,
     refreshing: false,

--- a/source/views/calendar/event-detail.android.js
+++ b/source/views/calendar/event-detail.android.js
@@ -91,7 +91,16 @@ const CalendarButton = ({message, disabled, onPress}) => {
   )
 }
 
-export class EventDetail extends React.PureComponent {
+type Props = TopLevelViewPropsType & {
+  navigation: {state: {params: {event: CleanedEventType}}},
+}
+
+type State = {
+  message: string,
+  disabled: boolean,
+}
+
+export class EventDetail extends React.PureComponent<Props, State> {
   static navigationOptions = ({navigation}) => {
     const {event} = navigation.state.params
     return {
@@ -100,14 +109,7 @@ export class EventDetail extends React.PureComponent {
     }
   }
 
-  props: TopLevelViewPropsType & {
-    navigation: {state: {params: {event: CleanedEventType}}},
-  }
-
-  state: {
-    message: string,
-    disabled: boolean,
-  } = {
+  state = {
     message: '',
     disabled: false,
   }

--- a/source/views/calendar/event-detail.android.js
+++ b/source/views/calendar/event-detail.android.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Text, ScrollView, StyleSheet} from 'react-native'
 import type {CleanedEventType} from './types'
 import type {TopLevelViewPropsType} from '../types'

--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Text, ScrollView, StyleSheet} from 'react-native'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import type {CleanedEventType} from './types'

--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -63,7 +63,16 @@ const CalendarButton = ({message, disabled, onPress}) => {
   )
 }
 
-export class EventDetail extends React.PureComponent {
+type Props = TopLevelViewPropsType & {
+  navigation: {state: {params: {event: CleanedEventType}}},
+}
+
+type State = {
+  message: string,
+  disabled: boolean,
+}
+
+export class EventDetail extends React.PureComponent<Props, State> {
   static navigationOptions = ({navigation}) => {
     const {event} = navigation.state.params
     return {
@@ -72,14 +81,7 @@ export class EventDetail extends React.PureComponent {
     }
   }
 
-  props: TopLevelViewPropsType & {
-    navigation: {state: {params: {event: CleanedEventType}}},
-  }
-
-  state: {
-    message: string,
-    disabled: boolean,
-  } = {
+  state = {
     message: '',
     disabled: false,
   }

--- a/source/views/calendar/event-list.js
+++ b/source/views/calendar/event-list.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, SectionList} from 'react-native'
 import * as c from '../components/colors'
 import toPairs from 'lodash/toPairs'

--- a/source/views/calendar/event-list.js
+++ b/source/views/calendar/event-list.js
@@ -17,15 +17,15 @@ const FullWidthSeparator = props => (
   <ListSeparator fullWidth={true} {...props} />
 )
 
-export class EventList extends React.PureComponent {
-  props: TopLevelViewPropsType & {
-    events: EventType[],
-    message: ?string,
-    refreshing: boolean,
-    onRefresh: () => any,
-    now: moment,
-  }
+type Props = TopLevelViewPropsType & {
+  events: EventType[],
+  message: ?string,
+  refreshing: boolean,
+  onRefresh: () => any,
+  now: moment,
+}
 
+export class EventList extends React.PureComponent<Props> {
   groupEvents = (events: EventType[], now: moment): any => {
     // the proper return type is $ReadOnlyArray<{title: string, data: $ReadOnlyArray<EventType>}>
     const grouped = groupBy(events, event => {

--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Text} from 'react-native'
 import type {EventType} from './types'
 import * as c from '../components/colors'

--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -32,12 +32,12 @@ const styles = StyleSheet.create({
   },
 })
 
-export default class EventRow extends React.PureComponent {
-  props: {
-    event: EventType,
-    onPress: EventType => any,
-  }
+type Props = {
+  event: EventType,
+  onPress: EventType => any,
+}
 
+export default class EventRow extends React.PureComponent<Props> {
   _onPress = () => this.props.onPress(this.props.event)
 
   render() {

--- a/source/views/calendar/index.js
+++ b/source/views/calendar/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {TabNavigator} from '../components/tabbed-view'
 import {TabBarIcon} from '../components/tabbar-icon'
 

--- a/source/views/calendar/vertical-bar.js
+++ b/source/views/calendar/vertical-bar.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, View, Platform} from 'react-native'
 import * as c from '../components/colors'
 

--- a/source/views/components/__tests__/__snapshots__/notice.test.js.snap
+++ b/source/views/components/__tests__/__snapshots__/notice.test.js.snap
@@ -18,7 +18,6 @@ exports[`renders a button, if given 1`] = `
   <Text
     accessible={true}
     allowFontScaling={true}
-    disabled={false}
     ellipsizeMode="tail"
     selectable={true}
     style={
@@ -54,7 +53,6 @@ exports[`renders the given text 1`] = `
   <Text
     accessible={true}
     allowFontScaling={true}
-    disabled={false}
     ellipsizeMode="tail"
     selectable={true}
     style={
@@ -99,7 +97,6 @@ exports[`shows an ActivityIndicator if given [spinner] 1`] = `
   <Text
     accessible={true}
     allowFontScaling={true}
-    disabled={false}
     ellipsizeMode="tail"
     selectable={true}
     style={

--- a/source/views/components/__tests__/button.test.js
+++ b/source/views/components/__tests__/button.test.js
@@ -2,7 +2,7 @@
 // @flow
 
 import 'react-native'
-import React from 'react'
+import * as React from 'react'
 import ReactShallowRenderer from 'react-test-renderer/shallow'
 
 import {Button} from '../button'

--- a/source/views/components/__tests__/notice.test.js
+++ b/source/views/components/__tests__/notice.test.js
@@ -2,7 +2,7 @@
 // @flow
 
 import 'react-native'
-import React from 'react'
+import * as React from 'react'
 import ReactShallowRenderer from 'react-test-renderer/shallow'
 
 import {NoticeView} from '../notice'

--- a/source/views/components/__tests__/open-url.test.js
+++ b/source/views/components/__tests__/open-url.test.js
@@ -1,5 +1,7 @@
 /* eslint-env jest */
 
+jest.mock('react-native-safari-view', () => 'ReactNativeSafariView')
+
 import {canOpenUrl} from '../open-url'
 
 describe('canOpenUrl', () => {

--- a/source/views/components/alphabet-listview.js
+++ b/source/views/components/alphabet-listview.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import AlphabetListView from '@hawkrives/react-native-alphabetlistview'
 import * as c from '../components/colors'

--- a/source/views/components/badge.js
+++ b/source/views/components/badge.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View, Text, StyleSheet} from 'react-native'
 import * as c from '../components/colors'
 

--- a/source/views/components/button.js
+++ b/source/views/components/button.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import BasicButton from 'react-native-button'
 import noop from 'lodash/noop'

--- a/source/views/components/card.js
+++ b/source/views/components/card.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View, Text, StyleSheet} from 'react-native'
 import * as c from './colors'
 

--- a/source/views/components/cells/__tests__/toggle.test.js
+++ b/source/views/components/cells/__tests__/toggle.test.js
@@ -2,7 +2,7 @@
 // @flow
 
 import 'react-native'
-import React from 'react'
+import * as React from 'react'
 import ReactShallowRenderer from 'react-test-renderer/shallow'
 
 import {CellToggle} from '../toggle'

--- a/source/views/components/cells/button.js
+++ b/source/views/components/cells/button.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Text} from 'react-native'
 import {Cell} from 'react-native-tableview-simple'
 import * as c from '../../components/colors'

--- a/source/views/components/cells/delete-button.js
+++ b/source/views/components/cells/delete-button.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Alert} from 'react-native'
 import {Cell} from 'react-native-tableview-simple'
 import * as c from '../colors'

--- a/source/views/components/cells/push-button.js
+++ b/source/views/components/cells/push-button.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Cell} from 'react-native-tableview-simple'
 
 export const PushButtonCell = ({

--- a/source/views/components/cells/textfield.js
+++ b/source/views/components/cells/textfield.js
@@ -25,7 +25,21 @@ const styles = StyleSheet.create({
   },
 })
 
-export class CellTextField extends React.Component {
+type Props = {
+  label?: string,
+  _ref: any => any,
+  disabled: boolean,
+  onChangeText: string => any,
+  onSubmitEditing: string => any,
+  placeholder: string,
+  returnKeyType: 'done' | 'next' | 'default',
+  secureTextEntry: boolean,
+  autoCapitalize: 'characters' | 'words' | 'sentences' | 'none',
+  value: string,
+  labelWidth?: number,
+}
+
+export class CellTextField extends React.Component<Props> {
   static defaultProps = {
     disabled: false,
     placeholder: '',
@@ -33,20 +47,6 @@ export class CellTextField extends React.Component {
     returnKeyType: 'default',
     secureTextEntry: false,
     autoCapitalize: 'none',
-  }
-
-  props: {
-    label?: string,
-    _ref: any => any,
-    disabled: boolean,
-    onChangeText: string => any,
-    onSubmitEditing: string => any,
-    placeholder: string,
-    returnKeyType: 'done' | 'next' | 'default',
-    secureTextEntry: boolean,
-    autoCapitalize: 'characters' | 'words' | 'sentences' | 'none',
-    value: string,
-    labelWidth?: number,
   }
 
   _input: any

--- a/source/views/components/cells/textfield.js
+++ b/source/views/components/cells/textfield.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Text, Platform, TextInput} from 'react-native'
 import {Cell} from 'react-native-tableview-simple'
 import * as c from '../../components/colors'

--- a/source/views/components/cells/toggle.js
+++ b/source/views/components/cells/toggle.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Switch} from 'react-native'
 import {Cell} from 'react-native-tableview-simple'
 

--- a/source/views/components/datepicker/datepicker.android.js
+++ b/source/views/components/datepicker/datepicker.android.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {
   View,
   Text,

--- a/source/views/components/datepicker/datepicker.android.js
+++ b/source/views/components/datepicker/datepicker.android.js
@@ -37,7 +37,7 @@ type TimePickerResponse = {
   minute: number,
 }
 
-export class DatePicker extends React.PureComponent<any, Props, void> {
+export class DatePicker extends React.PureComponent<Props> {
   static defaultProps = {
     mode: 'date',
     androidMode: 'default',

--- a/source/views/components/datepicker/datepicker.ios.js
+++ b/source/views/components/datepicker/datepicker.ios.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {
   View,
   Text,

--- a/source/views/components/datepicker/datepicker.ios.js
+++ b/source/views/components/datepicker/datepicker.ios.js
@@ -34,7 +34,7 @@ type State = {
   allowPointerEvents: boolean,
 }
 
-export class DatePicker extends React.Component<any, Props, State> {
+export class DatePicker extends React.Component<Props, State> {
   static defaultProps = {
     mode: 'date',
     height: 259, // 216 (DatePickerIOS) + 1 (borderTop) + 42 (marginTop), iOS only
@@ -125,7 +125,7 @@ type ModalProps = {
   timezone: string,
 }
 
-class DatePickerModal extends React.PureComponent<any, ModalProps, void> {
+class DatePickerModal extends React.PureComponent<ModalProps> {
   static SUPPORTED_ORIENTATIONS = [
     'portrait',
     'portrait-upside-down',

--- a/source/views/components/datepicker/index.js
+++ b/source/views/components/datepicker/index.js
@@ -32,7 +32,7 @@ type State = {
   timezone: string,
 }
 
-export class DatePicker extends React.Component<any, Props, State> {
+export class DatePicker extends React.Component<Props, State> {
   static defaultProps = {
     mode: 'date',
     androidMode: 'default',

--- a/source/views/components/filter/__tests__/apply-filter.test.js
+++ b/source/views/components/filter/__tests__/apply-filter.test.js
@@ -9,7 +9,6 @@ it('should return `true` if the filter is disabled', () => {
     key: 'key',
     enabled: false,
     spec: {
-      label: 'label',
       options: filterValue('1', '2', '3'),
       selected: [],
       mode: 'OR',

--- a/source/views/components/filter/filter-view.js
+++ b/source/views/components/filter/filter-view.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {ScrollView, StyleSheet} from 'react-native'
 import {type FilterType} from './types'
 import {type ReduxState} from '../../../flux'

--- a/source/views/components/filter/section-list.js
+++ b/source/views/components/filter/section-list.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Text, Image, StyleSheet} from 'react-native'
 import type {ListType, ListItemSpecType} from './types'
 import {Section, Cell} from 'react-native-tableview-simple'

--- a/source/views/components/filter/section-picker.js
+++ b/source/views/components/filter/section-picker.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Picker, StyleSheet} from 'react-native'
 import * as c from '../colors'
 import type {PickerType} from './types'

--- a/source/views/components/filter/section-toggle.js
+++ b/source/views/components/filter/section-toggle.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import type {ToggleType} from './types'
 import {Section} from 'react-native-tableview-simple'
 import {CellToggle} from '../../components/cells/toggle'

--- a/source/views/components/filter/section.js
+++ b/source/views/components/filter/section.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import type {FilterType} from './types'
 import {SingleToggleSection} from './section-toggle'
 import {ListSection} from './section-list'

--- a/source/views/components/html-view.js
+++ b/source/views/components/html-view.js
@@ -4,12 +4,13 @@ import * as React from 'react'
 import {WebView} from 'react-native'
 import openUrl, {canOpenUrl} from '../components/open-url'
 
-export class HtmlView extends React.Component {
-  props: {
-    html: string,
-    baseUrl?: ?string,
-    style?: number | Object | Array<number | Object>,
-  }
+type Props = {
+  html: string,
+  baseUrl?: ?string,
+  style?: number | Object | Array<number | Object>,
+}
+
+export class HtmlView extends React.Component<Props> {
   _webview: WebView
 
   onNavigationStateChange = ({url}: {url: string}) => {

--- a/source/views/components/html-view.js
+++ b/source/views/components/html-view.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {WebView} from 'react-native'
 import openUrl, {canOpenUrl} from '../components/open-url'
 

--- a/source/views/components/layout/column.js
+++ b/source/views/components/layout/column.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyledComponent} from './styled-component'
 import type {PropsType} from './styled-component'
 

--- a/source/views/components/layout/row.js
+++ b/source/views/components/layout/row.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyledComponent} from './styled-component'
 import type {PropsType} from './styled-component'
 

--- a/source/views/components/layout/styled-component.js
+++ b/source/views/components/layout/styled-component.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View} from 'react-native'
 
 export type PropsType = {children?: any, style?: any, props: mixed}

--- a/source/views/components/list/disclosure-arrow.js
+++ b/source/views/components/list/disclosure-arrow.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Platform, StyleSheet, View} from 'react-native'
 import * as c from '../colors'
 import Icon from 'react-native-vector-icons/Ionicons'

--- a/source/views/components/list/list-empty.js
+++ b/source/views/components/list/list-empty.js
@@ -2,11 +2,11 @@
 import * as React from 'react'
 import {View, Text} from 'react-native'
 
-export class ListEmpty extends React.PureComponent {
-  props: {
-    mode: 'bug',
-  }
+type Props = {
+  mode: 'bug' | 'normal',
+}
 
+export class ListEmpty extends React.PureComponent<Props> {
   render() {
     return (
       <View>

--- a/source/views/components/list/list-empty.js
+++ b/source/views/components/list/list-empty.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View, Text} from 'react-native'
 
 export class ListEmpty extends React.PureComponent {

--- a/source/views/components/list/list-footer.js
+++ b/source/views/components/list/list-footer.js
@@ -13,12 +13,12 @@ const styles = StyleSheet.create({
   },
 })
 
-export class ListFooter extends React.PureComponent {
-  props: {
-    title: string,
-    href?: string,
-  }
+type Props = {
+  title: string,
+  href?: string,
+}
 
+export class ListFooter extends React.PureComponent<Props> {
   render() {
     const {title} = this.props
     return (

--- a/source/views/components/list/list-footer.js
+++ b/source/views/components/list/list-footer.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Text, StyleSheet} from 'react-native'
 import * as c from '../colors'
 

--- a/source/views/components/list/list-item-detail.js
+++ b/source/views/components/list/list-item-detail.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Platform, Text} from 'react-native'
 import * as c from '../colors'
 

--- a/source/views/components/list/list-item-title.js
+++ b/source/views/components/list/list-item-title.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Platform, Text} from 'react-native'
 import * as c from '../colors'
 

--- a/source/views/components/list/list-row.js
+++ b/source/views/components/list/list-row.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Platform, StyleSheet, View} from 'react-native'
 import * as c from '../colors'
 import {Touchable} from '../touchable'

--- a/source/views/components/list/list-section-header.js
+++ b/source/views/components/list/list-section-header.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Platform, StyleSheet, Text, View} from 'react-native'
 import * as c from '../colors'
 

--- a/source/views/components/list/list-separator.js
+++ b/source/views/components/list/list-separator.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Platform, StyleSheet} from 'react-native'
 import {Separator} from '../separator'
 

--- a/source/views/components/loading.js
+++ b/source/views/components/loading.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {NoticeView} from './notice'
 
 export default function LoadingView({text = 'Loading…'}: {text?: string}) {

--- a/source/views/components/markdown/code.js
+++ b/source/views/components/markdown/code.js
@@ -7,7 +7,9 @@ export const Code = glamorous.text({})
 
 export const CodeBlock = glamorous.text({})
 
-export class HighlightedCodeBlock extends React.PureComponent {
+type Props = {nodeKey: any, language?: string, literal: string}
+
+export class HighlightedCodeBlock extends React.PureComponent<Props> {
   render() {
     const {nodeKey, language, literal} = this.props
     return (

--- a/source/views/components/markdown/code.js
+++ b/source/views/components/markdown/code.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import glamorous from 'glamorous-native'
 
 export const Code = glamorous.text({})

--- a/source/views/components/markdown/index.js
+++ b/source/views/components/markdown/index.js
@@ -24,7 +24,28 @@ const HorizontalRule = glamorous.view({
   backgroundColor: 'black',
 })
 
-export class Markdown extends React.PureComponent {
+type MarkdownBlockEnum =
+  | 'BlockQuote'
+  | 'Code'
+  | 'CodeBlock'
+  | 'Emph'
+  | 'Heading'
+  | 'Image'
+  | 'ListItem'
+  | 'Link'
+  | 'List'
+  | 'Paragraph'
+  | 'Strong'
+  | 'ThematicBreak'
+
+type StyleSheetRule = number | Object | Array<StyleSheetRule>
+
+type Props = {
+  styles?: {[key: MarkdownBlockEnum]: ?StyleSheetRule},
+  source: string,
+}
+
+export class Markdown extends React.PureComponent<Props> {
   render() {
     const {styles = {}, source} = this.props
     return (

--- a/source/views/components/markdown/index.js
+++ b/source/views/components/markdown/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {View, Text} from 'react-native'
 import glamorous from 'glamorous-native'
 import ReactMarkdown from 'react-markdown'

--- a/source/views/components/markdown/link.js
+++ b/source/views/components/markdown/link.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {ActionSheetIOS, Clipboard} from 'react-native'
 import glamorous from 'glamorous-native'
 import openUrl from '../open-url'

--- a/source/views/components/markdown/link.js
+++ b/source/views/components/markdown/link.js
@@ -13,14 +13,16 @@ export const LinkText = glamorous.text({
   color: c.infoBlue,
 })
 
-export class Link extends React.PureComponent {
-  props: {
-    href: string,
-    title?: string,
-    children: Array<string>,
-  }
+type Props = {
+  href: string,
+  title?: string,
+  children: React.ChildrenArray<string>,
+}
 
-  options = [
+type Callback = ({title?: string, href: string}) => any
+
+export class Link extends React.PureComponent<Props> {
+  options: Array<[string, Callback]> = [
     ['Open', ({href}: {href: string}) => openUrl(href)],
     [
       'Copy',

--- a/source/views/components/markdown/list.js
+++ b/source/views/components/markdown/list.js
@@ -12,11 +12,11 @@ export const List = glamorous.view({})
 export const ListText = glamorous(Paragraph)({})
 
 // the list item's container box thing
-export class ListItem extends React.PureComponent {
-  props: {
-    children?: React$Element<*>,
-  }
+type Props = {
+  children?: React.Node,
+}
 
+export class ListItem extends React.PureComponent<Props> {
   render() {
     return (
       <glamorous.View flexDirection="row">

--- a/source/views/components/markdown/list.js
+++ b/source/views/components/markdown/list.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {Text} from 'react-native'
 import glamorous from 'glamorous-native'
 import {Paragraph} from './formatting'

--- a/source/views/components/markdown/selectable.js
+++ b/source/views/components/markdown/selectable.js
@@ -3,7 +3,9 @@
 import * as React from 'react'
 import {Text} from 'react-native'
 
-export class SelectableText extends React.PureComponent {
+type Props = {}
+
+export class SelectableText extends React.PureComponent<Props> {
   render() {
     return <Text selectable={true} {...this.props} />
   }

--- a/source/views/components/markdown/selectable.js
+++ b/source/views/components/markdown/selectable.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {Text} from 'react-native'
 
 export class SelectableText extends React.PureComponent {

--- a/source/views/components/nav-buttons/close-screen.js
+++ b/source/views/components/nav-buttons/close-screen.js
@@ -3,7 +3,7 @@
  * Exports a button that closes the current overlay screen
  */
 
-import React from 'react'
+import * as React from 'react'
 import {Text, Platform, StyleSheet} from 'react-native'
 import {Touchable} from '../touchable'
 import type {NavType} from '../../types'

--- a/source/views/components/nav-buttons/edit-home.js
+++ b/source/views/components/nav-buttons/edit-home.js
@@ -3,7 +3,7 @@
  * Exports a button that opens the Edit Home screen
  */
 
-import React from 'react'
+import * as React from 'react'
 import {Text} from 'react-native'
 import {Touchable} from '../touchable'
 import type {NavType} from '../../types'

--- a/source/views/components/nav-buttons/open-settings.js
+++ b/source/views/components/nav-buttons/open-settings.js
@@ -3,7 +3,7 @@
  * Exports a button that opens the Settings screen
  */
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Platform} from 'react-native'
 import * as c from '../colors'
 import {Touchable} from '../touchable'

--- a/source/views/components/nav-buttons/share.js
+++ b/source/views/components/nav-buttons/share.js
@@ -6,11 +6,11 @@ import Icon from 'react-native-vector-icons/Ionicons'
 import {Touchable} from '../touchable'
 import {rightButtonStyles as styles} from './styles'
 
-export class ShareButton extends React.PureComponent {
-  props: {
-    onPress: () => any,
-  }
+type Props = {
+  onPress: () => any,
+}
 
+export class ShareButton extends React.PureComponent<Props> {
   render() {
     return (
       <Touchable

--- a/source/views/components/nav-buttons/share.js
+++ b/source/views/components/nav-buttons/share.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {Platform} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {Touchable} from '../touchable'

--- a/source/views/components/notice.js
+++ b/source/views/components/notice.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {ActivityIndicator, StyleSheet, Text, View} from 'react-native'
 import * as c from './colors'
 import {Button} from './button'

--- a/source/views/components/searchable-alphabet-listview.js
+++ b/source/views/components/searchable-alphabet-listview.js
@@ -16,11 +16,7 @@ const styles = StyleSheet.create({
 
 type Props = any
 
-export class SearchableAlphabetListView extends React.PureComponent<
-  void,
-  Props,
-  void,
-> {
+export class SearchableAlphabetListView extends React.PureComponent<Props> {
   searchBar: any = null
 
   _performSearch = (text: string | Object) => {

--- a/source/views/components/searchable-alphabet-listview.js
+++ b/source/views/components/searchable-alphabet-listview.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Platform, View} from 'react-native'
 import {StyledAlphabetListView} from '../components/alphabet-listview'
 import debounce from 'lodash/debounce'

--- a/source/views/components/searchbar/index.android.js
+++ b/source/views/components/searchbar/index.android.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View} from 'react-native'
 // import MaterialSearchBar from 'react-native-material-design-searchbar'
 

--- a/source/views/components/searchbar/index.ios.js
+++ b/source/views/components/searchbar/index.ios.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import NativeSearchBar from '@hawkrives/react-native-search-bar'
 import * as c from '../colors'

--- a/source/views/components/separator.js
+++ b/source/views/components/separator.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View, StyleSheet, Platform} from 'react-native'
 import * as c from './colors'
 

--- a/source/views/components/tabbar-icon.js
+++ b/source/views/components/tabbar-icon.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 

--- a/source/views/components/toolbar/toolbar-button.js
+++ b/source/views/components/toolbar/toolbar-button.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, View, Text, Platform} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import * as c from '../../components/colors'

--- a/source/views/components/toolbar/toolbar.js
+++ b/source/views/components/toolbar/toolbar.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Platform, View} from 'react-native'
 import {Touchable} from '../touchable'
 import * as c from '../colors'

--- a/source/views/components/touchable.js
+++ b/source/views/components/touchable.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {
   TouchableOpacity,
   TouchableHighlight,

--- a/source/views/contacts/contact-detail.js
+++ b/source/views/contacts/contact-detail.js
@@ -47,14 +47,14 @@ function promptCall(buttonText: string, phoneNumber: string) {
   ])
 }
 
-export class ContactsDetailView extends React.PureComponent {
+type Props = {navigation: {state: {params: {contact: ContactType}}}}
+
+export class ContactsDetailView extends React.PureComponent<Props> {
   static navigationOptions = ({navigation}) => {
     return {
       title: navigation.state.params.contact.title,
     }
   }
-
-  props: {navigation: {state: {params: {contact: ContactType}}}}
 
   onPress = () => {
     const {

--- a/source/views/contacts/contact-detail.js
+++ b/source/views/contacts/contact-detail.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Alert, StyleSheet, ScrollView, Image} from 'react-native'
 import {contactImages} from '../../../images/contact-images'
 import {Markdown} from '../components/markdown'

--- a/source/views/contacts/contact-list.js
+++ b/source/views/contacts/contact-list.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {SectionList, StyleSheet} from 'react-native'
 import {ListSeparator, ListSectionHeader} from '../components/list'
 import {ListEmpty} from '../components/list'

--- a/source/views/contacts/contact-list.js
+++ b/source/views/contacts/contact-list.js
@@ -36,7 +36,7 @@ type State = {
   refreshing: boolean,
 }
 
-export class ContactsListView extends React.PureComponent<void, Props, State> {
+export class ContactsListView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     title: 'Important Contacts',
     headerBackTitle: 'Contacts',
@@ -54,7 +54,7 @@ export class ContactsListView extends React.PureComponent<void, Props, State> {
     })
   }
 
-  refresh = async () => {
+  refresh = async (): any => {
     const start = Date.now()
     this.setState(() => ({refreshing: true}))
 

--- a/source/views/contacts/contact-row.js
+++ b/source/views/contacts/contact-row.js
@@ -5,12 +5,12 @@ import type {ContactType} from './types'
 import {ListRow, Detail, Title} from '../components/list'
 import {Column, Row} from '../components/layout'
 
-export class ContactRow extends React.PureComponent {
-  props: {
-    onPress: ContactType => any,
-    contact: ContactType,
-  }
+type Props = {
+  onPress: ContactType => any,
+  contact: ContactType,
+}
 
+export class ContactRow extends React.PureComponent<Props> {
   _onPress = () => this.props.onPress(this.props.contact)
 
   render() {

--- a/source/views/contacts/contact-row.js
+++ b/source/views/contacts/contact-row.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import type {ContactType} from './types'
 import {ListRow, Detail, Title} from '../components/list'
 import {Column, Row} from '../components/layout'

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -28,15 +28,15 @@ const styles = StyleSheet.create({
   },
 })
 
-export class DictionaryDetailView extends React.PureComponent {
+type Props = {
+  navigation: {state: {params: {item: WordType}}},
+}
+
+export class DictionaryDetailView extends React.PureComponent<Props> {
   static navigationOptions = ({navigation}) => {
     return {
       title: navigation.state.params.item.word,
     }
-  }
-
-  props: {
-    navigation: {state: {params: {item: WordType}}},
   }
 
   render() {

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import {Markdown} from '../components/markdown'
 import {ListFooter} from '../components/list'

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -51,7 +51,7 @@ type State = {
   refreshing: boolean,
 }
 
-export class DictionaryView extends React.PureComponent<void, Props, State> {
+export class DictionaryView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     title: 'Campus Dictionary',
     headerBackTitle: 'Dictionary',

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, RefreshControl, Platform} from 'react-native'
 import {SearchableAlphabetListView} from '../components/searchable-alphabet-listview'
 import {Column} from '../components/layout'

--- a/source/views/faqs/index.js
+++ b/source/views/faqs/index.js
@@ -10,7 +10,15 @@ import delay from 'delay'
 
 const faqsUrl = 'https://stodevx.github.io/AAO-React-Native/faqs.json'
 
-export class FaqView extends React.PureComponent {
+type Props = {}
+
+type State = {
+  text: string,
+  loading: boolean,
+  refreshing: boolean,
+}
+
+export class FaqView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     title: 'FAQs',
   }
@@ -40,7 +48,7 @@ export class FaqView extends React.PureComponent {
     this.setState(() => ({text}))
   }
 
-  refresh = async () => {
+  refresh = async (): any => {
     const start = Date.now()
     this.setState(() => ({refreshing: true}))
 

--- a/source/views/faqs/index.js
+++ b/source/views/faqs/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {RefreshControl} from 'react-native'
 import {ScrollView} from 'glamorous-native'
 import {Markdown} from '../components/markdown'

--- a/source/views/help/index.js
+++ b/source/views/help/index.js
@@ -5,7 +5,9 @@ import {View} from 'react-native'
 
 import {ReportWifiProblemView} from './wifi'
 
-export default class HelpView extends React.Component {
+type Props = {}
+
+export default class HelpView extends React.Component<Props> {
   static navigationOptions = {
     title: 'Help',
   }

--- a/source/views/help/index.js
+++ b/source/views/help/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {View} from 'react-native'
 
 import {ReportWifiProblemView} from './wifi'

--- a/source/views/help/wifi.js
+++ b/source/views/help/wifi.js
@@ -57,7 +57,14 @@ function reportToServer(data) {
   })
 }
 
-export class ReportWifiProblemView extends React.Component {
+type Props = {}
+
+type State = {
+  status: string,
+  data: ?any,
+}
+
+export class ReportWifiProblemView extends React.Component<Props, State> {
   state = {
     status: '',
     data: null,

--- a/source/views/help/wifi.js
+++ b/source/views/help/wifi.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {ScrollView, Text} from 'react-native'
 import {Card} from '../components/card'
 import {Button} from '../components/button'

--- a/source/views/home/button.js
+++ b/source/views/home/button.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {Text, StyleSheet, Platform} from 'react-native'
 import Icon from 'react-native-vector-icons/Entypo'
 import type {ViewType} from '../views'

--- a/source/views/home/edit/list.android.js
+++ b/source/views/home/edit/list.android.js
@@ -30,7 +30,7 @@ type ReduxDispatchProps = {
 
 type Props = ReduxStateProps & ReduxDispatchProps
 
-class EditHomeView extends React.PureComponent<any, Props, void> {
+class EditHomeView extends React.PureComponent<Props> {
   static navigationOptions = {
     title: 'Edit Home',
   }

--- a/source/views/home/edit/list.android.js
+++ b/source/views/home/edit/list.android.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, FlatList} from 'react-native'
 import {type ReduxState} from '../../../flux'
 import {saveHomescreenOrder} from '../../../flux/parts/homescreen'

--- a/source/views/home/edit/list.ios.js
+++ b/source/views/home/edit/list.ios.js
@@ -40,7 +40,7 @@ type State = {
   width: number,
 }
 
-class EditHomeView extends React.PureComponent<void, Props, State> {
+class EditHomeView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     title: 'Edit Home',
   }

--- a/source/views/home/edit/list.ios.js
+++ b/source/views/home/edit/list.ios.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {Dimensions, StyleSheet} from 'react-native'
 import {type ReduxState} from '../../../flux'
 import {saveHomescreenOrder} from '../../../flux/parts/homescreen'

--- a/source/views/home/edit/row.android.js
+++ b/source/views/home/edit/row.android.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {View, StyleSheet, Text} from 'react-native'
 import EntypoIcon from 'react-native-vector-icons/Entypo'
 import IonIcon from 'react-native-vector-icons/Ionicons'

--- a/source/views/home/edit/row.android.js
+++ b/source/views/home/edit/row.android.js
@@ -51,7 +51,7 @@ type Props = {
   onMoveDown: (string[], string) => any,
 }
 
-export class EditHomeRow extends React.PureComponent<void, Props, void> {
+export class EditHomeRow extends React.PureComponent<Props> {
   onMoveUp = () => {
     this.props.onMoveUp(this.props.order, this.props.item.view)
   }

--- a/source/views/home/edit/row.ios.js
+++ b/source/views/home/edit/row.ios.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {Animated, Easing, StyleSheet, Text} from 'react-native'
 
 import * as c from '../../components/colors'

--- a/source/views/home/edit/row.ios.js
+++ b/source/views/home/edit/row.ios.js
@@ -62,7 +62,7 @@ type State = {
   },
 }
 
-export class EditHomeRow extends React.Component<void, Props, State> {
+export class EditHomeRow extends React.Component<Props, State> {
   static startStyle = {
     shadowRadius: 2,
     transform: [{scale: 1}],

--- a/source/views/home/home.js
+++ b/source/views/home/home.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {ScrollView, StyleSheet, StatusBar} from 'react-native'
 
 import {connect} from 'react-redux'

--- a/source/views/menus/carleton-menus.js
+++ b/source/views/menus/carleton-menus.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {TabBarIcon} from '../components/tabbar-icon'
 import {View, Platform, ScrollView, StyleSheet} from 'react-native'
 import type {TopLevelViewPropsType} from '../types'

--- a/source/views/menus/carleton-menus.js
+++ b/source/views/menus/carleton-menus.js
@@ -65,9 +65,9 @@ CarletonSaylesMenuScreen.navigationOptions = {
   tabBarIcon: TabBarIcon('menu'),
 }
 
-export class CarletonCafeIndex extends React.Component {
-  props: TopLevelViewPropsType
+type Props = TopLevelViewPropsType
 
+export class CarletonCafeIndex extends React.Component<Props> {
   render() {
     const carletonCafes = [
       {id: 'CarletonBurtonMenuView', title: 'Burton'},

--- a/source/views/menus/components/dietary-tags.js
+++ b/source/views/menus/components/dietary-tags.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View, StyleSheet, Image} from 'react-native'
 
 import keys from 'lodash/keys'

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, SectionList} from 'react-native'
 import * as c from '../../components/colors'
 import {connect} from 'react-redux'

--- a/source/views/menus/components/fancy-menu.js
+++ b/source/views/menus/components/fancy-menu.js
@@ -61,7 +61,7 @@ const styles = StyleSheet.create({
 const LEFT_MARGIN = 28
 const Separator = () => <ListSeparator spacing={{left: LEFT_MARGIN}} />
 
-class FancyMenu extends React.PureComponent<any, Props, void> {
+class FancyMenu extends React.PureComponent<Props> {
   static defaultProps = {
     applyFilters: applyFiltersToItem,
   }

--- a/source/views/menus/components/filter-menu-toolbar.js
+++ b/source/views/menus/components/filter-menu-toolbar.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, View, Text, Platform} from 'react-native'
 import type momentT from 'moment'
 import type {FilterType} from '../../components/filter'

--- a/source/views/menus/components/food-item-row.js
+++ b/source/views/menus/components/food-item-row.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View, StyleSheet, Platform} from 'react-native'
 import {DietaryTags} from './dietary-tags'
 import {Row, Column} from '../../components/layout'

--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View, TextInput, StyleSheet} from 'react-native'
 import {TabBarIcon} from '../components/tabbar-icon'
 import * as c from '../components/colors'

--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -22,18 +22,20 @@ const styles = StyleSheet.create({
   },
 })
 
-export class BonAppPickerView extends React.Component {
+type Props = TopLevelViewPropsType
+
+type State = {
+  cafeId: string,
+  menu: ?any,
+}
+
+export class BonAppPickerView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     tabBarLabel: 'BonApp',
     tabBarIcon: TabBarIcon('ionic'),
   }
 
-  props: TopLevelViewPropsType
-
-  state: {
-    cafeId: string,
-    menu: ?any,
-  } = {
+  state = {
     cafeId: '34',
     menu: null,
   }

--- a/source/views/menus/index.js
+++ b/source/views/menus/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {TabNavigator} from '../components/tabbed-view'
 import {TabBarIcon} from '../components/tabbar-icon'
 

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -61,7 +61,7 @@ type State = {
   cafeMenu: ?MenuInfoType,
 }
 
-export class BonAppHostedMenu extends React.Component<void, Props, State> {
+export class BonAppHostedMenu extends React.PureComponent<Props, State> {
   state = {
     error: null,
     loading: true,
@@ -101,7 +101,7 @@ export class BonAppHostedMenu extends React.Component<void, Props, State> {
     this.setState(() => ({cafeMenu, cafeInfo, now: moment.tz(CENTRAL_TZ)}))
   }
 
-  refresh = async () => {
+  refresh = async (): any => {
     const start = Date.now()
     this.setState(() => ({refreshing: true}))
 

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import LoadingView from '../components/loading'
 import qs from 'querystring'
 import {NoticeView} from '../components/notice'

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -38,7 +38,7 @@ type State = {
   meals: ProcessedMealType[],
 }
 
-export class GitHubHostedMenu extends React.PureComponent<any, Props, State> {
+export class GitHubHostedMenu extends React.PureComponent<Props, State> {
   state = {
     error: null,
     loading: true,

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import LoadingView from '../components/loading'
 import {NoticeView} from '../components/notice'
 import {ConnectedFancyMenu as FancyMenu} from './components/fancy-menu'

--- a/source/views/news/index.js
+++ b/source/views/news/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {TabNavigator} from '../components/tabbed-view'
 import {TabBarIcon} from '../components/tabbar-icon'
 

--- a/source/views/news/news-container.js
+++ b/source/views/news/news-container.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import delay from 'delay'
 import type {StoryType} from './types'
 import LoadingView from '../components/loading'

--- a/source/views/news/news-container.js
+++ b/source/views/news/news-container.js
@@ -25,11 +25,7 @@ type State = {
   refreshing: boolean,
   error: ?Error,
 }
-export default class NewsContainer extends React.PureComponent<
-  any,
-  Props,
-  State,
-> {
+export default class NewsContainer extends React.PureComponent<Props, State> {
   state = {
     entries: [],
     loading: true,

--- a/source/views/news/news-item.js
+++ b/source/views/news/news-item.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {HtmlView} from '../components/html-view'
 import {Share} from 'react-native'
 import type {StoryType} from './types'

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -23,7 +23,7 @@ type Props = TopLevelViewPropsType & {
   thumbnail: number,
 }
 
-export class NewsList extends React.PureComponent<any, Props, void> {
+export class NewsList extends React.PureComponent<Props> {
   onPressNews = (story: StoryType) => {
     this.props.navigation.navigate('NewsItemView', {
       story,

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, FlatList} from 'react-native'
 import * as c from '../components/colors'
 import type {StoryType} from './types'

--- a/source/views/news/news-row.js
+++ b/source/views/news/news-row.js
@@ -12,7 +12,7 @@ type Props = {
   thumbnail: number,
 }
 
-export class NewsRow extends React.PureComponent<any, Props, void> {
+export class NewsRow extends React.PureComponent<Props> {
   _onPress = () => this.props.onPress(this.props.story)
 
   render() {

--- a/source/views/news/news-row.js
+++ b/source/views/news/news-row.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Image} from 'react-native'
 import {Column, Row} from '../components/layout'
 import {ListRow, Detail, Title} from '../components/list'

--- a/source/views/settings/components/login-button.js
+++ b/source/views/settings/components/login-button.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {ButtonCell} from '../../components/cells/button'
 
 export function LoginButton({

--- a/source/views/settings/credits.js
+++ b/source/views/settings/credits.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Text, ScrollView, Image, StyleSheet} from 'react-native'
 import {data as credits} from '../../../docs/credits.json'
 

--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, ScrollView, Platform} from 'react-native'
 import {TableView} from 'react-native-tableview-simple'
 import type {TopLevelViewPropsType} from '../types'

--- a/source/views/settings/legal.js
+++ b/source/views/settings/legal.js
@@ -4,7 +4,9 @@ import {ScrollView} from 'glamorous-native'
 import {Markdown} from '../components/markdown'
 import {text} from '../../../docs/legal.json'
 
-export default class LegalView extends React.PureComponent {
+type Props = {}
+
+export default class LegalView extends React.PureComponent<Props> {
   static navigationOptions = {
     title: 'Legal',
   }

--- a/source/views/settings/legal.js
+++ b/source/views/settings/legal.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {ScrollView} from 'glamorous-native'
 import {Markdown} from '../components/markdown'
 import {text} from '../../../docs/legal.json'

--- a/source/views/settings/privacy.js
+++ b/source/views/settings/privacy.js
@@ -4,7 +4,9 @@ import {ScrollView} from 'glamorous-native'
 import {Markdown} from '../components/markdown'
 import {text} from '../../../docs/privacy.json'
 
-export default class PrivacyView extends React.PureComponent {
+type Props = {}
+
+export default class PrivacyView extends React.PureComponent<Props> {
   static navigationOptions = {
     title: 'Privacy Policy',
   }

--- a/source/views/settings/privacy.js
+++ b/source/views/settings/privacy.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {ScrollView} from 'glamorous-native'
 import {Markdown} from '../components/markdown'
 import {text} from '../../../docs/privacy.json'

--- a/source/views/settings/sections/login-credentials.js
+++ b/source/views/settings/sections/login-credentials.js
@@ -35,7 +35,7 @@ type State = {
   password: string,
 }
 
-class CredentialsLoginSection extends React.PureComponent<any, Props, State> {
+class CredentialsLoginSection extends React.PureComponent<Props, State> {
   _usernameInput: any
   _passwordInput: any
 

--- a/source/views/settings/sections/login-credentials.js
+++ b/source/views/settings/sections/login-credentials.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {Cell, Section} from 'react-native-tableview-simple'
 import {CellTextField} from '../../components/cells/textfield'
 import {LoginButton} from '../components/login-button'

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {View} from 'react-native'
 import {Cell, Section} from 'react-native-tableview-simple'
 import {version} from '../../../../package.json'

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -10,12 +10,12 @@ import {CellToggle} from '../../components/cells/toggle'
 import {PushButtonCell} from '../../components/cells/push-button'
 import {trackedOpenUrl} from '../../components/open-url'
 
-class OddsAndEndsSection extends React.Component {
-  props: TopLevelViewPropsType & {
-    onChangeFeedbackToggle: (feedbackDisabled: boolean) => any,
-    feedbackDisabled: boolean,
-  }
+type Props = TopLevelViewPropsType & {
+  onChangeFeedbackToggle: (feedbackDisabled: boolean) => any,
+  feedbackDisabled: boolean,
+}
 
+class OddsAndEndsSection extends React.PureComponent<Props> {
   onPressButton = (id: string) => {
     this.props.navigation.navigate(id)
   }

--- a/source/views/settings/sections/support.js
+++ b/source/views/settings/sections/support.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Alert} from 'react-native'
 import {Section} from 'react-native-tableview-simple'
 import type {TopLevelViewPropsType} from '../../types'

--- a/source/views/settings/sections/support.js
+++ b/source/views/settings/sections/support.js
@@ -9,9 +9,9 @@ import {version} from '../../../../package.json'
 import {PushButtonCell} from '../../components/cells/push-button'
 import {refreshApp} from '../../../lib/refresh'
 
-export default class SupportSection extends React.Component {
-  props: TopLevelViewPropsType
+type Props = TopLevelViewPropsType
 
+export default class SupportSection extends React.PureComponent<Props> {
   onPressButton = (id: string) => {
     this.props.navigation.navigate(id)
   }

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {
   StyleSheet,
   ScrollView,

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -51,7 +51,7 @@ type State = {
   loading: boolean,
 }
 
-class BalancesView extends React.PureComponent<any, Props, State> {
+class BalancesView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     tabBarLabel: 'Balances',
     tabBarIcon: TabBarIcon('card'),

--- a/source/views/sis/student-work/detail.android.js
+++ b/source/views/sis/student-work/detail.android.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Text, View, ScrollView, StyleSheet} from 'react-native'
 import {email} from 'react-native-communications'
 import {Card} from '../../components/card'

--- a/source/views/sis/student-work/detail.android.js
+++ b/source/views/sis/student-work/detail.android.js
@@ -137,7 +137,7 @@ type Props = {
   navigation: {state: {params: {job: JobType}}},
 }
 
-export class JobDetailView extends React.PureComponent<any, Props, void> {
+export class JobDetailView extends React.PureComponent<Props> {
   static navigationOptions = ({navigation}) => {
     const {job} = navigation.state.params
     return {

--- a/source/views/sis/student-work/detail.ios.js
+++ b/source/views/sis/student-work/detail.ios.js
@@ -130,7 +130,7 @@ type Props = {
   navigation: {state: {params: {job: JobType}}},
 }
 
-export class JobDetailView extends React.PureComponent<any, Props, void> {
+export class JobDetailView extends React.PureComponent<Props> {
   static navigationOptions = ({navigation}) => {
     const {job} = navigation.state.params
     return {

--- a/source/views/sis/student-work/detail.ios.js
+++ b/source/views/sis/student-work/detail.ios.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Text, ScrollView, StyleSheet} from 'react-native'
 import {email} from 'react-native-communications'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Text, SectionList} from 'react-native'
 import {TabBarIcon} from '../../components/tabbar-icon'
 import type {TopLevelViewPropsType} from '../../types'

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -27,21 +27,23 @@ const styles = StyleSheet.create({
   },
 })
 
-export default class StudentWorkView extends React.PureComponent {
+type Props = TopLevelViewPropsType
+
+type State = {
+  jobs: Array<{title: string, data: Array<JobType>}>,
+  loading: boolean,
+  refreshing: boolean,
+  error: boolean,
+}
+
+export default class StudentWorkView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     headerBackTitle: 'Open Jobs',
     tabBarLabel: 'Open Jobs',
     tabBarIcon: TabBarIcon('briefcase'),
   }
 
-  props: TopLevelViewPropsType
-
-  state: {
-    jobs: Array<{title: string, data: Array<JobType>}>,
-    loading: boolean,
-    refreshing: boolean,
-    error: boolean,
-  } = {
+  state = {
     jobs: [],
     loading: true,
     refreshing: false,
@@ -86,7 +88,7 @@ export default class StudentWorkView extends React.PureComponent {
     }
   }
 
-  refresh = async () => {
+  refresh = async (): any => {
     const start = Date.now()
     this.setState(() => ({refreshing: true}))
 

--- a/source/views/sis/student-work/job-row.js
+++ b/source/views/sis/student-work/job-row.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {Column, Row} from '../../components/layout'
 import {ListRow, Detail, Title} from '../../components/list'
 import {fastGetTrimmedText} from '../../../lib/html'

--- a/source/views/sis/student-work/job-row.js
+++ b/source/views/sis/student-work/job-row.js
@@ -6,12 +6,12 @@ import {ListRow, Detail, Title} from '../../components/list'
 import {fastGetTrimmedText} from '../../../lib/html'
 import type {JobType} from './types'
 
-export class JobRow extends React.PureComponent {
-  props: {
-    onPress: JobType => any,
-    job: JobType,
-  }
+type Props = {
+  onPress: JobType => any,
+  job: JobType,
+}
 
+export class JobRow extends React.PureComponent<Props> {
   _onPress = () => this.props.onPress(this.props.job)
 
   render() {

--- a/source/views/sis/student-work/selectable.js
+++ b/source/views/sis/student-work/selectable.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Text, StyleSheet} from 'react-native'
 import {Cell} from 'react-native-tableview-simple'
 

--- a/source/views/streaming/movie.js
+++ b/source/views/streaming/movie.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, View, Text} from 'react-native'
 import {TabBarIcon} from '../components/tabbar-icon'
 

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -33,7 +33,7 @@ type State = {
   viewport: Viewport,
 }
 
-export default class KSTOView extends React.PureComponent<void, Props, State> {
+export default class KSTOView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     tabBarLabel: 'KSTO',
     tabBarIcon: TabBarIcon('radio'),
@@ -190,7 +190,7 @@ type HtmlAudioEvent =
   | {type: HtmlAudioState}
   | {type: 'error', error: HtmlAudioError}
 
-class StreamPlayer extends React.PureComponent<void, StreamPlayerProps, void> {
+class StreamPlayer extends React.PureComponent<StreamPlayerProps> {
   _webview: WebView
 
   componentWillReceiveProps(nextProps: StreamPlayerProps) {

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -54,7 +54,7 @@ export default class KSTOView extends React.PureComponent<Props, State> {
     Dimensions.removeEventListener('change', this.handleResizeEvent)
   }
 
-  handleResizeEvent = (event: {window: {width: number}}) => {
+  handleResizeEvent = (event: {window: {width: number, height: number}}) => {
     this.setState(() => ({viewport: event.window}))
   }
 

--- a/source/views/streaming/radio.js
+++ b/source/views/streaming/radio.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {
   Dimensions,
   Image,

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -26,18 +26,22 @@ const styles = StyleSheet.create({
   },
 })
 
-export class StreamListView extends React.PureComponent {
+type Props = {}
+
+type State = {
+  error: ?string,
+  loading: boolean,
+  refreshing: boolean,
+  streams: Array<{title: string, data: Array<StreamType>}>,
+}
+
+export class StreamListView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     tabBarLabel: 'Streaming',
     tabBarIcon: TabBarIcon('recording'),
   }
 
-  state: {
-    error: ?string,
-    loading: boolean,
-    refreshing: boolean,
-    streams: Array<{title: string, data: Array<StreamType>}>,
-  } = {
+  state = {
     error: null,
     loading: true,
     refreshing: false,
@@ -50,7 +54,7 @@ export class StreamListView extends React.PureComponent {
     })
   }
 
-  refresh = async () => {
+  refresh = async (): any => {
     let start = Date.now()
     this.setState(() => ({refreshing: true}))
 

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, SectionList} from 'react-native'
 
 import * as c from '../../components/colors'

--- a/source/views/streaming/streams/row.js
+++ b/source/views/streaming/streams/row.js
@@ -42,9 +42,9 @@ function Thumbnail({item}: {item: StreamType}) {
   ) : null
 }
 
-export class StreamRow extends React.PureComponent {
-  props: {stream: StreamType}
+type Props = {stream: StreamType}
 
+export class StreamRow extends React.PureComponent<Props> {
   onPressStream = () => {
     const {stream} = this.props
     trackedOpenUrl({url: stream.player, id: 'StreamingMedia_StreamView'})

--- a/source/views/streaming/streams/row.js
+++ b/source/views/streaming/streams/row.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, Image} from 'react-native'
 
 import {ListRow, Detail, Title} from '../../components/list'

--- a/source/views/streaming/webcams.js
+++ b/source/views/streaming/webcams.js
@@ -43,7 +43,7 @@ type State = {
   refreshing: boolean,
 }
 
-export class WebcamsView extends React.PureComponent<void, Props, State> {
+export class WebcamsView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     tabBarLabel: 'Webcams',
     tabBarIcon: TabBarIcon('videocam'),
@@ -125,7 +125,7 @@ type ThumbnailProps = {
   viewportWidth: number,
 }
 
-class StreamThumbnail extends React.PureComponent<void, ThumbnailProps, void> {
+class StreamThumbnail extends React.PureComponent<ThumbnailProps> {
   handlePress = () => {
     const {name, pageUrl} = this.props.webcam
     trackedOpenUrl({url: pageUrl, id: `${name}WebcamView`})

--- a/source/views/streaming/webcams.js
+++ b/source/views/streaming/webcams.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {
   StyleSheet,
   View,

--- a/source/views/student-orgs/detail.android.js
+++ b/source/views/student-orgs/detail.android.js
@@ -54,16 +54,16 @@ const styles = StyleSheet.create({
   },
 })
 
-export class StudentOrgsDetailView extends React.Component {
+type Props = TopLevelViewPropsType & {
+  navigation: {state: {params: {org: StudentOrgType}}},
+}
+
+export class StudentOrgsDetailView extends React.PureComponent<Props> {
   static navigationOptions = ({navigation}) => {
     const {org} = navigation.state.params
     return {
       title: org.name,
     }
-  }
-
-  props: TopLevelViewPropsType & {
-    navigation: {state: {params: {org: StudentOrgType}}},
   }
 
   // Using the Communications library because `mailTo` complains about

--- a/source/views/student-orgs/detail.android.js
+++ b/source/views/student-orgs/detail.android.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {ScrollView, Text, View, StyleSheet} from 'react-native'
 import moment from 'moment'
 import {Card} from '../components/card'

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {ScrollView, Text, View, StyleSheet, Linking} from 'react-native'
 import moment from 'moment'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -47,16 +47,16 @@ const styles = StyleSheet.create({
   },
 })
 
-export class StudentOrgsDetailView extends React.Component {
+type Props = TopLevelViewPropsType & {
+  navigation: {state: {params: {org: StudentOrgType}}},
+}
+
+export class StudentOrgsDetailView extends React.PureComponent<Props> {
   static navigationOptions = ({navigation}) => {
     const {org} = navigation.state.params
     return {
       title: org.name,
     }
-  }
-
-  props: TopLevelViewPropsType & {
-    navigation: {state: {params: {org: StudentOrgType}}},
   }
 
   render() {

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -76,7 +76,7 @@ type State = {
   loading: boolean,
 }
 
-export class StudentOrgsView extends React.PureComponent<any, Props, State> {
+export class StudentOrgsView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     title: 'Student Orgs',
     headerBackTitle: 'Orgs',

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet, View, Text, Platform, RefreshControl} from 'react-native'
 import {SearchableAlphabetListView} from '../components/searchable-alphabet-listview'
 import type {TopLevelViewPropsType} from '../types'

--- a/source/views/transportation/bus/components/bus-stop-row.js
+++ b/source/views/transportation/bus/components/bus-stop-row.js
@@ -45,7 +45,7 @@ type Props = {|
   +status: BusStateEnum,
 |}
 
-export class BusStopRow extends React.PureComponent<any, Props, void> {
+export class BusStopRow extends React.PureComponent<Props, void> {
   render() {
     const {
       barColor,

--- a/source/views/transportation/bus/components/progress-chunk.js
+++ b/source/views/transportation/bus/components/progress-chunk.js
@@ -55,7 +55,7 @@ type Props = {|
   +stopStatus: BusStopStatusEnum,
 |}
 
-export class ProgressChunk extends React.PureComponent<any, Props, void> {
+export class ProgressChunk extends React.PureComponent<Props, void> {
   render() {
     const {
       stopStatus,

--- a/source/views/transportation/bus/components/progress-chunk.js
+++ b/source/views/transportation/bus/components/progress-chunk.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import * as c from '../../../components/colors'
 import {View, StyleSheet, Platform} from 'react-native'
 import type {BusStopStatusEnum} from '../lib'

--- a/source/views/transportation/bus/components/times.js
+++ b/source/views/transportation/bus/components/times.js
@@ -11,7 +11,7 @@ type Props = {|
   +style?: any,
 |}
 
-export class ScheduleTimes extends React.PureComponent<any, Props, void> {
+export class ScheduleTimes extends React.PureComponent<Props, void> {
   render() {
     const {times} = this.props
 

--- a/source/views/transportation/bus/line.js
+++ b/source/views/transportation/bus/line.js
@@ -58,7 +58,7 @@ function startsIn(now, start: ?moment) {
   return `Starts ${nowCopy.seconds(0).to(start)}`
 }
 
-export class BusLine extends React.Component<any, Props, State> {
+export class BusLine extends React.Component<Props, State> {
   state = {
     subtitle: 'Loading',
     schedule: null,

--- a/source/views/transportation/bus/line.js
+++ b/source/views/transportation/bus/line.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {Text, StyleSheet, Platform, FlatList} from 'react-native'
 import type {BusTimetableEntry, UnprocessedBusLine, BusSchedule} from './types'
 import {

--- a/source/views/transportation/bus/map.js
+++ b/source/views/transportation/bus/map.js
@@ -38,7 +38,7 @@ type State = {|
   },
 |}
 
-export class BusMap extends React.PureComponent<any, Props, State> {
+export class BusMap extends React.PureComponent<Props, State> {
   static navigationOptions = (args: {
     navigation: {state: {params: {line: UnprocessedBusLine}}},
   }) => ({

--- a/source/views/transportation/bus/map.js
+++ b/source/views/transportation/bus/map.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import type {UnprocessedBusLine} from './types'
 import MapView from 'react-native-maps'

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import type {UnprocessedBusLine} from './types'
 import {BusLine} from './line'
 import moment from 'moment-timezone'

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -29,7 +29,7 @@ type State = {|
   now: moment,
 |}
 
-export class BusView extends React.PureComponent<any, Props, State> {
+export class BusView extends React.PureComponent<Props, State> {
   state = {
     busLines: defaultData.data,
     activeBusLine: null,

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -16,9 +16,9 @@ const TIMEZONE = 'America/Winnipeg'
 
 const GITHUB_URL = 'https://stodevx.github.io/AAO-React-Native/bus-times.json'
 
-type Props = TopLevelViewPropsType & {|
+type Props = TopLevelViewPropsType & {
   +line: string,
-|}
+}
 
 type State = {|
   busLines: Array<UnprocessedBusLine>,

--- a/source/views/transportation/index.js
+++ b/source/views/transportation/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 
 import {TabNavigator} from '../components/tabbed-view'
 import {TabBarIcon} from '../components/tabbar-icon'

--- a/source/views/transportation/other-modes/detail.js
+++ b/source/views/transportation/other-modes/detail.js
@@ -29,14 +29,14 @@ const styles = StyleSheet.create({
   },
 })
 
-export class OtherModesDetailView extends React.PureComponent {
+type Props = {navigation: {state: {params: {mode: OtherModeType}}}}
+
+export class OtherModesDetailView extends React.PureComponent<Props> {
   static navigationOptions = ({navigation}) => {
     return {
       title: navigation.state.params.mode.name,
     }
   }
-
-  props: {navigation: {state: {params: {mode: OtherModeType}}}}
 
   onPress = () => {
     const {name, url} = this.props.navigation.state.params.mode

--- a/source/views/transportation/other-modes/detail.js
+++ b/source/views/transportation/other-modes/detail.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import {Markdown} from '../../components/markdown'
 import {ListFooter} from '../../components/list'

--- a/source/views/transportation/other-modes/list.js
+++ b/source/views/transportation/other-modes/list.js
@@ -36,7 +36,7 @@ type State = {
   refreshing: boolean,
 }
 
-export class OtherModesView extends React.PureComponent<void, Props, State> {
+export class OtherModesView extends React.PureComponent<Props, State> {
   static navigationOptions = {
     tabBarLabel: 'Other Modes',
     tabBarIcon: TabBarIcon('boat'),
@@ -54,7 +54,7 @@ export class OtherModesView extends React.PureComponent<void, Props, State> {
     })
   }
 
-  refresh = async () => {
+  refresh = async (): any => {
     const start = Date.now()
     this.setState(() => ({refreshing: true}))
 

--- a/source/views/transportation/other-modes/list.js
+++ b/source/views/transportation/other-modes/list.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import delay from 'delay'
 import {OtherModesRow} from './row'
 import {reportNetworkProblem} from '../../../lib/report-network-problem'

--- a/source/views/transportation/other-modes/row.js
+++ b/source/views/transportation/other-modes/row.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import type {OtherModeType} from '../types'
 import {ListRow, Detail, Title} from '../../components/list'
 import {Column, Row} from '../../components/layout'

--- a/source/views/transportation/other-modes/row.js
+++ b/source/views/transportation/other-modes/row.js
@@ -5,12 +5,12 @@ import type {OtherModeType} from '../types'
 import {ListRow, Detail, Title} from '../../components/list'
 import {Column, Row} from '../../components/layout'
 
-export class OtherModesRow extends React.PureComponent {
-  props: {
-    onPress: OtherModeType => any,
-    mode: OtherModeType,
-  }
+type Props = {
+  onPress: OtherModeType => any,
+  mode: OtherModeType,
+}
 
+export class OtherModesRow extends React.PureComponent<Props> {
   _onPress = () => this.props.onPress(this.props.mode)
 
   render() {


### PR DESCRIPTION
It, er, ends? Begins? IDK.

---

Part of #1888.
Merges into #1890.

---

Just to start off, this might get a bit messy.

We're going to have a merge sequence.

1. **`component-changes` will merge into `dependency-updates`**
2. `dependency-updates` will merge into `flow-typed-updates`
3. `flow-typed-updates` will merge into `react-native-50`
4. `react-native-50` will merge into `master`

These PRs should be reviewed in that order, and once I have _two_ approvals for __all__ of them, I will merge them in the appropriate sequence.

If you wish to test any of these PRs, you must test `component-changes`. The others are effectively broken.

That lets us review diffs of ~+500,-400 instead of +5000,-3000 (*cough* flow-typed */cough*).

---

So! With that said, _this_ PR is the remaining fixes needed to make the app run / typecheck again.

Things to note: 

- `import React` → `import * as React`

    Imports the type definitions from React, as well as the JS exports. So, not strictly necessary, but if we get in the habit of writing it out we won't wonder why we can only sometimes do `React.Node`.

- A `NetInfo` event changed its name.

- f879e9c is the biggie – it's where I did the `… extends React.Component<DefaultProps, Props, State>` → `… extends React.Component<Props, State>` changeover.

- The remaining commits are fixing flow config problems, mocking `react-native-safari-view` in Jest, and fixing more flow problems.

---

You should probably be able to review this one commit at a time if you so wish.

---

I believe that there are still two known issues:

- [ ] There's a dark line at the bottom of our toolbar now
- [ ] "Error: the `<Image>` component cannot contain children. If you want to render content on top of the image, consider using absolute positioning." (https://github.com/facebook/react-native/commit/c55fae1e2697520a55d23a0816552bec09920142)