### PR TITLE
use an array to fix TableviewSimple's inspection of children

### DIFF
--- a/source/views/settings/sections/login-credentials.js
+++ b/source/views/settings/sections/login-credentials.js
@@ -14,7 +14,6 @@ import {
 import {type ReduxState} from '../../../flux'
 import {connect} from 'react-redux'
 import noop from 'lodash/noop'
-import {View} from 'react-native'
 
 type ReduxStateProps = {
 	initialUsername: string,

--- a/source/views/settings/sections/login-credentials.js
+++ b/source/views/settings/sections/login-credentials.js
@@ -77,8 +77,9 @@ class CredentialsLoginSection extends React.PureComponent<Props, State> {
 				{loggedIn ? (
 					<Cell title={`Logged in as ${username}.`} />
 				) : (
-					<View>
+					[
 						<CellTextField
+							key="username"
 							_ref={this.getUsernameRef}
 							disabled={loading}
 							label="Username"
@@ -88,9 +89,10 @@ class CredentialsLoginSection extends React.PureComponent<Props, State> {
 							returnKeyType="next"
 							secureTextEntry={false}
 							value={username}
-						/>
+						/>,
 
 						<CellTextField
+							key="password"
 							_ref={this.getPasswordRef}
 							disabled={loading}
 							label="Password"
@@ -100,8 +102,8 @@ class CredentialsLoginSection extends React.PureComponent<Props, State> {
 							returnKeyType="done"
 							secureTextEntry={true}
 							value={password}
-						/>
-					</View>
+						/>,
+					]
 				)}
 
 				<LoginButton


### PR DESCRIPTION
Fixes https://github.com/StoDevX/AAO-React-Native/issues/2195

`react-native-tableview-simple` has the following code in the `<Section>` component:

```js
     // Skip rendering of separator
      if (
        hideSeparator ||
        !Array.isArray(children) ||
        React.Children.count(children) === 1 ||
        index === React.Children.count(children) - 1
      ) {
        return React.cloneElement(child, propsToAdd);
      }
```

It's intended to determine when a separator needs to be drawn.

If you only provide it a single child that happens to wrap two table rows, then it won't draw the line between those rows because they're not Section's children.

Passing arrays is one way to bypass this; theoretically, React.Fragment would also get around this, but the above heuristic fails on them.

Before | After |
--- | ---
<img width="375" alt="screen shot 2018-01-22 at 9 21 33 am" src="https://user-images.githubusercontent.com/464441/35228165-a7207494-ff55-11e7-9438-70a120a2d881.png"> | <img width="375" alt="screen shot 2018-01-22 at 9 19 10 am" src="https://user-images.githubusercontent.com/464441/35228164-a70c159e-ff55-11e7-98d5-a7f77994d45b.png">