### PR TITLE
Remove Mess from NSTemporaryExceptionAllowsInsecureHTTPLoads list

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -91,11 +91,6 @@
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
-			<key>manitoumessenger.com</key>
-			<dict>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 			<key>oleville.com</key>
 			<dict>
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>


### PR DESCRIPTION
As the title says.

Now that they're back on Pages, they have HTTPS. Woot!