### PR TITLE
Make Danger always run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,15 @@ version: 2
 
 x-config:
   - &restore-cache-yarn
-      keys:
-        - 'v2-dependencies-{{ checksum "yarn.lock" }}'
-        - 'v2-dependencies-'
+    keys:
+      - 'v2-dependencies-{{ checksum "yarn.lock" }}'
+      - 'v2-dependencies-'
   - &save-cache-yarn
-      paths: [~/.cache/yarn]
-      key: 'v2-dependencies-{{ checksum "yarn.lock" }}'
+    paths: [~/.cache/yarn]
+    key: 'v2-dependencies-{{ checksum "yarn.lock" }}'
+  - &run-danger
+    command: yarn run danger --id $task
+    when: always
 
 workflows:
   version: 2
@@ -29,7 +32,7 @@ jobs:
       - restore_cache: *restore-cache-yarn
       - run: yarn install
       - save_cache: *save-cache-yarn
-      - run: yarn run danger --id $task
+      - run: *run-danger
 
   flow:
     docker: [{image: 'circleci/node:8'}]
@@ -42,7 +45,7 @@ jobs:
       - run: mkdir -p logs/
       - run: yarn run bundle-data
       - run: yarn run --silent flow check --quiet | tee logs/flow
-      - run: yarn run danger --id $task
+      - run: *run-danger
 
   jest:
     docker: [{image: 'circleci/node:8'}]
@@ -55,7 +58,7 @@ jobs:
       - run: mkdir -p logs/
       - run: yarn run bundle-data
       - run: yarn run --silent test --coverage 2>&1 | tee logs/jest
-      - run: yarn run danger --id $task
+      - run: *run-danger
       - run: yarn global add coveralls
       - run:
           name: coveralls
@@ -82,7 +85,7 @@ jobs:
             if ! git diff --quiet *.js source/ scripts/; then
               git diff *.js source/ scripts/ | tee logs/prettier
             fi
-      - run: yarn run danger --id $task
+      - run: *run-danger
 
   eslint:
     docker: [{image: 'circleci/node:8'}]
@@ -95,7 +98,7 @@ jobs:
       - run: mkdir -p logs/
       - run: yarn run bundle-data
       - run: yarn run --silent lint | tee logs/eslint
-      - run: yarn run danger --id $task
+      - run: *run-danger
 
   data:
     docker: [{image: 'circleci/node:8'}]
@@ -108,4 +111,4 @@ jobs:
       - run: mkdir -p logs/
       - run: yarn run --silent validate-data --quiet | tee logs/validate-data
       - run: yarn run --silent validate-bus-data | tee logs/validate-bus-data
-      - run: yarn run danger --id $task
+      - run: *run-danger


### PR DESCRIPTION
CircleCI's [`run:` configuration](https://circleci.com/docs/2.0/configuration-reference/#run) allows you to control what certain jobs are run: `always`, `on_success` (the default), or `on_fail`.

I went with `on_success` figuring that I didn't want Danger to try and run if the `yarn install` failed, but I didn't count on the way that the other tasks exit with a non-zero exit code.

Now I'm figuring that even if Danger tries to run without `yarn` having finished properly, it'll just die too, and we'll know something went really wrong because there won't be a message from Danger.