### PR TITLE
Only reset the app icon if it has been changed

### DIFF
--- a/source/lib/refresh.js
+++ b/source/lib/refresh.js
@@ -7,7 +7,7 @@ import * as icons from '@hawkrives/react-native-alternate-icons'
 export async function refreshApp() {
   await clearAsyncStorage()
   await clearLoginCredentials()
-  if (await icons.getIconName() !== 'default') {
+  if ((await icons.getIconName()) !== 'default') {
     await icons.reset()
   }
   restart.Restart()

--- a/source/lib/refresh.js
+++ b/source/lib/refresh.js
@@ -2,11 +2,13 @@
 import {clearAsyncStorage} from './storage'
 import restart from 'react-native-restart'
 import {clearLoginCredentials} from './login'
-import {reset as resetAppIcon} from '@hawkrives/react-native-alternate-icons'
+import * as icons from '@hawkrives/react-native-alternate-icons'
 
 export async function refreshApp() {
   await clearAsyncStorage()
   await clearLoginCredentials()
-  await resetAppIcon()
+  if (await icons.getIconName() !== 'default') {
+    await icons.reset()
+  }
   restart.Restart()
 }


### PR DESCRIPTION
iOS will show a notice any time you change the icon, even if you're changing it to what it's set to right now.

Let's avoid showing a dialog unless we need to.

(impetus provided by @drewvolz)