### PR TITLE
Update react-navigation to v1.0.0-beta.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-native-safari-view": "2.1.0",
     "react-native-tableview-simple": "0.17.1",
     "react-native-vector-icons": "4.4.2",
-    "react-navigation": "1.0.0-beta.19",
+    "react-navigation": "1.0.0-beta.21",
     "react-redux": "5.0.6",
     "redux": "3.7.2",
     "redux-logger": "3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4380,9 +4380,9 @@ react-native@0.50.4:
     xmldoc "^0.4.0"
     yargs "^9.0.0"
 
-react-navigation@1.0.0-beta.19:
-  version "1.0.0-beta.19"
-  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.0.0-beta.19.tgz#96e159c4b6760f51fc92d5c1c3690790cff4dbcf"
+react-navigation@1.0.0-beta.21:
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.0.0-beta.21.tgz#086c504ba84c966ef8db898baef6fa14ff45a06f"
   dependencies:
     babel-plugin-transform-define "^1.3.0"
     clamp "^1.0.1"


### PR DESCRIPTION
yay

Needs testing, but I don't think it broke anything.