### PR TITLE
More whitespace between network warnings

### DIFF
--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -183,7 +183,7 @@ class CourseSearchView extends React.PureComponent<Props, State> {
 					text={
 						this.props.isConnected
 							? PROMPT_TEXT
-							: PROMPT_TEXT.concat(`\n${NETWORK_WARNING}`)
+							: PROMPT_TEXT.concat(`\n\n${NETWORK_WARNING}`)
 					}
 				/>
 			)


### PR DESCRIPTION
Closes #2332

Solution taken from @hannesmcman's https://github.com/StoDevX/AAO-React-Native/issues/2332#issuecomment-365300860 