### PR TITLE
Force nightlies to always be version 1.0.0

### DIFF
--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -47,14 +47,14 @@ def propagate_version(**args)
   UI.message "Propagating version: #{version}"
   UI.message 'into the Info.plist and build.gradle files'
 
-  version = '1.0.0' if should_nightly?
-  UI.message "Actually using #{version} (because we're doing a nightly)"
-
   # encode build number into js-land – we've already fetched it, so we'll
   # never set the "+" into the binaries
   unless version.include? '+'
     set_package_data(data: { version: "#{version}+#{build}" })
   end
+    
+  version = '1.0.0' if should_nightly?
+  UI.message "Actually putting #{version} into the binaries (because we're doing a nightly)"
 
   case lane_context[:PLATFORM_NAME]
   when :android

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -47,6 +47,9 @@ def propagate_version(**args)
   UI.message "Propagating version: #{version}"
   UI.message 'into the Info.plist and build.gradle files'
 
+  version = '1.0.0' if should_nightly?
+  UI.message "Actually using #{version} (because we're doing a nightly)"
+
   # encode build number into js-land – we've already fetched it, so we'll
   # never set the "+" into the binaries
   unless version.include? '+'


### PR DESCRIPTION
@rye and I think that this might be the cause of our Play build issues, pushing two versions with the same "version name".

Also, this will allow easier filtering of nightly builds from the analytics, because we'll never ship v1 again.