### PR TITLE
Move native builds to Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,17 +20,17 @@ x-config:
     paths: [~/Library/Caches/Yarn]
   - &restore-cache-bundler
     keys:
-      - 'v1-ruby-dependencies-{{ checksum "Gemfile.lock" }}'
-      - 'v1-ruby-dependencies-'
+      - 'v2-ruby-dependencies-{{ checksum "Gemfile.lock" }}'
+      - 'v2-ruby-dependencies-'
   - &save-cache-bundler
-    key: 'v1-ruby-dependencies-{{ checksum "Gemfile.lock" }}'
+    key: 'v2-ruby-dependencies-{{ checksum "Gemfile.lock" }}'
     paths: [./vendor/bundle]
   - &restore-cache-bundler-macos
     keys:
-      - 'v1-ruby-dependencies-macos-{{ checksum "Gemfile.lock" }}'
-      - 'v1-ruby-dependencies-macos-'
+      - 'v2-ruby-dependencies-macos-{{ checksum "Gemfile.lock" }}'
+      - 'v2-ruby-dependencies-macos-'
   - &save-cache-bundler-macos
-    key: 'v1-ruby-dependencies-macos-{{ checksum "Gemfile.lock" }}'
+    key: 'v2-ruby-dependencies-macos-{{ checksum "Gemfile.lock" }}'
     paths: [./vendor/bundle]
   - &restore-cache-gradle
     keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,5 +161,5 @@ jobs:
       - run: bundle exec fastlane ios ci-run | tee ./logs/build
       - run:
           name: Analyze Fastlane Logfile
-          commane: python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true
+          command: python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true
       - run: *run-danger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,16 @@ x-config:
     paths:
       - ./vendor/bundle
     key: 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+  - &restore-cache-gradle
+    keys:
+      - 'v1-gradle-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}-{{ "android/react-native-version.txt" }}'
+      - 'v1-gradle-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}-'
+      - 'v1-gradle-{{ checksum "android/build.gradle" }}-'
+      - 'v1-gradle-'
+  - &save-cache-gradle
+      paths:
+        - ~/.gradle
+      key: gradle-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}-{{ "android/react-native-version.txt" }}
   - &set-ruby-version
     name: Set Ruby Version
     command:  echo "ruby-2.4.2" > ~/.ruby-version
@@ -157,6 +167,10 @@ jobs:
       - restore_cache: *restore-cache-bundler
       - run: bundle check || bundle install --path ./vendor/bundle
       - save_cache: *save-cache-bundler
+      - restore_cache: *restore-cache-gradle
+      - command: cd android && ./gradlew androidDependencies
+      - command: grep '["]react-native["]:' < package.json > ./android/react-native-version.txt
+      - save_cache: *save-cache-gradle
       - run: mkdir -p logs/
       - run: touch .env.js
       - run: bundle exec fastlane android ci-run | tee ./logs/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,14 +179,14 @@ jobs:
       - restore_cache: *restore-cache-bundler
       - run: bundle check || bundle install --path ./vendor/bundle
       - save_cache: *save-cache-bundler
-      - restore_cache: *restore-cache-gradle
-      - run:
-          command: cd android && ./gradlew androidDependencies
-          environment: {TERM: xterm-256color}
-      - save_cache: *save-cache-gradle
+      # - run:
+      #     command: cd android && ./gradlew androidDependencies
+      #     environment: {TERM: xterm-256color}
       - run: mkdir -p logs/
       - run: touch .env.js
+      - restore_cache: *restore-cache-gradle
       - run: bundle exec fastlane android ci-run | tee ./logs/build
+      - save_cache: *save-cache-gradle
       - run: *run-danger
 
   ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,10 @@ jobs:
       - run: mkdir -p logs/
       - run: yarn run bundle-data
       - run: yarn run --silent lint | tee logs/eslint
+      - run: yarn run --silent lint --format > logs/eslint-junit.xml
       - run: *run-danger
+      - store_test_results:
+          path: ./logs/eslint-junit.xml
 
   data:
     docker: [*docker-node-8]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ jobs:
     docker: [*docker-node-8]
     environment:
       task: JS-jest
+      JEST_JUNIT_OUTPUT: ./logs/jest-junit.xml
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
@@ -108,8 +109,10 @@ jobs:
       - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
       - run: yarn run bundle-data
-      - run: yarn run --silent test --coverage 2>&1 | tee logs/jest
+      - run: yarn run --silent test --coverage --testResultsProcessor="jest-junit" 2>&1 | tee logs/jest
       - run: *run-danger
+      - store_test_results:
+          path: ./logs/jest-junit.xml
       - run: yarn global add coveralls
       - run:
           name: coveralls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,14 +179,14 @@ jobs:
       - restore_cache: *restore-cache-bundler
       - run: bundle check || bundle install --path ./vendor/bundle
       - save_cache: *save-cache-bundler
-      # - run:
-      #     command: cd android && ./gradlew androidDependencies
-      #     environment: {TERM: xterm-256color}
+      - restore_cache: *restore-cache-gradle
+      - run:
+          command: cd android && ./gradlew androidDependencies
+          environment: {TERM: xterm-256color}
+      - save_cache: *save-cache-gradle
       - run: mkdir -p logs/
       - run: touch .env.js
-      - restore_cache: *restore-cache-gradle
       - run: bundle exec fastlane android ci-run | tee ./logs/build
-      - save_cache: *save-cache-gradle
       - run: *run-danger
 
   ios:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,16 @@ x-config:
     key: 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
     paths:
       - ~/.gradle
+  - &restore-cache-ios-third-party
+    keys:
+      - 'v1-ios-rn-third-party-{{ arch }}-{{ checksum "node_modules/react-native/package.json" }}'
+      - 'v1-ios-rn-third-party-{{ arch }}-'
+      - 'v1-ios-rn-third-party-'
+  - &save-cache-ios-third-party
+    key: 'v1-ios-rn-third-party-{{ arch }}-{{ checksum "node_modules/react-native/package.json" }}'
+    paths:
+      - ~/.rncache
+      - ./node_modules/react-native/third-party
   - &set-ruby-version
     name: Set Ruby Version
     command: echo "ruby-2.4.2" > ~/.ruby-version
@@ -198,7 +208,9 @@ jobs:
       - save_cache: *save-cache-bundler
       - run: mkdir -p logs/
       - run: touch .env.js
+      - restore_cache: *restore-cache-ios-third-party
       - run: bundle exec fastlane ios ci-run | tee ./logs/build
+      - save_cache: *restore-cache-ios-third-party
       - run:
           name: Analyze Fastlane Logfile
           command: python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,51 +6,41 @@ x-config:
     image: 'circleci/node:8'
   - &restore-cache-yarn
     keys:
-      - 'v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
-      - 'v2-dependencies-{{ arch }}-'
-      - 'v2-dependencies-'
+      - 'v2-yarn-dependencies-{{ checksum "yarn.lock" }}'
+      - 'v2-yarn-dependencies-'
   - &save-cache-yarn
-    key: 'v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
-    paths:
-      - ~/.cache/yarn
+    key: 'v2-yarn-dependencies-{{ checksum "yarn.lock" }}'
+    paths: [~/.cache/yarn]
   - &restore-cache-yarn-macos
     keys:
-      - 'v2-dependencies-macos-{{ arch }}-{{ checksum "yarn.lock" }}'
-      - 'v2-dependencies-macos-{{ arch }}-'
-      - 'v2-dependencies-macos-'
+      - 'v2-yarn-dependencies-macos-{{ checksum "yarn.lock" }}'
+      - 'v2-yarn-dependencies-macos-'
   - &save-cache-yarn-macos
-    key: 'v2-dependencies-macos-{{ arch }}-{{ checksum "yarn.lock" }}'
-    paths:
-      - ~/Library/Caches/Yarn
+    key: 'v2-yarn-dependencies-macos-{{ checksum "yarn.lock" }}'
+    paths: [~/Library/Caches/Yarn]
   - &restore-cache-bundler
     keys:
-      - 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
-      - 'v1-ruby-dependencies-{{ arch }}-'
+      - 'v1-ruby-dependencies-{{ checksum "Gemfile.lock" }}'
       - 'v1-ruby-dependencies-'
   - &save-cache-bundler
-    key: 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
-    paths:
-      - ./vendor/bundle
+    key: 'v1-ruby-dependencies-{{ checksum "Gemfile.lock" }}'
+    paths: [./vendor/bundle]
   - &restore-cache-bundler-macos
     keys:
-      - 'v1-ruby-dependencies-macos-{{ arch }}-{{ checksum "Gemfile.lock" }}'
-      - 'v1-ruby-dependencies-macos-{{ arch }}-'
+      - 'v1-ruby-dependencies-macos-{{ checksum "Gemfile.lock" }}'
       - 'v1-ruby-dependencies-macos-'
   - &save-cache-bundler-macos
-    key: 'v1-ruby-dependencies-macos-{{ arch }}-{{ checksum "Gemfile.lock" }}'
-    paths:
-      - ./vendor/bundle
+    key: 'v1-ruby-dependencies-macos-{{ checksum "Gemfile.lock" }}'
+    paths: [./vendor/bundle]
   - &restore-cache-gradle
     keys:
-      - 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
-      - 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-'
-      - 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-'
-      - 'v1-gradle-{{ arch }}-'
-      - 'v1-gradle-'
+      - 'v1-gradle-dependencies-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+      - 'v1-gradle-dependencies-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-'
+      - 'v1-gradle-dependencies-{{ checksum "android/build.gradle" }}-'
+      - 'v1-gradle-dependencies-'
   - &save-cache-gradle
-    key: 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
-    paths:
-      - ~/.gradle
+    key: 'v1-gradle-dependencies-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+    paths: [~/.gradle]
   - &set-ruby-version
     name: Set Ruby Version
     command: echo "ruby-2.4.2" > ~/.ruby-version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
       - run: mkdir -p logs/ test-results/
       - run: yarn run bundle-data
       - run: yarn run --silent lint | tee logs/eslint
-      - run: yarn run --silent lint --format > test-results/eslint.xml
+      - run: yarn run --silent lint --format junit > test-results/eslint.xml
       - run: *run-danger
       - store_test_results: {path: ./test-results}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
       - run: touch .env.js
       - restore_cache: *restore-cache-ios-third-party
       - run: bundle exec fastlane ios ci-run | tee ./logs/build
-      - save_cache: *restore-cache-ios-third-party
+      - save_cache: *save-cache-ios-third-party
       - run:
           name: Analyze Fastlane Logfile
           command: python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
       - restore_cache: *restore-cache-yarn
       - run: yarn install
       - save_cache: *save-cache-yarn
-      - run: mkdir -p logs/ test-results/
+      - run: mkdir -p logs/ test-results/jest/
       - run: yarn run bundle-data
       - run: yarn run --silent test --coverage --testResultsProcessor="jest-junit" 2>&1 | tee logs/jest
       - run: *run-danger
@@ -129,7 +129,7 @@ jobs:
       - restore_cache: *restore-cache-yarn
       - run: yarn install
       - save_cache: *save-cache-yarn
-      - run: mkdir -p logs/ test-results/
+      - run: mkdir -p logs/ test-results/eslint/
       - run: yarn run bundle-data
       - run: yarn run --silent lint | tee logs/eslint
       - run: yarn run --silent lint --format junit > test-results/eslint/junit.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,14 +23,15 @@ x-config:
       - ./vendor/bundle
   - &restore-cache-gradle
     keys:
-      - 'v1-gradle-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}-{{ "android/react-native-version.txt" }}'
-      - 'v1-gradle-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}-'
-      - 'v1-gradle-{{ checksum "android/build.gradle" }}-'
+      - 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+      - 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-'
+      - 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-'
+      - 'v1-gradle-{{ arch }}-'
       - 'v1-gradle-'
   - &save-cache-gradle
-      paths:
-        - ~/.gradle
-      key: gradle-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}-{{ "android/react-native-version.txt" }}
+    key: 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+    paths:
+      - ~/.gradle
   - &set-ruby-version
     name: Set Ruby Version
     command:  echo "ruby-2.4.2" > ~/.ruby-version
@@ -168,8 +169,9 @@ jobs:
       - run: bundle check || bundle install --path ./vendor/bundle
       - save_cache: *save-cache-bundler
       - restore_cache: *restore-cache-gradle
-      - run: cd android && ./gradlew androidDependencies
-      - run: grep '["]react-native["]:' < package.json > ./android/react-native-version.txt
+      - run:
+          command: cd android && ./gradlew androidDependencies
+          environment: {TERM: xterm-256color}
       - save_cache: *save-cache-gradle
       - run: mkdir -p logs/
       - run: touch .env.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run: *run-danger
 
   android:
-    docker: {image: circleci/android:api-27-node8-alpha}
+    docker: [{image: 'circleci/android:api-27-node8-alpha'}]
     environment: {task: ANDROID}
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
     docker: [*docker-node-8]
     environment:
       task: JS-jest
-      JEST_JUNIT_OUTPUT: ./test-results/jest.xml
+      JEST_JUNIT_OUTPUT: ./test-results/jest/junit.xml
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
@@ -131,7 +131,7 @@ jobs:
       - run: mkdir -p logs/ test-results/
       - run: yarn run bundle-data
       - run: yarn run --silent lint | tee logs/eslint
-      - run: yarn run --silent lint --format junit > test-results/eslint.xml
+      - run: yarn run --silent lint --format junit > test-results/eslint/junit.xml
       - run: *run-danger
       - store_test_results: {path: ./test-results}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,18 +9,18 @@ x-config:
       - 'v2-dependencies-{{ arch }}-'
       - 'v2-dependencies-'
   - &save-cache-yarn
+    key: 'v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
     paths:
       - ~/.cache/yarn
-    key: 'v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
   - &restore-cache-bundler
     keys:
       - 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
       - 'v1-ruby-dependencies-{{ arch }}-'
       - 'v1-ruby-dependencies-'
   - &save-cache-bundler
+    key: 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
     paths:
       - ./vendor/bundle
-    key: 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
   - &restore-cache-gradle
     keys:
       - 'v1-gradle-{{ checksum "android/build.gradle" }}-{{ checksum  "android/app/build.gradle" }}-{{ "android/react-native-version.txt" }}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,29 +2,29 @@
 version: 2
 
 x-config:
-  - &docker-node-8
-    image: 'circleci/node:8'
-  - &restore-cache-yarn
-    key: 'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
-  - &save-cache-yarn
-    key: 'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
-    paths: [~/.cache/yarn, ~/Library/Caches/Yarn]
-  - &restore-cache-bundler
-    key: 'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
-  - &save-cache-bundler
-    key: 'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
-    paths: [./vendor/bundle]
-  - &restore-cache-gradle
-    key: 'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
-  - &save-cache-gradle
-    key: 'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
-    paths: [~/.gradle]
-  - &set-ruby-version
-    name: Set Ruby Version
-    command: echo "ruby-2.4.2" > ~/.ruby-version
-  - &run-danger
-    command: yarn run danger --id $task
-    when: always
+  x-caching: # caching instructions
+    - &save-cache-yarn
+      key: 'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
+      paths: [~/.cache/yarn, ~/Library/Caches/Yarn]
+    - &restore-cache-yarn
+      key: 'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
+    - &save-cache-bundler
+      key: 'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+      paths: [./vendor/bundle]
+    - &restore-cache-bundler
+      key: 'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+    - &save-cache-gradle
+      key: 'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+      paths: [~/.gradle]
+    - &restore-cache-gradle
+      key: 'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+  x-commands: # command shorthands
+    - &set-ruby-version
+      name: Set Ruby Version
+      command: echo "ruby-2.4.2" > ~/.ruby-version
+    - &run-danger
+      command: yarn run danger --id $task
+      when: always
 
 workflows:
   version: 2
@@ -42,7 +42,7 @@ workflows:
 
 jobs:
   cache-yarn-linux:
-    docker: [*docker-node-8]
+    docker: [{image: 'circleci/node:8'}]
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
@@ -51,7 +51,7 @@ jobs:
       - save_cache: *save-cache-yarn
 
   danger:
-    docker: [*docker-node-8]
+    docker: [{image: 'circleci/node:8'}]
     environment:
       task: JS-general
     steps:
@@ -62,7 +62,7 @@ jobs:
       - run: *run-danger
 
   flow:
-    docker: [*docker-node-8]
+    docker: [{image: 'circleci/node:8'}]
     environment:
       task: JS-flow
     steps:
@@ -76,7 +76,7 @@ jobs:
       - run: *run-danger
 
   jest:
-    docker: [*docker-node-8]
+    docker: [{image: 'circleci/node:8'}]
     environment:
       task: JS-jest
       JEST_JUNIT_OUTPUT: ./test-results/jest/junit.xml
@@ -85,11 +85,12 @@ jobs:
       - restore_cache: *restore-cache-yarn
       - run: yarn install
       - save_cache: *save-cache-yarn
-      - run: mkdir -p logs/ test-results
+      - run: mkdir -p logs/ test-results/
       - run: yarn run bundle-data
       - run: yarn run --silent test --coverage --testResultsProcessor="jest-junit" 2>&1 | tee logs/jest
       - run: *run-danger
-      - store_test_results: {path: ./test-results}
+      - store_test_results:
+          path: ./test-results
       - run: yarn global add coveralls
       - run:
           name: coveralls
@@ -100,7 +101,7 @@ jobs:
             coveralls < ./coverage/lcov.info
 
   prettier:
-    docker: [*docker-node-8]
+    docker: [{image: 'circleci/node:8'}]
     environment:
       task: JS-prettier
     steps:
@@ -120,7 +121,7 @@ jobs:
       - run: *run-danger
 
   eslint:
-    docker: [*docker-node-8]
+    docker: [{image: 'circleci/node:8'}]
     environment:
       task: JS-lint
     steps:
@@ -133,10 +134,11 @@ jobs:
       - run: yarn run --silent lint | tee logs/eslint
       - run: yarn run --silent lint --format junit > test-results/eslint/junit.xml
       - run: *run-danger
-      - store_test_results: {path: ./test-results}
+      - store_test_results:
+          path: ./test-results
 
   data:
-    docker: [*docker-node-8]
+    docker: [{image: 'circleci/node:8'}]
     environment:
       task: JS-data
     steps:
@@ -167,6 +169,7 @@ jobs:
       - save_cache: *save-cache-bundler
       - restore_cache: *restore-cache-gradle
       - run:
+          name: Download Android dependencies
           command: cd android && ./gradlew androidDependencies
           environment: {TERM: xterm-256color}
       - save_cache: *save-cache-gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 
 x-config:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,18 +79,17 @@ jobs:
     docker: [*docker-node-8]
     environment:
       task: JS-jest
-      JEST_JUNIT_OUTPUT: ./logs/jest-junit.xml
+      JEST_JUNIT_OUTPUT: ./test-results/jest.xml
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install
       - save_cache: *save-cache-yarn
-      - run: mkdir -p logs/
+      - run: mkdir -p logs/ test-results
       - run: yarn run bundle-data
       - run: yarn run --silent test --coverage --testResultsProcessor="jest-junit" 2>&1 | tee logs/jest
       - run: *run-danger
-      - store_test_results:
-          path: ./logs/jest-junit.xml
+      - store_test_results: {path: ./test-results}
       - run: yarn global add coveralls
       - run:
           name: coveralls
@@ -129,13 +128,12 @@ jobs:
       - restore_cache: *restore-cache-yarn
       - run: yarn install
       - save_cache: *save-cache-yarn
-      - run: mkdir -p logs/
+      - run: mkdir -p logs/ test-results/
       - run: yarn run bundle-data
       - run: yarn run --silent lint | tee logs/eslint
-      - run: yarn run --silent lint --format > logs/eslint-junit.xml
+      - run: yarn run --silent lint --format > test-results/eslint.xml
       - run: *run-danger
-      - store_test_results:
-          path: ./logs/eslint-junit.xml
+      - store_test_results: {path: ./test-results}
 
   data:
     docker: [*docker-node-8]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,17 @@ x-config:
     image: 'circleci/node:8'
   - &restore-cache-yarn
     keys:
-      - 'v2-yarn-dependencies-{{ checksum "yarn.lock" }}'
-      - 'v2-yarn-dependencies-'
+      - 'v3-yarn-dependencies-{{ checksum "yarn.lock" }}'
+      - 'v3-yarn-dependencies-'
   - &save-cache-yarn
-    key: 'v2-yarn-dependencies-{{ checksum "yarn.lock" }}'
+    key: 'v3-yarn-dependencies-{{ checksum "yarn.lock" }}'
     paths: [~/.cache/yarn]
   - &restore-cache-yarn-macos
     keys:
-      - 'v2-yarn-dependencies-macos-{{ checksum "yarn.lock" }}'
-      - 'v2-yarn-dependencies-macos-'
+      - 'v3-yarn-dependencies-macos-{{ checksum "yarn.lock" }}'
+      - 'v3-yarn-dependencies-macos-'
   - &save-cache-yarn-macos
-    key: 'v2-yarn-dependencies-macos-{{ checksum "yarn.lock" }}'
+    key: 'v3-yarn-dependencies-macos-{{ checksum "yarn.lock" }}'
     paths: [~/Library/Caches/Yarn]
   - &restore-cache-bundler
     keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,8 @@ jobs:
 
   danger:
     docker: [*docker-node-8]
-    environment: {task: JS-general}
+    environment:
+      task: JS-general
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
@@ -84,7 +85,8 @@ jobs:
 
   flow:
     docker: [*docker-node-8]
-    environment: {task: JS-flow}
+    environment:
+      task: JS-flow
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
@@ -97,7 +99,8 @@ jobs:
 
   jest:
     docker: [*docker-node-8]
-    environment: {task: JS-jest}
+    environment:
+      task: JS-jest
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
@@ -118,7 +121,8 @@ jobs:
 
   prettier:
     docker: [*docker-node-8]
-    environment: {task: JS-prettier}
+    environment:
+      task: JS-prettier
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
@@ -137,7 +141,8 @@ jobs:
 
   eslint:
     docker: [*docker-node-8]
-    environment: {task: JS-lint}
+    environment:
+      task: JS-lint
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
@@ -150,7 +155,8 @@ jobs:
 
   data:
     docker: [*docker-node-8]
-    environment: {task: JS-data}
+    environment:
+      task: JS-data
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,15 @@ x-config:
     key: 'v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
     paths:
       - ~/.cache/yarn
+  - &restore-cache-yarn-macos
+    keys:
+      - 'v2-dependencies-macos-{{ arch }}-{{ checksum "yarn.lock" }}'
+      - 'v2-dependencies-macos-{{ arch }}-'
+      - 'v2-dependencies-macos-'
+  - &save-cache-yarn-macos
+    key: 'v2-dependencies-macos-{{ arch }}-{{ checksum "yarn.lock" }}'
+    paths:
+      - ~/Library/Caches/Yarn
   - &restore-cache-bundler
     keys:
       - 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
@@ -200,9 +209,9 @@ jobs:
       - checkout
       - run: yarn --version
       - run: *set-ruby-version
-      - restore_cache: *restore-cache-yarn
+      - restore_cache: *restore-cache-yarn-macos
       - run: yarn install
-      - save_cache: *save-cache-yarn
+      - save_cache: *save-cache-yarn-macos
       - restore_cache: *restore-cache-bundler
       - run: bundle check || bundle install --path ./vendor/bundle
       - save_cache: *save-cache-bundler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ x-config:
       - ~/.gradle
   - &set-ruby-version
     name: Set Ruby Version
-    command:  echo "ruby-2.4.2" > ~/.ruby-version
+    command: echo "ruby-2.4.2" > ~/.ruby-version
   - &run-danger
     command: yarn run danger --id $task
     when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,8 +168,8 @@ jobs:
       - run: bundle check || bundle install --path ./vendor/bundle
       - save_cache: *save-cache-bundler
       - restore_cache: *restore-cache-gradle
-      - command: cd android && ./gradlew androidDependencies
-      - command: grep '["]react-native["]:' < package.json > ./android/react-native-version.txt
+      - run: cd android && ./gradlew androidDependencies
+      - run: grep '["]react-native["]:' < package.json > ./android/react-native-version.txt
       - save_cache: *save-cache-gradle
       - run: mkdir -p logs/
       - run: touch .env.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install
+      - run: yarn --version
       - save_cache: *save-cache-yarn
 
   danger:
@@ -148,6 +149,7 @@ jobs:
       FASTLANE_DISABLE_ANIMATION: '1'
     steps:
       - checkout
+      - run: yarn --version
       - run: *set-ruby-version
       - restore_cache: *restore-cache-yarn
       - run: yarn install
@@ -169,6 +171,7 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - run: yarn --version
       - run: *set-ruby-version
       - restore_cache: *restore-cache-yarn
       - run: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ jobs:
       - run: *run-danger
 
   ios:
-    macos: {xcode: '9.2'}
+    macos: {xcode: '9.0'}
     environment:
       task: IOS
       FASTLANE_SKIP_UPDATE_CHECK: '1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,8 @@ jobs:
       task: IOS
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_ANIMATION: '1'
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,41 +5,19 @@ x-config:
   - &docker-node-8
     image: 'circleci/node:8'
   - &restore-cache-yarn
-    keys:
-      - 'v3-yarn-dependencies-{{ checksum "yarn.lock" }}'
-      - 'v3-yarn-dependencies-'
+    key: 'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
   - &save-cache-yarn
-    key: 'v3-yarn-dependencies-{{ checksum "yarn.lock" }}'
-    paths: [~/.cache/yarn]
-  - &restore-cache-yarn-macos
-    keys:
-      - 'v3-yarn-dependencies-macos-{{ checksum "yarn.lock" }}'
-      - 'v3-yarn-dependencies-macos-'
-  - &save-cache-yarn-macos
-    key: 'v3-yarn-dependencies-macos-{{ checksum "yarn.lock" }}'
-    paths: [~/Library/Caches/Yarn]
+    key: 'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
+    paths: [~/.cache/yarn, ~/Library/Caches/Yarn]
   - &restore-cache-bundler
-    keys:
-      - 'v2-ruby-dependencies-{{ checksum "Gemfile.lock" }}'
-      - 'v2-ruby-dependencies-'
+    key: 'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
   - &save-cache-bundler
-    key: 'v2-ruby-dependencies-{{ checksum "Gemfile.lock" }}'
-    paths: [./vendor/bundle]
-  - &restore-cache-bundler-macos
-    keys:
-      - 'v2-ruby-dependencies-macos-{{ checksum "Gemfile.lock" }}'
-      - 'v2-ruby-dependencies-macos-'
-  - &save-cache-bundler-macos
-    key: 'v2-ruby-dependencies-macos-{{ checksum "Gemfile.lock" }}'
+    key: 'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
     paths: [./vendor/bundle]
   - &restore-cache-gradle
-    keys:
-      - 'v1-gradle-dependencies-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
-      - 'v1-gradle-dependencies-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-'
-      - 'v1-gradle-dependencies-{{ checksum "android/build.gradle" }}-'
-      - 'v1-gradle-dependencies-'
+    key: 'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
   - &save-cache-gradle
-    key: 'v1-gradle-dependencies-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+    key: 'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
     paths: [~/.gradle]
   - &set-ruby-version
     name: Set Ruby Version
@@ -212,12 +190,12 @@ jobs:
       - checkout
       - run: yarn --version
       - run: *set-ruby-version
-      - restore_cache: *restore-cache-yarn-macos
+      - restore_cache: *restore-cache-yarn
       - run: yarn install
-      - save_cache: *save-cache-yarn-macos
-      - restore_cache: *restore-cache-bundler-macos
+      - save_cache: *save-cache-yarn
+      - restore_cache: *restore-cache-bundler
       - run: bundle check || bundle install --path ./vendor/bundle
-      - save_cache: *save-cache-bundler-macos
+      - save_cache: *save-cache-bundler
       - run: mkdir -p logs/
       - run: touch .env.js
       - run: bundle exec fastlane ios ci-run | tee ./logs/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,15 @@ x-config:
     key: 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
     paths:
       - ./vendor/bundle
+  - &restore-cache-bundler-macos
+    keys:
+      - 'v1-ruby-dependencies-macos-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+      - 'v1-ruby-dependencies-macos-{{ arch }}-'
+      - 'v1-ruby-dependencies-macos-'
+  - &save-cache-bundler-macos
+    key: 'v1-ruby-dependencies-macos-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+    paths:
+      - ./vendor/bundle
   - &restore-cache-gradle
     keys:
       - 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
@@ -212,9 +221,9 @@ jobs:
       - restore_cache: *restore-cache-yarn-macos
       - run: yarn install
       - save_cache: *save-cache-yarn-macos
-      - restore_cache: *restore-cache-bundler
+      - restore_cache: *restore-cache-bundler-macos
       - run: bundle check || bundle install --path ./vendor/bundle
-      - save_cache: *save-cache-bundler
+      - save_cache: *save-cache-bundler-macos
       - run: mkdir -p logs/
       - run: touch .env.js
       - restore_cache: *restore-cache-ios-third-party

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,13 @@ workflows:
   version: 2
   analyze:
     jobs:
-      - yarn-linux-cache
-      - danger: {requires: [yarn-linux-cache]}
-      - flow: {requires: [yarn-linux-cache]}
-      - jest: {requires: [yarn-linux-cache]}
-      - prettier: {requires: [yarn-linux-cache]}
-      - eslint: {requires: [yarn-linux-cache]}
-      - data: {requires: [yarn-linux-cache]}
+      - cache-yarn-linux
+      - danger: {requires: [cache-yarn-linux]}
+      - flow: {requires: [cache-yarn-linux]}
+      - jest: {requires: [cache-yarn-linux]}
+      - prettier: {requires: [cache-yarn-linux]}
+      - eslint: {requires: [cache-yarn-linux]}
+      - data: {requires: [cache-yarn-linux]}
       - ios: {requires: [danger, flow, jest, prettier, eslint, data]}
       - android: {requires: [danger, flow, jest, prettier, eslint, data]}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,29 @@
 version: 2
 
 x-config:
+  - &docker-node-8
+    image: 'circleci/node:8'
   - &restore-cache-yarn
     keys:
-      - 'v2-dependencies-{{ checksum "yarn.lock" }}'
+      - 'v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
+      - 'v2-dependencies-{{ arch }}-'
       - 'v2-dependencies-'
   - &save-cache-yarn
-    paths: [~/.cache/yarn]
-    key: 'v2-dependencies-{{ checksum "yarn.lock" }}'
+    paths:
+      - ~/.cache/yarn
+    key: 'v2-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
   - &restore-cache-bundler
     keys:
-      - 'v1-dependencies-{{ checksum "Gemfile.lock" }}'
-      - 'v1-dependencies-'
+      - 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+      - 'v1-ruby-dependencies-{{ arch }}-'
+      - 'v1-ruby-dependencies-'
   - &save-cache-bundler
-    paths: [./vendor/bundle]
-    key: 'v1-dependencies-{{ checksum "Gemfile.lock" }}'
+    paths:
+      - ./vendor/bundle
+    key: 'v1-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+  - &set-ruby-version
+    name: Set Ruby Version
+    command:  echo "ruby-2.4.2" > ~/.ruby-version
   - &run-danger
     command: yarn run danger --id $task
     when: always
@@ -23,18 +32,27 @@ workflows:
   version: 2
   analyze:
     jobs:
-      - danger
-      - flow
-      - jest
-      - prettier
-      - eslint
-      - data
+      - yarn-linux-cache
+      - danger: {requires: [yarn-linux-cache]}
+      - flow: {requires: [yarn-linux-cache]}
+      - jest: {requires: [yarn-linux-cache]}
+      - prettier: {requires: [yarn-linux-cache]}
+      - eslint: {requires: [yarn-linux-cache]}
+      - data: {requires: [yarn-linux-cache]}
       - ios: {requires: [danger, flow, jest, prettier, eslint, data]}
       - android: {requires: [danger, flow, jest, prettier, eslint, data]}
 
 jobs:
+  cache-yarn-linux:
+    docker: [*docker-node-8]
+    steps:
+      - checkout
+      - restore_cache: *restore-cache-yarn
+      - run: yarn install
+      - save_cache: *save-cache-yarn
+
   danger:
-    docker: [{image: 'circleci/node:8'}]
+    docker: [*docker-node-8]
     environment: {task: JS-general}
     steps:
       - checkout
@@ -44,7 +62,7 @@ jobs:
       - run: *run-danger
 
   flow:
-    docker: [{image: 'circleci/node:8'}]
+    docker: [*docker-node-8]
     environment: {task: JS-flow}
     steps:
       - checkout
@@ -57,7 +75,7 @@ jobs:
       - run: *run-danger
 
   jest:
-    docker: [{image: 'circleci/node:8'}]
+    docker: [*docker-node-8]
     environment: {task: JS-jest}
     steps:
       - checkout
@@ -78,7 +96,7 @@ jobs:
             coveralls < ./coverage/lcov.info
 
   prettier:
-    docker: [{image: 'circleci/node:8'}]
+    docker: [*docker-node-8]
     environment: {task: JS-prettier}
     steps:
       - checkout
@@ -97,7 +115,7 @@ jobs:
       - run: *run-danger
 
   eslint:
-    docker: [{image: 'circleci/node:8'}]
+    docker: [*docker-node-8]
     environment: {task: JS-lint}
     steps:
       - checkout
@@ -110,7 +128,7 @@ jobs:
       - run: *run-danger
 
   data:
-    docker: [{image: 'circleci/node:8'}]
+    docker: [*docker-node-8]
     environment: {task: JS-data}
     steps:
       - checkout
@@ -124,12 +142,13 @@ jobs:
 
   android:
     docker: [{image: 'circleci/android:api-27-node8-alpha'}]
-    environment: {task: ANDROID}
+    environment:
+      task: ANDROID
+      FASTLANE_SKIP_UPDATE_CHECK: '1'
+      FASTLANE_DISABLE_ANIMATION: '1'
     steps:
       - checkout
-      - run:
-          name: Set Ruby Version
-          command:  echo "ruby-2.4.2" > ~/.ruby-version
+      - run: *set-ruby-version
       - restore_cache: *restore-cache-yarn
       - run: yarn install
       - save_cache: *save-cache-yarn
@@ -143,13 +162,14 @@ jobs:
 
   ios:
     macos: {xcode: '9.2'}
-    environment: {task: IOS}
+    environment:
+      task: IOS
+      FASTLANE_SKIP_UPDATE_CHECK: '1'
+      FASTLANE_DISABLE_ANIMATION: '1'
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
-      - run:
-          name: Set Ruby Version
-          command:  echo "ruby-2.4.2" > ~/.ruby-version
+      - run: *set-ruby-version
       - restore_cache: *restore-cache-yarn
       - run: yarn install
       - save_cache: *save-cache-yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,13 @@ x-config:
   - &save-cache-yarn
     paths: [~/.cache/yarn]
     key: 'v2-dependencies-{{ checksum "yarn.lock" }}'
+  - &restore-cache-bundler
+    keys:
+      - 'v1-dependencies-{{ checksum "Gemfile.lock" }}'
+      - 'v1-dependencies-'
+  - &save-cache-bundler
+    paths: [./vendor/bundle]
+    key: 'v1-dependencies-{{ checksum "Gemfile.lock" }}'
   - &run-danger
     command: yarn run danger --id $task
     when: always
@@ -22,6 +29,8 @@ workflows:
       - prettier
       - eslint
       - data
+      - ios: {requires: [danger, flow, jest, prettier, eslint, data]}
+      - android: {requires: [danger, flow, jest, prettier, eslint, data]}
 
 jobs:
   danger:
@@ -111,4 +120,46 @@ jobs:
       - run: mkdir -p logs/
       - run: yarn run --silent validate-data --quiet | tee logs/validate-data
       - run: yarn run --silent validate-bus-data | tee logs/validate-bus-data
+      - run: *run-danger
+
+  android:
+    docker: {image: circleci/android:api-27-node8-alpha}
+    environment: {task: ANDROID}
+    steps:
+      - checkout
+      - run:
+          name: Set Ruby Version
+          command:  echo "ruby-2.4.2" > ~/.ruby-version
+      - restore_cache: *restore-cache-yarn
+      - run: yarn install
+      - save_cache: *save-cache-yarn
+      - restore_cache: *restore-cache-bundler
+      - run: bundle check || bundle install --path ./vendor/bundle
+      - save_cache: *save-cache-bundler
+      - run: mkdir -p logs/
+      - run: touch .env.js
+      - run: bundle exec fastlane android ci-run | tee ./logs/build
+      - run: *run-danger
+
+  ios:
+    macos: {xcode: '9.2'}
+    environment: {task: IOS}
+    shell: /bin/bash --login -o pipefail
+    steps:
+      - checkout
+      - run:
+          name: Set Ruby Version
+          command:  echo "ruby-2.4.2" > ~/.ruby-version
+      - restore_cache: *restore-cache-yarn
+      - run: yarn install
+      - save_cache: *save-cache-yarn
+      - restore_cache: *restore-cache-bundler
+      - run: bundle check || bundle install --path ./vendor/bundle
+      - save_cache: *save-cache-bundler
+      - run: mkdir -p logs/
+      - run: touch .env.js
+      - run: bundle exec fastlane ios ci-run | tee ./logs/build
+      - run:
+          name: Analyze Fastlane Logfile
+          commane: python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true
       - run: *run-danger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,16 +51,6 @@ x-config:
     key: 'v1-gradle-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
     paths:
       - ~/.gradle
-  - &restore-cache-ios-third-party
-    keys:
-      - 'v1-ios-rn-third-party-{{ arch }}-{{ checksum "node_modules/react-native/package.json" }}'
-      - 'v1-ios-rn-third-party-{{ arch }}-'
-      - 'v1-ios-rn-third-party-'
-  - &save-cache-ios-third-party
-    key: 'v1-ios-rn-third-party-{{ arch }}-{{ checksum "node_modules/react-native/package.json" }}'
-    paths:
-      - ~/.rncache
-      - ./node_modules/react-native/third-party
   - &set-ruby-version
     name: Set Ruby Version
     command: echo "ruby-2.4.2" > ~/.ruby-version
@@ -228,9 +218,7 @@ jobs:
       - save_cache: *save-cache-bundler-macos
       - run: mkdir -p logs/
       - run: touch .env.js
-      - restore_cache: *restore-cache-ios-third-party
       - run: bundle exec fastlane ios ci-run | tee ./logs/build
-      - save_cache: *save-cache-ios-third-party
       - run:
           name: Analyze Fastlane Logfile
           command: python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ stages:
     if: branch =~ ^greenkeeper\/
   - name: Deploy Data
     if: branch = master AND type != pull_request
-  - name: Build + Deploy App
+  - name: Build + Deploy
     if: type = cron OR tag IS present
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ stages:
   - name: Deploy Data
     if: branch = master AND type != pull_request
   - name: Build + Deploy App
+    if: type = cron OR tag IS present
 
 
 #

--- a/fastlane/lib/before_all.rb
+++ b/fastlane/lib/before_all.rb
@@ -1,7 +1,8 @@
 before_all do
   case lane_context[:PLATFORM_NAME]
   when :ios
-    setup_travis
+    setup_travis if travis?
+    setup_circle_ci if circle?
   end
 
   # set up global info for `gym`

--- a/fastlane/lib/git.rb
+++ b/fastlane/lib/git.rb
@@ -8,7 +8,7 @@ def newest_tag
 end
 
 def git_changelog
-  to_ref = ENV['TRAVIS_COMMIT'] || 'HEAD'
+  to_ref = ENV['TRAVIS_COMMIT'] || ENV['CIRCLE_SHA1'] || 'HEAD'
   from_ref = newest_tag
 
   graph = sh("git log #{from_ref}..#{to_ref} --oneline --graph")

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -1,15 +1,31 @@
 # coding: utf-8
 
 def should_deploy?
-  cron? ||
-    !ENV['TRAVIS_TAG'].empty? ||
-    ENV['TRAVIS_COMMIT_MESSAGE'] =~ /\[ci run beta\]/
+  cron? || tagged? || forced_deploy?
 end
 
 def cron?
   ENV['TRAVIS_EVENT_TYPE'] == 'cron'
 end
 
+def tagged?
+  !ENV['TRAVIS_TAG'].empty?
+end
+
+def forced_deploy?
+  ENV['TRAVIS_COMMIT_MESSAGE'] =~ /\[ci run beta\]/
+end
+
 def pr?
-  ENV['TRAVIS_PULL_REQUEST'] != 'false'
+  # todo: figure out how to handle forked-pr/non-forked, or if we even want to
+  # ENV['TRAVIS_PULL_REQUEST'] != 'false' || ENV['CIRCLE_PR_NUMBER']
+  ENV['TRAVIS_PULL_REQUEST'] != 'false' || false
+end
+
+def travis?
+  ENV['TRAVIS'] == 'true'
+end
+
+def circle?
+  ENV['CIRCLECI'] == 'true'
 end

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -9,7 +9,7 @@ def cron?
 end
 
 def tagged?
-  !ENV['TRAVIS_TAG'].empty?
+  ENV['TRAVIS_TAG'] && !ENV['TRAVIS_TAG'].empty?
 end
 
 def forced_deploy?

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -19,8 +19,8 @@ def current_build_number(**args)
 end
 
 # get the current build number from the environment
-def build_number()
-  return ENV['TRAVIS_BUILD_NUMBER'] || ENV['CIRCLE_BUILD_NUM']
+def build_number
+  ENV['TRAVIS_BUILD_NUMBER'] || ENV['CIRCLE_BUILD_NUM']
 end
 
 # Get the current "app bundle" version

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -2,7 +2,7 @@
 
 # Gets the version, be it from Travis, Testflight, or Google Play
 def current_build_number(**args)
-  return ENV['TRAVIS_BUILD_NUMBER'] if ENV.key?('TRAVIS_BUILD_NUMBER')
+  return build_number if build_number != nil
 
   begin
     case lane_context[:PLATFORM_NAME]
@@ -16,6 +16,11 @@ def current_build_number(**args)
   rescue
     '1'
   end
+end
+
+# get the current build number from the environment
+def build_number()
+  return ENV['TRAVIS_BUILD_NUMBER'] || ENV['CIRCLE_BUILD_NUM']
 end
 
 # Get the current "app bundle" version

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "eslint-plugin-react-native": "3.2.0",
     "flow-bin": "0.57.3",
     "jest": "22.0.6",
+    "jest-junit": "3.4.1",
     "js-yaml": "3.10.0",
     "junk": "2.1.0",
     "minimist": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   },
   "dependencies": {
     "@hawkrives/react-native-alphabetlistview": "1.0.0",
+    "@hawkrives/react-native-alternate-icons": "0.4.5",
     "@hawkrives/react-native-search-bar": "3.0.0-3",
     "@hawkrives/react-native-sortable-list": "1.0.1",
-    "@hawkrives/react-native-alternate-icons": "0.4.5",
     "buffer": "5.0.8",
     "bugsnag-react-native": "2.5.1",
     "css-select": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3204,6 +3204,14 @@ jest-jasmine2@^22.0.6:
     jest-snapshot "^22.0.6"
     source-map-support "^0.5.0"
 
+jest-junit@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-3.4.1.tgz#0f0aea65551290cabdf9a29a1681edb4eba418c5"
+  dependencies:
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-leak-detector@^22.0.6:
   version "22.0.6"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.0.6.tgz#e983e6fca0959f095cd5b39df2a9a8c956f45988"
@@ -6059,6 +6067,10 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
 
 xmlbuilder@4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5880,7 +5880,7 @@ vinyl@^0.5.0:
     clone-stats "^0.0.1"
     replace-ext "0.0.1"
 
-"vm2@github:patriksimek/vm2#custom_files":
+vm2@patriksimek/vm2#custom_files:
   version "3.5.0"
   resolved "https://codeload.github.com/patriksimek/vm2/tar.gz/7e82f90ac705fc44fad044147cb0df09b4c79a57"
 


### PR DESCRIPTION
Travis is having a (few) bad day(s).

Let's try moving all of our PR build status jobs to Circle.

This leaves the following tasks on Travis:

- building tagged builds and uploading to testflight/google play
- building nightlies and uploading to testflight/google play
- running greenkeeper and pushing back to the branch
- building the data and pushing to github pages

All of these tasks have something in common: they need privileges.

It's much easier to move things that don't need encrypted environment variables and ssh keys added so they can clone another git repo… much easier.

With this PR, most of our PRs won't need to hit Travis' infrastructure at all.

---

On Circle, our Android builds run in around 5 minutes, uncached, and around 3, cached. Our iOS builds run in around 6 minutes, uncached, or 5 ½, cached.

On Travis, our Android builds are nearly 8 minutes, and the iOS builds are roughly 20 minutes.

This is more speed than I dared dream of.

Heck, let's compare our iOS build times notice:

<details><summary>Analysis of slow build times (>20s) [Travis]</summary>

```
0m 40s: React/double-conversion [Debug]
  0m 38s: Running script 'Install Third Party'
0m 19s: RCTText/RCTText [Debug]
0m 24s: React/third-party [Debug]
0m 17s: Bugsnag/BugsnagStatic [Debug]
3m 39s: React/React [Debug]
  1m 22s: Compiling RCTModalManager.m
0m 18s: React/jschelpers [Debug]
0m 19s: React/yoga [Debug]
1m 16s: React/cxxreact [Debug]
  0m 25s: Compiling SampleCxxModule.cpp

```
</details>

<details><summary>Analysis of slow build times (>20s) [circle]</summary>

```
0m 25s: React/double-conversion [Debug]
  0m 24s: Running script 'Install Third Party'
0m 10s: React/third-party [Debug]
1m 14s: React/React [Debug]
  0m 30s: Compiling RCTModalManager.m
0m 32s: React/cxxreact [Debug]
0m 11s: React/yoga [Debug]

```
</details>

---

I think there are two Circle config changes to note:

1. I added "junit" test reporting.

    Circle will now say things like "Your build ran 292 tests in eslint with 0 failures. Slowest test: /home/circleci/project/source/analytics.js (took 0.00 seconds)." when you look at the eslint or jest jobs.

2. I removed the fallback caching keys ([see docs on caching](https://circleci.com/docs/2.0/caching/))
    > Because the second key is less specific than the first, it is more likely that there will be differences between the current state and the most recent cache. When a dependency tool runs, it would discover outdated dependencies and update them. This is referred to as a _partial cache restore_.

    We have three caches, currently: yarn, bundler, and gradle. Each of them only takes around 30 seconds to fully repopulate their cache from scratch.

    I'd rather invalidate the caches than deal with future potential (probable?) bugs around stale caches that something failed to bring up to date.