### PR TITLE
Webcam thumbnail highlight wrapper

### DIFF
--- a/source/views/streaming/webcams/thumbnail.js
+++ b/source/views/streaming/webcams/thumbnail.js
@@ -41,6 +41,7 @@ export class StreamThumbnail extends React.PureComponent<Props> {
         : transparentPixel
 
     return (
+      // do not remove this View; it is needed to prevent extra highlighting
       <View style={styles.cell}>
         <Touchable
           highlight={true}

--- a/source/views/streaming/webcams/thumbnail.js
+++ b/source/views/streaming/webcams/thumbnail.js
@@ -41,25 +41,30 @@ export class StreamThumbnail extends React.PureComponent<Props> {
         : transparentPixel
 
     return (
-      <Touchable
-        highlight={true}
-        underlayColor={baseColor}
-        activeOpacity={0.7}
-        onPress={this.handlePress}
-        style={[styles.cell, {width, height}]}
-      >
-        <Image
-          source={img}
-          style={[StyleSheet.absoluteFill, {width, height}]}
-          resizeMode="cover"
-        />
+      <View style={styles.cell}>
+        <Touchable
+          highlight={true}
+          underlayColor={baseColor}
+          activeOpacity={0.7}
+          onPress={this.handlePress}
+          style={{width, height}}
+        >
+          <Image
+            source={img}
+            style={[StyleSheet.absoluteFill, {width, height}]}
+            resizeMode="cover"
+          />
 
-        <View style={styles.titleWrapper}>
-          <LinearGradient colors={[startColor, baseColor]} locations={[0, 0.8]}>
-            <Text style={[styles.titleText, {color: textColor}]}>{name}</Text>
-          </LinearGradient>
-        </View>
-      </Touchable>
+          <View style={styles.titleWrapper}>
+            <LinearGradient
+              colors={[startColor, baseColor]}
+              locations={[0, 0.8]}
+            >
+              <Text style={[styles.titleText, {color: textColor}]}>{name}</Text>
+            </LinearGradient>
+          </View>
+        </Touchable>
+      </View>
     )
   }
 }


### PR DESCRIPTION
Closes #1905

Adds a `<View>` wrapper with the `cell` styling. Fixes the highlight to be just around the image container.