### PR TITLE
Message on open jobs error

### DIFF
--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -118,7 +118,7 @@ export default class StudentWorkView extends React.PureComponent<Props, State> {
 
   render() {
     if (this.state.error) {
-      return <Text selectable={true}>{this.state.error}</Text>
+      return <NoticeView text="Could not get open jobs." />
     }
 
     if (this.state.loading) {

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {StyleSheet, Text, SectionList} from 'react-native'
+import {StyleSheet, SectionList} from 'react-native'
 import {TabBarIcon} from '../../components/tabbar-icon'
 import type {TopLevelViewPropsType} from '../../types'
 import * as c from '../../components/colors'


### PR DESCRIPTION
Closes #1910 

The error was a boolean and never had a string value.

Before | After
--|--
<img width="447" alt="screen shot 2017-11-19 at 11 31 19 am" src="https://user-images.githubusercontent.com/5240843/32993988-ef372800-cd1d-11e7-8874-b2f6170bd731.png"> | <img width="447" alt="screen shot 2017-11-19 at 11 30 02 am" src="https://user-images.githubusercontent.com/5240843/32993987-ef1ec148-cd1d-11e7-8c38-4dc133670739.png">
