### PR TITLE
Center bullets vertically in Markdown text

### DIFF
--- a/data/privacy.md
+++ b/data/privacy.md
@@ -2,21 +2,23 @@
 
 This privacy policy has been compiled to better serve those who are concerned with how their 'Personally Identifiable Information' (PII) is being used online. PII, as described in US privacy law and information security, is information that can be used on its own or with other information to identify, contact, or locate a single person, or to identify an individual in context. Please read our privacy policy carefully to get a clear understanding of how we collect, use, protect or otherwise handle your Personally Identifiable Information in accordance with our website.
 
-> What personal information do we collect from the people that visit our blog, website or app? When do we collect information?
+## Introduction
+
+### What personal information do we collect from the people that visit our blog, website or app? When do we collect information?
 
 We collect information from you when you register on our site or enter information on our site.
 
-> How do we use your information?
+### How do we use your information?
 
 We may use the information we collect from you when you register, make a purchase, sign up for our newsletter, respond to a survey or marketing communication, surf the website, or use certain other site features in the following ways:
 
 - To improve our website in order to better serve you.
 
-> How do we protect your information?
+### How do we protect your information?
 
 Our website is scanned on a regular basis for security holes and known vulnerabilities in order to make your visit to our site as safe as possible. We use regular Malware Scanning. Your personal information is contained behind secured networks and is only accessible by a limited number of persons who have special access rights to such systems, and are required to keep the information confidential. In addition, all sensitive/credit information you supply is encrypted via Secure Socket Layer (SSL) technology. We implement a variety of security measures when a user places an order enters, submits, or accesses their information to maintain the safety of your personal information. All transactions are processed through a gateway provider and are not stored or processed on our servers.
 
-> Do we use 'cookies'?
+### Do we use 'cookies'?
 
 We do not use cookies for tracking purposes.
 
@@ -44,9 +46,7 @@ According to CalOPPA, we agree to the following:
 
 Users can visit our site anonymously. Once this privacy policy is created, we will add a link to it on our home page or as a minimum, on the first significant page after entering our website. Our Privacy Policy link includes the word 'Privacy' and can be easily be found on the page specified above.
 
-You will be notified of any Privacy Policy changes:
-
-- On our Privacy Policy Page
+You will be notified of any Privacy Policy changes on our Privacy Policy Page.
 
 ## COPPA (Children Online Privacy Protection Act)
 
@@ -60,13 +60,9 @@ The Fair Information Practices Principles form the backbone of privacy law in th
 
 In order to be in line with Fair Information Practices we will take the following responsive action, should a data breach occur:
 
-We will notify you via email
+We will notify you via email within 1 business day.
 
-- Within 1 business day
-
-We will notify the users via in-site notification
-
-- Within 1 business day
+We will notify the users via in-site notification within 1 business day.
 
 We also agree to the Individual Redress Principle which requires that individuals have the right to legally pursue enforceable rights against data collectors and processors who fail to adhere to the law. This principle requires not only that individuals have enforceable rights against data users, but also that individuals have recourse to courts or government agencies to investigate and/or prosecute non-compliance by data processors.
 
@@ -98,4 +94,4 @@ Student Government Assoc. ATTN: Webmaster
 Northfield, MN 55057 USA
 <allaboutolaf@stolaf.edu>
 
-Last Edited on 2017-10-02
+Last Edited on 2018-01-14

--- a/source/views/components/markdown/formatting.js
+++ b/source/views/components/markdown/formatting.js
@@ -5,6 +5,7 @@ import {SelectableText} from './selectable'
 
 export const Paragraph = glamorous(SelectableText)({
   marginVertical: 3,
+  paddingRight: 4,
 })
 
 export const BlockQuote = glamorous(Paragraph)({

--- a/source/views/components/markdown/list.js
+++ b/source/views/components/markdown/list.js
@@ -1,15 +1,16 @@
 // @flow
 
 import * as React from 'react'
-import {Text} from 'react-native'
-import glamorous from 'glamorous-native'
+import glamorous, {View, Text} from 'glamorous-native'
 import {Paragraph} from './formatting'
 
 // the list itself
-export const List = glamorous.view({})
+export const List = glamorous(View)({})
 
 // the list item's text
-export const ListText = glamorous(Paragraph)({})
+export const ListText = glamorous(Paragraph)({
+  flex: 1,
+})
 
 // the list item's container box thing
 type Props = {
@@ -19,10 +20,10 @@ type Props = {
 export class ListItem extends React.PureComponent<Props> {
   render() {
     return (
-      <glamorous.View flexDirection="row">
-        <Text>• </Text>
+      <View alignItems="center" flexDirection="row">
+        <Text paddingRight={4}>• </Text>
         <ListText {...this.props} />
-      </glamorous.View>
+      </View>
     )
   }
 }


### PR DESCRIPTION
Before | After
--- | ---
<img src="https://user-images.githubusercontent.com/464441/30671175-2f9312f0-9e2b-11e7-9e7e-b2cfe0914ede.jpeg" width="320"> | <img width="320" alt="screen shot 2018-01-14 at 4 51 09 pm" src="https://user-images.githubusercontent.com/464441/34921658-27351cfe-f94b-11e7-9a1d-52f683afe057.png">

I added some right-hand spacing to the paragraphs / list items, and configured the bullets to be centered.

What I'd _really_ like to do would be to align the bullet with the baseline of the first line of text, but I couldn't figure out how to manage that.

<details><summary>Example of what I'd like</summary>

from [https://stackoverflow.com/a/46891740/2347774](https://stackoverflow.com/a/46891740/2347774)

![7vwgm](https://user-images.githubusercontent.com/464441/34921693-6ebe7dfe-f94b-11e7-9716-6197f6cce763.png)
</details>