### PR TITLE
Building Hours update for Rølvaag Library

### DIFF
--- a/data/building-hours/4-3-rølvaag-library.yaml
+++ b/data/building-hours/4-3-rølvaag-library.yaml
@@ -1,17 +1,14 @@
 name: Rølvaag Library
 image: rolvaag-library
 category: Libraries
+
 schedule:
   - title: Hours
     hours:
-      # - {days: [Mo, Tu, We, Th], from: '7:45am', to: '2:00am'}
-      # - {days: [Fr], from: '7:45am', to: '9:00pm'}
-      # - {days: [Sa], from: '9:00am', to: '9:00pm'}
-      # - {days: [Su], from: '12:00pm', to: '2:00am'}
-      - {days: [Mo, Tu, We, Th], from: '8:00am', to: '12:00am'}
-      - {days: [Fr], from: '8:00am', to: '6:00pm'}
-      - {days: [Sa], from: '9:00am', to: '6:00pm'}
-      - {days: [Su], from: '12:00pm', to: '12:00am'}
+      - {days: [Mo, Tu, We, Th], from: '7:45am', to: '2:00am'}
+      - {days: [Fr], from: '7:45am', to: '9:00pm'}
+      - {days: [Sa], from: '9:00am', to: '9:00pm'}
+      - {days: [Su], from: '12:00pm', to: '2:00am'}
 
 breakSchedule:
   fall: []


### PR DESCRIPTION
Closes #2425.