### PR TITLE
Fix St. Olaf login at launch

### DIFF
--- a/source/flux/init.js
+++ b/source/flux/init.js
@@ -24,12 +24,12 @@ async function loginCredentials(store) {
 		return
 	}
 
-	store.dispatch(setLoginCredentials(username, password))
+	store.dispatch(setLoginCredentials({username, password}))
 }
 
 async function validateOlafCredentials(store) {
-	const {username, password} = await loadLoginCredentials()
-	store.dispatch(validateLoginCredentials(username, password))
+	const credentials = await loadLoginCredentials()
+	store.dispatch(validateLoginCredentials(credentials))
 }
 
 function netInfoIsConnected(store) {

--- a/source/flux/init.js
+++ b/source/flux/init.js
@@ -19,17 +19,18 @@ import {updateBalances} from './parts/sis'
 
 async function loginCredentials(store) {
 	const {username, password} = await loadLoginCredentials()
-
 	if (!username || !password) {
 		return
 	}
-
 	store.dispatch(setLoginCredentials({username, password}))
 }
 
 async function validateOlafCredentials(store) {
-	const credentials = await loadLoginCredentials()
-	store.dispatch(validateLoginCredentials(credentials))
+	const {username, password} = await loadLoginCredentials()
+	if (!username || !password) {
+		return
+	}
+	store.dispatch(validateLoginCredentials({username, password}))
 }
 
 function netInfoIsConnected(store) {

--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -4,6 +4,7 @@ import {
 	performLogin,
 	saveLoginCredentials,
 	clearLoginCredentials,
+	type Credentials,
 } from '../../lib/login'
 
 import {
@@ -61,7 +62,6 @@ export async function hasSeenAcknowledgement(): Promise<SisAlertSeenAction> {
 	return {type: SIS_ALERT_SEEN, payload: true}
 }
 
-type Credentials = {username?: string, password?: string}
 type SetCredentialsAction = {|
 	type: 'settings/SET_LOGIN_CREDENTIALS',
 	payload: Credentials,

--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -61,22 +61,22 @@ export async function hasSeenAcknowledgement(): Promise<SisAlertSeenAction> {
 	return {type: SIS_ALERT_SEEN, payload: true}
 }
 
+type Credentials = {username?: string, password?: string}
 type SetCredentialsAction = {|
 	type: 'settings/SET_LOGIN_CREDENTIALS',
-	payload: {username: string, password: string},
+	payload: Credentials,
 |}
 export async function setLoginCredentials(
-	username: string,
-	password: string,
+	credentials: Credentials,
 ): Promise<SetCredentialsAction> {
-	await saveLoginCredentials(username, password)
-	return {type: SET_LOGIN_CREDENTIALS, payload: {username, password}}
+	await saveLoginCredentials(credentials)
+	return {type: SET_LOGIN_CREDENTIALS, payload: credentials}
 }
 
 type LoginStartAction = {|type: 'settings/CREDENTIALS_LOGIN_START'|}
 type LoginSuccessAction = {|
 	type: 'settings/CREDENTIALS_LOGIN_SUCCESS',
-	payload: {username: string, password: string},
+	payload: Credentials,
 |}
 type LoginFailureAction = {|type: 'settings/CREDENTIALS_LOGIN_FAILURE'|}
 type LogInActions = LoginStartAction | LoginSuccessAction | LoginFailureAction
@@ -96,16 +96,15 @@ const showInvalidLoginMessage = () =>
 	)
 
 export function logInViaCredentials(
-	username: string,
-	password: string,
+	credentials: Credentials,
 ): ThunkAction<LogInActions | UpdateBalancesType> {
 	return async (dispatch, getState) => {
 		dispatch({type: CREDENTIALS_LOGIN_START})
 		const state = getState()
 		const isConnected = state.app ? state.app.isConnected : false
-		const result = await performLogin(username, password)
+		const result = await performLogin(credentials)
 		if (result) {
-			dispatch({type: CREDENTIALS_LOGIN_SUCCESS, payload: {username, password}})
+			dispatch({type: CREDENTIALS_LOGIN_SUCCESS, payload: credentials})
 			// since we logged in successfully, go ahead and fetch the meal info
 			dispatch(updateBalances())
 		} else {
@@ -133,17 +132,19 @@ type ValidateCredentialsActions =
 	| ValidateSuccessAction
 	| ValidateFailureAction
 export function validateLoginCredentials(
-	username?: string,
-	password?: string,
+	credentials: Credentials,
 ): ThunkAction<ValidateCredentialsActions> {
 	return async dispatch => {
+		const {username, password} = credentials
 		if (!username || !password) {
 			return
 		}
 
 		dispatch({type: CREDENTIALS_VALIDATE_START})
 
-		const result = await performLogin(username, password)
+		// we try a few times here because the network may not have stabilized
+		// quite yet.
+		const result = await performLogin(credentials, {attempts: 3})
 		if (result) {
 			dispatch({type: CREDENTIALS_VALIDATE_SUCCESS})
 		} else {

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -28,7 +28,7 @@ export function clearLoginCredentials() {
 
 export async function performLogin(
 	{username, password}: Credentials,
-	{attempts = 3}: {attempts: number} = {},
+	{attempts = 0}: {attempts: number} = {},
 ): Promise<boolean> {
 	if (!username || !password) {
 		return false

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -26,14 +26,6 @@ export function clearLoginCredentials() {
 	return resetInternetCredentials(SIS_LOGIN_KEY).catch(empty)
 }
 
-export async function isLoggedIn(): Promise<boolean> {
-	const result = await Promise.all([
-		storage.getTokenValid(),
-		storage.getCredentialsValid(),
-	])
-	return result.every(result => result === true)
-}
-
 export async function performLogin(
 	{username, password}: Credentials,
 	{attempts = 3}: {attempts: number} = {},
@@ -61,14 +53,10 @@ export async function performLogin(
 	const page = await loginResult.text()
 
 	if (page.includes('Password')) {
-		await storage.setCredentialsValid(false)
 		return false
 	}
 
-	await Promise.all([
-		saveLoginCredentials({username, password}),
-		storage.setCredentialsValid(true),
-	])
+	await saveLoginCredentials({username, password})
 
 	return true
 }

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -13,11 +13,13 @@ const SIS_LOGIN_KEY = 'stolaf.edu'
 
 const empty = () => ({})
 
-type Credentials = {username?: string, password?: string}
+export type Credentials = {username: string, password: string}
+export type MaybeCredentials = {username?: string, password?: string}
+
 export function saveLoginCredentials({username, password}: Credentials) {
 	return setInternetCredentials(SIS_LOGIN_KEY, username, password).catch(empty)
 }
-export function loadLoginCredentials(): Promise<Credentials> {
+export function loadLoginCredentials(): Promise<MaybeCredentials> {
 	return getInternetCredentials(SIS_LOGIN_KEY).catch(empty)
 }
 export function clearLoginCredentials() {

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -39,6 +39,7 @@ export async function isLoggedIn(): Promise<boolean> {
 export async function performLogin(
 	username?: string,
 	password?: string,
+	{remainingAttempts = 1}: {remainingAttempts: number} = {},
 ): Promise<boolean> {
 	if (!username || !password) {
 		return false
@@ -52,6 +53,11 @@ export async function performLogin(
 			body: form,
 		})
 	} catch (err) {
+		const networkFailure = err.message === 'Network request failed'
+		if (networkFailure && remainingAttempts > 0) {
+			// console.log(`login failed; trying ${remainingAttempts - 1} more time(s)`)
+			return performLogin(username, password, {remainingAttempts: remainingAttempts - 1})
+		}
 		return false
 	}
 

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -5,7 +5,6 @@ import {
 	resetInternetCredentials,
 } from 'react-native-keychain'
 
-import * as storage from './storage'
 import buildFormData from './formdata'
 import {OLECARD_AUTH_URL} from './financials/urls'
 

--- a/source/lib/storage.js
+++ b/source/lib/storage.js
@@ -75,14 +75,6 @@ export function clearTokenValid(): Promise<any> {
 	return removeItem(tokenValidKey)
 }
 
-const credentialsValidKey = 'olafCredentials:valid'
-export function setCredentialsValid(valid: boolean) {
-	return setItem(credentialsValidKey, valid)
-}
-export function getCredentialsValid(): Promise<boolean> {
-	return getItemAsBoolean(credentialsValidKey)
-}
-
 /// MARK: Favorite Buildings
 
 const favoriteBuildingsKey = 'buildings:favorited'

--- a/source/lib/storage.js
+++ b/source/lib/storage.js
@@ -7,12 +7,15 @@ export function clearAsyncStorage() {
 
 /// MARK: Utilities
 
+// eslint-disable-next-line no-unused-vars
 function setItem(key: string, value: mixed) {
 	return AsyncStorage.setItem(`aao:${key}`, JSON.stringify(value))
 }
+// eslint-disable-next-line no-unused-vars
 function getItem(key: string): Promise<?any> {
 	return AsyncStorage.getItem(`aao:${key}`).then(stored => JSON.parse(stored))
 }
+// eslint-disable-next-line no-unused-vars
 function removeItem(key: string): Promise<void> {
 	return AsyncStorage.removeItem(`aao:${key}`)
 }

--- a/source/lib/storage.js
+++ b/source/lib/storage.js
@@ -62,19 +62,6 @@ export function getAcknowledgementStatus(): Promise<boolean> {
 	return getItemAsBoolean(acknowledgementStatusKey)
 }
 
-/// MARK: Credentials
-
-const tokenValidKey = 'credentials:valid'
-export function setTokenValid(valid: boolean) {
-	return setItem(tokenValidKey, valid)
-}
-export function getTokenValid(): Promise<boolean> {
-	return getItemAsBoolean(tokenValidKey)
-}
-export function clearTokenValid(): Promise<any> {
-	return removeItem(tokenValidKey)
-}
-
 /// MARK: Favorite Buildings
 
 const favoriteBuildingsKey = 'buildings:favorited'

--- a/source/views/settings/sections/login-credentials.js
+++ b/source/views/settings/sections/login-credentials.js
@@ -137,10 +137,13 @@ function mapStateToProps(state: ReduxState): ReduxStateProps {
 
 function mapDispatchToProps(dispatch): ReduxDispatchProps {
 	return {
-		logIn: (u, p) => dispatch(logInViaCredentials(u, p)),
 		logOut: () => dispatch(logOutViaCredentials()),
-		validateCredentials: (u, p) => dispatch(validateLoginCredentials(u, p)),
-		setCredentials: (u, p) => dispatch(setLoginCredentials(u, p)),
+		logIn: (username, password) =>
+			dispatch(logInViaCredentials({username, password})),
+		validateCredentials: (username, password) =>
+			dispatch(validateLoginCredentials({username, password})),
+		setCredentials: (username, password) =>
+			dispatch(setLoginCredentials({username, password})),
 	}
 }
 


### PR DESCRIPTION
Closes #2043 

I think the problem was in fact that the network hadn't initialized yet… odd. Anyway, trying it again works.

I'm only retrying on the login-from-launch state, because we have other alerts and whatnot for the normal login process.

This also cleans up some of the login function cruft, and passes around login objects instead of positional arguments.