### PR TITLE
Revert "Update ajv to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "xml2js": "0.4.19"
   },
   "devDependencies": {
-    "ajv": "6.1.1",
+    "ajv": "6.1.0",
     "babel-core": "6.26.0",
     "babel-eslint": "8.2.1",
     "babel-jest": "22.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,9 +162,9 @@ ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
-ajv@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.1.1.tgz#978d597fbc2b7d0e5a5c3ddeb149a682f2abfa0e"
+ajv@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.1.0.tgz#adc4b3dd64b2d8740d13c5b38e4596115970e59d"
   dependencies:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"


### PR DESCRIPTION
Reverts StoDevX/AAO-React-Native#2282

Temporarily until we cut 2.5.1