### PR TITLE
Trim news excerpts

### DIFF
--- a/source/views/news/news-row.js
+++ b/source/views/news/news-row.js
@@ -33,7 +33,7 @@ export class NewsRow extends React.PureComponent<Props> {
 					<Image source={thumb} style={styles.image} />
 					<Column flex={1}>
 						<Title lines={2}>{story.title}</Title>
-						<Detail lines={3}>{story.excerpt}</Detail>
+						<Detail lines={3}>{story.excerpt.trim()}</Detail>
 					</Column>
 				</Row>
 			</ListRow>


### PR DESCRIPTION
I'm noticing spaces at the beginning of some stories. Let's clean that up!

3 stories on the news feed with spaces at the start
<img src="https://user-images.githubusercontent.com/5240843/36870124-3bc10794-1d5b-11e8-8e19-048817006552.jpg" width=450 />