### PR TITLE
Revert "Update react-native-device-info to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-native-calendar-events": "1.4.3",
     "react-native-communications": "2.2.1",
     "react-native-custom-tabs": "0.1.7",
-    "react-native-device-info": "0.14.0",
+    "react-native-device-info": "0.13.0",
     "react-native-google-analytics-bridge": "5.5.2",
     "react-native-keychain": "2.0.0",
     "react-native-linear-gradient": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4750,9 +4750,9 @@ react-native-custom-tabs@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/react-native-custom-tabs/-/react-native-custom-tabs-0.1.7.tgz#2dfb4028b0a443610d94792b2019810f68dde525"
 
-react-native-device-info@0.14.0:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-0.14.0.tgz#b77d0368e197c7a6fc8de612f8272d3526847bd4"
+react-native-device-info@0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-0.13.0.tgz#81051eebd3db6959e4f1d2cb0ae8df74105040cf"
 
 react-native-dismiss-keyboard@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Reverts StoDevX/AAO-React-Native#2283

Until after 2.5.1