### PR TITLE
Limit recent course searches to one line

### DIFF
--- a/source/views/sis/components/recent-search/list.js
+++ b/source/views/sis/components/recent-search/list.js
@@ -15,7 +15,9 @@ export class RecentSearchList extends React.PureComponent<Props> {
 
 	renderItem = ({item}: {item: string}) => (
 		<ListRow arrowPosition="none" onPress={() => this.onPressRow(item)}>
-			<Text style={styles.listItem}>{item}</Text>
+			<Text numberOfLines={1} style={styles.listItem}>
+				{item}
+			</Text>
 		</ListRow>
 	)
 


### PR DESCRIPTION
Prevents long searches from taking up more than one line.