### PR TITLE
Fix Fastlane iOS betas

### DIFF
--- a/fastlane/lib/before_all.rb
+++ b/fastlane/lib/before_all.rb
@@ -4,10 +4,6 @@ before_all do
     setup_travis
   end
 
-  # too lazy to change the name in travis, so we jut copy it here
-  ENV['FL_HOCKEY_API_TOKEN'] = ENV['HOCKEYAPP_TOKEN']
-  ENV['FL_HOCKEY_COMMIT_SHA'] = ENV['TRAVIS_COMMIT']
-
   # set up global info for `gym`
   ENV['GYM_PROJECT'] = './ios/AllAboutOlaf.xcodeproj'
   ENV['GYM_SCHEME'] = 'AllAboutOlaf'

--- a/fastlane/lib/before_all.rb
+++ b/fastlane/lib/before_all.rb
@@ -10,6 +10,9 @@ before_all do
   ENV['GYM_OUTPUT_DIRECTORY'] = './ios/build'
   ENV['GYM_OUTPUT_NAME'] = 'AllAboutOlaf'
 
+  # set the testflight itunesconnect provider ID from Appfile
+  ENV['PILOT_ITC_PROVIDER'] = CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
+
   # set up global info for `gradle`
   ENV['FL_GRADLE_PROJECT_DIR'] = './android'
 


### PR DESCRIPTION
Travis says:

> Your Apple ID account is attached to other iTunes providers. You will need to specify which provider you intend to submit content to by using the -itc_provider command. Please contact us if you have questions or need help. (1627)

Docs say:

> Argument `itc_provider`
> 
> The provider short name to be used with the iTMSTransporter to identify your team. To get provider short name, run `pathToXcode.app/Contents/Applications/Application\ Loader.app/Contents/itms/bin/iTMSTransporter -m provider -u 'USERNAME' -p 'PASSWORD' -account_type itunes_connect -v off`. The short names of providers should be listed in the second column.
> 
> Available from the env var `PILOT_ITC_PROVIDER`

Command says:

```
Provider listing:
   - Long Name -        - Short Name -
1  <redacted>           <redacted>
2  <redacted>           <redacted>
3  Hawken Rives         TMK6S7TPX2
```

Appfile says that `TMK6S7TPX2` is our Team ID, as well, so I've decided to just set `PILOT_ITC_PROVIDER` by way of fetching the team ID out of the Appfile.

We'll have to see if this works by seeing if we get a beta tonight.