### PR TITLE
cache artifacts on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
     # different CIRCLE_WORKFLOW_ID, which should allow us to only deploy
     # nightlies from that branch.
     jobs: &basic-jobs
-      - cache-yarn-linux: 
+      - cache-yarn-linux:
           filters: &filters {tags: {only: /.*/}}
       - danger:
           filters: *filters
@@ -230,7 +230,7 @@ jobs:
           environment:
             GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $CIRCLE_SHA1)
       - run: *run-danger
-  
+
   android-nightly:
     <<: *android
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,8 @@ jobs:
           command: bundle exec fastlane android ci-run | tee ./logs/build
           environment:
             GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $CIRCLE_SHA1)
+      - store_artifacts:
+          path: ./android/app/build/outputs/apk/release/
       - run: *run-danger
 
   android-nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,11 @@ jobs:
       - run: yarn run bundle-data
       - run: yarn run --silent bundle:android
       - store_artifacts:
-          path: ./android/app/src/main/assets/
+          path: ./android/app/src/main/assets/index.android.bundle
+          name: android.jsbundle
+      - store_artifacts:
+          path: ./android/app/src/main/assets/index.android.bundle.map
+          name: android.jsbundle.map
       - run: *run-danger
 
   ios: &ios
@@ -320,8 +324,8 @@ jobs:
       - run: yarn run --silent bundle:ios
       - store_artifacts:
           path: ./ios/AllAboutOlaf/main.jsbundle
-          destination: main.jsbundle
+          destination: ios.jsbundle
       - store_artifacts:
           path: ./ios/AllAboutOlaf/main.jsbundle.map
-          destination: main.jsbundle.map
+          destination: ios.jsbundle.map
       - run: *run-danger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,8 @@ jobs:
           command: bundle exec fastlane ios ci-run | tee ./logs/build
           environment:
             GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $CIRCLE_SHA1)
+      - store_artifacts:
+          path: ./ios/build/
       - run:
           name: Analyze Fastlane Logfile
           command: python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,12 @@ workflows:
       - android:
           filters: *filters
           requires: [danger, flow, jest, prettier, eslint, data]
+      - ios-bundle:
+          filters: *filters
+          requires: [danger, flow, jest, prettier, eslint, data]
+      - android-bundle:
+          filters: *filters
+          requires: [danger, flow, jest, prettier, eslint, data]
   nightly:
     triggers:
       - schedule:
@@ -239,6 +245,21 @@ jobs:
       <<: *android-env
       IS_NIGHTLY: '1'
 
+  android-bundle:
+    docker: [{image: 'circleci/node:8'}]
+    environment:
+      task: JS-bundle-android
+    steps:
+      - checkout
+      - restore_cache: *restore-cache-yarn
+      - run: yarn install --frozen-lockfile
+      - save_cache: *save-cache-yarn
+      - run: mkdir -p logs/
+      - run: yarn run --silent bundle:android
+      - store_artifacts:
+          path: ./android/app/src/main/assets/
+      - run: *run-danger
+
   ios: &ios
     macos: {xcode: '9.0'}
     environment: &ios-env
@@ -277,3 +298,22 @@ jobs:
     environment:
       <<: *ios-env
       IS_NIGHTLY: '1'
+
+  ios-bundle:
+    docker: [{image: 'circleci/node:8'}]
+    environment:
+      task: JS-bundle-ios
+    steps:
+      - checkout
+      - restore_cache: *restore-cache-yarn
+      - run: yarn install --frozen-lockfile
+      - save_cache: *save-cache-yarn
+      - run: mkdir -p logs/
+      - run: yarn run --silent bundle:ios
+      - store_artifacts:
+          path: ./ios/AllAboutOlaf/main.jsbundle
+          destination: main.jsbundle
+      - store_artifacts:
+          path: ./ios/AllAboutOlaf/main.jsbundle.map
+          destination: main.jsbundle.map
+      - run: *run-danger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,10 @@ jobs:
       - run: mkdir -p logs/
       - run: yarn run --silent validate-data --quiet | tee logs/validate-data
       - run: yarn run --silent validate-bus-data | tee logs/validate-bus-data
+      - run: yarn run bundle-data
+      - run: yarn run compress-data
+      - store_artifacts:
+          path: ./docs/
       - run: *run-danger
 
   android: &android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,10 +264,10 @@ jobs:
       - run: yarn run --silent bundle:android
       - store_artifacts:
           path: ./android/app/src/main/assets/index.android.bundle
-          name: android.jsbundle
+          destination: android.jsbundle
       - store_artifacts:
           path: ./android/app/src/main/assets/index.android.bundle.map
-          name: android.jsbundle.map
+          destination: android.jsbundle.map
       - run: *run-danger
 
   ios: &ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
+      - run: *embed-env-vars
       - run: yarn run bundle-data
       - run: yarn run --silent bundle:android
       - store_artifacts:
@@ -310,6 +311,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
+      - run: *embed-env-vars
       - run: yarn run bundle-data
       - run: yarn run --silent bundle:ios
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
+      - run: yarn run bundle-data
       - run: yarn run --silent bundle:android
       - store_artifacts:
           path: ./android/app/src/main/assets/
@@ -309,6 +310,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
+      - run: yarn run bundle-data
       - run: yarn run --silent bundle:ios
       - store_artifacts:
           path: ./ios/AllAboutOlaf/main.jsbundle

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -20,9 +20,6 @@ async function main() {
 		case 'IOS':
 			await runiOS()
 			break
-		case 'GREENKEEPER':
-			await runGreenkeeper()
-			break
 		case 'JS-general':
 			await runJSのGeneral()
 			await yarn()
@@ -42,17 +39,11 @@ async function main() {
 		case 'JS-prettier':
 			await runJSのPrettier()
 			break
+		case 'GREENKEEPER':
+			break
 		default:
 			warn(`Unknown task name "${taskName}"; Danger cannot report anything.`)
 	}
-}
-
-//
-// task=GREENKEEPER
-//
-
-function runGreenkeeper() {
-	// message('greenkeeper ran')
 }
 
 //
@@ -74,31 +65,7 @@ async function runAndroid() {
 		return
 	}
 
-	/*
-  const appPaths = readJsonLogFile('./logs/products')
-  const apkInfos = appPaths.map(listZip)
-
-  markdown('## Android Report')
-  markdown(
-    h.details(
-      h.summary('contents of <code>apkInfos</code>'),
-      m.json(apkInfos),
-      m.json(appPaths),
-    ),
-  )
-
-  markdown(`Generated ${apkInfos.length} APK${apkInfos.length !== 1 ? 's' : ''}
-
-${outputFilesInfo
-    .map((filename, i) => [filename, apkInfos[i]])
-    .map(([filename, apk]) =>
-      h.details(
-        h.summary(`${filename} (${bytes(apk.size)})`),
-        m.json(apk),
-      ),
-    )}
-  `)
-*/
+	// we do not currently do any android analysis
 }
 
 //
@@ -122,10 +89,8 @@ async function runiOS() {
 
 	markdown('## iOS Report')
 
-	// ideas:
-	// - tee the "fastlane" output to a log, and run the analysis script
-	//   to report back the longest compilation units
-	//   (maybe only on react-native / package.json changes?)
+	// tee the "fastlane" output to a log, and run the analysis script
+	// to report back the longest compilation units
 	const analysisFile = readFile('./logs/analysis')
 	markdown(
 		h.details(
@@ -133,21 +98,6 @@ async function runiOS() {
 			m.code({}, analysisFile),
 		),
 	)
-
-	/*
-  // - report the .ipa size
-  // - report the .ipa file list
-  const appPaths = readJsonLogFile('./logs/products')
-
-  appPaths.forEach(appPath => {
-    const info = listDirectoryTree(appPath)
-    markdown(`## <code>.app</code>
-Total <code>.app</code> size: ${info.size}
-
-${h.details(h.summary('.app contents'), m.json(info))}
-`)
-  })
-*/
 }
 
 //

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -40,6 +40,8 @@ async function main() {
 			await runJSのPrettier()
 			break
 		case 'GREENKEEPER':
+		case 'JS-bundle-android':
+		case 'JS-bundle-ios':
 			break
 		default:
 			warn(`Unknown task name "${taskName}"; Danger cannot report anything.`)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "bundle:android": "react-native bundle --entry-file index.js --dev true --platform android --bundle-output ./android/app/src/main/assets/index.android.bundle --assets-dest ./android/app/src/main/res/ --sourcemap-output ./android/app/src/main/assets/index.android.bundle.map",
     "bundle:ios": "react-native bundle --entry-file index.js --dev false --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --assets-dest ./ios --sourcemap-output ./ios/AllAboutOlaf/main.jsbundle.map",
     "check": "npm run prettier && npm run lint && npm run flow && npm run validate-data -- --quiet && npm run test",
-    "compress-data": "gzip docs/*.json",
+    "compress-data": "gzip --keep docs/*.json",
     "danger": "danger ci",
     "data": "node scripts/bundle-data.js data/ docs/",
     "flow": "flow",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bundle:android": "react-native bundle --entry-file index.js --dev true --platform android --bundle-output ./android/app/src/main/assets/index.android.bundle --assets-dest ./android/app/src/main/res/ --sourcemap-output ./android/app/src/main/assets/index.android.bundle.map",
     "bundle:ios": "react-native bundle --entry-file index.js --dev false --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --assets-dest ./ios --sourcemap-output ./ios/AllAboutOlaf/main.jsbundle.map",
     "check": "npm run prettier && npm run lint && npm run flow && npm run validate-data -- --quiet && npm run test",
+    "compress-data": "gzip docs/*.json",
     "danger": "danger ci",
     "data": "node scripts/bundle-data.js data/ docs/",
     "flow": "flow",


### PR DESCRIPTION
This should allow us to monitor the size of each native app bundle, as well as the JS payloads we send with the native binaries.

Maybe.

Hopefully Buildsize will kick in and do something here.

We'll see.

Maybe Buildsize doesn't comment until it's got something on master. Who knows. 

We'll find out!

---

Note: this iOS build path only exists for PRs from this repository! Any forked PRs will not be able to upload artifacts as the path won't exist. I don't know how Circle handles that.