### PR TITLE
Orgs detail textinput changes (second try)

### DIFF
--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -6,6 +6,7 @@ import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
 import type {TopLevelViewPropsType} from '../types'
+import {openUrl} from '../components/open-url'
 import {sendEmail} from '../components/send-email'
 import {cleanOrg, showNameOrEmail} from './util'
 import {SelectableCell} from '../sis/student-work/selectable'
@@ -78,7 +79,12 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
 
 					{website ? (
 						<Section header="WEBSITE">
-							<SelectableCell text={website} />
+							<Cell
+								 accessory="DisclosureIndicator"
+								 cellStyle="Basic"
+								 onPress={() => openUrl(website)}
+								 title={website}
+						 	/>
 						</Section>
 					) : null}
 

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -80,11 +80,11 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
 					{website ? (
 						<Section header="WEBSITE">
 							<Cell
-								 accessory="DisclosureIndicator"
-								 cellStyle="Basic"
-								 onPress={() => openUrl(website)}
-								 title={website}
-						 	/>
+								accessory="DisclosureIndicator"
+								cellStyle="Basic"
+								onPress={() => openUrl(website)}
+								title={website}
+							/>
 						</Section>
 					) : null}
 

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -1,14 +1,14 @@
 // @flow
 import * as React from 'react'
-import {ScrollView, Text, View, StyleSheet} from 'react-native'
+import {ScrollView, Text, StyleSheet} from 'react-native'
 import moment from 'moment'
 import {Cell, Section, TableView} from 'react-native-tableview-simple'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
 import type {TopLevelViewPropsType} from '../types'
-import {openUrl} from '../components/open-url'
 import {sendEmail} from '../components/send-email'
 import {cleanOrg, showNameOrEmail} from './util'
+import {SelectableCell} from '../sis/student-work/selectable'
 
 const styles = StyleSheet.create({
 	name: {
@@ -19,21 +19,6 @@ const styles = StyleSheet.create({
 		color: c.black,
 		fontSize: 32,
 		fontWeight: '300',
-	},
-	meetings: {
-		flex: 1,
-		paddingVertical: 8,
-		fontSize: 16,
-	},
-	description: {
-		paddingTop: 13,
-		paddingBottom: 13,
-		paddingLeft: 16,
-		paddingRight: 16,
-		backgroundColor: c.white,
-	},
-	descriptionText: {
-		fontSize: 16,
 	},
 	footer: {
 		fontSize: 10,
@@ -87,23 +72,13 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
 
 					{meetings ? (
 						<Section header="MEETINGS">
-							<Cell
-								cellContentView={
-									<Text style={styles.meetings}>{meetings}</Text>
-								}
-								cellStyle="Basic"
-							/>
+							<SelectableCell text={meetings} />
 						</Section>
 					) : null}
 
 					{website ? (
 						<Section header="WEBSITE">
-							<Cell
-								accessory="DisclosureIndicator"
-								cellStyle="Basic"
-								onPress={() => openUrl(website)}
-								title={website}
-							/>
+							<SelectableCell text={website} />
 						</Section>
 					) : null}
 
@@ -138,9 +113,7 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
 
 					{description ? (
 						<Section header="DESCRIPTION">
-							<View style={styles.description}>
-								<Text style={styles.descriptionText}>{description}</Text>
-							</View>
+							<SelectableCell text={description} />
 						</Section>
 					) : null}
 


### PR DESCRIPTION
I didn't merge them in the correct order the first time through.

> This PR builds off of #2394 and should be merged after/into #2394. This replaces student org detail meetings, description, and site texts with TextInput on iOS.
> 
> This allows for meetings, description, and website texts to natively present text selection and apply data detectors inline.