### PR TITLE
Handle getting HTML from BonApp when we expected JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "lodash": "4.17.4",
     "moment": "2.19.2",
     "moment-timezone": "0.5.14",
+    "p-retry": "1.0.0",
     "querystring": "0.2.0",
     "react": "16.0.0",
     "react-markdown": "2.5.1",

--- a/source/views/components/notice.js
+++ b/source/views/components/notice.js
@@ -22,28 +22,23 @@ const styles = StyleSheet.create({
   },
 })
 
-export function NoticeView({
-  text,
-  style,
-  spinner,
-  buttonText,
-  onPress,
-}: {
+type Props = {
   text?: string,
   style?: any,
   spinner?: boolean,
   buttonText?: string,
   onPress?: () => any,
-}) {
-  let activityIndicator = spinner ? (
-    <ActivityIndicator style={styles.spinner} />
-  ) : null
+}
+
+export function NoticeView({text, style, spinner, buttonText, onPress}: Props) {
   return (
     <View style={[styles.container, style]}>
-      {activityIndicator}
+      {spinner ? <ActivityIndicator style={styles.spinner} /> : null}
+
       <Text selectable={true} style={styles.text}>
         {text || 'Notice!'}
       </Text>
+
       {buttonText ? <Button onPress={onPress} title={buttonText} /> : null}
     </View>
   )

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -53,7 +53,7 @@ type Props = TopLevelViewPropsType & {
   name: string,
 }
 type State = {
-  error: ?Error,
+  errormsg: ?string,
   loading: boolean,
   refreshing: boolean,
   now: momentT,
@@ -63,7 +63,7 @@ type State = {
 
 export class BonAppHostedMenu extends React.PureComponent<Props, State> {
   state = {
-    error: null,
+    errormsg: null,
     loading: true,
     refreshing: false,
     now: moment.tz(CENTRAL_TZ),
@@ -95,7 +95,7 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
     } catch (error) {
       tracker.trackException(error.message)
       bugsnag.notify(error)
-      this.setState(() => ({error}))
+      this.setState(() => ({errormsg: error.message}))
     }
 
     this.setState(() => ({cafeMenu, cafeInfo, now: moment.tz(CENTRAL_TZ)}))
@@ -220,8 +220,8 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
       return <LoadingView text={sample(this.props.loadingMessage)} />
     }
 
-    if (this.state.error) {
-      return <NoticeView text={`Error: ${this.state.error.message}`} />
+    if (this.state.errormsg) {
+      return <NoticeView text={`Error: ${this.state.errormsg}`} />
     }
 
     if (!this.state.cafeMenu || !this.state.cafeInfo) {

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -233,12 +233,10 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
     }
 
     if (this.state.errormsg) {
-      let msg = ''
+      let msg = `Error: ${this.state.errormsg}`
       if (this.state.errormsg === BONAPP_HTML_ERROR_CODE) {
         msg =
           'Something between you and BonApp is having problems. Try again in a minute or two?'
-      } else {
-        msg = `Error: ${this.state.errormsg}`
       }
       return <NoticeView text={msg} />
     }

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -226,7 +226,7 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
 
     if (!this.state.cafeMenu || !this.state.cafeInfo) {
       const err = new Error(
-        `Something went wrong loading BonApp cafe ${this.props.cafeId}`,
+        `Something went wrong loading BonApp cafe #${this.props.cafeId}`,
       )
       tracker.trackException(err)
       bugsnag.notify(err)

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -86,6 +86,12 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
     }
   }
 
+  retry = () => {
+    this.fetchData(this.props).then(() => {
+      this.setState(() => ({loading: false, errormsg: ''}))
+    })
+  }
+
   requestMenu = (cafeId: string) => () =>
     fetchJsonQuery(bonappMenuBaseUrl, {cafe: cafeId})
   requestCafe = (cafeId: string) => () =>
@@ -238,7 +244,7 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
         msg =
           'Something between you and BonApp is having problems. Try again in a minute or two?'
       }
-      return <NoticeView text={msg} />
+      return <NoticeView text={msg} buttonText="Again!" onPress={this.retry} />
     }
 
     if (!this.state.cafeMenu || !this.state.cafeInfo) {

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -230,9 +230,9 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
       )
       tracker.trackException(err)
       bugsnag.notify(err)
-      return (
-        <NoticeView text="Something went wrong. Email odt@stolaf.edu to let them know?" />
-      )
+
+      const msg = 'Something went wrong. Email odt@stolaf.edu to let them know?'
+      return <NoticeView text={msg} />
     }
 
     const {cafeId, ignoreProvidedMenus = false} = this.props

--- a/yarn.lock
+++ b/yarn.lock
@@ -3919,6 +3919,12 @@ p-map@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
+p-retry@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-1.0.0.tgz#3927332a4b7d70269b535515117fc547da1a6968"
+  dependencies:
+    retry "^0.10.0"
+
 parse-diff@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/parse-diff/-/parse-diff-0.4.0.tgz#9ce35bcce8fc0b7c58f46d71113394fc0b4982dd"
@@ -4640,6 +4646,10 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
+
+retry@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
 
 rfc6902@^2.0.0:
   version "2.2.1"


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/1884 (or ameliorates it at least)

---

I made two main changes here:

1. I check to see if we're handling the "json parse error unexpected token <" error and special-case it if we are
2. I added [`p-retry`](https://www.npmjs.com/package/p-retry) to do exponential backoff and retry the menu fetch up to three times before giving up – given that we see this error right after network changes, I figure that giving it some more time to reconnect would probably fix this

I also don't report the error to bugsnag/google anymore. We could if we wanted to, I guess. I can't decide if I want to or not.

Screenshot of the new error screen:

<img width="320" alt="screen shot 2017-11-18 at 6 31 29 pm" src="https://user-images.githubusercontent.com/464441/32986087-d44f6500-cc8e-11e7-93fb-370c1e18093c.png">

Edit: I updated the screenshot