### PR TITLE
Synopsis field to transportation other modes

### DIFF
--- a/data/_schemas/transportation.yaml
+++ b/data/_schemas/transportation.yaml
@@ -1,9 +1,10 @@
 $schema: http://json-schema.org/draft-06/schema#
 
 additionalProperties: false
-required: [name, category, url, description]
+required: [name, category, url, synopsis, description]
 properties:
   name: {type: string}
   category: {type: string}
   url: {type: string, format: uri}
+  synopsis: {type: string}
   description: {type: string}

--- a/data/transportation/break-airport-shuttles.yaml
+++ b/data/transportation/break-airport-shuttles.yaml
@@ -1,6 +1,7 @@
 name: Break Airport Shuttles
 category: Bus
 url: https://northfield.betterez.com/cart/5787e3b01f39300a1a000085
+synopsis: Northfield Lines shuttle operates only immediately before and after break. You must buy tickets 48 hours in advance.
 description: >-
   Northfield Lines shuttle operates only immediately before and after break.
   You must buy tickets 48 hours in advance.

--- a/data/transportation/enterprise-car-share.yaml
+++ b/data/transportation/enterprise-car-share.yaml
@@ -1,5 +1,6 @@
 name: Enterprise CarShare
 category: Car
 url: https://www.enterprisecarshare.com/us/en/programs/university/st-olaf.html
+synopsis: Car sharing program for business, school, or personal use.
 description: >-
   Car sharing program for business, school, or personal use.

--- a/data/transportation/first-choice-shuttle.yaml
+++ b/data/transportation/first-choice-shuttle.yaml
@@ -1,6 +1,7 @@
 name: First Choice Shuttle
 category: Bus
 url: http://youarriveontime.com
+synopsis: Shuttle service to and from MSP airports, bus and train depots, local shuttle, medical appointments, casinos, and package delivery.
 description: >-
   Shuttle service to and from MSP airports, bus and train depots, local
   shuttle, medical appointments, casinos, and package delivery.

--- a/data/transportation/hiawathaland-transit.yaml
+++ b/data/transportation/hiawathaland-transit.yaml
@@ -1,6 +1,7 @@
 name: Hiawathaland Transit
 category: Bus
 url: https://wp.stolaf.edu/sa/transportation/localexpressbus/
+synopsis: Free route bus that stops at both colleges, Division Street, Target/Cub, and El Tequila/Culvers.
 description: >-
   Free route bus that stops at both colleges, Division Street, Target/Cub, and
   El Tequila/Culvers.

--- a/data/transportation/ole-bikes.yaml
+++ b/data/transportation/ole-bikes.yaml
@@ -1,5 +1,6 @@
 name: Ole Bikes
 category: Bike
 url: https://www.stolaf.edu/library/libinfo/bikes.cfm
+synopsis: Great green alternative, available for check-out through Rølvaag Library.
 description: >-
   Great green alternative, available for check-out through Rølvaag Library.

--- a/data/transportation/ride-board.yaml
+++ b/data/transportation/ride-board.yaml
@@ -1,5 +1,6 @@
 name: Ride Board
 category: Car
 url: https://www.stolaf.edu/apps/rideboard/index.cfm?fuseaction=browse
+synopsis: Post a ride or look for a ride with students.
 description: >-
   Post a ride or look for a ride with students.

--- a/data/transportation/van-go.yaml
+++ b/data/transportation/van-go.yaml
@@ -1,6 +1,7 @@
 name: Van-GO!
 category: Bus
 url: http://van-go.info/schedule/
+synopsis: Van-Go is not running over Thanksgiving Break. Van service that operates Monday - Friday from 7 a.m. to 6 p.m. Business use only.
 description: >
   **Van-Go is not running over Thanksgiving Break.** Van service that operates
   Monday - Friday from 7 a.m. to 6 p.m. Business use only.

--- a/source/views/transportation/other-modes/row.js
+++ b/source/views/transportation/other-modes/row.js
@@ -21,7 +21,7 @@ export class OtherModesRow extends React.PureComponent<Props> {
         <Row alignItems="center">
           <Column flex={1}>
             <Title lines={1}>{mode.name}</Title>
-            <Detail lines={1}>{mode.description}</Detail>
+            <Detail lines={1}>{mode.synopsis}</Detail>
           </Column>
         </Row>
       </ListRow>

--- a/source/views/transportation/types.js
+++ b/source/views/transportation/types.js
@@ -2,6 +2,7 @@
 export type OtherModeType = {
   name: string,
   description: string,
+  synopsis: string,
   url: string,
   category: string,
 }


### PR DESCRIPTION
Closes #1931

Fix for markdown appearing as plain text in the descriptions for Other Modes in the Transportation view. Notice that "Van-GO!" no longer renders with asterisks in the text.

Before | After
--|--
<img width="375" alt="before" src="https://user-images.githubusercontent.com/5240843/33245762-3ba1fcc8-d2c9-11e7-9fbd-ff46de351f5a.png"> | <img width="375" alt="after" src="https://user-images.githubusercontent.com/5240843/33245763-3bbc2526-d2c9-11e7-84b6-987d16e34514.png">