### PR TITLE
Update flow to v0.57

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -65,4 +65,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 unsafe.enable_getters_and_setters=true
 
 [version]
-^0.56.0
+^0.57.0

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "eslint-plugin-flowtype": "2.39.1",
     "eslint-plugin-react": "7.5.1",
     "eslint-plugin-react-native": "3.2.0",
-    "flow-bin": "0.56.0",
+    "flow-bin": "0.57.3",
     "jest": "21.2.1",
     "js-yaml": "3.10.0",
     "junk": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2115,9 +2115,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.56.0:
-  version "0.56.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.56.0.tgz#ce43092203a344ba9bf63c0cabe95d95145f6cad"
+flow-bin@0.57.3:
+  version "0.57.3"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.3.tgz#843fb80a821b6d0c5847f7bb3f42365ffe53b27b"
 
 flux-standard-action@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
Doesn't present any new errors on my machine.

Release notes: https://github.com/facebook/flow/releases/tag/v0.57.1

Best change:

> Flow will now only check the files in node_modules/ which are direct or transitive dependencies of the non-node_modules code.