### PR TITLE
Update stav hours for interim break

### DIFF
--- a/data/building-hours/1-3-stav.yaml
+++ b/data/building-hours/1-3-stav.yaml
@@ -4,21 +4,23 @@ category: Food
 
 schedule:
   - title: Breakfast
-    hours:
-      - {days: [Mo, Tu, We, Th, Fr, Sa], from: '7:00am', to: '9:45am'}
-      - {days: [Su], from: '8:30am', to: '10:15am'}
+    # hours:
+      # - {days: [Mo, Tu, We, Th, Fr, Sa], from: '7:00am', to: '9:45am'}
+      # - {days: [Su], from: '8:30am', to: '10:15am'}
+    hours: []
 
   - title: Lunch
+    notes: NO MEAL PLANS - department charges, cash, credit, Ole or Flex dollars only
     hours:
       # - {days: [Mo, Tu, We, Th, Fr], from: '10:30am', to: '2:00pm'}
       # - {days: [Sa, Su], from: '11:00am', to: '1:30pm'}
-      - {days: [Mo, Tu, We, Th, Fr], from: '10:45am', to: '1:30pm'}
-      - {days: [Sa, Su], from: '11:00am', to: '1:30pm'}
+      - {days: [Mo, Tu, We, Th, Fr], from: '12:00pm', to: '1:00pm'}
 
   - title: Dinner
+    notes: NO MEAL PLANS - department charges, cash, credit, Ole or Flex dollars only
     hours:
       # - {days: [Mo, Tu, We, Th, Fr, Sa, Su], from: '4:30pm', to: '7:30pm'}
-      - {days: [Mo, Tu, We, Th, Fr, Sa, Su], from: '4:30pm', to: '7:00pm'}
+      - {days: [Mo, Tu, We, Th, Fr], from: '5:00pm', to: '6:00pm'}
 
 breakSchedule:
   fall: []


### PR DESCRIPTION
<details>
 <summary>Schedule provided by @rye </summary>
<img src="https://user-images.githubusercontent.com/5240843/35641767-5331fd00-067e-11e8-8075-37859ac51472.jpg" width=450 />
</details>

<hr>

**January 31 - February 6**

Day | Breakfast | Lunch | Dinner
--|--|--|--
Wednesday | Closed | 12-1 | 5-6 | 
Thursday | Closed | 12-1 | 5-6 | 
Friday | Closed | 12-1 | 5-6 | 
Saturday | Closed | Closed | Closed
Sunday | Closed | Closed | Closed
Monday | Closed | 12-1 | 5-6 | 
Tuesday | Closed | 12-1 | 5-6 | 

Have not made changes to account for **Wednesday, Feb 7**

Day | Breakfast | Lunch | Dinner
--|--|--|--
Wednesday | Closed | 11:30-1:30 | 4:30-7:30