### PR TITLE
Make the empty Help view look nicer

### DIFF
--- a/source/views/help/index.js
+++ b/source/views/help/index.js
@@ -58,10 +58,10 @@ export class HelpView extends React.Component<Props> {
 			.map(getToolView)
 			.map(([Tool, conf]) => <Tool key={conf.key} config={conf} />)
 
-		return (
-			<ScrollView contentContainerStyle={styles.container}>
-				{views.length ? views : <NoticeView text="No tools are enabled." />}
-			</ScrollView>
+		return views.length ? (
+			<ScrollView contentContainerStyle={styles.container}>views</ScrollView>
+		) : (
+			<NoticeView text="No tools are enabled." />
 		)
 	}
 }


### PR DESCRIPTION
Before | After
--- | ---
<img width="320" alt="screen shot 2018-01-20 at 1 09 22 pm" src="https://user-images.githubusercontent.com/464441/35187032-24a427ea-fde3-11e7-9d10-cef6be6fd10e.png"> | <img width="320" alt="screen shot 2018-01-20 at 1 10 48 pm" src="https://user-images.githubusercontent.com/464441/35187070-a9b10548-fde3-11e7-8197-09715c3181c5.png">

Closes https://github.com/StoDevX/AAO-React-Native/issues/2157