### PR TITLE
Update to pastors' office name

### DIFF
--- a/data/building-hours/10-pastor-office.yaml
+++ b/data/building-hours/10-pastor-office.yaml
@@ -1,4 +1,4 @@
-name: Pastor's Office
+name: Pastors' Office
 category: Offices
 
 schedule:


### PR DESCRIPTION
https://wp.stolaf.edu/a-z lists it as `pastors'` instead of `pastor's`