### PR TITLE
Allow tabs to scroll on Android

### DIFF
--- a/source/views/components/tabbed-view/index.js
+++ b/source/views/components/tabbed-view/index.js
@@ -29,7 +29,7 @@ export const TabNavigator: ComponentType = (screens, options) =>
 					activeTintColor: c.mandarin,
 				},
 			}),
-			scrollEnabled: Platform.OS == 'ios',
+			scrollEnabled: Platform.OS !== 'ios',
 			...(options.tabBarOptions || {}),
 			style: {
 				...Platform.select({

--- a/source/views/help/wifi.js
+++ b/source/views/help/wifi.js
@@ -40,7 +40,6 @@ export class ToolView extends React.Component<Props, State> {
 	start = async () => {
 		let reportUrl =
 			'https://www.stolaf.edu/apps/all-about-olaf/wifi/index.cfm?fuseaction=Submit'
- 
 
 		if (this.props.config.buttons && this.props.config.buttons.length >= 1) {
 			const btnConfig = this.props.config.buttons[0]


### PR DESCRIPTION
Ignore the purple titlebar…

This has been a problem since we switched to react-navigation however long ago.

![screenshot_1517025792](https://user-images.githubusercontent.com/464441/35468501-e4eb36be-02e4-11e8-8b0d-0582cd11a3ad.png)
