### PR TITLE
Drop old OSes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -102,7 +102,7 @@ android {
 
     defaultConfig {
         applicationId "com.allaboutolaf"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 23
         versionCode 1
         versionName "1.0.0"

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -1771,7 +1771,7 @@
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1828,7 +1828,7 @@
 					"$(SRCROOT)/../node_modules/react-native-safari-view",
 					"$(SRCROOT)/../node_modules/react-native-custom-tabs/ios/ReactNativeCustomTabs",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";


### PR DESCRIPTION
Raises our minimum iOS version to 9.3, and our minimum Android SDK version to 19 (4.4).