### PR TITLE
Force gradle to use root package.json

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -219,6 +219,7 @@ task copyDownloadableDepsToLibs(type: Copy) {
 
 // Bundles the app's data for the build process
 task bundleData(type: Exec) {
+    workingDir '../../'
     commandLine 'npm', 'run', 'bundle-data'
 }
 


### PR DESCRIPTION
I don't know what evidence it would have that it should do otherwise, but this PR explicitly tells it to do the right thing.  This was suggested by the other comments in the file.

I don't think this could cause breakage, but we'll see what CI says, now won't we. 😉