### PR TITLE
Update to react-native-restart v0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react-native-maps": "0.17.1",
     "react-native-network-info": "3.0.0",
     "react-native-onesignal": "3.0.6",
-    "react-native-restart": "0.0.4",
+    "react-native-restart": "0.0.6",
     "react-native-safari-view": "2.1.0",
     "react-native-tableview-simple": "0.17.1",
     "react-native-vector-icons": "4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4276,9 +4276,9 @@ react-native-onesignal@3.0.6:
   dependencies:
     invariant "^2.2.2"
 
-react-native-restart@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/react-native-restart/-/react-native-restart-0.0.4.tgz#e742c2f9833592214147bb39321d2cd5d172ad8c"
+react-native-restart@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/react-native-restart/-/react-native-restart-0.0.6.tgz#77770d078683947b2c1f2adb876f179269d8443a"
 
 react-native-safari-view@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
I think this (well, technically v0.0.5) fixes the Android-not-fully-refreshing-the-app bug.