### PR TITLE
Forbid unnecessary curly brackets in jsx attrs

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -71,6 +71,7 @@ rules:
 
   # react rules – https://github.com/yannickcr/eslint-plugin-react
   react/display-name: off
+  react/jsx-curly-brace-presence: [warn, never]
   react/jsx-key: warn
   react/jsx-no-bind:
     - warn
@@ -89,11 +90,11 @@ rules:
   react/sort-comp:
     - warn
     - order:
-      - static-methods
-      - type-annotations
-      - lifecycle
-      - everything-else
-      - render
+        - static-methods
+        - type-annotations
+        - lifecycle
+        - everything-else
+        - render
   react/sort-prop-types: warn
   react/wrap-multilines: off
   react/jsx-boolean-value: [error, always]

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -111,7 +111,7 @@ export class GitHubHostedMenu extends React.PureComponent<Props, State> {
     }
 
     if (this.state.error) {
-      return <NoticeView text={'Error: ' + this.state.error.message} />
+      return <NoticeView text={`Error: ${this.state.error.message}`} />
     }
 
     return (

--- a/source/views/sis/student-work/detail.ios.js
+++ b/source/views/sis/student-work/detail.ios.js
@@ -38,7 +38,7 @@ function Information({job}: {job: JobType}) {
     <Cell
       accessory="DisclosureIndicator"
       cellStyle="LeftDetail"
-      detail={'Contact'}
+      detail="Contact"
       onPress={() => email([job.contactEmail], null, null, job.title, '')}
       title={getContactName(job).trim() || job.contactEmail}
     />
@@ -48,21 +48,17 @@ function Information({job}: {job: JobType}) {
   const hours = job.hoursPerWeek ? (
     <Cell
       cellStyle="LeftDetail"
-      detail={'Hours'}
+      detail="Hours"
       title={job.hoursPerWeek + ending}
     />
   ) : null
 
   const amount = job.timeOfHours ? (
-    <Cell
-      cellStyle="LeftDetail"
-      detail={'Time of Day'}
-      title={job.timeOfHours}
-    />
+    <Cell cellStyle="LeftDetail" detail="Time of Day" title={job.timeOfHours} />
   ) : null
 
   const category = job.type ? (
-    <Cell cellStyle="LeftDetail" detail={'Category'} title={job.type} />
+    <Cell cellStyle="LeftDetail" detail="Category" title={job.type} />
   ) : null
 
   return (

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -132,7 +132,7 @@ export class StreamListView extends React.PureComponent<Props, State> {
     }
 
     if (this.state.error) {
-      return <NoticeView text={'Error: ' + this.state.error} />
+      return <NoticeView text={`Error: ${this.state.error}`} />
     }
 
     return (

--- a/source/views/transportation/other-modes/detail.js
+++ b/source/views/transportation/other-modes/detail.js
@@ -56,7 +56,7 @@ export class OtherModesDetailView extends React.PureComponent<Props> {
           styles={{Paragraph: styles.paragraph}}
         />
 
-        <Button onPress={this.onPress} title={'More Info'} />
+        <Button onPress={this.onPress} title="More Info" />
 
         <ListFooter
           href={GH_NEW_ISSUE_URL}


### PR DESCRIPTION
Sometimes, we get code written like this: `<Element attr={'foo'} />`, instead of `<Element attr="foo" />`. The curly braces provide no benefit.

I found an ESLint rule to forbid them, [`react/jsx-curly-brace-presence`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md), and this PR enables it.

If you find yourself running afoul of this rule often, know that it's autofixable with `yarn lint --fix`.