### PR TITLE
Remove console.log calls from the production app

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
   "babel": {
     "presets": [
       "react-native"
-    ]
+    ],
+    "env": {
+      "production": {
+        "plugins": ["transform-remove-console"]
+      }
+    }
   },
   "greenkeeper": {
     "ignore": [
@@ -103,6 +108,7 @@
     "babel-core": "6.26.0",
     "babel-eslint": "8.1.2",
     "babel-jest": "22.0.4",
+    "babel-plugin-transform-remove-console": "6.8.5",
     "babel-preset-react-native": "4.0.0",
     "bugsnag-sourcemaps": "1.0.1",
     "danger": "2.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,6 +799,10 @@ babel-plugin-transform-regenerator@^6.5.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
+babel-plugin-transform-remove-console@6.8.5:
+  version "6.8.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.8.5.tgz#fde9d2d3d725530b0fadd8d31078402410386810"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"


### PR DESCRIPTION
They're pointless, and apparently are actually still processed (maybe they show up in Console.app? I wonder.)

