### PR TITLE
fix onChangeOrder/onSaveOrder typo

### DIFF
--- a/source/views/home/edit/list.android.js
+++ b/source/views/home/edit/list.android.js
@@ -58,7 +58,7 @@ class EditHomeView extends React.PureComponent<Props> {
     const newOrder = currentOrder.filter(v => v !== viewName)
     newOrder.splice(newIndex, 0, viewName)
 
-    this.props.onChangeOrder(newOrder)
+    this.props.onSaveOrder(newOrder)
   }
 
   renderItem = ({item}: {item: ViewType}) => {


### PR DESCRIPTION
closes https://github.com/StoDevX/AAO-React-Native/issues/2060

I think. haven't tested in the simulator. pretty positive, though.