### PR TITLE
Increase number of lines shown in news lists

### DIFF
--- a/source/views/news/news-row.js
+++ b/source/views/news/news-row.js
@@ -32,8 +32,8 @@ export class NewsRow extends React.PureComponent<Props> {
 				<Row alignItems="center">
 					<Image source={thumb} style={styles.image} />
 					<Column flex={1}>
-						<Title lines={1}>{story.title}</Title>
-						<Detail lines={2}>{story.excerpt}</Detail>
+						<Title lines={2}>{story.title}</Title>
+						<Detail lines={3}>{story.excerpt}</Detail>
 					</Column>
 				</Row>
 			</ListRow>


### PR DESCRIPTION
<details><summary>iPhone SE</summary>

|  | Before | After
--- | --- | ---
Manitou Messenger | ![mess-before copy](https://user-images.githubusercontent.com/464441/35197785-865890a8-feaa-11e7-9a80-63fc25c6047d.png) | ![mess-after copy](https://user-images.githubusercontent.com/464441/35197784-863ccd14-feaa-11e7-840a-b60280014e14.png)
St. Olaf | ![stolaf-before copy](https://user-images.githubusercontent.com/464441/35197786-867a51c0-feaa-11e7-84d1-7b7a4aa70aee.png) | ![stolaf-after copy](https://user-images.githubusercontent.com/464441/35197787-869611c6-feaa-11e7-89f2-2208d000ac27.png)

</details>

<details><summary>iPhone 6s</summary>

|  | Before | After
--- | --- | ---
Manitou Messenger | ![mess-before-6s copy](https://user-images.githubusercontent.com/464441/35197881-f9ba35aa-feab-11e7-8f57-350325f2e541.png) | ![mess-after-6s copy](https://user-images.githubusercontent.com/464441/35197879-f982a996-feab-11e7-915c-9fca9e3ab841.png)
St. Olaf | ![stolaf-before-6s copy](https://user-images.githubusercontent.com/464441/35197880-f99d724e-feab-11e7-9534-95539204ba55.png) | ![stolaf-after-6s copy](https://user-images.githubusercontent.com/464441/35197878-f96636ee-feab-11e7-806a-34a22b3e8f00.png)

</details>

I was looking at the news feeds on the SE simulator, and I was struck by how _little_ of the titles you could see.

I feel like this is a good change to make, even on larger phones.

Thoughts?