### PR TITLE
Don't ask for notifications permissions at app launch

### DIFF
--- a/ios/AllAboutOlaf/AppDelegate.m
+++ b/ios/AllAboutOlaf/AppDelegate.m
@@ -48,7 +48,8 @@
   rootView.loadingView = loadingViewController.view;
 
   self.oneSignal = [[RCTOneSignal alloc] initWithLaunchOptions:launchOptions
-                                                         appId:@"aa46a500-ab1c-4127-b9ff-e7373da3ce35"];
+                                                         appId:@"aa46a500-ab1c-4127-b9ff-e7373da3ce35"
+                                                      settings:@{kOSSettingsKeyAutoPrompt: @false}];
 
   // set up the requests cacher
   NSURLCache *URLCache = [[NSURLCache alloc] initWithMemoryCapacity:4 * 1024 * 1024   // 4 MiB

--- a/source/app.js
+++ b/source/app.js
@@ -41,6 +41,9 @@ export default class App extends React.Component<Props> {
     OneSignal.addEventListener('registered', this.onRegistered)
     OneSignal.addEventListener('ids', this.onIds)
 
+    // When we finally want to ask for push notifications, enable this:
+    // OneSignal.registerForPushNotifications()
+
     startStatusBarColorChanger()
   }
 


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/1874

---

Instead of requesting permissions at app launch, which (a) we never use and (b) doesn't give us any time to tell the user why they should let us bug them, I'm using Onesignal's ability to request permissions at a later date.

Note that I'm not currently actually requesting them, ever; given that we don't have anything hooked up to them, I see no point to asking for them at this time.