### PR TITLE
Allow editing events after fetching but before rendering

### DIFF
--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -13,7 +13,11 @@ import qs from 'querystring'
 import {GOOGLE_CALENDAR_API_KEY} from '../../lib/config'
 const TIMEZONE = 'America/Winnipeg'
 
-type Props = TopLevelViewPropsType & {calendarId: string, poweredBy: ?PoweredBy}
+type Props = TopLevelViewPropsType & {
+	calendarId: string,
+	eventMapper?: EventType => EventType,
+	poweredBy: ?PoweredBy,
+}
 
 type State = {
 	events: EventType[],
@@ -52,7 +56,7 @@ export class GoogleCalendarView extends React.Component<Props, State> {
 	}
 
 	convertEvents(data: GoogleEventType[], now: moment): EventType[] {
-		return data.map(event => {
+		let events = data.map(event => {
 			const startTime = moment(event.start.date || event.start.dateTime)
 			const endTime = moment(event.end.date || event.end.dateTime)
 
@@ -70,6 +74,12 @@ export class GoogleCalendarView extends React.Component<Props, State> {
 				},
 			}
 		})
+
+		if (this.props.eventMapper) {
+			events = events.map(this.props.eventMapper)
+		}
+
+		return events
 	}
 
 	getEvents = async (now: moment = moment.tz(TIMEZONE)) => {

--- a/source/views/calendar/calendar-google.js
+++ b/source/views/calendar/calendar-google.js
@@ -55,13 +55,19 @@ export class GoogleCalendarView extends React.Component<Props, State> {
 		return data.map(event => {
 			const startTime = moment(event.start.date || event.start.dateTime)
 			const endTime = moment(event.end.date || event.end.dateTime)
+
 			return {
 				startTime,
 				endTime,
-				summary: event.summary || '',
+				title: event.summary || '',
+				description: event.description || '',
 				location: event.location || '',
 				isOngoing: startTime.isBefore(now, 'day'),
-				extra: {type: 'google', data: event},
+				config: {
+					startTime: true,
+					endTime: true,
+					subtitle: 'location',
+				},
 			}
 		})
 	}

--- a/source/views/calendar/clean-event.js
+++ b/source/views/calendar/clean-event.js
@@ -1,48 +1,26 @@
 // @flow
 import type {EventType} from './types'
 import {fastGetTrimmedText} from '../../lib/html'
-import getUrls from 'get-urls'
-import {detailTimes} from './times'
 
 export function cleanEvent(event: EventType) {
-	const title = fastGetTrimmedText(event.summary || '')
-	const summary = fastGetTrimmedText(event.extra.data.description || '')
-	const rawSummary = cleanDescription(event.extra.data.description || '')
-	const location = fastGetTrimmedText(event.location || '')
-	const times = getTimes(event) ? getTimes(event) : ''
+	const title = fastGetTrimmedText(event.title)
+	const description = cleanDescription(event.description)
+	const location = fastGetTrimmedText(event.location)
 
 	return {
 		...event,
 		title,
-		summary,
-		rawSummary,
+		description,
 		location,
-		times,
 	}
 }
 
 function cleanDescription(desc: string) {
 	const description = fastGetTrimmedText(desc || '')
+
 	if (description == 'See more details') {
 		return ''
 	}
 
 	return description
-}
-
-export function getTimes(event: EventType) {
-	const {allDay, start, end} = detailTimes(event)
-
-	if (allDay) {
-		return `All-Day on ${event.startTime.format('MMM D.')}`
-	}
-
-	return `${start}${end ? ' to ' + end : ''}`
-}
-
-export function getLinksFromEvent(event: EventType) {
-	// Clean up returns, newlines, tabs, and misc symbols...
-	// ...and search for links in the text
-	const description = event.extra.data.description || ''
-	return Array.from(getUrls(description))
 }

--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -2,14 +2,18 @@
 import * as React from 'react'
 import {Text, ScrollView, StyleSheet} from 'react-native'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
-import type {CleanedEventType, PoweredBy} from './types'
+import type {EventType, PoweredBy} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {ShareButton} from '../components/nav-buttons'
 import openUrl from '../components/open-url'
 import {ListFooter} from '../components/list'
-import {getLinksFromEvent} from './clean-event'
 import {ButtonCell} from '../components/cells/button'
-import {addToCalendar, shareEvent} from './calendar-util'
+import {
+	getLinksFromEvent,
+	addToCalendar,
+	shareEvent,
+	getTimes,
+} from './calendar-util'
 import delay from 'delay'
 
 const styles = StyleSheet.create({
@@ -32,7 +36,7 @@ function MaybeSection({header, content}: {header: string, content: string}) {
 	) : null
 }
 
-function Links({header, event}: {header: string, event: CleanedEventType}) {
+function Links({header, event}: {header: string, event: EventType}) {
 	const links = getLinksFromEvent(event)
 
 	return links.length ? (
@@ -63,7 +67,7 @@ const CalendarButton = ({message, disabled, onPress}) => {
 
 type Props = TopLevelViewPropsType & {
 	navigation: {
-		state: {params: {event: CleanedEventType, poweredBy: ?PoweredBy}},
+		state: {params: {event: EventType, poweredBy: ?PoweredBy}},
 	},
 }
 
@@ -86,7 +90,7 @@ export class EventDetail extends React.PureComponent<Props, State> {
 		disabled: false,
 	}
 
-	addEvent = async (event: CleanedEventType) => {
+	addEvent = async (event: EventType) => {
 		const start = Date.now()
 		this.setState(() => ({message: 'Adding event to calendar…'}))
 
@@ -120,9 +124,9 @@ export class EventDetail extends React.PureComponent<Props, State> {
 			<ScrollView>
 				<TableView>
 					<MaybeSection content={event.title} header="EVENT" />
-					<MaybeSection content={event.times} header="TIME" />
+					<MaybeSection content={getTimes(event)} header="TIME" />
 					<MaybeSection content={event.location} header="LOCATION" />
-					<MaybeSection content={event.rawSummary} header="DESCRIPTION" />
+					<MaybeSection content={event.description} header="DESCRIPTION" />
 					<Links event={event} header="LINKS" />
 					<CalendarButton
 						disabled={this.state.disabled}

--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -42,12 +42,10 @@ export default class EventRow extends React.PureComponent<Props> {
 
 	render() {
 		const {event} = this.props
-		const title = fastGetTrimmedText(event.summary)
+		const title = fastGetTrimmedText(event.title)
 
-		const location =
-			event.location && event.location.trim().length ? (
-				<Detail>{event.location}</Detail>
-			) : null
+		let subtitle = event[event.config.subtitle]
+		subtitle = subtitle ? subtitle.trim() : null
 
 		return (
 			<ListRow
@@ -68,7 +66,7 @@ export default class EventRow extends React.PureComponent<Props> {
 						paddingTop={2}
 					>
 						<Title>{title}</Title>
-						{location}
+						{subtitle ? <Detail>{subtitle}</Detail> : null}
 					</Column>
 				</Row>
 			</ListRow>
@@ -89,8 +87,12 @@ function CalendarTimes({event, style}: {event: EventType, style: any}) {
 
 	return (
 		<Column style={style}>
-			<Text style={[styles.time, styles.start]}>{start}</Text>
-			<Text style={[styles.time, styles.end]}>{end}</Text>
+			{event.config.startTime ? (
+				<Text style={[styles.time, styles.start]}>{start}</Text>
+			) : null}
+			{event.config.endTime ? (
+				<Text style={[styles.time, styles.end]}>{end}</Text>
+			) : null}
 		</Column>
 	)
 }

--- a/source/views/calendar/types.js
+++ b/source/views/calendar/types.js
@@ -12,28 +12,22 @@ export type GoogleEventType = {
 	location?: string,
 }
 
-type EmbeddedEventDetailType = {type: 'google', data: GoogleEventType}
 
 export type PoweredBy = {
 	title: string,
 	href: string,
 }
 
-export type EventType = {
-	summary: string,
-	location: string,
-	startTime: moment,
-	endTime: moment,
-	isOngoing: boolean,
-	extra: EmbeddedEventDetailType,
-}
-
-export type CleanedEventType = {
+export type EventType = {|
 	title: string,
-	summary: string,
+	description: string,
 	location: string,
 	startTime: moment,
 	endTime: moment,
 	isOngoing: boolean,
-	extra: EmbeddedEventDetailType,
-}
+	config: {
+		startTime: boolean,
+		endTime: boolean,
+		subtitle: 'location' | 'description',
+	},
+|}

--- a/source/views/calendar/types.js
+++ b/source/views/calendar/types.js
@@ -12,7 +12,6 @@ export type GoogleEventType = {
 	location?: string,
 }
 
-
 export type PoweredBy = {
 	title: string,
 	href: string,


### PR DESCRIPTION
This PR adds a new optional `eventMapper` prop to `<GoogleCalendar/>`.

Usage: 

```jsx
<GoogleCalendarView
	calendarId="kstonarwhal@gmail.com"
	eventMapper={event => ({
		...event,
		title: event.title.replace(/^SUMO: /, ''),
		config: {
			...event.config,
			endTime: false,
		},
	})}
/>
```

That's actually an example from CARLS, but it's demonstrative.

That configuration will remove the prefix `SUMO: ` from each event, and will tell the row to hide the end time of the events.

You can also tell the rows to show the "description" of the event instead of the "location".