### PR TITLE
Added feedback for failed SIS login, simplified logged in display

### DIFF
--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -80,6 +80,21 @@ type LoginSuccessAction = {|
 |}
 type LoginFailureAction = {|type: 'settings/CREDENTIALS_LOGIN_FAILURE'|}
 type LogInActions = LoginStartAction | LoginSuccessAction | LoginFailureAction
+
+const showNetworkFailureMessage = () =>
+  Alert.alert(
+    'Network Failure',
+    'You are not connected to the internet. Please connect if you want to access this feature.',
+    [{text: 'OK'}],
+  )
+
+const showInvalidLoginMessage = () =>
+  Alert.alert(
+    'Invalid Login',
+    'The username and password you provided do not match a valid account. Please try again.',
+    [{text: 'OK'}],
+  )
+
 export function logInViaCredentials(
   username: string,
   password: string,
@@ -88,20 +103,6 @@ export function logInViaCredentials(
     dispatch({type: CREDENTIALS_LOGIN_START})
     const state = getState()
     const isConnected = state.app ? state.app.isConnected : false
-    function showNetworkFailureMessage() {
-      Alert.alert(
-        'Network Failure',
-        'You are not connected to the internet. Please connect if you want to access this feature.',
-        [{text: 'OK'}],
-      )
-    }
-    function showInvalidLoginMessage() {
-      Alert.alert(
-        'Invalid Login',
-        'The username and password you provided do not match a valid account. Please try again.',
-        [{text: 'OK'}],
-      )
-    }
     if (!isConnected) {
       dispatch({type: CREDENTIALS_LOGIN_FAILURE})
       showNetworkFailureMessage()

--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -17,7 +17,6 @@ import {type ReduxState} from '../index'
 import {type UpdateBalancesType} from './sis'
 import {updateBalances} from './sis'
 import {Alert} from 'react-native'
-import {updateOnlineStatus} from './app'
 
 export type LoginStateType = 'logged-out' | 'logged-in' | 'checking' | 'invalid'
 

--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -17,6 +17,7 @@ import {type ReduxState} from '../index'
 import {type UpdateBalancesType} from './sis'
 import {updateBalances} from './sis'
 import {Alert} from 'react-native'
+import {updateOnlineStatus} from './app'
 
 export type LoginStateType = 'logged-out' | 'logged-in' | 'checking' | 'invalid'
 
@@ -103,10 +104,6 @@ export function logInViaCredentials(
     dispatch({type: CREDENTIALS_LOGIN_START})
     const state = getState()
     const isConnected = state.app ? state.app.isConnected : false
-    if (!isConnected) {
-      dispatch({type: CREDENTIALS_LOGIN_FAILURE})
-      showNetworkFailureMessage()
-    }
     const result = await performLogin(username, password)
     if (result) {
       dispatch({type: CREDENTIALS_LOGIN_SUCCESS, payload: {username, password}})
@@ -114,7 +111,11 @@ export function logInViaCredentials(
       dispatch(updateBalances())
     } else {
       dispatch({type: CREDENTIALS_LOGIN_FAILURE})
-      showInvalidLoginMessage()
+      if (isConnected) {
+        showInvalidLoginMessage()
+      } else {
+        showNetworkFailureMessage()
+      }
     }
   }
 }

--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -88,6 +88,20 @@ export function logInViaCredentials(
     dispatch({type: CREDENTIALS_LOGIN_START})
     const state = getState()
     const isConnected = state.app ? state.app.isConnected : false
+    function showNetworkFailureMessage() {
+      Alert.alert(
+        'Network Failure',
+        'You are not connected to the internet. Please connect if you want to access this feature.',
+        [{text: 'OK'}],
+      )
+    }
+    function showInvalidLoginMessage() {
+      Alert.alert(
+        'Invalid Login',
+        'The username and password you provided do not match a valid account. Please try again.',
+        [{text: 'OK'}],
+      )
+    }
     if (!isConnected) {
       dispatch({type: CREDENTIALS_LOGIN_FAILURE})
       showNetworkFailureMessage()
@@ -102,22 +116,6 @@ export function logInViaCredentials(
       showInvalidLoginMessage()
     }
   }
-}
-
-function showNetworkFailureMessage() {
-  Alert.alert(
-    'Network Failure',
-    'You are not connected to the internet. Please connect if you want to access this feature.',
-    [{text: 'OK'}],
-  )
-}
-
-function showInvalidLoginMessage() {
-  Alert.alert(
-    'Invalid Login',
-    'The username and password you provided do not match a valid account. Please try again.',
-    [{text: 'OK'}],
-  )
 }
 
 type LogOutAction = {|type: 'settings/CREDENTIALS_LOGOUT'|}

--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -87,7 +87,8 @@ export function logInViaCredentials(
   return async (dispatch, getState) => {
     dispatch({type: CREDENTIALS_LOGIN_START})
     const state = getState()
-    if (!state.app.isConnected) {
+    const isConnected = state.app ? state.app.isConnected : false
+    if (!isConnected) {
       dispatch({type: CREDENTIALS_LOGIN_FAILURE})
       showNetworkFailureMessage()
     }

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -4,6 +4,7 @@ import * as Keychain from 'react-native-keychain'
 import * as storage from './storage'
 import buildFormData from './formdata'
 import {OLECARD_AUTH_URL} from './financials/urls'
+import {Alert} from 'react-native'
 
 const SIS_LOGIN_CREDENTIAL_KEY = 'stolaf.edu'
 
@@ -45,10 +46,16 @@ export async function performLogin(
   }
 
   const form = buildFormData({username, password})
+  let loginFailed = false
   const loginResult = await fetch(OLECARD_AUTH_URL, {
     method: 'POST',
     body: form,
+  }).catch(() => {
+    loginFailed = true
   })
+  if (loginFailed) {
+    return false
+  }
   const page = await loginResult.text()
 
   if (page.includes('Password')) {

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -4,7 +4,6 @@ import * as Keychain from 'react-native-keychain'
 import * as storage from './storage'
 import buildFormData from './formdata'
 import {OLECARD_AUTH_URL} from './financials/urls'
-import {Alert} from 'react-native'
 
 const SIS_LOGIN_CREDENTIAL_KEY = 'stolaf.edu'
 
@@ -46,16 +45,16 @@ export async function performLogin(
   }
 
   const form = buildFormData({username, password})
-  let loginFailed = false
-  const loginResult = await fetch(OLECARD_AUTH_URL, {
+  let loginResult = null
+  try {
+    loginResult = await fetch(OLECARD_AUTH_URL, {
     method: 'POST',
     body: form,
-  }).catch(() => {
-    loginFailed = true
-  })
-  if (loginFailed) {
+    })
+  } catch (err) {
     return false
   }
+  
   const page = await loginResult.text()
 
   if (page.includes('Password')) {

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -48,13 +48,13 @@ export async function performLogin(
   let loginResult = null
   try {
     loginResult = await fetch(OLECARD_AUTH_URL, {
-    method: 'POST',
-    body: form,
+      method: 'POST',
+      body: form,
     })
   } catch (err) {
     return false
   }
-  
+
   const page = await loginResult.text()
 
   if (page.includes('Password')) {

--- a/source/views/settings/sections/login-credentials.js
+++ b/source/views/settings/sections/login-credentials.js
@@ -14,6 +14,7 @@ import {
 import {type ReduxState} from '../../../flux'
 import {connect} from 'react-redux'
 import noop from 'lodash/noop'
+import {View} from 'react-native'
 
 type ReduxStateProps = {
   initialUsername: string,
@@ -68,41 +69,40 @@ class CredentialsLoginSection extends React.PureComponent<Props, State> {
     const loading = loginState === 'checking'
     const loggedIn = loginState === 'logged-in'
 
-    let message
-    if (loginState === 'invalid') {
-      message = 'Login failed'
-    }
-
     return (
       <Section
         footer="St. Olaf login enables the &quot;meals remaining&quot; feature."
         header="ST. OLAF LOGIN"
       >
-        <CellTextField
-          _ref={this.getUsernameRef}
-          disabled={loading}
-          label="Username"
-          onChangeText={this.onChangeUsername}
-          onSubmitEditing={this.focusPassword}
-          placeholder="username"
-          returnKeyType="next"
-          secureTextEntry={false}
-          value={username}
-        />
+        {loggedIn ? (
+          <Cell title={`Logged in as ${username}.`} />
+        ) : (
+          <View>
+            <CellTextField
+              _ref={this.getUsernameRef}
+              disabled={loading}
+              label="Username"
+              onChangeText={this.onChangeUsername}
+              onSubmitEditing={this.focusPassword}
+              placeholder="username"
+              returnKeyType="next"
+              secureTextEntry={false}
+              value={username}
+            />
 
-        <CellTextField
-          _ref={this.getPasswordRef}
-          disabled={loading}
-          label="Password"
-          onChangeText={this.onChangePassword}
-          onSubmitEditing={loggedIn ? noop : this.logIn}
-          placeholder="password"
-          returnKeyType="done"
-          secureTextEntry={true}
-          value={password}
-        />
-
-        {message ? <Cell title={`⚠️ ${message}`} /> : null}
+            <CellTextField
+              _ref={this.getPasswordRef}
+              disabled={loading}
+              label="Password"
+              onChangeText={this.onChangePassword}
+              onSubmitEditing={loggedIn ? noop : this.logIn}
+              placeholder="password"
+              returnKeyType="done"
+              secureTextEntry={true}
+              value={password}
+            />
+          </View>
+        )}
 
         <LoginButton
           disabled={loading || (!username || !password)}


### PR DESCRIPTION
I started this PR with the intention of resolving #1907...I realized halfway through that this was already resolved when I checked the live version on my phone, but it wasn't working on master so I stuck it out. I modified the failed login feedback to be an alert and added a similar alert if the user is not connected to the internet. I also simplified the display of the login-credentials section on the settings view so that the inputs disappear when the user is logged in. I think the showNetworkFailureMessage() can be moved to another module and imported, but I wasn't sure where to put it so I thought I'd ask. 