### PR TITLE
Add <Viewport/> component with a render prop

### DIFF
--- a/source/views/components/__tests__/__snapshots__/notice.test.js.snap
+++ b/source/views/components/__tests__/__snapshots__/notice.test.js.snap
@@ -28,11 +28,67 @@ exports[`renders a button, if given 1`] = `
   >
     Label
   </Text>
-  <Button
-    disabled={undefined}
-    onPress={undefined}
-    title="Button"
-  />
+  <View
+    accessibilityComponentType="button"
+    accessibilityLabel={undefined}
+    accessibilityTraits="button"
+    accessible={true}
+    collapsable={undefined}
+    hasTVPreferredFocus={undefined}
+    hitSlop={undefined}
+    isTVSelectable={true}
+    nativeID={undefined}
+    onLayout={undefined}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignSelf": "center",
+        "backgroundColor": "rgb(67, 114, 170)",
+        "borderRadius": 6,
+        "marginVertical": 10,
+        "opacity": 1,
+        "overflow": "hidden",
+        "paddingHorizontal": 20,
+        "paddingVertical": 10,
+      }
+    }
+    testID={undefined}
+    tvParallaxProperties={undefined}
+  >
+    <Text
+      accessible={true}
+      allowFontScaling={true}
+      ellipsizeMode="tail"
+      style={
+        Array [
+          Object {
+            "color": "#007aff",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "textAlign": "center",
+          },
+          null,
+          Object {
+            "backgroundColor": "transparent",
+            "color": "#FFFFFF",
+            "fontFamily": "System",
+            "fontSize": 16,
+            "fontWeight": "400",
+            "letterSpacing": -0.32,
+            "lineHeight": 21,
+          },
+          null,
+        ]
+      }
+    >
+      Button
+    </Text>
+  </View>
 </View>
 `;
 

--- a/source/views/components/__tests__/notice.test.js
+++ b/source/views/components/__tests__/notice.test.js
@@ -3,27 +3,21 @@
 
 import 'react-native'
 import * as React from 'react'
-import ReactShallowRenderer from 'react-test-renderer/shallow'
+import ReactTestRenderer from 'react-test-renderer'
 
 import {NoticeView} from '../notice'
 
-const shallow = component => {
-	const r = new ReactShallowRenderer()
-	r.render(component)
-	return r.getRenderOutput()
-}
-
 test('renders the given text', () => {
-	const tree = shallow(<NoticeView text="A Label I Am" />)
+	const tree = ReactTestRenderer.create(<NoticeView text="A Label I Am" />)
 	expect(tree).toMatchSnapshot()
 })
 
 test('renders a button, if given', () => {
-	const tree = shallow(<NoticeView buttonText="Button" text="Label" />)
+	const tree = ReactTestRenderer.create(<NoticeView buttonText="Button" text="Label" />)
 	expect(tree).toMatchSnapshot()
 })
 
 test('shows an ActivityIndicator if given [spinner]', () => {
-	const tree = shallow(<NoticeView spinner={true} text="Label" />)
+	const tree = ReactTestRenderer.create(<NoticeView spinner={true} text="Label" />)
 	expect(tree).toMatchSnapshot()
 })

--- a/source/views/components/__tests__/notice.test.js
+++ b/source/views/components/__tests__/notice.test.js
@@ -13,11 +13,15 @@ test('renders the given text', () => {
 })
 
 test('renders a button, if given', () => {
-	const tree = ReactTestRenderer.create(<NoticeView buttonText="Button" text="Label" />)
+	const tree = ReactTestRenderer.create(
+		<NoticeView buttonText="Button" text="Label" />,
+	)
 	expect(tree).toMatchSnapshot()
 })
 
 test('shows an ActivityIndicator if given [spinner]', () => {
-	const tree = ReactTestRenderer.create(<NoticeView spinner={true} text="Label" />)
+	const tree = ReactTestRenderer.create(
+		<NoticeView spinner={true} text="Label" />,
+	)
 	expect(tree).toMatchSnapshot()
 })

--- a/source/views/components/notice.js
+++ b/source/views/components/notice.js
@@ -4,6 +4,7 @@ import {ActivityIndicator, StyleSheet, Text, View} from 'react-native'
 import * as c from './colors'
 import {Button} from './button'
 import {Heading} from './markdown/heading'
+import {Viewport} from './viewport'
 
 const styles = StyleSheet.create({
 	container: {
@@ -33,32 +34,32 @@ type Props = {
 	onPress?: () => any,
 }
 
-export function NoticeView({
-	buttonDisabled,
-	header,
-	text,
-	style,
-	spinner,
-	buttonText,
-	onPress,
-}: Props) {
+export function NoticeView(props: Props) {
+	const {header, text, style} = props
+	const {buttonDisabled, buttonText, onPress} = props
+	const {spinner} = props
+
 	return (
-		<View style={[styles.container, style]}>
-			{spinner ? <ActivityIndicator style={styles.spinner} /> : null}
+		<Viewport
+			render={() => (
+				<View style={[styles.container, style]}>
+					{spinner ? <ActivityIndicator style={styles.spinner} /> : null}
 
-			{header ? <Heading level={1}>{header}</Heading> : null}
+					{header ? <Heading level={1}>{header}</Heading> : null}
 
-			<Text selectable={true} style={styles.text}>
-				{text || 'Notice!'}
-			</Text>
+					<Text selectable={true} style={styles.text}>
+						{text || 'Notice!'}
+					</Text>
 
-			{buttonText ? (
-				<Button
-					disabled={buttonDisabled}
-					onPress={onPress}
-					title={buttonText}
-				/>
-			) : null}
-		</View>
+					{buttonText ? (
+						<Button
+							disabled={buttonDisabled}
+							onPress={onPress}
+							title={buttonText}
+						/>
+					) : null}
+				</View>
+			)}
+		/>
 	)
 }

--- a/source/views/components/viewport.js
+++ b/source/views/components/viewport.js
@@ -1,0 +1,36 @@
+// @flow
+
+import * as React from 'react'
+import {Dimensions} from 'react-native'
+
+type WindowDimensions = {width: number, height: number}
+
+type Props = {
+	render: WindowDimensions => React.Node,
+}
+
+type State = {
+	viewport: WindowDimensions,
+}
+
+export class Viewport extends React.PureComponent<Props, State> {
+	state = {
+		viewport: Dimensions.get('window'),
+	}
+
+	componentWillMount() {
+		Dimensions.addEventListener('change', this.handleResizeEvent)
+	}
+
+	componentWillUnmount() {
+		Dimensions.removeEventListener('change', this.handleResizeEvent)
+	}
+
+	handleResizeEvent = (event: {window: WindowDimensions}) => {
+		this.setState(() => ({viewport: event.window}))
+	}
+
+	render() {
+		return this.props.render(this.state.viewport)
+	}
+}

--- a/source/views/home/edit/list.ios.js
+++ b/source/views/home/edit/list.ios.js
@@ -1,12 +1,13 @@
 // @flow
 
 import * as React from 'react'
-import {Dimensions, StyleSheet} from 'react-native'
+import {StyleSheet} from 'react-native'
 import {type ReduxState} from '../../../flux'
 import {saveHomescreenOrder} from '../../../flux/parts/homescreen'
 import {connect} from 'react-redux'
 import * as c from '../../components/colors'
 import fromPairs from 'lodash/fromPairs'
+import {Viewport} from '../../components/viewport'
 
 import SortableList from '@hawkrives/react-native-sortable-list'
 
@@ -39,32 +40,13 @@ type ReduxDispatchProps = {
 
 type Props = ReduxStateProps & ReduxDispatchProps
 
-type State = {
-	width: number,
-}
-
-class EditHomeView extends React.PureComponent<Props, State> {
+class EditHomeView extends React.PureComponent<Props> {
 	static navigationOptions = {
 		title: 'Edit Home',
 	}
 
-	state = {
-		width: Dimensions.get('window').width,
-	}
-
-	componentWillMount() {
-		Dimensions.addEventListener('change', this.handleResizeEvent)
-	}
-
-	componentWillUnmount() {
-		Dimensions.removeEventListener('change', this.handleResizeEvent)
-	}
-
-	handleResizeEvent = event => {
-		this.setState(() => ({width: event.window.width}))
-	}
-
-	renderRow = ({data, active}: {data: ViewType, active: boolean}) => {
+	renderRow = (args: {data: ViewType, active: boolean, width: number}) => {
+		const {data, active, width} = args
 		const enabled = !this.props.inactiveViews.includes(data.view)
 		return (
 			<EditHomeRow
@@ -72,7 +54,7 @@ class EditHomeView extends React.PureComponent<Props, State> {
 				data={data}
 				isEnabled={enabled}
 				onToggle={this.props.onToggleViewDisabled}
-				width={this.state.width}
+				width={width}
 			/>
 		)
 	}
@@ -81,15 +63,16 @@ class EditHomeView extends React.PureComponent<Props, State> {
 
 	render() {
 		return (
-			<SortableList
-				contentContainerStyle={[
-					styles.contentContainer,
-					{width: this.state.width},
-				]}
-				data={objViews}
-				onChangeOrder={this.onChangeOrder}
-				order={this.props.order}
-				renderRow={this.renderRow}
+			<Viewport
+				render={({width}) => (
+					<SortableList
+						contentContainerStyle={[styles.contentContainer, {width}]}
+						data={objViews}
+						onChangeOrder={this.onChangeOrder}
+						order={this.props.order}
+						renderRow={props => this.renderRow({...props, width})}
+					/>
+				)}
 			/>
 		)
 	}

--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {StyleSheet, View, Animated, Dimensions, Platform} from 'react-native'
+import {StyleSheet, View, Animated, Platform} from 'react-native'
 import {TabBarIcon} from '../../components/tabbar-icon'
 import * as c from '../../components/colors'
 import {SearchBar} from '../../components/searchbar'
@@ -20,6 +20,7 @@ import {CourseSearchResultsList} from './list'
 import LoadingView from '../../components/loading'
 import {deptNum} from './lib/format-dept-num'
 import {NoticeView} from '../../components/notice'
+import {Viewport} from '../../components/viewport'
 
 const PROMPT_TEXT =
 	'We need to download the courses from the server. This will take a few seconds.'
@@ -168,11 +169,6 @@ class CourseSearchView extends React.PureComponent<Props, State> {
 	}
 
 	render() {
-		const screenWidth = Dimensions.get('window').width
-		const searchBarWidth = screenWidth - 20
-		const headerAnimation = {opacity: this.headerOpacity}
-		const searchBarAnimation = {top: this.searchBarTop}
-		const containerAnimation = {height: this.containerHeight}
 		const {searchActive, searchPerformed, searchResults} = this.state
 
 		if (this.state.dataLoading) {
@@ -196,46 +192,53 @@ class CourseSearchView extends React.PureComponent<Props, State> {
 		}
 
 		return (
-			<View style={styles.container}>
-				<Animated.View
-					style={[styles.searchContainer, styles.common, containerAnimation]}
-				>
-					<Animated.Text style={[styles.header, headerAnimation]}>
-						Search Courses
-					</Animated.Text>
-					<Animated.View
-						style={[
-							styles.searchBarWrapper,
-							{width: searchBarWidth},
-							searchBarAnimation,
-						]}
-					>
-						<SearchBar
-							getRef={ref => (this.searchBar = ref)}
-							onCancel={this.onCancel}
-							onFocus={this.onFocus}
-							onSearchButtonPress={text => {
-								if (Platform.OS === 'ios') {
-									this.searchBar.blur()
-								}
-								this.performSearch(text)
-							}}
-							placeholder="Search Class & Lab"
-							searchActive={searchActive}
-							textFieldBackgroundColor={c.sto.lightGray}
-						/>
-					</Animated.View>
-				</Animated.View>
-				{searchActive ? (
-					<CourseSearchResultsList
-						navigation={this.props.navigation}
-						searchPerformed={searchPerformed}
-						terms={searchResults}
-					/>
-				) : (
-					<View />
-				)}
-			</View>
+			<Viewport
+				render={viewport => {
+					const searchBarWidth = viewport.width - 20
+
+					const aniContainerStyle = [
+						styles.searchContainer,
+						styles.common,
+						{height: this.containerHeight},
+					]
+					const aniSearchStyle = [
+						styles.searchBarWrapper,
+						{width: searchBarWidth},
+						{top: this.searchBarTop},
+					]
+					const aniHeaderStyle = [styles.header, {opacity: this.headerOpacity}]
+
+					return (
+						<View style={styles.container}>
+							<Animated.View style={aniContainerStyle}>
+								<Animated.Text style={aniHeaderStyle}>
+									Search Courses
+								</Animated.Text>
+								<Animated.View style={aniSearchStyle}>
+									<SearchBar
+										getRef={ref => (this.searchBar = ref)}
+										onCancel={this.onCancel}
+										onFocus={this.onFocus}
+										onSearchButtonPress={this.onSearchButtonPress}
+										placeholder="Search Class & Lab"
+										searchActive={searchActive}
+										textFieldBackgroundColor={c.sto.lightGray}
+									/>
+								</Animated.View>
+							</Animated.View>
+							{searchActive ? (
+								<CourseSearchResultsList
+									navigation={this.props.navigation}
+									searchPerformed={searchPerformed}
+									terms={searchResults}
+								/>
+							) : (
+								<View />
+							)}
+						</View>
+					)
+				}}
+			/>
 		)
 	}
 }

--- a/source/views/streaming/radio/controller.js
+++ b/source/views/streaming/radio/controller.js
@@ -1,15 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {
-	Dimensions,
-	Image,
-	ScrollView,
-	StyleSheet,
-	Text,
-	View,
-	Platform,
-} from 'react-native'
+import {Image, ScrollView, StyleSheet, Text, View, Platform} from 'react-native'
 import noop from 'lodash/noop'
 import {
 	trackStreamPlay,
@@ -21,9 +13,10 @@ import {callPhone} from '../../components/call-phone'
 import {Row} from '../../components/layout'
 import type {TopLevelViewPropsType} from '../../types'
 import {StreamPlayer} from './player'
-import type {PlayState, HtmlAudioError, Viewport} from './types'
+import type {PlayState, HtmlAudioError} from './types'
 import {ActionButton, ShowCalendarButton, CallButton} from './buttons'
 import {openUrl} from '../../components/open-url'
+import {Viewport} from '../../components/viewport'
 
 type Props = TopLevelViewPropsType & {
 	image: number,
@@ -43,7 +36,6 @@ type State = {
 	playState: PlayState,
 	streamError: ?HtmlAudioError,
 	uplinkError: ?string,
-	viewport: Viewport,
 }
 
 export class RadioControllerView extends React.PureComponent<Props, State> {
@@ -51,19 +43,6 @@ export class RadioControllerView extends React.PureComponent<Props, State> {
 		playState: 'paused',
 		streamError: null,
 		uplinkError: null,
-		viewport: Dimensions.get('window'),
-	}
-
-	componentWillMount() {
-		Dimensions.addEventListener('change', this.handleResizeEvent)
-	}
-
-	componentWillUnmount() {
-		Dimensions.removeEventListener('change', this.handleResizeEvent)
-	}
-
-	handleResizeEvent = (event: {window: {width: number, height: number}}) => {
-		this.setState(() => ({viewport: event.window}))
 	}
 
 	play = () => {
@@ -138,18 +117,6 @@ export class RadioControllerView extends React.PureComponent<Props, State> {
 	}
 
 	render() {
-		const sideways = this.state.viewport.width > this.state.viewport.height
-
-		const logoWidth = Math.min(
-			this.state.viewport.width / 1.5,
-			this.state.viewport.height / 1.75,
-		)
-
-		const logoSize = {
-			width: logoWidth,
-			height: logoWidth,
-		}
-
 		const error = this.state.uplinkError ? (
 			<Text style={styles.status}>{this.state.uplinkError}</Text>
 		) : this.state.streamError ? (
@@ -160,54 +127,74 @@ export class RadioControllerView extends React.PureComponent<Props, State> {
 		) : null
 
 		return (
-			<ScrollView
-				contentContainerStyle={[styles.root, sideways && landscape.root]}
-			>
-				<View style={[styles.logoWrapper, sideways && landscape.logoWrapper]}>
-					<Image
-						resizeMode="contain"
-						source={this.props.image}
-						style={[styles.logo, logoSize]}
-					/>
-				</View>
+			<Viewport
+				render={viewport => {
+					const sideways = viewport.width > viewport.height
 
-				<View style={styles.container}>
-					<View style={styles.titleWrapper}>
-						<Text selectable={true} style={styles.heading}>
-							{this.props.title}
-						</Text>
-						<Text selectable={true} style={styles.subHeading}>
-							{this.props.stationName}
-						</Text>
+					const logoWidth = Math.min(
+						viewport.width / 1.5,
+						viewport.height / 1.75,
+					)
 
-						{error}
-					</View>
+					const logoSize = {
+						width: logoWidth,
+						height: logoWidth,
+					}
 
-					<Row>
-						{this.renderPlayButton(this.state.playState)}
-						<View style={styles.spacer} />
-						<CallButton onPress={this.callStation} />
-						<View style={styles.spacer} />
-						<ShowCalendarButton onPress={this.openSchedule} />
-					</Row>
+					return (
+						<ScrollView
+							contentContainerStyle={[styles.root, sideways && landscape.root]}
+						>
+							<View
+								style={[styles.logoWrapper, sideways && landscape.logoWrapper]}
+							>
+								<Image
+									resizeMode="contain"
+									source={this.props.image}
+									style={[styles.logo, logoSize]}
+								/>
+							</View>
 
-					{Platform.OS !== 'android' ? (
-						<StreamPlayer
-							embeddedPlayerUrl={this.props.source.embeddedPlayerUrl}
-							onEnded={this.handleStreamEnd}
-							// onWaiting={this.handleStreamWait}
-							onError={this.handleStreamError}
-							// onStalled={this.handleStreamStall}
-							onPause={this.handleStreamPause}
-							onPlay={this.handleStreamPlay}
-							playState={this.state.playState}
-							streamSourceUrl={this.props.source.streamSourceUrl}
-							style={styles.webview}
-							useEmbeddedPlayer={this.props.source.useEmbeddedPlayer}
-						/>
-					) : null}
-				</View>
-			</ScrollView>
+							<View style={styles.container}>
+								<View style={styles.titleWrapper}>
+									<Text selectable={true} style={styles.heading}>
+										{this.props.title}
+									</Text>
+									<Text selectable={true} style={styles.subHeading}>
+										{this.props.stationName}
+									</Text>
+
+									{error}
+								</View>
+
+								<Row>
+									{this.renderPlayButton(this.state.playState)}
+									<View style={styles.spacer} />
+									<CallButton onPress={this.callStation} />
+									<View style={styles.spacer} />
+									<ShowCalendarButton onPress={this.openSchedule} />
+								</Row>
+
+								{Platform.OS !== 'android' ? (
+									<StreamPlayer
+										embeddedPlayerUrl={this.props.source.embeddedPlayerUrl}
+										onEnded={this.handleStreamEnd}
+										// onWaiting={this.handleStreamWait}
+										onError={this.handleStreamError}
+										// onStalled={this.handleStreamStall}
+										onPause={this.handleStreamPause}
+										onPlay={this.handleStreamPlay}
+										playState={this.state.playState}
+										streamSourceUrl={this.props.source.streamSourceUrl}
+										style={styles.webview}
+										useEmbeddedPlayer={this.props.source.useEmbeddedPlayer}
+									/>
+								) : null}
+							</View>
+						</ScrollView>
+					)
+				}}
+			/>
 		)
 	}
 }

--- a/source/views/streaming/radio/controller.js
+++ b/source/views/streaming/radio/controller.js
@@ -117,79 +117,82 @@ export class RadioControllerView extends React.PureComponent<Props, State> {
 	}
 
 	render() {
-		const error = this.state.uplinkError ? (
-			<Text style={styles.status}>{this.state.uplinkError}</Text>
-		) : this.state.streamError ? (
+		const {source, title, stationName, image} = this.props
+		const {uplinkError, streamError, playState} = this.state
+
+		const error = uplinkError ? (
+			<Text style={styles.status}>{uplinkError}</Text>
+		) : streamError ? (
 			<Text style={styles.status}>
-				Error Code {this.state.streamError.code}:{' '}
-				{this.state.streamError.message}
+				Error Code {streamError.code}: {streamError.message}
 			</Text>
 		) : null
 
+		const titleBlock = (
+			<View style={styles.titleWrapper}>
+				<Text selectable={true} style={styles.heading}>
+					{title}
+				</Text>
+				<Text selectable={true} style={styles.subHeading}>
+					{stationName}
+				</Text>
+
+				{error}
+			</View>
+		)
+
+		const controlsBlock = (
+			<Row>
+				{this.renderPlayButton(playState)}
+				<View style={styles.spacer} />
+				<CallButton onPress={this.callStation} />
+				<View style={styles.spacer} />
+				<ShowCalendarButton onPress={this.openSchedule} />
+			</Row>
+		)
+
+		const playerBlock =
+			Platform.OS !== 'android' ? (
+				<StreamPlayer
+					embeddedPlayerUrl={source.embeddedPlayerUrl}
+					onEnded={this.handleStreamEnd}
+					// onWaiting={this.handleStreamWait}
+					onError={this.handleStreamError}
+					// onStalled={this.handleStreamStall}
+					onPause={this.handleStreamPause}
+					onPlay={this.handleStreamPlay}
+					playState={playState}
+					streamSourceUrl={source.streamSourceUrl}
+					style={styles.webview}
+					useEmbeddedPlayer={source.useEmbeddedPlayer}
+				/>
+			) : null
+
 		return (
 			<Viewport
-				render={viewport => {
-					const sideways = viewport.width > viewport.height
+				render={({width, height}) => {
+					const sideways = width > height
 
-					const logoWidth = Math.min(
-						viewport.width / 1.5,
-						viewport.height / 1.75,
-					)
+					const logoWidth = Math.min(width / 1.5, height / 1.75)
+					const logoSize = {width: logoWidth, height: logoWidth}
 
-					const logoSize = {
-						width: logoWidth,
-						height: logoWidth,
-					}
+					const root = [styles.root, sideways && landscape.root]
+					const logo = [styles.logo, logoSize]
+					const logoWrapper = [
+						styles.logoWrapper,
+						sideways && landscape.logoWrapper,
+					]
 
 					return (
-						<ScrollView
-							contentContainerStyle={[styles.root, sideways && landscape.root]}
-						>
-							<View
-								style={[styles.logoWrapper, sideways && landscape.logoWrapper]}
-							>
-								<Image
-									resizeMode="contain"
-									source={this.props.image}
-									style={[styles.logo, logoSize]}
-								/>
+						<ScrollView contentContainerStyle={root}>
+							<View style={logoWrapper}>
+								<Image resizeMode="contain" source={image} style={logo} />
 							</View>
 
 							<View style={styles.container}>
-								<View style={styles.titleWrapper}>
-									<Text selectable={true} style={styles.heading}>
-										{this.props.title}
-									</Text>
-									<Text selectable={true} style={styles.subHeading}>
-										{this.props.stationName}
-									</Text>
-
-									{error}
-								</View>
-
-								<Row>
-									{this.renderPlayButton(this.state.playState)}
-									<View style={styles.spacer} />
-									<CallButton onPress={this.callStation} />
-									<View style={styles.spacer} />
-									<ShowCalendarButton onPress={this.openSchedule} />
-								</Row>
-
-								{Platform.OS !== 'android' ? (
-									<StreamPlayer
-										embeddedPlayerUrl={this.props.source.embeddedPlayerUrl}
-										onEnded={this.handleStreamEnd}
-										// onWaiting={this.handleStreamWait}
-										onError={this.handleStreamError}
-										// onStalled={this.handleStreamStall}
-										onPause={this.handleStreamPause}
-										onPlay={this.handleStreamPlay}
-										playState={this.state.playState}
-										streamSourceUrl={this.props.source.streamSourceUrl}
-										style={styles.webview}
-										useEmbeddedPlayer={this.props.source.useEmbeddedPlayer}
-									/>
-								) : null}
+								{titleBlock}
+								{controlsBlock}
+								{playerBlock}
 							</View>
 						</ScrollView>
 					)

--- a/source/views/streaming/webcams/list.js
+++ b/source/views/streaming/webcams/list.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {StyleSheet, ScrollView, Dimensions} from 'react-native'
+import {StyleSheet, ScrollView} from 'react-native'
 import delay from 'delay'
 import {reportNetworkProblem} from '../../../lib/report-network-problem'
 import {TabBarIcon} from '../../components/tabbar-icon'
@@ -11,13 +11,13 @@ import {partitionByIndex} from '../../../lib/partition-by-index'
 import type {Webcam} from './types'
 import {StreamThumbnail} from './thumbnail'
 import {GH_PAGES_URL} from '../../../globals'
+import {Viewport} from '../../components/viewport'
 
 const webcamsUrl = GH_PAGES_URL('webcams.json')
 
 type Props = {}
 
 type State = {
-	width: number,
 	webcams: Array<Webcam>,
 	loading: boolean,
 	refreshing: boolean,
@@ -30,23 +30,13 @@ export class WebcamsView extends React.PureComponent<Props, State> {
 	}
 
 	state = {
-		width: Dimensions.get('window').width,
 		webcams: defaultData.data,
 		loading: false,
 		refreshing: false,
 	}
 
 	componentWillMount() {
-		Dimensions.addEventListener('change', this.handleResizeEvent)
 		this.fetchData()
-	}
-
-	componentWillUnmount() {
-		Dimensions.removeEventListener('change', this.handleResizeEvent)
-	}
-
-	handleResizeEvent = (event: {window: {width: number}}) => {
-		this.setState(() => ({width: event.window.width}))
 	}
 
 	refresh = async () => {
@@ -83,19 +73,23 @@ export class WebcamsView extends React.PureComponent<Props, State> {
 		const columns = partitionByIndex(this.state.webcams)
 
 		return (
-			<ScrollView contentContainerStyle={styles.container}>
-				{columns.map((contents, i) => (
-					<Column key={i} style={styles.column}>
-						{contents.map(webcam => (
-							<StreamThumbnail
-								key={webcam.name}
-								viewportWidth={this.state.width}
-								webcam={webcam}
-							/>
+			<Viewport
+				render={({width}) => (
+					<ScrollView contentContainerStyle={styles.container}>
+						{columns.map((contents, i) => (
+							<Column key={i} style={styles.column}>
+								{contents.map(webcam => (
+									<StreamThumbnail
+										key={webcam.name}
+										viewportWidth={width}
+										webcam={webcam}
+									/>
+								))}
+							</Column>
 						))}
-					</Column>
-				))}
-			</ScrollView>
+					</ScrollView>
+				)}
+			/>
 		)
 	}
 }


### PR DESCRIPTION
The [“Use a Render Prop!”](https://cdb.reacttraining.com/use-a-render-prop-50de598f11ce) article has resonated with me since I first read it, but this is the first spot I've remembered to put it to use.

This adds a new component to our repo, `<Viewport/>`.

It takes one argument: 

```ts
render: ({width: number, height: number}) => React.Node
```

It's used as follows:

```tsx
<Viewport
  render={({width, height}) =>
    <Text>The current size of the viewport is {width}px × {height}px</Text>}
/>
```

Because it subscribes to the Dimensions listener itself, and updates its own state when that changes, it will automatically propagate downwards.

Voila!

Closes #2337 
Closes #2338 

---

I also did a few cleanups to the components that I touched, but nothing drastic, and nothing touching functionality.