### PR TITLE
Add margin back to help cards

### DIFF
--- a/source/views/help/tool.js
+++ b/source/views/help/tool.js
@@ -86,7 +86,7 @@ export const styles = StyleSheet.create({
 	card: {
 		paddingHorizontal: 20,
 		paddingVertical: 15,
-		marginHorizontal: 0,
+		marginHorizontal: 10,
 		marginBottom: 10,
 	},
 })


### PR DESCRIPTION
This PR adds the horizontal margin back to the help tool cards.

Before | After
--|--
<img width="422" alt="screen shot 2018-02-18 at 5 15 49 pm" src="https://user-images.githubusercontent.com/5240843/36358677-7c250cca-14cf-11e8-9ab2-2598090941ff.png"> | <img width="422" alt="screen shot 2018-02-18 at 5 10 17 pm" src="https://user-images.githubusercontent.com/5240843/36358678-7c404526-14cf-11e8-8eff-9ed1f6a98d95.png">
