### PR TITLE
Hide scrollbar on calendar view

### DIFF
--- a/source/views/calendar/event-list.js
+++ b/source/views/calendar/event-list.js
@@ -79,6 +79,7 @@ export class EventList extends React.PureComponent<Props> {
 				renderItem={this.renderItem}
 				renderSectionHeader={this.renderSectionHeader}
 				sections={this.groupEvents(this.props.events, this.props.now)}
+				showsVerticalScrollIndicator={false}
 				style={styles.container}
 			/>
 		)


### PR DESCRIPTION
Arguments:

- iOS calendar hides the scrollbar
    Admittedly, that's because they have a truly infinite list of events, but I'd eventually like to progressively load more events as the user scrolls (not for 2.5)
- React Native's scrollbar jumps annoyingly
    Whenever new content is rendered at the bottom of the list, the scrollbar gets resized and annoys me. This would avoid that, by way of hiding the scrollbar.

So my argument is that I don't like the scrollbar in Calendar, and that iOS (at least) hides the scrollbar in their equivalent app.

Pretty please? 😁 

I'm going to wait for two 👍s before merging.