### PR TITLE
Improvements to open jobs detail cells

### DIFF
--- a/source/views/sis/student-work/clean-job.js
+++ b/source/views/sis/student-work/clean-job.js
@@ -1,6 +1,7 @@
 // @flow
 import type {JobType} from './types'
 
+import getUrls from 'get-urls'
 import {fastGetTrimmedText, removeHtmlWithRegex} from '../../../lib/html'
 
 export function cleanJob(job: JobType): JobType {
@@ -38,6 +39,16 @@ export function cleanJob(job: JobType): JobType {
 
 export function getContactName(job: JobType) {
 	return `${job.contactFirstName} ${job.contactLastName}`
+}
+
+export function getLinksFromJob(job: JobType) {
+	// Clean up returns, newlines, tabs, and misc symbols...
+	// ...and search for application links in the text
+	return [
+		...getUrls(job.description),
+		...getUrls(job.comments),
+		...getUrls(job.skills),
+	]
 }
 
 function fixupEmailFormat(email: string) {

--- a/source/views/sis/student-work/clean-job.js
+++ b/source/views/sis/student-work/clean-job.js
@@ -1,7 +1,6 @@
 // @flow
 import type {JobType} from './types'
 
-import getUrls from 'get-urls'
 import {fastGetTrimmedText, removeHtmlWithRegex} from '../../../lib/html'
 
 export function cleanJob(job: JobType): JobType {
@@ -39,16 +38,6 @@ export function cleanJob(job: JobType): JobType {
 
 export function getContactName(job: JobType) {
 	return `${job.contactFirstName} ${job.contactLastName}`
-}
-
-export function getLinksFromJob(job: JobType) {
-	// Clean up returns, newlines, tabs, and misc symbols...
-	// ...and search for application links in the text
-	return [
-		...getUrls(job.description),
-		...getUrls(job.comments),
-		...getUrls(job.skills),
-	]
 }
 
 function fixupEmailFormat(email: string) {

--- a/source/views/sis/student-work/detail.ios.js
+++ b/source/views/sis/student-work/detail.ios.js
@@ -4,10 +4,9 @@ import {Text, ScrollView, StyleSheet} from 'react-native'
 import {sendEmail} from '../../components/send-email'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import moment from 'moment'
-import {openUrl} from '../../components/open-url'
 import * as c from '../../components/colors'
 import type {JobType} from './types'
-import {cleanJob, getContactName, getLinksFromJob} from './clean-job'
+import {cleanJob, getContactName} from './clean-job'
 import {SelectableCell} from './selectable'
 import glamorous from 'glamorous-native'
 
@@ -98,22 +97,6 @@ function Comments({job}: {job: JobType}) {
 	) : null
 }
 
-function Links({job}: {job: JobType}) {
-	const links = getLinksFromJob(job)
-	return links.length ? (
-		<Section header="LINKS">
-			{links.map(url => (
-				<Cell
-					key={url}
-					accessory="DisclosureIndicator"
-					onPress={() => openUrl(url)}
-					title={url}
-				/>
-			))}
-		</Section>
-	) : null
-}
-
 function LastUpdated({when}: {when: string}) {
 	return when ? (
 		<Text selectable={true} style={[styles.footer, styles.lastUpdated]}>
@@ -147,7 +130,6 @@ export class JobDetailView extends React.PureComponent<Props> {
 					<Description job={job} />
 					<Skills job={job} />
 					<Comments job={job} />
-					<Links job={job} />
 				</TableView>
 				<LastUpdated when={job.lastModified} />
 			</ScrollView>

--- a/source/views/sis/student-work/selectable.js
+++ b/source/views/sis/student-work/selectable.js
@@ -11,7 +11,6 @@ const styles = StyleSheet.create({
 		color: c.black,
 		backgroundColor: c.white,
 		paddingHorizontal: 15,
-		paddingVertical: 15,
 		paddingTop: 10,
 		paddingBottom: 10,
 		...Platform.select({

--- a/source/views/sis/student-work/selectable.js
+++ b/source/views/sis/student-work/selectable.js
@@ -1,20 +1,36 @@
 // @flow
 import * as React from 'react'
-import {Text, StyleSheet} from 'react-native'
-import {Cell} from 'react-native-tableview-simple'
+import {Platform, TextInput, StyleSheet} from 'react-native'
+import * as c from '../../components/colors'
+import {AllHtmlEntities} from 'html-entities'
+
+const entities = new AllHtmlEntities()
 
 const styles = StyleSheet.create({
-	cell: {
-		paddingVertical: 10,
+	text: {
+		color: c.black,
+		backgroundColor: c.white,
+		paddingHorizontal: 15,
+		paddingVertical: 15,
+		paddingTop: 10,
+		paddingBottom: 10,
+		...Platform.select({
+			ios: {
+				fontWeight: '500',
+			},
+			android: {
+				fontWeight: '600',
+			},
+		}),
 	},
 })
 
 export const SelectableCell = ({text}: {text: string}) => (
-	<Cell
-		cellContentView={
-			<Text selectable={true} style={styles.cell}>
-				{text}
-			</Text>
-		}
+	<TextInput
+		dataDetectorTypes="all"
+		editable={false}
+		multiline={true}
+		style={styles.text}
+		value={entities.decode(text)}
 	/>
 )


### PR DESCRIPTION
This PR converts the contents of `<SelectableCell />` to a `<TextInput />`.

This PR picks up something we've been testing over on the carls app. I've swapped out our home-brewed link detecting on the Open Jobs detail views in favor of `<TextInput />` which, for iOS, has the ability to parse links, allow native selection of text, and applies data detectors inline.