### PR TITLE
Add app support to the help section

### DIFF
--- a/data/help/0-wifi.yaml
+++ b/data/help/0-wifi.yaml
@@ -2,7 +2,6 @@
 key: wifi
 enabled: true
 hidden: false
-versionRange: '>=2.5.0-beta'
 
 title: Report a Wi-Fi Problem
 body: |

--- a/data/help/1-it-helpdesk.yaml
+++ b/data/help/1-it-helpdesk.yaml
@@ -1,9 +1,7 @@
 ---
 key: it-helpdesk
-enabled: false
+enabled: true
 hidden: false
-message: 'Disabled because reason'
-# versionRange: '1.x <1.3 >=1.2'
 
 title: Open a Helpdesk Ticket
 body: |
@@ -24,7 +22,6 @@ buttons:
       url: https://help.stolaf.edu/
 
   - title: Call the Helpdesk
-    enabled: false
     action: call-phone
     params:
       number: '15077863830'

--- a/data/help/3-app.yaml
+++ b/data/help/3-app.yaml
@@ -1,0 +1,19 @@
+---
+key: app-support
+enabled: true
+hidden: false
+
+title: Have an App Question?
+body: |
+  If you've got a question about the app, or a new feature idea, let us know!
+
+buttons:
+  - title: Email Us
+    action: send-email
+    params:
+      to: allaboutolaf@stolaf.edu
+      subject: A Thing
+      body: |
+        Idea? Question? Comment? Concern?
+
+        Let us know!


### PR DESCRIPTION
I'm leaving the Contact Us button in Settings because I can't replicate the device info bit in here.

Closes https://github.com/StoDevX/AAO-React-Native/issues/2199?