### PR TITLE
Limit gradle memory to 512MB

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -11,7 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx1024m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.jvmargs=-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx512m -XX:+HeapDumpOnOutOfMemoryError
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
@@ -23,6 +23,7 @@ org.gradle.parallel=true
 #
 # Be glad you're not building for iOS. :P
 org.gradle.workers.max=2
+org.gradle.daemon=false
 
 android.useDeprecatedNdk=true
 android.enableAapt2=false


### PR DESCRIPTION
I also disabled the gradle daemon… maybe we only want to do that on CI? (Can we?)