### PR TITLE
Fix course search toolbar to display 'All Terms' when appropriate

### DIFF
--- a/source/views/sis/components/filter-toolbar.js
+++ b/source/views/sis/components/filter-toolbar.js
@@ -32,7 +32,9 @@ export function FilterToolbar({filters, onPress}: Props) {
 	if (termFilter) {
 		const selectedTerms = termFilter ? termFilter.spec.selected : []
 		const terms = selectedTerms.map(t => parseInt(t.title))
-		toolbarTitle = terms.length ? formatTerms(terms) : 'No Terms'
+		if (termFilter.enabled) {
+			toolbarTitle = terms.length ? formatTerms(terms) : 'No Terms'
+		}
 	}
 
 	const buttonTitle = isFiltered


### PR DESCRIPTION
We only want the toolbar to show our concatenated list of selected years/term is the filter is enabled.