### PR TITLE
Refactor settings->choose icon to not prompt again when icon is already selected

### DIFF
--- a/source/views/settings/icon.js
+++ b/source/views/settings/icon.js
@@ -79,6 +79,7 @@ export class IconSettingsView extends React.PureComponent<Props, State> {
         <Section header="CHANGE YOUR APP ICON" separatorInsetLeft={58}>
           {icons.map(icon => (
             <IconCell
+              key={icon.type}
               icon={icon}
               isSelected={selectedIcon === icon.type}
               onPress={this.setIcon}

--- a/source/views/settings/icon.js
+++ b/source/views/settings/icon.js
@@ -77,13 +77,13 @@ export class IconSettingsView extends React.PureComponent<Props, State> {
     return (
       <ScrollView>
         <Section header="CHANGE YOUR APP ICON" separatorInsetLeft={58}>
-          {icons.map(icon =>
+          {icons.map(icon => (
             <IconCell
               icon={icon}
               isSelected={selectedIcon === icon.type}
               onPress={this.setIcon}
             />
-          )}
+          ))}
         </Section>
       </ScrollView>
     )

--- a/source/views/settings/icon.js
+++ b/source/views/settings/icon.js
@@ -73,24 +73,49 @@ export class IconSettingsView extends React.PureComponent<Props, State> {
   }
 
   render() {
+    const selectedIcon = this.state.iconType
     return (
       <ScrollView>
         <Section header="CHANGE YOUR APP ICON" separatorInsetLeft={58}>
-          {icons.map(icon => (
-            <Cell
-              key={icon.title}
-              accessory={
-                this.state.iconType === icon.type ? 'Checkmark' : undefined
-              }
-              cellStyle="RightDetail"
-              disableImageResize={false}
-              image={<Image source={icon.src} style={styles.icon} />}
-              onPress={() => this.setIcon(icon.type)}
-              title={icon.title}
+          {icons.map(icon =>
+            <IconCell
+              icon={icon}
+              isSelected={selectedIcon === icon.type}
+              onPress={this.setIcon}
             />
-          ))}
+          )}
         </Section>
       </ScrollView>
+    )
+  }
+}
+
+type IconCellProps = {|
+  +icon: Icon,
+  +isSelected: boolean,
+  +onPress: string => any,
+|}
+
+class IconCell extends React.Component<IconCellProps> {
+  setIcon = () => {
+    if (this.props.isSelected) {
+      return
+    }
+    this.props.onPress(this.props.icon.type)
+  }
+
+  render() {
+    const {isSelected, icon} = this.props
+    return (
+      <Cell
+        key={icon.title}
+        accessory={isSelected ? 'Checkmark' : undefined}
+        cellStyle="RightDetail"
+        disableImageResize={false}
+        image={<Image source={icon.src} style={styles.icon} />}
+        onPress={this.setIcon}
+        title={icon.title}
+      />
     )
   }
 }


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/2094

I pulled the Icon-picking table cells into their own component because… i wanted to, tbh.

I dislike defining functions at render time, because you get a new one every time you render. You can call it a premature optimization, but it's just kinda a habit. Also I like naming things.

Anyway, the meat of this change is in `IconCell#setIcon`, wherein we check if the icon you're picking is the selected icon.

@drewvolz, if you don't want to take this approach, we can do it another way.