### PR TITLE
Prevent unneeded app icon change

### DIFF
--- a/source/views/settings/icon.js
+++ b/source/views/settings/icon.js
@@ -85,7 +85,11 @@ export class IconSettingsView extends React.PureComponent<Props, State> {
               cellStyle="RightDetail"
               disableImageResize={false}
               image={<Image source={icon.src} style={styles.icon} />}
-              onPress={() => this.setIcon(icon.type)}
+              onPress={() =>
+                this.state.iconType === icon.type
+                  ? null
+                  : this.setIcon(icon.type)
+              }
               title={icon.title}
             />
           ))}


### PR DESCRIPTION
Closes #2094 

This prevents the currently selected icon from calling if it is already the app's icon.