### PR TITLE
Save the build status on "fastlane ios build"

### DIFF
--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -60,8 +60,20 @@ platform :ios do
   lane :build do
     match(type: 'appstore', readonly: true)
     propagate_version
-    gym(include_bitcode: true,
-        include_symbols: true)
+
+    # save it to a log file for later use
+    FileUtils.mkdir_p('../logs')
+    File.open('../logs/products', 'w') { |file| file.write('[]') }
+    build_status = 0
+    begin
+      gym(include_bitcode: true,
+          include_symbols: true)
+    rescue IOError => e
+      build_status = 1
+      raise e
+    ensure
+      File.open('../logs/build-status', 'w') { |file| file.write(build_status.to_s) }
+    end
   end
 
   desc 'Submit a new Beta Build to Testflight'


### PR DESCRIPTION
We were already saving it for the `fastlane ios check_build` lane, and Danger expects it to exist now.

Unlike Travis, Circle _will_ fail the build if Danger yells. (this keeps it quiet.)