### PR TITLE
Add building hour notice support

### DIFF
--- a/data/_schemas/building-hours.yaml
+++ b/data/_schemas/building-hours.yaml
@@ -8,6 +8,8 @@ properties:
   abbreviation: {type: string}
   category: {type: string}
   image: {type: string}
+  isNotice: {type: boolean}
+  noticeMessage: {type: string}
   schedule:
     type: array
     items: {$ref: '#/definitions/schedule'}

--- a/source/views/building-hours/row.js
+++ b/source/views/building-hours/row.js
@@ -154,17 +154,18 @@ export class BuildingRow extends React.Component<Props, State> {
         <View style={styles.detailWrapper}>
           {info.noticeMessage ? (
             <Detail style={styles.detailRow}>{info.noticeMessage}</Detail>
-          ) : (
-            hours.map(({isActive, label, status}, i) => (
-              <Detail key={i} style={styles.detailRow}>
-                <BuildingTimeSlot
-                  highlight={hours.length > 1 && isActive}
-                  label={label}
-                  status={status}
-                />
-              </Detail>
-            ))
-          )}
+          ) : null}
+          {!(info.noticeMessage && info.isNotice)
+            ? hours.map(({isActive, label, status}, i) => (
+                <Detail key={i} style={styles.detailRow}>
+                  <BuildingTimeSlot
+                    highlight={hours.length > 1 && isActive}
+                    label={label}
+                    status={status}
+                  />
+                </Detail>
+              ))
+            : null}
         </View>
       </ListRow>
     )

--- a/source/views/building-hours/row.js
+++ b/source/views/building-hours/row.js
@@ -141,24 +141,30 @@ export class BuildingRow extends React.Component<Props, State> {
             ) : null}
           </Title>
 
-          <Badge
-            accentColor={accentBg}
-            style={styles.accessoryBadge}
-            text={openStatus}
-            textColor={accentText}
-          />
+          {!info.isNotice ? (
+            <Badge
+              accentColor={accentBg}
+              style={styles.accessoryBadge}
+              text={openStatus}
+              textColor={accentText}
+            />
+          ) : null}
         </Row>
 
         <View style={styles.detailWrapper}>
-          {hours.map(({isActive, label, status}, i) => (
-            <Detail key={i} style={styles.detailRow}>
-              <BuildingTimeSlot
-                highlight={hours.length > 1 && isActive}
-                label={label}
-                status={status}
-              />
-            </Detail>
-          ))}
+          {info.noticeMessage ? (
+            <Detail style={styles.detailRow}>{info.noticeMessage}</Detail>
+          ) : (
+            hours.map(({isActive, label, status}, i) => (
+              <Detail key={i} style={styles.detailRow}>
+                <BuildingTimeSlot
+                  highlight={hours.length > 1 && isActive}
+                  label={label}
+                  status={status}
+                />
+              </Detail>
+            ))
+          )}
         </View>
       </ListRow>
     )

--- a/source/views/building-hours/types.js
+++ b/source/views/building-hours/types.js
@@ -41,6 +41,8 @@ export type BuildingType = {
   name: string,
   subtitle?: string,
   abbreviation?: string,
+  isNotice?: boolean,
+  noticeMessage?: string,
   image?: string,
   category: string,
   schedule: NamedBuildingScheduleType[],


### PR DESCRIPTION
Allows us to add "notice" entries to the hours screen.

<details><summary>screenshot</summary>
<img width="320" alt="screen shot 2018-01-05 at 10 00 23 am" src="https://user-images.githubusercontent.com/464441/34616929-45bb50d8-f1ff-11e7-8d6a-c0a55ce860ab.png">
</details>

This allows us to add "notices", like our now-traditional group-0 "Break Notice" notice, without having `[Closed]` show up several times on the notice.

It also allows us to add messages to individual buildings, as seen in the Pause in the screenshot above.

The `[Closed]` badge is now predicated on the `isNotice` key at the top level of a building. If the badge is not shown, the list of hours will also be hidden.

---

<details><summary>diff of the hours files</summary>

```diff
diff --git a/data/building-hours/1-1-cage.yaml b/data/building-hours/1-1-cage.yaml
index 53f84122..6a34a1b1 100644
--- a/data/building-hours/1-1-cage.yaml
+++ b/data/building-hours/1-1-cage.yaml
@@ -1,13 +1,10 @@
 name: The Cage
 image: cage
 category: Food
+isNotice: true
+noticeMessage: Closed for finals.
 
-schedule:
-  - title: Kitchen
-    notes: The kitchen stops cooking at 8 p.m.
-    hours:
-      - {days: [Mo, Tu, We, Th, Fr], from: '7:30am', to: '8:00pm'}
-      - {days: [Sa, Su], from: '9:00am', to: '8:00pm'}
+schedule: []
 
 breakSchedule:
   fall: []
diff --git a/data/building-hours/1-2-pause-kitchen.yaml b/data/building-hours/1-2-pause-kitchen.yaml
index 7c521ecf..56356f14 100644
--- a/data/building-hours/1-2-pause-kitchen.yaml
+++ b/data/building-hours/1-2-pause-kitchen.yaml
@@ -1,12 +1,9 @@
 name: The Pause Kitchen
 image: pause-kitchen
 category: Food
+noticeMessage: 'Closed for finals!'
 
-schedule:
-  - title: Finals
-    notes: The late night menu starts at 9 p.m.
-    hours:
-      - {days: [Mo], from: '10:30am', to: '6:00pm'}
+schedule: []
 
 breakSchedule:
   fall: []
```
</details>

Because we leave `schedule` as an empty array, old versions of the app will still process it and just show "Unknown hours" or a blank line, depending on the version.

Because we are only adding new keys, old versions of the app will ignore them.