### PR TITLE
Android Wifi Reporting: Use Lazy Geolocation

### DIFF
--- a/source/views/help/wifi-tools.js
+++ b/source/views/help/wifi-tools.js
@@ -15,7 +15,7 @@ export const getIpAddress = (): Promise<?string> =>
 
 export const getPosition = (): Promise<Object> =>
 	new Promise((resolve, reject) => {
-		navigator.geolocation.getCurrentPosition(resolve, err => reject(err))
+		navigator.geolocation.getCurrentPosition(resolve, reject)
 	})
 
 export const collectData = async () => ({

--- a/source/views/help/wifi-tools.js
+++ b/source/views/help/wifi-tools.js
@@ -2,6 +2,7 @@
 
 import deviceInfo from 'react-native-device-info'
 import networkInfo from 'react-native-network-info'
+import {Platform} from 'react-native'
 import pkg from '../../../package.json'
 
 export const getIpAddress = (): Promise<?string> =>
@@ -13,9 +14,18 @@ export const getIpAddress = (): Promise<?string> =>
 		}
 	})
 
-export const getPosition = (): Promise<Object> =>
+export const getPosition = (args: any = {}): Promise<Object> =>
 	new Promise((resolve, reject) => {
-		navigator.geolocation.getCurrentPosition(resolve, reject)
+		if(Platform.OS === 'ios') {
+			navigator.geolocation.getCurrentPosition(resolve, reject, {
+				...args,
+				enableHighAccuracy: true,
+				maximumAge: 1000 /* ms */,
+				timeout: 5000 /* ms */,
+			})
+		} else {
+			navigator.geolocation.getCurrentPosition(resolve, reject)
+		}
 	})
 
 export const collectData = async () => ({

--- a/source/views/help/wifi-tools.js
+++ b/source/views/help/wifi-tools.js
@@ -15,7 +15,7 @@ export const getIpAddress = (): Promise<?string> =>
 
 export const getPosition = (): Promise<Object> =>
 	new Promise(resolve => {
-		navigator.geolocation.getCurrentPosition(resolve, () => resolve({}))
+		navigator.geolocation.getCurrentPosition(resolve, err => { throw err })
 	})
 
 export const collectData = async () => ({

--- a/source/views/help/wifi-tools.js
+++ b/source/views/help/wifi-tools.js
@@ -13,7 +13,7 @@ export const getIpAddress = (): Promise<?string> =>
 		}
 	})
 
-export const getPosition = (args: any = {}): Promise<Object> =>
+export const getPosition = (): Promise<Object> =>
 	new Promise(resolve => {
 		navigator.geolocation.getCurrentPosition(resolve, () => resolve({}))
 	})

--- a/source/views/help/wifi-tools.js
+++ b/source/views/help/wifi-tools.js
@@ -21,7 +21,7 @@ export const getPosition = (args: any = {}): Promise<Object> =>
 				...args,
 				enableHighAccuracy: true,
 				maximumAge: 1000 /* ms */,
-				timeout: 5000 /* ms */,
+				timeout: 15000 /* ms */,
 			})
 		} else {
 			navigator.geolocation.getCurrentPosition(resolve, reject)

--- a/source/views/help/wifi-tools.js
+++ b/source/views/help/wifi-tools.js
@@ -16,15 +16,15 @@ export const getIpAddress = (): Promise<?string> =>
 
 export const getPosition = (args: any = {}): Promise<Object> =>
 	new Promise((resolve, reject) => {
-		if (Platform.OS === 'ios') {
+		if (Platform.OS === 'android') {
+			navigator.geolocation.getCurrentPosition(resolve, reject)
+		} else {
 			navigator.geolocation.getCurrentPosition(resolve, reject, {
 				...args,
 				enableHighAccuracy: true,
 				maximumAge: 1000 /* ms */,
 				timeout: 15000 /* ms */,
 			})
-		} else {
-			navigator.geolocation.getCurrentPosition(resolve, reject)
 		}
 	})
 

--- a/source/views/help/wifi-tools.js
+++ b/source/views/help/wifi-tools.js
@@ -14,8 +14,8 @@ export const getIpAddress = (): Promise<?string> =>
 	})
 
 export const getPosition = (): Promise<Object> =>
-	new Promise(resolve => {
-		navigator.geolocation.getCurrentPosition(resolve, err => { throw err })
+	new Promise((resolve, reject) => {
+		navigator.geolocation.getCurrentPosition(resolve, err => reject(err))
 	})
 
 export const collectData = async () => ({

--- a/source/views/help/wifi-tools.js
+++ b/source/views/help/wifi-tools.js
@@ -15,12 +15,7 @@ export const getIpAddress = (): Promise<?string> =>
 
 export const getPosition = (args: any = {}): Promise<Object> =>
 	new Promise(resolve => {
-		navigator.geolocation.getCurrentPosition(resolve, () => resolve({}), {
-			...args,
-			enableHighAccuracy: true,
-			maximumAge: 1000 /*ms*/,
-			timeout: 5000 /*ms*/,
-		})
+		navigator.geolocation.getCurrentPosition(resolve, () => resolve({}))
 	})
 
 export const collectData = async () => ({

--- a/source/views/help/wifi-tools.js
+++ b/source/views/help/wifi-tools.js
@@ -16,7 +16,7 @@ export const getIpAddress = (): Promise<?string> =>
 
 export const getPosition = (args: any = {}): Promise<Object> =>
 	new Promise((resolve, reject) => {
-		if(Platform.OS === 'ios') {
+		if (Platform.OS === 'ios') {
 			navigator.geolocation.getCurrentPosition(resolve, reject, {
 				...args,
 				enableHighAccuracy: true,

--- a/source/views/help/wifi.js
+++ b/source/views/help/wifi.js
@@ -51,7 +51,10 @@ export class ToolView extends React.Component<Props, State> {
 
 		this.setState(() => ({status: 'collecting', error: ''}))
 		const [position, device] = await Promise.all([
-			getPosition().catch(bugsnag.notify),
+			getPosition().catch(error => {
+				bugsnag.notify(error)
+				return null
+			}),
 			collectData(),
 		])
 		this.setState(() => ({status: 'reporting'}))

--- a/source/views/help/wifi.js
+++ b/source/views/help/wifi.js
@@ -11,6 +11,7 @@ import {Error, ErrorMessage} from './components'
 import {getPosition, collectData, reportToServer} from './wifi-tools'
 import {styles} from './tool'
 import type {ToolOptions} from './types'
+import bugsnag from '../../bugsnag'
 
 export const toolName = 'wifi'
 
@@ -49,7 +50,10 @@ export class ToolView extends React.Component<Props, State> {
 		}
 
 		this.setState(() => ({status: 'collecting', error: ''}))
-		const [position, device] = await Promise.all([getPosition(), collectData()])
+		const [position, device] = await Promise.all([
+			getPosition().catch(bugsnag.notify),
+			collectData(),
+		])
 		this.setState(() => ({status: 'reporting'}))
 
 		try {


### PR DESCRIPTION
This PR removes the third argument from the `Geolocation.getCurrentPosition` call which we use for collecting positions when doing Wifi reporting, but only on Android.  On iOS, this third argument is preserved, but is turned from 5 seconds on timeout up to 15 seconds.  This gives the phone more time to think about where it is.

In the event of a timeout or something, we'd also rather not submit an empty object as "yeah sure this is good."  I have instead changed that to be a Promise rejection, [edit: on both platforms] which is then caught in the tool's handler and shipped off to BugSnag.  I think (?) that catching it like that will keep the client happy?  We won't throw an error state or something like that, because I don't think users will want to hear from our app about being sad. 🙃