### PR TITLE
Use generic phone call and email functions

### DIFF
--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -2,7 +2,7 @@
 
 import jsYaml from 'js-yaml'
 import type {BuildingType} from '../types'
-import {email} from 'react-native-communications'
+import {sendEmail} from '../../components/send-email'
 import querystring from 'querystring'
 import {GH_NEW_ISSUE_URL} from '../../../globals'
 
@@ -13,13 +13,11 @@ export function submitReport(current: BuildingType, suggestion: BuildingType) {
 
   const body = makeEmailBody(before, after, current.name)
 
-  return email(
-    ['allaboutolaf@stolaf.edu'],
-    [],
-    [],
-    `[building] Suggestion for ${current.name}`,
+  return sendEmail({
+    to: ['allaboutolaf@stolaf.edu'],
+    subject: `[building] Suggestion for ${current.name}`,
     body,
-  )
+  })
 }
 
 function makeEmailBody(before: string, after: string, title: string): string {

--- a/source/views/components/call-phone.js
+++ b/source/views/components/call-phone.js
@@ -1,0 +1,25 @@
+// @flow
+
+import {Alert, Clipboard} from 'react-native'
+import {phonecall} from 'react-native-communications'
+
+export function callPhone(phoneNumber: string) {
+  try {
+    phonecall(phoneNumber, true)
+  } catch (err) {
+    Alert.alert(
+      "Apologies, we couldn't call that number",
+      `We were trying to call "${phoneNumber}".`,
+      [
+        {
+          text: 'Darn',
+          onPress: () => {},
+        },
+        {
+          text: 'Copy number',
+          onPress: () => Clipboard.setString(phoneNumber),
+        },
+      ],
+    )
+  }
+}

--- a/source/views/components/call-phone.js
+++ b/source/views/components/call-phone.js
@@ -3,9 +3,14 @@
 import {Alert, Clipboard} from 'react-native'
 import {phonecall} from 'react-native-communications'
 
-export function callPhone(phoneNumber: string) {
+type Options = {|
+  prompt?: boolean,
+|}
+
+export function callPhone(phoneNumber: string, opts?: Options) {
+  const {prompt = true} = opts || {}
   try {
-    phonecall(phoneNumber, true)
+    phonecall(phoneNumber, prompt)
   } catch (err) {
     Alert.alert(
       "Apologies, we couldn't call that number",

--- a/source/views/components/open-url.js
+++ b/source/views/components/open-url.js
@@ -78,6 +78,7 @@ export default function openUrl(url: string) {
       return genericOpen(url)
   }
 }
+export {openUrl}
 
 export function trackedOpenUrl({url, id}: {url: string, id?: string}) {
   tracker.trackScreenView(id || url)

--- a/source/views/components/send-email.js
+++ b/source/views/components/send-email.js
@@ -3,8 +3,16 @@
 import {Alert, Clipboard} from 'react-native'
 import {email} from 'react-native-communications'
 
-export function sendEmail(args: {to: Array<string>, cc: Array<string>, bcc: Array<string>, subject: string, body: string}) {
-  const {to, cc, bcc, subject, body} = args
+type Args = {|
+  to?: Array<string>,
+  cc?: Array<string>,
+  bcc?: Array<string>,
+  subject?: string,
+  body?: string,
+|}
+
+export function sendEmail(args: Args) {
+  const {to = [], cc = [], bcc = [], subject = '', body = ''} = args
   try {
     email(to, cc, bcc, subject, body)
   } catch (err) {

--- a/source/views/components/send-email.js
+++ b/source/views/components/send-email.js
@@ -1,0 +1,28 @@
+// @flow
+
+import {Alert, Clipboard} from 'react-native'
+import {email} from 'react-native-communications'
+
+export function sendEmail(args: {to: Array<string>, cc: Array<string>, bcc: Array<string>, subject: string, body: string}) {
+  const {to, cc, bcc, subject, body} = args
+  try {
+    email(to, cc, bcc, subject, body)
+  } catch (err) {
+    const toString = to.join(', ')
+
+    Alert.alert(
+      "Apologies, we couldn't open an email client",
+      `We were trying to email "${toString}".`,
+      [
+        {
+          text: 'Darn',
+          onPress: () => {},
+        },
+        {
+          text: 'Copy addresses',
+          onPress: () => Clipboard.setString(toString),
+        },
+      ],
+    )
+  }
+}

--- a/source/views/contacts/contact-detail.js
+++ b/source/views/contacts/contact-detail.js
@@ -5,10 +5,10 @@ import {contactImages} from '../../../images/contact-images'
 import {Markdown} from '../components/markdown'
 import {ListFooter} from '../components/list'
 import glamorous from 'glamorous-native'
-import {phonecall} from 'react-native-communications'
+import {callPhone} from '../components/call-phone'
 import {tracker} from '../../analytics'
 import {Button} from '../components/button'
-import openUrl from '../components/open-url'
+import {openUrl} from '../components/open-url'
 import type {ContactType} from './types'
 import {GH_NEW_ISSUE_URL} from '../../globals'
 
@@ -41,8 +41,8 @@ function formatNumber(phoneNumber: string) {
 
 function promptCall(buttonText: string, phoneNumber: string) {
   Alert.alert(buttonText, formatNumber(phoneNumber), [
-    {text: 'Cancel', onPress: () => console.log('Call cancel pressed')},
-    {text: 'Call', onPress: () => phonecall(phoneNumber, false)},
+    {text: 'Cancel', onPress: () => {}},
+    {text: 'Call', onPress: () => callPhone(phoneNumber, {prompt: false})},
   ])
 }
 

--- a/source/views/help/tool.js
+++ b/source/views/help/tool.js
@@ -1,12 +1,13 @@
 // @flow
 
 import * as React from 'react'
-import {Alert, StyleSheet, Clipboard} from 'react-native'
+import {StyleSheet} from 'react-native'
 import {Card} from '../components/card'
 import {Button} from '../components/button'
 import {Markdown} from '../components/markdown'
-import actualOpenUrl from '../components/open-url'
-import {email, phonecall} from 'react-native-communications'
+import {openUrl} from '../components/open-url'
+import {sendEmail} from '../components/send-email'
+import {callPhone} from '../components/call-phone'
 import type {
   ToolOptions,
   CallPhoneButtonParams,
@@ -14,67 +15,30 @@ import type {
   OpenUrlButtonParams,
 } from './types'
 
-function callPhone(params: CallPhoneButtonParams) {
-  try {
-    phonecall(params.number, true)
-  } catch (err) {
-    Alert.alert(
-      "Apologies, we couldn't call that number",
-      `We were trying to call "${params.number}".`,
-      [
-        {
-          text: 'Darn',
-          onPress: () => {},
-        },
-        {
-          text: 'Copy addresses',
-          onPress: () => Clipboard.setString(params.number),
-        },
-      ],
-    )
-  }
+function handleCallPhone(params: CallPhoneButtonParams) {
+  callPhone(params.number)
 }
 
-function sendEmail(params: SendEmailButtonParams) {
+function handleSendEmail(params: SendEmailButtonParams) {
   let {to, cc = [], bcc = [], subject, body} = params
   to = Array.isArray(to) ? to : [to]
   cc = Array.isArray(cc) ? cc : [cc]
   bcc = Array.isArray(bcc) ? bcc : [bcc]
-
-  try {
-    email(to, cc, bcc, subject, body)
-  } catch (err) {
-    const toString = to.join(', ')
-
-    Alert.alert(
-      "Apologies, we couldn't open an email client",
-      `We were trying to email "${toString}".`,
-      [
-        {
-          text: 'Darn',
-          onPress: () => {},
-        },
-        {
-          text: 'Copy addresses',
-          onPress: () => Clipboard.setString(toString),
-        },
-      ],
-    )
-  }
+  sendEmail({to, cc, bcc, subject, body})
 }
 
-function openUrl(params: OpenUrlButtonParams) {
-  return actualOpenUrl(params.url)
+function handleOpenUrl(params: OpenUrlButtonParams) {
+  return openUrl(params.url)
 }
 
 function handleButtonPress(btn) {
   switch (btn.action) {
     case 'open-url':
-      return openUrl(btn.params)
+      return handleOpenUrl(btn.params)
     case 'send-email':
-      return sendEmail(btn.params)
+      return handleSendEmail(btn.params)
     case 'call-phone':
-      return callPhone(btn.params)
+      return handleCallPhone(btn.params)
     default:
       ;(btn.action: empty)
   }

--- a/source/views/settings/sections/support.js
+++ b/source/views/settings/sections/support.js
@@ -3,7 +3,7 @@ import * as React from 'react'
 import {Alert} from 'react-native'
 import {Section} from 'react-native-tableview-simple'
 import type {TopLevelViewPropsType} from '../../types'
-import {email} from 'react-native-communications'
+import {sendEmail} from '../../components/send-email'
 import DeviceInfo from 'react-native-device-info'
 import {version} from '../../../../package.json'
 import {PushButtonCell} from '../../components/cells/push-button'
@@ -11,28 +11,26 @@ import {refreshApp} from '../../../lib/refresh'
 
 type Props = TopLevelViewPropsType
 
+const getDeviceInfo = () => `
+
+----- Please do not edit below here -----
+${DeviceInfo.getBrand()} ${DeviceInfo.getModel()}
+${DeviceInfo.getDeviceId()}
+${DeviceInfo.getSystemName()} ${version}
+${DeviceInfo.getReadableVersion()}
+`
+
+const openEmail = () => {
+  sendEmail({
+    to: ['allaboutolaf@stolaf.edu'],
+    subject: 'Support: All About Olaf',
+    body: getDeviceInfo(),
+  })
+}
+
 export default class SupportSection extends React.PureComponent<Props> {
   onPressButton = (id: string) => {
     this.props.navigation.navigate(id)
-  }
-
-  getDeviceInfo = () => `
-
-      ----- Please do not edit below here -----
-      ${DeviceInfo.getBrand()} ${DeviceInfo.getModel()}
-      ${DeviceInfo.getDeviceId()}
-      ${DeviceInfo.getSystemName()} ${version}
-      ${DeviceInfo.getReadableVersion()}
-    `
-
-  openEmail = () => {
-    email(
-      ['allaboutolaf@stolaf.edu'],
-      null,
-      null,
-      'Support: All About Olaf',
-      this.getDeviceInfo(),
-    )
   }
 
   onFaqButton = () => this.onPressButton('FaqView')
@@ -55,7 +53,7 @@ export default class SupportSection extends React.PureComponent<Props> {
   render() {
     return (
       <Section header="SUPPORT">
-        <PushButtonCell onPress={this.openEmail} title="Contact Us" />
+        <PushButtonCell onPress={openEmail} title="Contact Us" />
         <PushButtonCell onPress={this.onFaqButton} title="FAQs" />
         <PushButtonCell onPress={this.onResetButton} title="Reset Everything" />
       </Section>

--- a/source/views/sis/student-work/detail.android.js
+++ b/source/views/sis/student-work/detail.android.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react'
 import {Text, View, ScrollView, StyleSheet} from 'react-native'
-import {email} from 'react-native-communications'
+import {sendEmail} from '../../components/send-email'
 import {Card} from '../../components/card'
 import moment from 'moment'
-import openUrl from '../../components/open-url'
+import {openUrl} from '../../components/open-url'
 import * as c from '../../components/colors'
 import type {JobType} from './types'
 import {cleanJob, getContactName, getLinksFromJob} from './clean-job'
@@ -62,7 +62,9 @@ function Contact({job}: {job: JobType}) {
   return job.office || contactName ? (
     <Card header="Contact" style={styles.card}>
       <Text
-        onPress={() => email([job.contactEmail], null, null, job.title, '')}
+        onPress={() =>
+          sendEmail({to: [job.contactEmail], subject: job.title, body: ''})
+        }
         style={styles.cardBody}
       >
         {contactName} {job.title ? `(${job.title})` : ''}

--- a/source/views/sis/student-work/detail.ios.js
+++ b/source/views/sis/student-work/detail.ios.js
@@ -46,7 +46,7 @@ function Information({job}: {job: JobType}) {
     />
   ) : null
 
-  const ending = job.hoursPerWeek == 'Full-time' ? '' : ' hrs/week'
+  const ending = job.hoursPerWeek === 'Full-time' ? '' : ' hrs/week'
   const hours = job.hoursPerWeek ? (
     <Cell
       cellStyle="LeftDetail"

--- a/source/views/sis/student-work/detail.ios.js
+++ b/source/views/sis/student-work/detail.ios.js
@@ -1,10 +1,10 @@
 // @flow
 import * as React from 'react'
 import {Text, ScrollView, StyleSheet} from 'react-native'
-import {email} from 'react-native-communications'
+import {sendEmail} from '../../components/send-email'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import moment from 'moment'
-import openUrl from '../../components/open-url'
+import {openUrl} from '../../components/open-url'
 import * as c from '../../components/colors'
 import type {JobType} from './types'
 import {cleanJob, getContactName, getLinksFromJob} from './clean-job'
@@ -39,7 +39,9 @@ function Information({job}: {job: JobType}) {
       accessory="DisclosureIndicator"
       cellStyle="LeftDetail"
       detail={'Contact'}
-      onPress={() => email([job.contactEmail], null, null, job.title, '')}
+      onPress={() =>
+        sendEmail({to: [job.contactEmail], subject: job.title, body: ''})
+      }
       title={getContactName(job).trim() || job.contactEmail}
     />
   ) : null

--- a/source/views/streaming/radio/controller.js
+++ b/source/views/streaming/radio/controller.js
@@ -11,7 +11,7 @@ import {
 } from 'react-native'
 import * as c from '../../components/colors'
 import {TabBarIcon} from '../../components/tabbar-icon'
-import {phonecall} from 'react-native-communications'
+import {callPhone} from '../../components/call-phone'
 import {Row} from '../../components/layout'
 import type {TopLevelViewPropsType} from '../../types'
 import {StreamPlayer} from './player'
@@ -84,7 +84,7 @@ export class KSTOView extends React.PureComponent<Props, State> {
   }
 
   callStation = () => {
-    phonecall(stationNumber, false)
+    callPhone(stationNumber)
   }
 
   renderPlayButton = (state: PlayState) => {

--- a/source/views/student-orgs/detail.android.js
+++ b/source/views/student-orgs/detail.android.js
@@ -6,8 +6,8 @@ import {Card} from '../components/card'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
 import type {TopLevelViewPropsType} from '../types'
-import {email} from 'react-native-communications'
-import openUrl from '../components/open-url'
+import {sendEmail} from '../components/send-email'
+import {openUrl} from '../components/open-url'
 import {cleanOrg, showNameOrEmail} from './util'
 
 const styles = StyleSheet.create({
@@ -66,12 +66,6 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
     }
   }
 
-  // Using the Communications library because `mailTo` complains about
-  // the lack of an available Activity...
-  openEmail = (to: string, org: string) => {
-    email([to], null, null, org, '')
-  }
-
   render() {
     const {
       name: orgName,
@@ -113,7 +107,7 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
             {contacts.map((c, i) => (
               <Text
                 key={i}
-                onPress={() => this.openEmail(c.email, orgName)}
+                onPress={() => sendEmail({to: [c.email], subject: orgName})}
                 selectable={true}
                 style={styles.cardBody}
               >
@@ -132,7 +126,7 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
             {advisors.map((c, i) => (
               <Text
                 key={i}
-                onPress={() => this.openEmail(c.email, orgName)}
+                onPress={() => sendEmail({to: [c.email], subject: orgName})}
                 selectable={true}
                 style={styles.cardBody}
               >

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -1,12 +1,13 @@
 // @flow
 import * as React from 'react'
-import {ScrollView, Text, View, StyleSheet, Linking} from 'react-native'
+import {ScrollView, Text, View, StyleSheet} from 'react-native'
 import moment from 'moment'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
 import type {TopLevelViewPropsType} from '../types'
-import openUrl from '../components/open-url'
+import {openUrl} from '../components/open-url'
+import {sendEmail} from '../components/send-email'
 import {cleanOrg, showNameOrEmail} from './util'
 
 const styles = StyleSheet.create({
@@ -114,7 +115,7 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
                   accessory="DisclosureIndicator"
                   cellStyle={c.title ? 'Subtitle' : 'Basic'}
                   detail={c.title}
-                  onPress={() => Linking.openURL(`mailto:${c.email}`)}
+                  onPress={() => sendEmail({to: [c.email], subject: orgName})}
                   title={showNameOrEmail(c)}
                 />
               ))}
@@ -128,7 +129,7 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
                   key={i}
                   accessory="DisclosureIndicator"
                   cellStyle="Basic"
-                  onPress={() => Linking.openURL(`mailto:${c.email}`)}
+                  onPress={() => sendEmail({to: [c.email], subject: orgName})}
                   title={c.name}
                 />
               ))}


### PR DESCRIPTION
I pulled the new callPhone and sendEmail functions that I made for the Help views out into generic, reusable files.

These are nicer than the `react-native-communications` ones not only because I made the arguments nicer, but also because they automatically handle alerting the user when they can't send an email or call a phone number.

Closes https://github.com/StoDevX/AAO-React-Native/issues/1799