### PR TITLE
Run android version code changing in fastlane, instead of gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,17 +133,20 @@ android {
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
+            // Because we're only generating one universal APK, this is commented out and the "nil"
+            // logic described here is instead implemented in fastlane.
+
             // For each separate APK per architecture, set a unique version code as described here:
             // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a":1, "x86":2, nil:2]
+            // def versionCodes = ["armeabi-v7a":1, "x86":2, nil:2]
 
             // `abi` is null for the universal-debug, universal-release variants
-            def abi = output.getFilter(OutputFile.ABI)
+            // def abi = output.getFilter(OutputFile.ABI)
 
-            if (abi != null) { 
-                output.versionCodeOverride =
-                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
-            }
+            // if (abi != null) { 
+            //     output.versionCodeOverride =
+            //             versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            // }
         }
     }
     android {

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -47,6 +47,13 @@ def propagate_version(**args)
   UI.message "Propagating version: #{version}"
   UI.message 'into the Info.plist and build.gradle files'
   
+  UI.message "Setting build number to #{build}"
+
+  # android's build number goes way up because we need to exceed the old build
+  # numbers generated for the x86 build.
+  build = (2 * 1048576) + build if lane_context[:PLATFORM_NAME] == :android
+  UI.message "Actually setting build number to #{build} because we're on android"
+
   version = "#{version.split('-')[0]}-pre" if should_nightly?
   UI.message "Actually putting #{version} into the binaries (because we're doing a nightly)"
 

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -51,7 +51,7 @@ def propagate_version(**args)
 
   # android's build number goes way up because we need to exceed the old build
   # numbers generated for the x86 build.
-  build = (2 * 1048576) + build if lane_context[:PLATFORM_NAME] == :android
+  build = ((2 * 1048576) + build.to_i).to_s if lane_context[:PLATFORM_NAME] == :android
   UI.message "Actually setting build number to #{build} because we're on android"
 
   version = "#{version.split('-')[0]}-pre" if should_nightly?


### PR DESCRIPTION
1. I split the ARM and x86 builds apart a long time ago
2. This required different "version codes" for each
3. In order to give us breathing room, I took advice from http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits to do the algorithm (`$platform * 1048576 + versionCode`, where $platform is 1 for ARM and 2 for x86)
4. Android won't install a new build that has a lower version number
5. To provide a "universal" apk to both ARM and x86 clients, we need to go above the old x86 versionCode
6. If we just replicate the x86 logic (`*2`), we will exceed the x86 versionCode, as required, because we generate lots of builds
7. That will also exceed the ARM versionCode, as required, because multiplying by 2 instead of 1 generates larger numbers