### PR TITLE
Fix iPad alternate icons

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -25,6 +25,21 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>CFBundleIcons~ipad</key>
+	<dict>
+		<key>CFBundleAlternateIcons</key>
+		<dict>
+			<key>icon_type_windmill</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>windmill</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
Resolves #2194

Adds an iPad specific alternate icons plist

In Apple’s [documentation](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-SW14), it pointed out:

> Important: If your app contains iPad-specific versions of its icons, the system does not fall back to the alternate icons declared in the platform-agnostic version of `CFBundleIcons` key. Therefore, if you include any alternate icons in the `CFBundleIcons` key, you must include them again in your `CFBundleIcons~ipad` variant.

That means, in our `Info.plist`, we need to have a separate entry with `CFBundleIcons~ipad` key.
So, this copies our entries in `CFBundleIcons` and adds them to `CFBundleIcons~ipad`.