### PR TITLE
Use an Apple ID without two-factor auth enabled for Fastlane / Testflight

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,18 @@ env:
   # To update the secure tokens, run `travis encrypt NAME='VALUE' --add` after
   # installing the travis gem with `gem install travis`.
   global:
+    # variables from the web interface:
+    # - BOT_ITC_PASSWORD_FOR_FASTLANE
+    # - BUGSNAG_KEY: api key for Bugsnag connection
+    # - CI_USER_TOKEN: unknown
+    # - DANGER_GITHUB_API_TOKEN: api key to let Danger write comments to github
+    # - FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: app-specific password for the iTMS Transporter (obselete)
+    # - FASTLANE_PASSWORD: password for apple id used by fastlane
+    # - FASTLANE_SESSION: if fastlane's apple ID has 2fa enabled, this is the 1-month 2fa session cookie
+    # - GCAL_KEY: google calendar API key
+    # - GH_TOKEN: unknown
+    # - GITHUB_PAGES_TOKEN: token to push to gh-pages
+    # - GMAPS_KEY: google maps API key
     # sets our node version in one nice place
     - TRAVIS_NODE_VERSION=8
     # set the ruby version up top

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ env:
   # To update the secure tokens, run `travis encrypt NAME='VALUE' --add` after
   # installing the travis gem with `gem install travis`.
   global:
-    # dirty hack for https://github.com/travis-ci/travis-ci/issues/5092
-    - PATH=${PATH/\.\/node_modules\/\.bin/}
     # sets our node version in one nice place
     - TRAVIS_NODE_VERSION=8
     # set the ruby version up top
@@ -41,6 +39,9 @@ stages:
 x-definitions:
   - &base
     before_install:
+      # dirty hack for https://github.com/travis-ci/travis-ci/issues/5092
+      - export PATH="${PATH/\.\/node_modules\/\.bin/}"
+
       # print some travis debugging info
       - echo "Now testing on $TRAVIS_OS_NAME"
       - echo "Travis branch is $TRAVIS_BRANCH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
     # configure fastlane a bit
     - FASTLANE_SKIP_UPDATE_CHECK=1
     - FASTLANE_DISABLE_ANIMATION=1
+    # bypass the 2fa auth for fastlane
+    - FASTLANE_PASSWORD="$BOT_ITC_PASSWORD_FOR_FASTLANE"
     # this is `GH_TOKEN`: used by greenkeeper to update package-lock.json
     - secure: s2HicpDrioxVuS/1KyDMgFkgbM3eVxp1FVF1R922oKeUGhtNFERufXp+nXaG98trqmJhfjfx243i7qP8oEX1DoGtFAHAuILBG0KTXoY1HZG/ZlVpc2pjRQmfCt3tJCs8Trovv2q2yM21JtTKXJ6wZ+XUGK0zqXbd4IH7k30Q649CIZ+l/pcU4cVqoLojekFWMQuW9onPOiTGtBckdPngmJ9GgAGDQesYjZ/p5RTaggCleD4oFmgkUdPZtityr+6TYe6cU9fFIVHyxe5F4JsiXB2aKk0qbX86tXUdlneOTYAw0YsxzVbpjtjVeedG3lm+UDAABznaqyuj4EI2+ERIXEMXtDzG+knQuQIF1P9E5ZWRanuSbfwFRJecPXyw03AtT+lBEHls1klRFep0yYzSKPunuqyeFZG+QFFtiegPnk7C4R2KfJhghB8kr8Ysgwg1YJXP77AaTBET0YsEvhMNNqEGK0LsXhZJUCWUnZfINFwp8ggEB8ZHWqWmTD2SxufqWXCzcMBnNdyuoDAH8//myA/09UcxzRpQwBqy3wH/Nlb47n+RydQxxiSmpTw0xAa5f9/qRjy0DrIT0PowDN1VGLgy6wQIqzAN6Ex4Y7AIyaTZrga7cbpfHE7lKee8XTTfDJnfGywJ1+3CqpZpA1jQhRzeGQbxPfghaOxzI46i4p4=
 
@@ -41,6 +43,10 @@ x-definitions:
     before_install:
       # dirty hack for https://github.com/travis-ci/travis-ci/issues/5092
       - export PATH="${PATH/\.\/node_modules\/\.bin/}"
+
+      # finish bypassing 2fa auth for fastlane
+      - unset FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD
+      - unset FASTLANE_SESSION
 
       # print some travis debugging info
       - echo "Now testing on $TRAVIS_OS_NAME"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ env:
   # To update the secure tokens, run `travis encrypt NAME='VALUE' --add` after
   # installing the travis gem with `gem install travis`.
   global:
-    # `match` keychain info – the values don't matter, they're defined
-    # here so they're consistent throughout
-    - MATCH_KEYCHAIN_NAME=travis-ios-keychain
-    - MATCH_KEYCHAIN_PASSWORD=alpine
     # dirty hack for https://github.com/travis-ci/travis-ci/issues/5092
     - PATH=${PATH/\.\/node_modules\/\.bin/}
     # sets our node version in one nice place

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ env:
     # configure fastlane a bit
     - FASTLANE_SKIP_UPDATE_CHECK=1
     - FASTLANE_DISABLE_ANIMATION=1
-    # GH_TOKEN:
-    # - used by greenkeeper to update package-lock.json
+    # this is `GH_TOKEN`: used by greenkeeper to update package-lock.json
     - secure: s2HicpDrioxVuS/1KyDMgFkgbM3eVxp1FVF1R922oKeUGhtNFERufXp+nXaG98trqmJhfjfx243i7qP8oEX1DoGtFAHAuILBG0KTXoY1HZG/ZlVpc2pjRQmfCt3tJCs8Trovv2q2yM21JtTKXJ6wZ+XUGK0zqXbd4IH7k30Q649CIZ+l/pcU4cVqoLojekFWMQuW9onPOiTGtBckdPngmJ9GgAGDQesYjZ/p5RTaggCleD4oFmgkUdPZtityr+6TYe6cU9fFIVHyxe5F4JsiXB2aKk0qbX86tXUdlneOTYAw0YsxzVbpjtjVeedG3lm+UDAABznaqyuj4EI2+ERIXEMXtDzG+knQuQIF1P9E5ZWRanuSbfwFRJecPXyw03AtT+lBEHls1klRFep0yYzSKPunuqyeFZG+QFFtiegPnk7C4R2KfJhghB8kr8Ysgwg1YJXP77AaTBET0YsEvhMNNqEGK0LsXhZJUCWUnZfINFwp8ggEB8ZHWqWmTD2SxufqWXCzcMBnNdyuoDAH8//myA/09UcxzRpQwBqy3wH/Nlb47n+RydQxxiSmpTw0xAa5f9/qRjy0DrIT0PowDN1VGLgy6wQIqzAN6Ex4Y7AIyaTZrga7cbpfHE7lKee8XTTfDJnfGywJ1+3CqpZpA1jQhRzeGQbxPfghaOxzI46i4p4=
 
 

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -2,7 +2,7 @@
 app_identifier 'NFMTHAZVS9.com.drewvolz.stolaf'
 
 # Your Apple email address
-apple_id 'hawkrives@gmail.com'
+apple_id 'aao_bot@fastmail.fm'
 
 # Your Apple Developer Team ID, if you are in multiple teams
 team_id 'TMK6S7TPX2'

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,4 +1,4 @@
 git_url 'https://github.com/hawkrives/aao-keys'
 
 # Your Apple Developer Portal username
-username 'hawkrives@gmail.com'
+username 'aao_bot@fastmail.fm'


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/2120.

I also did a bit of cleanup of the Travis env variables, which I've documented in the commits attached.

I don't think there's a good way to test this without just rolling it out and seeing if the nightly fails. _Especially_ not this weekend, since we're facing Travis queues of ≥ 24 hrs.