### PR TITLE
CodeClimate: Exclude tests in duplication engine

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,6 +6,8 @@ engines:
     enabled: true
   duplication:
     enabled: true
+    exclude_patterns:
+    - "__tests__/"
     config:
       languages:
       - ruby
@@ -34,6 +36,6 @@ ratings:
   - "**.py"
   - "**.rb"
 
-exclude_paths:
+exclude_patterns:
 - node_modules/
 - flow-typed/


### PR DESCRIPTION
Specifically: ignore any directory (at any level) that is called `__tests__`, but only in the duplication engine. (My thought was that eslint rules should still apply to tests.)

Also: switches from using `exclude_paths` to `exclude_patterns`.  The former is upconverted to the latter in the engine now, so I figure since we're tracking the latest that we might as well use the latter.

This should "fix" a bunch of CodeClimate issues.