### PR TITLE
Support custom powered-by messages in the calendar

### DIFF
--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -5,7 +5,7 @@ import {EventList} from './event-list'
 import bugsnag from '../../bugsnag'
 import {tracker} from '../../analytics'
 import type {TopLevelViewPropsType} from '../types'
-import type {EventType, GoogleEventType} from './types'
+import type {EventType, GoogleEventType, PoweredBy} from './types'
 import moment from 'moment-timezone'
 import delay from 'delay'
 import LoadingView from '../components/loading'
@@ -13,7 +13,7 @@ import qs from 'querystring'
 import {GOOGLE_CALENDAR_API_KEY} from '../../lib/config'
 const TIMEZONE = 'America/Winnipeg'
 
-type Props = {calendarId: string} & TopLevelViewPropsType
+type Props = TopLevelViewPropsType & {calendarId: string, poweredBy: ?PoweredBy}
 
 type State = {
   events: EventType[],
@@ -120,6 +120,7 @@ export class GoogleCalendarView extends React.Component<Props, State> {
         onRefresh={this.refresh}
         now={this.state.now}
         message={this.state.error ? this.state.error.message : null}
+        poweredBy={this.props.poweredBy}
       />
     )
   }

--- a/source/views/calendar/event-detail.android.js
+++ b/source/views/calendar/event-detail.android.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
 import {Text, ScrollView, StyleSheet} from 'react-native'
-import type {CleanedEventType} from './types'
+import type {CleanedEventType, PoweredBy} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {ShareButton} from '../components/nav-buttons'
 import openUrl from '../components/open-url'
@@ -12,8 +12,6 @@ import {ButtonCell} from '../components/cells/button'
 import {addToCalendar, shareEvent} from './calendar-util'
 import delay from 'delay'
 import {ListFooter} from '../components/list'
-
-const STO_CALENDAR_URL = 'https://www.stolaf.edu/calendar'
 
 const styles = StyleSheet.create({
   name: {
@@ -92,7 +90,9 @@ const CalendarButton = ({message, disabled, onPress}) => {
 }
 
 type Props = TopLevelViewPropsType & {
-  navigation: {state: {params: {event: CleanedEventType}}},
+  navigation: {
+    state: {params: {event: CleanedEventType, poweredBy: ?PoweredBy}},
+  },
 }
 
 type State = {
@@ -142,7 +142,7 @@ export class EventDetail extends React.PureComponent<Props, State> {
   onPressButton = () => this.addEvent(this.props.navigation.state.params.event)
 
   render() {
-    const event = this.props.navigation.state.params.event
+    const {event, poweredBy} = this.props.navigation.state.params
 
     return (
       <ScrollView>
@@ -157,10 +157,9 @@ export class EventDetail extends React.PureComponent<Props, State> {
           disabled={this.state.disabled}
         />
 
-        <ListFooter
-          title="Powered by the St. Olaf Calendar"
-          href={STO_CALENDAR_URL}
-        />
+        {poweredBy.title ? (
+          <ListFooter title={poweredBy.title} href={poweredBy.href} />
+        ) : null}
       </ScrollView>
     )
   }

--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -2,7 +2,7 @@
 import * as React from 'react'
 import {Text, ScrollView, StyleSheet} from 'react-native'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
-import type {CleanedEventType} from './types'
+import type {CleanedEventType, PoweredBy} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {ShareButton} from '../components/nav-buttons'
 import openUrl from '../components/open-url'
@@ -17,8 +17,6 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
   },
 })
-
-const STO_CALENDAR_URL = 'https://www.stolaf.edu/calendar'
 
 function MaybeSection({header, content}: {header: string, content: string}) {
   return content.trim() ? (
@@ -64,7 +62,9 @@ const CalendarButton = ({message, disabled, onPress}) => {
 }
 
 type Props = TopLevelViewPropsType & {
-  navigation: {state: {params: {event: CleanedEventType}}},
+  navigation: {
+    state: {params: {event: CleanedEventType, poweredBy: ?PoweredBy}},
+  },
 }
 
 type State = {
@@ -114,7 +114,7 @@ export class EventDetail extends React.PureComponent<Props, State> {
   onPressButton = () => this.addEvent(this.props.navigation.state.params.event)
 
   render() {
-    const event = this.props.navigation.state.params.event
+    const {event, poweredBy} = this.props.navigation.state.params
 
     return (
       <ScrollView>
@@ -130,10 +130,9 @@ export class EventDetail extends React.PureComponent<Props, State> {
             disabled={this.state.disabled}
           />
 
-          <ListFooter
-            title="Powered by the St. Olaf Calendar"
-            href={STO_CALENDAR_URL}
-          />
+          {poweredBy.title ? (
+            <ListFooter title={poweredBy.title} href={poweredBy.href} />
+          ) : null}
         </TableView>
       </ScrollView>
     )

--- a/source/views/calendar/event-list.js
+++ b/source/views/calendar/event-list.js
@@ -5,7 +5,7 @@ import {StyleSheet, SectionList} from 'react-native'
 import * as c from '../components/colors'
 import toPairs from 'lodash/toPairs'
 import type {TopLevelViewPropsType} from '../types'
-import type {EventType} from './types'
+import type {EventType, PoweredBy} from './types'
 import groupBy from 'lodash/groupBy'
 import moment from 'moment-timezone'
 import {ListSeparator, ListSectionHeader} from '../components/list'
@@ -23,6 +23,7 @@ type Props = TopLevelViewPropsType & {
   refreshing: boolean,
   onRefresh: () => any,
   now: moment,
+  poweredBy: ?PoweredBy,
 }
 
 export class EventList extends React.PureComponent<Props> {
@@ -46,7 +47,10 @@ export class EventList extends React.PureComponent<Props> {
 
   onPressEvent = (event: EventType) => {
     event = cleanEvent(event)
-    this.props.navigation.navigate('EventDetailView', {event})
+    this.props.navigation.navigate('EventDetailView', {
+      event,
+      poweredBy: this.props.poweredBy,
+    })
   }
 
   renderSectionHeader = ({section: {title}}: any) => (

--- a/source/views/calendar/index.js
+++ b/source/views/calendar/index.js
@@ -15,6 +15,10 @@ export default TabNavigator(
         <GoogleCalendarView
           navigation={navigation}
           calendarId="5g91il39n0sv4c2bjdv1jrvcpq4ulm4r@import.calendar.google.com"
+          poweredBy={{
+            title: 'Powered by the St. Olaf calendar',
+            href: 'https://wp.stolaf.edu/calendar/',
+          }}
         />
       ),
       navigationOptions: {
@@ -28,6 +32,10 @@ export default TabNavigator(
         <GoogleCalendarView
           navigation={navigation}
           calendarId="stolaf.edu_fvulqo4larnslel75740vglvko@group.calendar.google.com"
+          poweredBy={{
+            title: 'Powered by the Oleville calendar',
+            href: 'https://oleville.com/events/',
+          }}
         />
       ),
       navigationOptions: {
@@ -41,6 +49,10 @@ export default TabNavigator(
         <GoogleCalendarView
           navigation={navigation}
           calendarId="thisisnorthfield@gmail.com"
+          poweredBy={{
+            title: 'Powered by VisitingNorthfield.com',
+            href: 'http://visitingnorthfield.com/events/calendar/',
+          }}
         />
       ),
       navigationOptions: {

--- a/source/views/calendar/types.js
+++ b/source/views/calendar/types.js
@@ -14,6 +14,11 @@ export type GoogleEventType = {
 
 type EmbeddedEventDetailType = {type: 'google', data: GoogleEventType}
 
+export type PoweredBy = {
+  title: string,
+  href: string,
+}
+
 export type EventType = {
   summary: string,
   location: string,


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/1774

This adds a `poweredBy` prop to the `GoogleCalendarView`, and properly sets it for all three existing calendars.

This will be useful for https://github.com/StoDevX/AAO-React-Native/pull/1772 as well.

St. Olaf | Oleville | Northfield
--- | --- | ---
<img width="320" alt="screen shot 2017-11-18 at 4 18 35 pm" src="https://user-images.githubusercontent.com/464441/32985259-936fb7d6-cc7c-11e7-9d0c-2b7e57a4abd9.png"> |  <img width="320" alt="screen shot 2017-11-18 at 4 18 30 pm" src="https://user-images.githubusercontent.com/464441/32985260-9387c222-cc7c-11e7-9d8a-94d3d93d712d.png"> | <img width="320" alt="screen shot 2017-11-18 at 4 18 41 pm" src="https://user-images.githubusercontent.com/464441/32985258-93540f0e-cc7c-11e7-87b7-914a8154caa9.png">