### PR TITLE
Expose the CI's build number to the app interface

### DIFF
--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -46,11 +46,12 @@ def propagate_version(**args)
 
   UI.message "Propagating version: #{version}"
   UI.message 'into the Info.plist and build.gradle files'
-  
+
   UI.message "Setting build number to #{build}"
 
   # android's build number goes way up because we need to exceed the old build
   # numbers generated for the x86 build.
+  ci_build_num = build
   build = ((2 * 1048576) + build.to_i).to_s if lane_context[:PLATFORM_NAME] == :android
   UI.message "Actually setting build number to #{build} because we're on android"
 
@@ -60,7 +61,8 @@ def propagate_version(**args)
   # encode build number into js-land – we've already fetched it, so we'll
   # never set the "+" into the binaries
   unless version.include? '+'
-    set_package_data(data: { version: "#{version}+#{build}" })
+    # we always want the CI build number in js-land
+    set_package_data(data: { version: "#{version}+#{ci_build_num}" })
   end
 
   case lane_context[:PLATFORM_NAME]


### PR DESCRIPTION
stops android settings from reporting the versionCode (aka 2105020) as the build number