### PR TITLE
Try setting the `cmd` key on the Android build Docker spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - run: *run-danger
 
   android:
-    docker: [{image: 'circleci/android:api-27-node8-alpha'}]
+    docker: [{image: 'circleci/android:api-27-node8-alpha', cmd: '/bin/bash'}]
     environment:
       task: ANDROID
       FASTLANE_SKIP_UPDATE_CHECK: '1'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,9 @@ jobs:
       - run: *run-danger
 
   android:
+    # cmd: key is passed to solve a weird issue (see GitHub PR's 2170 and 2173).
+    # this overrides the thing and forces the container to run /bin/bash as the "command"
+    # so it doesn't get confused and OOM/exhaust the build resources (don't ask me)
     docker: [{image: 'circleci/android:api-27-node8-alpha', cmd: '/bin/bash'}]
     environment:
       task: ANDROID


### PR DESCRIPTION
This was a suggestion from a Feb '17 response on the CircleCI discussion board: https://discuss.circleci.com/t/builds-getting-killed-with-vague-message-received-signal-killed/10214/9

This would override the value if it's getting set weirdly.  Let's see what happens.

Closes #2170.