### PR TITLE
Integrate "npm run bundle-data" into the android build process

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -216,3 +216,14 @@ task copyDownloadableDepsToLibs(type: Copy) {
     from configurations.compile
     into 'libs'
 }
+
+// Bundles the app's data for the build process
+task bundleData(type: Exec) {
+    commandLine 'npm', 'run', 'bundle-data'
+}
+
+gradle.projectsEvaluated {
+    // hook bundleData into the android build process
+    bundleDebugJsAndAssets.dependsOn bundleData
+    bundleReleaseJsAndAssets.dependsOn bundleData
+}

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -2,9 +2,6 @@
 platform :android do
   desc 'Makes a build'
   lane :build do |options|
-    # make sure we have a copy of the data files
-    sh('npm run bundle-data')
-
     propagate_version(track: options[:track])
 
     gradle(task: 'assemble',


### PR DESCRIPTION
This mimics what iOS builds do already, where the normal `xcodebuild` calls `npm run bundle-data` so that there's no way to build the app without the data being bundled.

Closes https://github.com/StoDevX/AAO-React-Native/issues/1092