### PR TITLE
Prevent Android APKs from including x86_64 splits

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -115,7 +115,7 @@ android {
         ]
 
         ndk {
-            abiFilters "armeabi-v7a", "arm64-v8a", "x86"
+            abiFilters "armeabi-v7a", "x86"
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -222,6 +222,7 @@ dependencies {
     // this is for react-native itself
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:26.1.0"
+    //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -150,7 +150,7 @@ android {
             // `abi` is null for the universal-debug, universal-release variants
             // def abi = output.getFilter(OutputFile.ABI)
 
-            // if (abi != null) { 
+            // if (abi != null) {
             //     output.versionCodeOverride =
             //             versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
             // }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -113,6 +113,10 @@ android {
             BUGSNAG_KEY: System.getenv("BUGSNAG_KEY") ?: "",
             GMAPS_KEY: System.getenv("GMAPS_KEY") ?: "",
         ]
+
+        ndk {
+            abiFilters "armeabi-v7a", "arm64-v8a", "x86"
+        }
     }
 
     signingConfigs {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -101,20 +101,25 @@ android {
 
     defaultConfig {
         applicationId "com.allaboutolaf"
+
         minSdkVersion 19
         targetSdkVersion 26
+
         versionCode 1
         versionName "1.0.0"
+
         manifestPlaceholders = [
             manifestApplicationId: applicationId,
             BUGSNAG_KEY: System.getenv("BUGSNAG_KEY") ?: "",
             GMAPS_KEY: System.getenv("GMAPS_KEY") ?: "",
         ]
     }
+
     signingConfigs {
         // the signingConfig is configured below
         release
     }
+
     splits {
         abi {
             reset()
@@ -123,6 +128,7 @@ android {
             include "armeabi-v7a", "x86"
         }
     }
+
     buildTypes {
         release {
             minifyEnabled enableProguardInReleaseBuilds
@@ -130,6 +136,7 @@ android {
             signingConfig signingConfigs.release
         }
     }
+
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
@@ -149,12 +156,14 @@ android {
             // }
         }
     }
+
     android {
         dexOptions {
             // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
             preDexLibraries = preDexEnabled && !ciBuild
         }
     }
+
     configurations.all {
         resolutionStrategy.force 'com.android.support:appcompat-v7:26.1.0'
         resolutionStrategy.force 'com.android.support:customtabs:26.1.0'


### PR DESCRIPTION
This should address this morning's problem of devices trying to run 64-bit code that doesn't work.

Before | After
--- | ---
<img width="373" alt="screen shot 2018-01-25 at 11 43 26 pm" src="https://user-images.githubusercontent.com/464441/35426568-909932ac-0229-11e8-9e19-48447d931d77.png"> | <img width="373" alt="screen shot 2018-01-25 at 11 42 11 pm" src="https://user-images.githubusercontent.com/464441/35426538-66c32e24-0229-11e8-91d4-a7e67b37c475.png">

<img width="469" alt="screen shot 2018-01-25 at 11 44 50 pm" src="https://user-images.githubusercontent.com/464441/35426592-c4e722f8-0229-11e8-8ad2-211381e3e684.png">

According to https://android.jlelse.eu/controlling-apk-size-when-using-native-libraries-45c6c0e5b70a, 

> - `armeabi` – a very old ARM based architecture. Since Android 4.4, the CDD (compatibility definition) strictly requires ARMv7.
> - `armeabi-v7a` – the most common architecture currently available. This is a must-support ABI for all the applications.
> - `arm64-v8a` – the next generation 64 bit ARM architecture. All the flagship phones uses this architecture. Support of this ABI is optional as the devices can use armeabi-v7a version of the native library. 
> - `x86` – Intel-based devices; the ASUS ZenFone2 being the most well-known device of the lot along with many Lenovo phones. Any application has to support this.
> - `x86_64` – There are no android devices with 64-bit Intel processors available in the market.
> - `mips` and `mips64` – There are no android devices with MIPS architecture in market. (There was one device which was supposed to be launched in 2016 but I barely found any information.)

So we should be good with ARMv7 and x86.