### PR TITLE
tint the active switches with their row color

### DIFF
--- a/source/views/home/edit/row.ios.js
+++ b/source/views/home/edit/row.ios.js
@@ -175,6 +175,7 @@ export class EditHomeRow extends React.Component<Props, State> {
 				</Text>
 
 				<Switch
+					onTintColor={tint}
 					onValueChange={this.onToggleSwitch}
 					value={this.props.isEnabled}
 				/>


### PR DESCRIPTION
<img width="160" alt="screen shot 2018-01-18 at 6 37 54 pm" src="https://user-images.githubusercontent.com/464441/35128948-b5a14626-fc7e-11e7-904e-dcb61d8e4a11.png">

Do we want to color the Android arrow icons?