### PR TITLE
Fix missing android ksto icons

### DIFF
--- a/source/views/streaming/radio/buttons.js
+++ b/source/views/streaming/radio/buttons.js
@@ -23,14 +23,14 @@ export const ActionButton = ({icon, text, onPress}: ActionButtonProps) => (
 
 export const CallButton = ({onPress}: {onPress: () => mixed}) => (
   <SmallActionButton
-    icon={Platform.OS === 'ios' ? 'ios-call' : 'android-call'}
+    icon={Platform.OS === 'ios' ? 'ios-call' : 'md-call'}
     onPress={onPress}
   />
 )
 
 export const ShowCalendarButton = ({onPress}: {onPress: () => mixed}) => (
   <SmallActionButton
-    icon={Platform.OS === 'ios' ? 'ios-calendar' : 'android-calendar'}
+    icon={Platform.OS === 'ios' ? 'ios-calendar' : 'md-calendar'}
     onPress={onPress}
   />
 )


### PR DESCRIPTION
I think the prefix we have to use for android's ionicons are `md` instead of `android`.

Before | After
--|--
<img width="441" alt="screen shot 2018-01-06 at 9 33 14 am" src="https://user-images.githubusercontent.com/5240843/34641757-254399a6-f2c6-11e7-9643-e520054f6554.png"> | <img width="441" alt="screen shot 2018-01-06 at 9 42 41 am" src="https://user-images.githubusercontent.com/5240843/34641758-2573d602-f2c6-11e7-8a8b-42c3a84ac4d9.png">
