### PR TITLE
reduce the number of copies of lodash floating around

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3887,11 +3887,11 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
 
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@4.17.5:
+lodash@4.17.5, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 


### PR DESCRIPTION
I went looking in our `node_modules` folder, as I do occasionally, and I realized that we had a bunch of duplicate copies of lodash floating around (from #2302, I think).

I tweaked `yarn.lock` to resolve all the ranged lodash dependencies on our topmost copy of lodash, the one we depend on in `package.json`, which meant that yarn's deduping can dedupe many more copies of lodash.

<details><summary>Things that depend on `lodash`:</summary>

```
AllAboutOlaf@2.5.1 /Users/hawken/all-about-olaf
├─┬ babel-core@6.26.0
│ ├─┬ babel-generator@6.26.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-register@6.26.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-template@6.26.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-traverse@6.26.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-types@6.26.0
│ │ └── lodash@4.17.5  deduped
│ └── lodash@4.17.5  deduped
├─┬ babel-eslint@8.2.1
│ ├─┬ @babel/traverse@7.0.0-beta.36
│ │ ├─┬ @babel/helper-function-name@7.0.0-beta.36
│ │ │ └─┬ @babel/template@7.0.0-beta.36
│ │ │   └── lodash@4.17.5  deduped
│ │ └── lodash@4.17.5  deduped
│ └─┬ @babel/types@7.0.0-beta.36
│   └── lodash@4.17.5  deduped
├─┬ babel-preset-react-native@4.0.0
│ ├─┬ babel-plugin-react-transform@3.0.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-plugin-transform-es2015-block-scoping@6.26.0
│ │ └── lodash@4.17.5  deduped
│ ├─┬ babel-plugin-transform-es2015-classes@6.24.1
│ │ └─┬ babel-helper-define-map@6.26.0
│ │   └── lodash@4.17.5  deduped
│ └─┬ react-transform-hmr@1.0.4
│   └─┬ react-proxy@1.1.8
│     └── lodash@4.17.5  deduped
├─┬ danger@3.1.6
│ └─┬ @octokit/rest@14.0.4
│   └── lodash@4.17.5  deduped
├─┬ danger-plugin-yarn@1.2.0
│ └─┬ esdoc@0.5.2
│   ├─┬ babel-generator@6.11.4
│   │ └── lodash@4.17.5  deduped
│   ├─┬ babel-traverse@6.12.0
│   │ └── lodash@4.17.5  deduped
│   └─┬ ice-cap@0.0.4
│     └─┬ cheerio@0.20.0
│       └── lodash@4.17.5  deduped
├─┬ eslint@4.17.0
│ ├─┬ inquirer@3.3.0
│ │ └── lodash@4.17.5  deduped
│ ├── lodash@4.17.5  deduped
│ └─┬ table@4.0.2
│   └── lodash@4.17.5  deduped
├─┬ eslint-plugin-flowtype@2.43.0
│ └── lodash@4.17.5  deduped
├─┬ jest@22.1.4
│ └─┬ jest-cli@22.1.4
│   └─┬ jest-environment-jsdom@22.1.4
│     └─┬ jsdom@11.5.1
│       └─┬ request-promise-native@1.0.5
│         └─┬ request-promise-core@1.1.1
│           └── lodash@4.17.5  deduped
├── lodash@4.17.5 
├─┬ react-native-maps@0.20.0
│ └─┬ babel-preset-react-native@1.9.0
│   └─┬ babel-plugin-react-transform@2.0.2
│     └── lodash@4.17.5  deduped
├─┬ react-native-vector-icons@4.5.0
│ └── lodash@4.17.5  deduped
├─┬ react-navigation@1.0.0-beta.22
│ └─┬ babel-plugin-transform-define@1.3.0
│   └── lodash@4.17.4 
├─┬ react-redux@5.0.6
│ └── lodash@4.17.5  deduped
└─┬ redux@3.7.2
  └── lodash@4.17.5  deduped
```

</details>

<br/>

```markdown
<!-- before -->
# ~/all-about-olaf ⚘ yarn
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 19.31s.

# ~/all-about-olaf ⚘ du -hc -d 0 node_modules/
473M
```

```markdown
<!-- after -->
# ~/all-about-olaf ⚘ yarn
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 11.81s.

# ~/all-about-olaf ⚘ du -hc -d 0 node_modules/
337M
```