### PR TITLE
Write the status out into the Button rather than a footer

### DIFF
--- a/source/views/help/wifi.js
+++ b/source/views/help/wifi.js
@@ -82,7 +82,7 @@ export class ReportWifiProblemView extends React.Component<Props, State> {
   render() {
     return (
       <View>
-        <Card footer={this.state.status}>
+        <Card>
           <Container>
             <Title selectable={true}>Report a Wi-Fi Problem</Title>
             <Description selectable={true}>
@@ -97,7 +97,7 @@ export class ReportWifiProblemView extends React.Component<Props, State> {
             <Button
               disabled={this.state.status !== ''}
               onPress={this.start}
-              title="Report"
+              title={this.state.status || 'Report'}
             />
           </Container>
         </Card>


### PR DESCRIPTION
Part of #2061.

This will be more familiar to most people, I think.  Since `status` is human-readable text, I don't see why we need to have a button that doesn't change and a footer below it.

| Before | During | After |
|---|---|---|
| <img width="271" alt="screen shot 2018-01-06 at 12 50 58 pm" src="https://user-images.githubusercontent.com/1566689/34642887-77a8eb00-f2e0-11e7-8e3c-42d7a2e7d1de.png"> | <img width="271" alt="screen shot 2018-01-06 at 12 51 02 pm" src="https://user-images.githubusercontent.com/1566689/34642890-7cb59738-f2e0-11e7-9582-9f48ffa62ff3.png"> | <img width="271" alt="screen shot 2018-01-06 at 12 52 27 pm" src="https://user-images.githubusercontent.com/1566689/34642893-8032617a-f2e0-11e7-88ac-a5111abf5c4e.png"> |

Thoughts?