### PR TITLE
Pause interim hours

### DIFF
--- a/data/building-hours/1-2-pause-kitchen.yaml
+++ b/data/building-hours/1-2-pause-kitchen.yaml
@@ -3,10 +3,27 @@ image: pause-kitchen
 category: Food
 
 schedule:
-  - title: Finals
+  - title: Daylight
     notes: The late night menu starts at 9 p.m.
     hours:
-      - {days: [Mo], from: '10:30am', to: '6:00pm'}
+      # - {days: [Mo], from: '10:30am', to: '12:00am'}
+      # - {days: [Tu], from: '11:30am', to: '12:00am'}
+      # - {days: [We], from: '10:30am', to: '12:00am'}
+      # - {days: [Th], from: '11:30am', to: '12:00am'}
+      # - {days: [Fr], from: '10:30am', to: '9:00pm'}
+      # - {days: [Sa], from: '11:30am', to: '9:00pm'}
+      # - {days: [Su], from: '11:30am', to: '12:00am'}
+      - {days: [Mo], from: '10:45am', to: '11:00pm'}
+      - {days: [Tu], from: '11:30am', to: '12:00am'}
+      - {days: [We], from: '10:45am', to: '12:00am'}
+      - {days: [Th], from: '11:30am', to: '11:00pm'}
+      - {days: [Fr], from: '11:30am', to: '9:00pm'}
+      - {days: [Sa], from: '11:30am', to: '9:00pm'}
+      - {days: [Su], from: '11:30am', to: '11:00pm'}
+
+  - title: Late Night
+    hours:
+      - {days: [Fr, Sa], from: '9:00pm', to: '2:00am'}
 
 breakSchedule:
   fall: []


### PR DESCRIPTION
* Adds back daylight and late night hour schedules
* Contains the updated schedule for interim

Day | Hours
--|--
Monday | 10:45am - 11:00pm
Tuesday | 11:30am - Midnight
Wednesday | 10:45am - Midnight
Thursday | 11:30am - 11:00am
Friday | 11:30am - 2:00am
Saturday | 11:30am - 2:00am
Sunday | 11:30am - 11:00pm

[Image for reference](https://user-images.githubusercontent.com/5240843/34745355-75c133dc-f54d-11e7-80e3-e79ce1336b8d.jpg) provided by @hawkrives 