### PR TITLE
Remove badges from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# All About Olaf &middot; [![Build Status](https://travis-ci.org/StoDevX/AAO-React-Native.svg?branch=master)](https://travis-ci.org/StoDevX/AAO-React-Native) [![Coverage Status](https://coveralls.io/repos/github/StoDevX/AAO-React-Native/badge.svg)](https://coveralls.io/github/StoDevX/AAO-React-Native)
+# All About Olaf
 
 [![Get it on Google Play](images/get_google_play.svg)](https://play.google.com/store/apps/details?id=com.allaboutolaf)
 [![Download on the App Store](images/get_app_store.svg)](https://itunes.apple.com/us/app/all-about-olaf/id938588319)


### PR DESCRIPTION
I'll be frank: I don't like having the badges on the first line of the README. 

I also don't think that they gain us anything; I don't think that any of the primary maintainers use the badges to check on the app's status, and our code coverage % isn't really something to be proud of IMHO. 

I'd also make the argument that having the badges on the first line of the README makes it harder to read, both on GitHub's mobile view and (more importantly) in the plain-text Markdown file (which should always be nice to read IMHO.) I see the readme in those two forms much much more often than I see the desktop-sized README.

All that is to say, I don't think they bring us really any benefit, and I don't like them, so I'm proposing to remove both of the badges from the readme. 