### PR TITLE
hide react-markdown from greenkeeper updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "greenkeeper": {
     "ignore": [
       "flow-bin",
+      "react-markdown",
       "react"
     ]
   },


### PR DESCRIPTION
Closes #2386 

I'll try to summarize what I told @drewvolz this morning:

- We are a major version behind
- Both @rye and I have tried to upgrade
- It is a _big_ change
- v2 works for what we need it to
- v2 will continue to work for the foreseeable future – it would take a react-level change to force it to update
- I have no energy to put into upgrading it
- It annoys me to see it update and have to close it
- I want to hide it from Greenkeeper