### PR TITLE
Use eslint-plugin-react-native's `react-native/react-native` environment

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -20,6 +20,7 @@ env:
   es6: true
   node: true
   browser: true
+  react-native/react-native: true
 
 globals:
   fetch: true

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -18,6 +18,8 @@ extends:
 
 env:
   es6: true
+  # NOTE: `browser: true` is required for use of Headers in
+  # `source/globalize-fetch.js`; remove?
   browser: true
   react-native/react-native: true
 

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -18,13 +18,11 @@ extends:
 
 env:
   es6: true
-  # NOTE: `browser: true` is required for use of Headers in
-  # `source/globalize-fetch.js`; remove?
-  browser: true
   react-native/react-native: true
 
 globals:
   fetch: true
+  Headers: true
   FormData: true
   fetchJson: true
   rawFetch: true

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -18,7 +18,6 @@ extends:
 
 env:
   es6: true
-  node: true
   browser: true
   react-native/react-native: true
 


### PR DESCRIPTION
This removes the `node` and `browser` environments.  It also adds the `Headers` constant required to add our User-Agent string.