### PR TITLE
Enable universal APKs

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,7 +89,7 @@ apply from: "../../node_modules/react-native/react.gradle"
  * Upload all the APKs to the Play Store and people will download
  * the correct one based on the CPU architecture of their device.
  */
-def enableSeparateBuildPerCPUArchitecture = true
+def enableSeparateBuildPerCPUArchitecture = false
 
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
@@ -120,8 +120,7 @@ android {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            // include "armeabi-v7a", "x86"
-            include "armeabi-v7a"
+            include "armeabi-v7a", "x86"
         }
     }
     buildTypes {
@@ -136,9 +135,12 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a":1, "x86":2]
+            def versionCodes = ["armeabi-v7a":1, "x86":2, nil:2]
+
+            // `abi` is null for the universal-debug, universal-release variants
             def abi = output.getFilter(OutputFile.ABI)
-            if (abi != null) {  // null for the universal-debug, universal-release variants
+
+            if (abi != null) { 
                 output.versionCodeOverride =
                         versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
             }


### PR DESCRIPTION
I'm setting them to use the x86 APK numbering scheme, so that both ARM and x86 users will get to install it.

---

impetus: turns out that we can't launch android emulators without generating the x86 apk.