### PR TITLE
Use Globals and Global Functions for Constant URLs

### DIFF
--- a/source/globals.js
+++ b/source/globals.js
@@ -4,4 +4,5 @@ export const GH_PAGES_URL = (relativePath: string) => {
   return `https://stodevx.github.io/AAO-React-Native/${relativePath}`
 }
 
-export const GH_NEW_ISSUE_URL = 'https://github.com/StoDevX/AAO-React-Native/issues/new'
+export const GH_NEW_ISSUE_URL =
+  'https://github.com/StoDevX/AAO-React-Native/issues/new'

--- a/source/globals.js
+++ b/source/globals.js
@@ -1,0 +1,5 @@
+// @flow
+
+export const GH_PAGES_URL = (relativePath: string) => {
+  return `https://stodevx.github.io/AAO-React-Native/${relativePath}`
+}

--- a/source/globals.js
+++ b/source/globals.js
@@ -3,3 +3,5 @@
 export const GH_PAGES_URL = (relativePath: string) => {
   return `https://stodevx.github.io/AAO-React-Native/${relativePath}`
 }
+
+export const GH_NEW_ISSUE_URL = 'https://github.com/StoDevX/AAO-React-Native/issues/new'

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -4,7 +4,7 @@ import jsYaml from 'js-yaml'
 import type {BuildingType} from '../types'
 import {email} from 'react-native-communications'
 import querystring from 'querystring'
-import {GH_NEW_ISSUE_URL} from '../../globals'
+import {GH_NEW_ISSUE_URL} from '../../../globals'
 
 export function submitReport(current: BuildingType, suggestion: BuildingType) {
   // calling trim() on these to remove the trailing newlines

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -4,6 +4,7 @@ import jsYaml from 'js-yaml'
 import type {BuildingType} from '../types'
 import {email} from 'react-native-communications'
 import querystring from 'querystring'
+import {GH_NEW_ISSUE_URL} from '../../globals'
 
 export function submitReport(current: BuildingType, suggestion: BuildingType) {
   // calling trim() on these to remove the trailing newlines
@@ -64,7 +65,7 @@ function makeIssueLink(before: string, after: string, title: string): string {
     title: `Building hours update for ${title}`,
     body: makeMarkdownBody(before, after),
   })
-  return `https://github.com/StoDevX/AAO-React-Native/issues/new?${q}`
+  return `${GH_NEW_ISSUE_URL}?${q}`
 }
 
 function stringifyBuilding(building: BuildingType): string {

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -13,7 +13,6 @@ import {reportNetworkProblem} from '../../lib/report-network-problem'
 import toPairs from 'lodash/toPairs'
 import groupBy from 'lodash/groupBy'
 import delay from 'delay'
-
 import {CENTRAL_TZ} from './lib'
 import {GH_PAGES_URL} from '../../globals'
 

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -15,8 +15,9 @@ import groupBy from 'lodash/groupBy'
 import delay from 'delay'
 
 import {CENTRAL_TZ} from './lib'
-const githubBaseUrl =
-  'https://stodevx.github.io/AAO-React-Native/building-hours.json'
+import {GH_PAGES_URL} from '../../globals'
+
+const githubBaseUrl = GH_PAGES_URL('building-hours.json')
 
 const groupBuildings = (buildings: BuildingType[], favorites: string[]) => {
   const favoritesGroup = {

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -16,7 +16,7 @@ import delay from 'delay'
 import {CENTRAL_TZ} from './lib'
 import {GH_PAGES_URL} from '../../globals'
 
-const githubBaseUrl = GH_PAGES_URL('building-hours.json')
+const buildingHoursUrl = GH_PAGES_URL('building-hours.json')
 
 const groupBuildings = (buildings: BuildingType[], favorites: string[]) => {
   const favoritesGroup = {
@@ -109,7 +109,7 @@ export class BuildingHoursView extends React.PureComponent<Props, State> {
   }
 
   fetchData = async () => {
-    let {data: buildings} = await fetchJson(githubBaseUrl).catch(err => {
+    let {data: buildings} = await fetchJson(buildingHoursUrl).catch(err => {
       reportNetworkProblem(err)
       return defaultData
     })

--- a/source/views/contacts/contact-detail.js
+++ b/source/views/contacts/contact-detail.js
@@ -10,8 +10,7 @@ import {tracker} from '../../analytics'
 import {Button} from '../components/button'
 import openUrl from '../components/open-url'
 import type {ContactType} from './types'
-
-const AAO_URL = 'https://github.com/StoDevX/AAO-React-Native/issues/new'
+import {GH_NEW_ISSUE_URL} from '../../globals'
 
 const Title = glamorous.text({
   fontSize: 36,
@@ -93,7 +92,7 @@ export class ContactsDetailView extends React.PureComponent<Props> {
           <Button onPress={this.onPress} title={contact.buttonText} />
 
           <ListFooter
-            href={AAO_URL}
+            href={GH_NEW_ISSUE_URL}
             title="Collected by the humans of All About Olaf"
           />
         </Container>

--- a/source/views/contacts/contact-list.js
+++ b/source/views/contacts/contact-list.js
@@ -15,7 +15,7 @@ import type {ContactType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {GH_PAGES_URL} from '../../globals'
 
-const GITHUB_URL = GH_PAGES_URL('contact-info.json')
+const contactInfoUrl = GH_PAGES_URL('contact-info.json')
 
 const groupContacts = (contacts: ContactType[]) => {
   const grouped = groupBy(contacts, c => c.category)
@@ -70,7 +70,7 @@ export class ContactsListView extends React.PureComponent<Props, State> {
   }
 
   fetchData = async () => {
-    let {data: contacts} = await fetchJson(GITHUB_URL).catch(err => {
+    let {data: contacts} = await fetchJson(contactInfoUrl).catch(err => {
       reportNetworkProblem(err)
       return defaultData
     })

--- a/source/views/contacts/contact-list.js
+++ b/source/views/contacts/contact-list.js
@@ -14,8 +14,9 @@ import * as c from '../components/colors'
 import type {ContactType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 
-const GITHUB_URL =
-  'https://stodevx.github.io/AAO-React-Native/contact-info.json'
+import {GH_PAGES_URL} from '../../globals'
+
+const GITHUB_URL = GH_PAGES_URL('contact-info.json')
 
 const groupContacts = (contacts: ContactType[]) => {
   const grouped = groupBy(contacts, c => c.category)

--- a/source/views/contacts/contact-list.js
+++ b/source/views/contacts/contact-list.js
@@ -13,7 +13,6 @@ import toPairs from 'lodash/toPairs'
 import * as c from '../components/colors'
 import type {ContactType} from './types'
 import type {TopLevelViewPropsType} from '../types'
-
 import {GH_PAGES_URL} from '../../globals'
 
 const GITHUB_URL = GH_PAGES_URL('contact-info.json')

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -5,10 +5,11 @@ import {Markdown} from '../components/markdown'
 import {ListFooter} from '../components/list'
 import glamorous from 'glamorous-native'
 import type {WordType} from './types'
+import {GH_NEW_ISSUE_URL} from '../../globals'
 
 // TODO: This doesn't point at the SA dictionary because they don't have an
 // overview page.
-const STO_SA_DICT_URL = 'https://github.com/StoDevX/AAO-React-Native/issues/new'
+const STO_SA_DICT_URL = GH_NEW_ISSUE_URL
 
 const Term = glamorous.text({
   fontSize: 36,

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -21,8 +21,9 @@ import uniq from 'lodash/uniq'
 import words from 'lodash/words'
 import deburr from 'lodash/deburr'
 import * as defaultData from '../../../docs/dictionary.json'
+import {GH_PAGES_URL} from '../../globals'
 
-const GITHUB_URL = 'https://stodevx.github.io/AAO-React-Native/dictionary.json'
+const GITHUB_URL = GH_PAGES_URL('dictionary.json')
 const ROW_HEIGHT = Platform.OS === 'ios' ? 76 : 89
 const SECTION_HEADER_HEIGHT = Platform.OS === 'ios' ? 33 : 41
 

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -24,6 +24,7 @@ import * as defaultData from '../../../docs/dictionary.json'
 import {GH_PAGES_URL} from '../../globals'
 
 const GITHUB_URL = GH_PAGES_URL('dictionary.json')
+
 const ROW_HEIGHT = Platform.OS === 'ios' ? 76 : 89
 const SECTION_HEADER_HEIGHT = Platform.OS === 'ios' ? 33 : 41
 

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -23,7 +23,7 @@ import deburr from 'lodash/deburr'
 import * as defaultData from '../../../docs/dictionary.json'
 import {GH_PAGES_URL} from '../../globals'
 
-const GITHUB_URL = GH_PAGES_URL('dictionary.json')
+const dictionaryUrl = GH_PAGES_URL('dictionary.json')
 
 const ROW_HEIGHT = Platform.OS === 'ios' ? 76 : 89
 const SECTION_HEADER_HEIGHT = Platform.OS === 'ios' ? 33 : 41
@@ -85,7 +85,7 @@ export class DictionaryView extends React.PureComponent<Props, State> {
   }
 
   fetchData = async () => {
-    let {data: allTerms} = await fetchJson(GITHUB_URL).catch(err => {
+    let {data: allTerms} = await fetchJson(dictionaryUrl).catch(err => {
       reportNetworkProblem(err)
       return defaultData
     })

--- a/source/views/faqs/index.js
+++ b/source/views/faqs/index.js
@@ -7,8 +7,9 @@ import {reportNetworkProblem} from '../../lib/report-network-problem'
 import LoadingView from '../components/loading'
 import * as defaultData from '../../../docs/faqs.json'
 import delay from 'delay'
+import {GH_PAGES_URL} from '../../globals'
 
-const faqsUrl = 'https://stodevx.github.io/AAO-React-Native/faqs.json'
+const faqsUrl = GH_PAGES_URL('faqs.json')
 
 type Props = {}
 

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -20,9 +20,9 @@ import {upgradeMenuItem, upgradeStation} from './lib/process-menu-shorthands'
 import {data as fallbackMenu} from '../../../docs/pause-menu.json'
 import {tracker} from '../../analytics'
 import bugsnag from '../../bugsnag'
-const CENTRAL_TZ = 'America/Winnipeg'
+import {GH_PAGES_URL} from '../../globals'
 
-const githubMenuBaseUrl = 'https://stodevx.github.io/AAO-React-Native'
+const CENTRAL_TZ = 'America/Winnipeg'
 
 type Props = TopLevelViewPropsType & {
   name: string,
@@ -59,7 +59,7 @@ export class GitHubHostedMenu extends React.PureComponent<Props, State> {
     let stationMenus: StationMenuType[] = []
     let corIcons: MasterCorIconMapType = {}
     try {
-      let container = await fetchJson(`${githubMenuBaseUrl}/pause-menu.json`)
+      let container = await fetchJson(GH_PAGES_URL('pause-menu.json'))
       let data = container.data
       foodItems = data.foodItems || []
       stationMenus = data.stationMenus || []

--- a/source/views/streaming/webcams/list.js
+++ b/source/views/streaming/webcams/list.js
@@ -10,8 +10,9 @@ import {Column} from '../../components/layout'
 import {partitionByIndex} from '../../../lib/partition-by-index'
 import type {Webcam} from './types'
 import {StreamThumbnail} from './thumbnail'
+import {GH_PAGES_URL} from '../../../globals'
 
-const GITHUB_URL = 'https://stodevx.github.io/AAO-React-Native/webcams.json'
+const GITHUB_URL = GH_PAGES_URL('webcams.json')
 
 type Props = {}
 

--- a/source/views/streaming/webcams/list.js
+++ b/source/views/streaming/webcams/list.js
@@ -12,7 +12,7 @@ import type {Webcam} from './types'
 import {StreamThumbnail} from './thumbnail'
 import {GH_PAGES_URL} from '../../../globals'
 
-const GITHUB_URL = GH_PAGES_URL('webcams.json')
+const webcamsUrl = GH_PAGES_URL('webcams.json')
 
 type Props = {}
 
@@ -67,7 +67,7 @@ export class WebcamsView extends React.PureComponent<Props, State> {
   fetchData = async () => {
     this.setState(() => ({loading: true}))
 
-    let {data: webcams} = await fetchJson(GITHUB_URL).catch(err => {
+    let {data: webcams} = await fetchJson(webcamsUrl).catch(err => {
       reportNetworkProblem(err)
       return defaultData
     })

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -9,7 +9,6 @@ import LoadingView from '../../components/loading'
 import type {TopLevelViewPropsType} from '../../types'
 import delay from 'delay'
 import {reportNetworkProblem} from '../../../lib/report-network-problem'
-
 import * as defaultData from '../../../../docs/bus-times.json'
 import {GH_PAGES_URL} from '../../../globals'
 

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -14,7 +14,7 @@ import {GH_PAGES_URL} from '../../../globals'
 
 const TIMEZONE = 'America/Winnipeg'
 
-const GITHUB_URL = GH_PAGES_URL('bus-times.json')
+const busTimesUrl = GH_PAGES_URL('bus-times.json')
 
 type Props = TopLevelViewPropsType & {
   +line: string,
@@ -55,7 +55,7 @@ export class BusView extends React.PureComponent<Props, State> {
   }
 
   fetchData = async () => {
-    let {data: busLines} = await fetchJson(GITHUB_URL).catch(err => {
+    let {data: busLines} = await fetchJson(busTimesUrl).catch(err => {
       reportNetworkProblem(err)
       return defaultData
     })

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -11,10 +11,11 @@ import delay from 'delay'
 import {reportNetworkProblem} from '../../../lib/report-network-problem'
 
 import * as defaultData from '../../../../docs/bus-times.json'
+import {GH_PAGES_URL} from '../../../globals'
 
 const TIMEZONE = 'America/Winnipeg'
 
-const GITHUB_URL = 'https://stodevx.github.io/AAO-React-Native/bus-times.json'
+const GITHUB_URL = GH_PAGES_URL('bus-times.json')
 
 type Props = TopLevelViewPropsType & {
   +line: string,

--- a/source/views/transportation/other-modes/detail.js
+++ b/source/views/transportation/other-modes/detail.js
@@ -8,8 +8,7 @@ import {tracker} from '../../../analytics'
 import {Button} from '../../components/button'
 import openUrl from '../../components/open-url'
 import type {OtherModeType} from '../types'
-
-const AAO_URL = 'https://github.com/StoDevX/AAO-React-Native/issues/new'
+import {GH_NEW_ISSUE_URL} from '../../../globals'
 
 const Title = glamorous.text({
   fontSize: 36,
@@ -60,7 +59,7 @@ export class OtherModesDetailView extends React.PureComponent<Props> {
         <Button onPress={this.onPress} title={'More Info'} />
 
         <ListFooter
-          href={AAO_URL}
+          href={GH_NEW_ISSUE_URL}
           title="Collected by the humans of All About Olaf"
         />
       </Container>

--- a/source/views/transportation/other-modes/list.js
+++ b/source/views/transportation/other-modes/list.js
@@ -13,9 +13,9 @@ import groupBy from 'lodash/groupBy'
 import toPairs from 'lodash/toPairs'
 import type {TopLevelViewPropsType} from '../../types'
 import type {OtherModeType} from '../types'
+import {GH_PAGES_URL} from '../../../globals'
 
-const GITHUB_URL =
-  'https://stodevx.github.io/AAO-React-Native/transportation.json'
+const GITHUB_URL = GH_PAGES_URL('transportation.json')
 
 const groupModes = (modes: OtherModeType[]) => {
   const grouped = groupBy(modes, m => m.category)

--- a/source/views/transportation/other-modes/list.js
+++ b/source/views/transportation/other-modes/list.js
@@ -15,7 +15,7 @@ import type {TopLevelViewPropsType} from '../../types'
 import type {OtherModeType} from '../types'
 import {GH_PAGES_URL} from '../../../globals'
 
-const GITHUB_URL = GH_PAGES_URL('transportation.json')
+const transportationUrl = GH_PAGES_URL('transportation.json')
 
 const groupModes = (modes: OtherModeType[]) => {
   const grouped = groupBy(modes, m => m.category)
@@ -70,7 +70,7 @@ export class OtherModesView extends React.PureComponent<Props, State> {
   }
 
   fetchData = async () => {
-    let {data: modes} = await fetchJson(GITHUB_URL).catch(err => {
+    let {data: modes} = await fetchJson(transportationUrl).catch(err => {
       reportNetworkProblem(err)
       return defaultData
     })


### PR DESCRIPTION
This would make it feasibly easier to, for instance, change the repository URL, and also reduces the copying.

I wrote a `GH_PAGES_URL` function which takes a filename, (without a preceding `/`, though that wouldn't break anything) and spits out a url that is prefixed with our GitHub Pages URL.  We can add higher levels of sophistication and error handling to make that more robust, if we want.

Open to suggestions, and potentially other ideas about stuff that can be centralized like this.