### PR TITLE
added noticeview to course-search if data isn't cached

### DIFF
--- a/source/views/components/__tests__/__snapshots__/notice.test.js.snap
+++ b/source/views/components/__tests__/__snapshots__/notice.test.js.snap
@@ -29,6 +29,7 @@ exports[`renders a button, if given 1`] = `
     Label
   </Text>
   <Button
+    disabled={undefined}
     onPress={undefined}
     title="Button"
   />

--- a/source/views/components/notice.js
+++ b/source/views/components/notice.js
@@ -24,6 +24,7 @@ const styles = StyleSheet.create({
 })
 
 type Props = {
+	buttonDisabled?: boolean,
 	header?: string,
 	text?: string,
 	style?: any,
@@ -33,6 +34,7 @@ type Props = {
 }
 
 export function NoticeView({
+	buttonDisabled,
 	header,
 	text,
 	style,
@@ -50,7 +52,13 @@ export function NoticeView({
 				{text || 'Notice!'}
 			</Text>
 
-			{buttonText ? <Button onPress={onPress} title={buttonText} /> : null}
+			{buttonText ? (
+				<Button
+					disabled={buttonDisabled}
+					onPress={onPress}
+					title={buttonText}
+				/>
+			) : null}
 		</View>
 	)
 }


### PR DESCRIPTION
This should resolve any problems for users who haven't used the course-search feature or have cleared all app data. Users who have no cached course data will encounter a `NoticeView` upon entering the course search tab, prompting them to download the course data. Users will only have to take this step if they don't have any data cached on their phone yet.