### PR TITLE
Credits icon reflects custom icon

### DIFF
--- a/images/icon-images.js
+++ b/images/icon-images.js
@@ -1,6 +1,29 @@
 // @flow
 
 export const icons = {
-  oldMain: require('./about/IconTrans.png'),
-  windmill: require('../ios/AllAboutOlaf/windmill-icon/windmill.png'),
+	oldMain: require('./about/IconTrans.png'),
+	windmill: require('../ios/AllAboutOlaf/windmill-icon/windmill.png'),
+}
+
+export const defaultIcon = icons.oldMain
+
+// eslint-disable camelcase
+export const iosToNamedIconsMap: {[key: string]: $Keys<typeof icons>} = {
+	icon_type_windmill: 'windmill',
+	default: 'oldMain',
+}
+// eslint-enable camelcase
+
+export function lookup(iosIconName: $Keys<typeof iosToNamedIconsMap>): number {
+	const iconName = iosToNamedIconsMap[iosIconName]
+	if (!iconName) {
+		return defaultIcon
+	}
+
+	const icon = icons[iconName]
+	if (!icon) {
+		return defaultIcon
+	}
+
+	return icon
 }

--- a/source/views/components/logo.js
+++ b/source/views/components/logo.js
@@ -1,0 +1,38 @@
+// @flow
+
+import * as React from 'react'
+import * as Icons from '@hawkrives/react-native-alternate-icons'
+import glamorous from 'glamorous-native'
+
+import {lookup as getAppIcon} from '../../../images/icon-images'
+
+const LogoImage = glamorous.image({
+	width: 100,
+	height: 100,
+	alignSelf: 'center',
+})
+
+type Props = {
+	style?: StyleSheet,
+}
+
+type State = {
+	icon: number,
+}
+
+export class AppLogo extends React.Component<Props, State> {
+	state = {
+		icon: getAppIcon('default'),
+	}
+
+	async componentWillMount() {
+		const name = await Icons.getIconName()
+		console.warn(name)
+		this.setState(() => ({icon: getAppIcon(name)}))
+	}
+
+	render() {
+		console.warn(this.state.icon)
+		return <LogoImage source={this.state.icon} style={this.props.style} />
+	}
+}

--- a/source/views/settings/credits.js
+++ b/source/views/settings/credits.js
@@ -61,7 +61,6 @@ const formatPeopleList = arr => arr.map(w => w.replace(' ', ' ')).join(' • ')
 type Props = TopLevelViewPropsType
 
 type State = {
-	supported: boolean,
 	iconType: null | string,
 }
 
@@ -71,18 +70,11 @@ export default class CreditsView extends React.Component<Props, State> {
 	}
 
 	state = {
-		supported: false,
 		iconType: null,
 	}
 
 	componentWillMount() {
-		this.checkIfCustomIconsSupported()
 		this.getIcon()
-	}
-
-	checkIfCustomIconsSupported = async () => {
-		const supported = await Icons.isSupported()
-		this.setState(() => ({supported}))
 	}
 
 	getIcon = async () => {
@@ -91,9 +83,8 @@ export default class CreditsView extends React.Component<Props, State> {
 	}
 
 	render() {
-		const image = this.state.supported
-			? this.state.iconType === 'default' ? appIcons.oldMain : appIcons.windmill
-			: appIcons.oldMain
+		const image =
+			this.state.iconType === 'default' ? appIcons.oldMain : appIcons.windmill
 
 		return (
 			<Container contentInsetAdjustmentBehavior="automatic">

--- a/source/views/settings/credits.js
+++ b/source/views/settings/credits.js
@@ -6,7 +6,9 @@ import glamorous from 'glamorous-native'
 import {Platform} from 'react-native'
 import {iOSUIKit, material} from 'react-native-typography'
 
-const image = require('../../../images/about/IconTrans.png')
+import {icons as appIcons} from '../../../images/icon-images'
+import * as Icons from '@hawkrives/react-native-alternate-icons'
+import type {TopLevelViewPropsType} from '../types'
 
 const Container = glamorous.scrollView({
 	backgroundColor: c.white,
@@ -56,22 +58,49 @@ const Contributors = glamorous(About)({
 
 const formatPeopleList = arr => arr.map(w => w.replace(' ', ' ')).join(' • ')
 
-export default function CreditsView() {
-	return (
-		<Container contentInsetAdjustmentBehavior="automatic">
-			<Logo source={image} />
+export default class CreditsView extends React.Component<Props, State> {
+	static navigationOptions = {
+		title: 'Credits',
+	}
 
-			<Title>{credits.name}</Title>
-			<About>{credits.content}</About>
+	state = {
+		supported: false,
+		iconType: null,
+	}
 
-			<Heading>Contributors</Heading>
-			<Contributors>{formatPeopleList(credits.contributors)}</Contributors>
+	componentWillMount() {
+		this.checkIfCustomIconsSupported()
+		this.getIcon()
+	}
 
-			<Heading>Acknowledgements</Heading>
-			<Contributors>{formatPeopleList(credits.acknowledgements)}</Contributors>
-		</Container>
-	)
-}
-CreditsView.navigationOptions = {
-	title: 'Credits',
+	checkIfCustomIconsSupported = async () => {
+		const supported = await Icons.isSupported()
+		this.setState(() => ({supported}))
+	}
+
+	getIcon = async () => {
+		const name = await Icons.getIconName()
+		this.setState(() => ({iconType: name}))
+	}
+
+	render() {
+		const image = this.state.supported
+			? this.state.iconType === 'default' ? appIcons.oldMain : appIcons.windmill
+			: appIcons.oldMain
+
+		return (
+			<Container contentInsetAdjustmentBehavior="automatic">
+				<Logo source={image} />
+
+				<Title>{credits.name}</Title>
+				<About>{credits.content}</About>
+
+				<Heading>Contributors</Heading>
+				<Contributors>{formatPeopleList(credits.contributors)}</Contributors>
+
+				<Heading>Acknowledgements</Heading>
+				<Contributors>{formatPeopleList(credits.acknowledgements)}</Contributors>
+			</Container>
+		)
+	}
 }

--- a/source/views/settings/credits.js
+++ b/source/views/settings/credits.js
@@ -58,6 +58,13 @@ const Contributors = glamorous(About)({
 
 const formatPeopleList = arr => arr.map(w => w.replace(' ', ' ')).join(' • ')
 
+type Props = TopLevelViewPropsType
+
+type State = {
+	supported: boolean,
+	iconType: null | string,
+}
+
 export default class CreditsView extends React.Component<Props, State> {
 	static navigationOptions = {
 		title: 'Credits',
@@ -99,7 +106,9 @@ export default class CreditsView extends React.Component<Props, State> {
 				<Contributors>{formatPeopleList(credits.contributors)}</Contributors>
 
 				<Heading>Acknowledgements</Heading>
-				<Contributors>{formatPeopleList(credits.acknowledgements)}</Contributors>
+				<Contributors>
+					{formatPeopleList(credits.acknowledgements)}
+				</Contributors>
 			</Container>
 		)
 	}

--- a/source/views/settings/credits.js
+++ b/source/views/settings/credits.js
@@ -5,21 +5,12 @@ import {data as credits} from '../../../docs/credits.json'
 import glamorous from 'glamorous-native'
 import {Platform} from 'react-native'
 import {iOSUIKit, material} from 'react-native-typography'
-
-import {icons as appIcons} from '../../../images/icon-images'
-import * as Icons from '@hawkrives/react-native-alternate-icons'
-import type {TopLevelViewPropsType} from '../types'
+import {AppLogo} from '../components/logo'
 
 const Container = glamorous.scrollView({
 	backgroundColor: c.white,
 	paddingHorizontal: 5,
 	paddingVertical: 10,
-})
-
-const Logo = glamorous.image({
-	width: 100,
-	height: 100,
-	alignSelf: 'center',
 })
 
 const Title = glamorous.text({
@@ -58,49 +49,22 @@ const Contributors = glamorous(About)({
 
 const formatPeopleList = arr => arr.map(w => w.replace(' ', ' ')).join(' • ')
 
-type Props = TopLevelViewPropsType
+export default function CreditsView() {
+	return (
+		<Container contentInsetAdjustmentBehavior="automatic">
+			<AppLogo />
 
-type State = {
-	iconType: null | string,
+			<Title>{credits.name}</Title>
+			<About>{credits.content}</About>
+
+			<Heading>Contributors</Heading>
+			<Contributors>{formatPeopleList(credits.contributors)}</Contributors>
+
+			<Heading>Acknowledgements</Heading>
+			<Contributors>{formatPeopleList(credits.acknowledgements)}</Contributors>
+		</Container>
+	)
 }
-
-export default class CreditsView extends React.Component<Props, State> {
-	static navigationOptions = {
-		title: 'Credits',
-	}
-
-	state = {
-		iconType: null,
-	}
-
-	componentWillMount() {
-		this.getIcon()
-	}
-
-	getIcon = async () => {
-		const name = await Icons.getIconName()
-		this.setState(() => ({iconType: name}))
-	}
-
-	render() {
-		const image =
-			this.state.iconType === 'default' ? appIcons.oldMain : appIcons.windmill
-
-		return (
-			<Container contentInsetAdjustmentBehavior="automatic">
-				<Logo source={image} />
-
-				<Title>{credits.name}</Title>
-				<About>{credits.content}</About>
-
-				<Heading>Contributors</Heading>
-				<Contributors>{formatPeopleList(credits.contributors)}</Contributors>
-
-				<Heading>Acknowledgements</Heading>
-				<Contributors>
-					{formatPeopleList(credits.acknowledgements)}
-				</Contributors>
-			</Container>
-		)
-	}
+CreditsView.navigationOptions = {
+	title: 'Credits',
 }


### PR DESCRIPTION
This PR swaps out the app icon displayed in the Credits view for whichever icon the user has selected to represent the app within the icon preferences.

Feedback is welcomed and appreciated.

~I think there is a fair amount of code duplication relating to icon functions that should be colocated and reused within a single helper for all icon related functions.~ maybe not

(Edit &lt;Hawken&gt;: nicer diff at https://github.com/StoDevX/AAO-React-Native/pull/2189/files?w=1)