### PR TITLE
move refresh_dsyms call into the main fastlane invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,7 +178,6 @@ jobs:
       script:
         - bundle exec fastlane ios ci-run | tee ./logs/build
         - python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true
-        - bundle exec fastlane ios refresh_dsyms
 
 cache:
   bundler: true

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -106,6 +106,6 @@ platform :ios do
     auto_beta
 
     # go ahead and download dSYMs for bugsnag too
-    refresh_dsyms
+    refresh_dsyms if travis?
   end
 end

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -104,5 +104,8 @@ platform :ios do
 
     # and run
     auto_beta
+
+    # go ahead and download dSYMs for bugsnag too
+    refresh_dsyms
   end
 end


### PR DESCRIPTION
Travis "failed" tonight because the refresh_dsyms lane failed, because I think it tried to run `setup_travis` a second time, and something was nasty about setting up the keychain again.

https://travis-ci.org/StoDevX/AAO-React-Native/builds/328644162

This should fix that problem.