### PR TITLE
Horizontal scrolling movie showtimes

### DIFF
--- a/source/views/streaming/movie/view.js
+++ b/source/views/streaming/movie/view.js
@@ -1,7 +1,14 @@
 // @flow
 
 import * as React from 'react'
-import {StyleSheet, ScrollView, Dimensions, Platform} from 'react-native'
+import {
+	StyleSheet,
+	SectionList,
+	View,
+	ScrollView,
+	Dimensions,
+	Platform,
+} from 'react-native'
 import {connect} from 'react-redux'
 import {getWeeklyMovie} from '../../../flux/parts/weekly-movie'
 import {type ReduxState} from '../../../flux'
@@ -24,6 +31,12 @@ import {
 import {Touchable} from '../../components/touchable'
 import Icon from 'react-native-vector-icons/Ionicons'
 import LinearGradient from 'react-native-linear-gradient'
+import {
+	ListRow,
+	ListSectionHeader,
+	ListSeparator,
+	Detail,
+} from '../../components/list'
 import type {
 	Movie,
 	MovieShowing,
@@ -233,7 +246,7 @@ export class PlainWeeklyMovieView extends React.Component<Props> {
 					</Row>
 				</MovieInfo>
 
-				{/*<Showings showings={movie.showings} />*/}
+				<Showings showings={movie.showings} />
 
 				<Plot text={movie.info.Plot} />
 
@@ -531,6 +544,12 @@ const PaddedCard = ({children}) => (
 	</Card>
 )
 
+const PaddedShowingsCard = ({children}) => (
+	<Card marginHorizontal={10} marginVertical={16} paddingHorizontal={10}>
+		{children}
+	</Card>
+)
+
 const Heading = glamorous.text({...human.headlineObject})
 const Text = glamorous.text({...human.bodyObject})
 
@@ -576,7 +595,7 @@ const EmptyStar = () => (
 )
 
 const RottenTomatoesRating = ({ratings}) => {
-	const rating = ratings.find(r => r.Source === 'Rotten Tomatoes')
+	let rating = ratings.find(r => r.Source === 'Rotten Tomatoes')
 
 	if (!rating) {
 		return <glamorous.Text>Unrated</glamorous.Text>
@@ -601,6 +620,68 @@ const RottenTomatoesRating = ({ratings}) => {
 
 	const tint = colorizeScore(rating.Value)
 	return <glamorous.Text color={tint}>{starIcons}</glamorous.Text>
+}
+
+class Showings extends React.Component {
+	renderRow = ({item}: {item: Movie}) => (
+		<PaddedShowingsCard>
+			<ListRow
+				contentContainerStyle={[styles.row]}
+				arrowPosition="none"
+				fullWidth={true}
+			>
+				<Row alignItems="flex-start">
+					<Column flex={1}>
+						<Row alignItems="flex-end">
+							<Detail style={[styles.showingsDay, styles.shared]} lines={1}>
+								{moment(item.time).format('D')}
+							</Detail>
+							<Detail style={styles.showingsLocation} lines={1}>
+								{item.location.toUpperCase()}
+							</Detail>
+						</Row>
+						<Row alignItems="flex-end">
+							<Detail style={[styles.showingsMonth, styles.shared]} lines={1}>
+								{moment(item.time)
+									.format('MMM')
+									.toUpperCase()}
+							</Detail>
+							<Detail style={styles.showingsTime} lines={1}>
+								{moment(item.time).format('h:mmA')}
+							</Detail>
+						</Row>
+					</Column>
+				</Row>
+			</ListRow>
+		</PaddedShowingsCard>
+	)
+
+	renderSeparator = () => <ListSeparator fullWidth={true} />
+
+	keyExtractor = (item: Movie) => item.time
+
+	render() {
+		if (!this.props.showings) {
+			return null
+		}
+
+		const sections = [{title: 'Showings', data: this.props.showings}]
+
+		return (
+			<View style={styles.showingsWrapper}>
+				<SectionList
+					horizontal={true}
+					showsHorizontalScrollIndicator={false}
+					ListEmptyComponent={<Text>No Showings</Text>}
+					sections={sections}
+					ItemSeparatorComponent={this.renderSeparator}
+					keyExtractor={this.keyExtractor}
+					style={styles.listContainer}
+					renderItem={this.renderRow}
+				/>
+			</View>
+		)
+	}
 }
 
 class ImdbLink extends React.Component<{id: string}> {
@@ -640,5 +721,24 @@ class ImdbLink extends React.Component<{id: string}> {
 const styles = StyleSheet.create({
 	contentContainer: {
 		backgroundColor: c.white,
+	},
+	showingsLocation: {
+		fontSize: 14,
+		marginBottom: 3,
+	},
+	showingsDay: {
+		color: c.black,
+		fontSize: 22,
+	},
+	showingsMonth: {
+		color: c.black,
+		fontSize: 13,
+	},
+	showingsTime: {
+		color: c.black,
+		fontSize: 13,
+	},
+	shared: {
+		marginRight: 20,
 	},
 })

--- a/source/views/streaming/movie/view.js
+++ b/source/views/streaming/movie/view.js
@@ -595,7 +595,7 @@ const EmptyStar = () => (
 )
 
 const RottenTomatoesRating = ({ratings}) => {
-	let rating = ratings.find(r => r.Source === 'Rotten Tomatoes')
+	const rating = ratings.find(r => r.Source === 'Rotten Tomatoes')
 
 	if (!rating) {
 		return <glamorous.Text>Unrated</glamorous.Text>


### PR DESCRIPTION
**This is a PR into the WIP `weekly-movies-hawken-3` and not `master`.**

This adds a horizontal scrolling list of showtimes for when and where a movie is playing.

@hawkrives I know your vision was to combine the showtimes per time into one card. This does not do that as of yet. We can accept this and build upon it!

<img src="https://user-images.githubusercontent.com/5240843/35585696-e948d3d2-05b5-11e8-8550-bbab3ead4db2.png" width=320 />
