### PR TITLE
Fix android builds (¿by removing version resolutions?)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,6 @@ jobs:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
-      - save_cache: *save-cache-yarn
       - run: *run-danger
 
   flow:
@@ -138,7 +137,6 @@ jobs:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
-      - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
       - run: yarn run bundle-data
       - run: yarn run --silent flow check --quiet | tee logs/flow
@@ -153,7 +151,6 @@ jobs:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
-      - save_cache: *save-cache-yarn
       - run: mkdir -p logs/ test-results/jest/
       - run: yarn run bundle-data
       - run: yarn run --silent test --coverage --testResultsProcessor="jest-junit" 2>&1 | tee logs/jest
@@ -179,7 +176,6 @@ jobs:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
-      - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
       - run: yarn run prettier
       - run:
@@ -199,7 +195,6 @@ jobs:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
-      - save_cache: *save-cache-yarn
       - run: mkdir -p logs/ test-results/eslint/
       - run: yarn run bundle-data
       - run: yarn run --silent lint | tee logs/eslint
@@ -216,7 +211,6 @@ jobs:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
-      - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
       - run: yarn run --silent validate-data --quiet | tee logs/validate-data
       - run: yarn run --silent validate-bus-data | tee logs/validate-bus-data
@@ -242,10 +236,8 @@ jobs:
       - run: *set-ruby-version
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
-      - save_cache: *save-cache-yarn
       - restore_cache: *restore-cache-bundler
       - run: bundle check || bundle install --frozen --path ./vendor/bundle
-      - save_cache: *save-cache-bundler
       - restore_cache: *restore-cache-gradle
       - run:
           name: Download Android dependencies
@@ -277,7 +269,6 @@ jobs:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
-      - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
       - run: *embed-env-vars
       - run: yarn run bundle-data
@@ -337,7 +328,6 @@ jobs:
       - checkout
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
-      - save_cache: *save-cache-yarn
       - run: mkdir -p logs/
       - run: *embed-env-vars
       - run: yarn run bundle-data

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
       - restore_cache: *restore-cache-gradle
       - run:
           name: Download Android dependencies
-          command: cd android && ./gradlew androidDependencies
+          command: cd android && ./gradlew androidDependencies --console=plain
           environment: {TERM: xterm-256color}
       - save_cache: *save-cache-gradle
       - run: mkdir -p logs/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ workflows:
     jobs: &basic-jobs
       - cache-yarn-linux:
           filters: &filters {tags: {only: /.*/}}
+      - cache-bundler-linux:
+          filters: &filters {tags: {only: /.*/}}
       - danger:
           filters: *filters
           requires: [cache-yarn-linux]
@@ -71,7 +73,7 @@ workflows:
           requires: [danger, flow, jest, prettier, eslint, data]
       - android:
           filters: *filters
-          requires: [danger, flow, jest, prettier, eslint, data]
+          requires: [danger, flow, jest, prettier, eslint, data, cache-bundler-linux]
       - ios-bundle:
           filters: *filters
           requires: [danger, flow, jest, prettier, eslint, data]
@@ -85,6 +87,7 @@ workflows:
           filters: {branches: {only: [master]}}
     jobs:
       - cache-yarn-linux
+      - cache-bundler-linux
       - danger: {requires: [cache-yarn-linux]}
       - flow: {requires: [cache-yarn-linux]}
       - jest: {requires: [cache-yarn-linux]}
@@ -92,7 +95,7 @@ workflows:
       - eslint: {requires: [cache-yarn-linux]}
       - data: {requires: [cache-yarn-linux]}
       - ios-nightly: {requires: [danger, flow, jest, prettier, eslint, data]}
-      - android-nightly: {requires: [danger, flow, jest, prettier, eslint, data]}
+      - android-nightly: {requires: [danger, flow, jest, prettier, eslint, data, cache-bundler-linux]}
 
 jobs:
   cache-yarn-linux:
@@ -103,6 +106,18 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn --version
       - save_cache: *save-cache-yarn
+
+  cache-bundler-linux:
+    docker: [{image: 'circleci/ruby:2.4'}]
+    steps:
+      - checkout
+      - run: *set-ruby-version
+      - restore_cache: *restore-cache-bundler
+      - run: bundle check || bundle install --frozen --path ./vendor/bundle
+      - run: bundle --version
+      - run: gem --version
+      - run: ruby --version
+      - save_cache: *save-cache-bundler
 
   danger:
     docker: [{image: 'circleci/node:8'}]

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: "com.android.application"
 
-import com.android.build.OutputFile
-
 /**
  * The react.gradle file registers a task for each build variant (e.g. bundleDebugJsAndAssets
  * and bundleReleaseJsAndAssets).

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -177,7 +177,7 @@ android {
 }
 
 // borrowed from https://gist.github.com/gabrielemariotti/6856974
-def propFile = new File('android/app//signing.properties')
+def propFile = new File('android/app/signing.properties')
 if (propFile.canRead()) {
     Properties props = new Properties()
     props.load(new FileInputStream(propFile))

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -213,13 +213,13 @@ if (propFile.canRead()) {
 dependencies {
     // please keep this list sorted
     implementation project(':bugsnag-react-native')
+    implementation project(':mapbox-react-native-mapbox-gl')
     implementation project(':react-native-calendar-events')
     implementation project(':react-native-custom-tabs')
     implementation project(':react-native-device-info')
     implementation project(':react-native-google-analytics-bridge')
     implementation project(':react-native-keychain')
     implementation project(':react-native-linear-gradient')
-    implementation project(':mapbox-react-native-mapbox-gl')
     implementation project(':react-native-network-info')
     implementation project(':react-native-restart')
     implementation project(':react-native-vector-icons')

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,16 +94,18 @@ def enableSeparateBuildPerCPUArchitecture = false
  */
 def enableProguardInReleaseBuilds = false
 
+def COMPILE_SDK_VERSION = 27
+def TARGET_SDK_VERSION = 27
 def ANDROID_SUPPORT_LIBRARY_VERSION = '27.1.0'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion COMPILE_SDK_VERSION
 
     defaultConfig {
         applicationId "com.allaboutolaf"
 
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion TARGET_SDK_VERSION
 
         versionCode 1
         versionName "1.0.0"
@@ -117,6 +119,12 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
+    }
+
+    ext {
+        compileSdkVersion = COMPILE_SDK_VERSION
+        targetSdkVersion = TARGET_SDK_VERSION
+        androidSupportLibraryVersion = ANDROID_SUPPORT_LIBRARY_VERSION
     }
 
     signingConfigs {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -94,6 +94,8 @@ def enableSeparateBuildPerCPUArchitecture = false
  */
 def enableProguardInReleaseBuilds = false
 
+def ANDROID_SUPPORT_LIBRARY_VERSION = '27.1.0'
+
 android {
     compileSdkVersion 26
 
@@ -167,8 +169,10 @@ android {
     }
 
     configurations.all {
-        resolutionStrategy.force 'com.android.support:appcompat-v7:26.1.0'
-        resolutionStrategy.force 'com.android.support:customtabs:26.1.0'
+        resolutionStrategy.force "com.android.support:appcompat-v7:$ANDROID_SUPPORT_LIBRARY_VERSION"
+        resolutionStrategy.force "com.android.support:customtabs:$ANDROID_SUPPORT_LIBRARY_VERSION"
+        resolutionStrategy.force "com.android.support:support-media-compat:$ANDROID_SUPPORT_LIBRARY_VERSION"
+        resolutionStrategy.force "com.android.support:support-v4:$ANDROID_SUPPORT_LIBRARY_VERSION"
     }
 }
 
@@ -221,7 +225,7 @@ dependencies {
     implementation project(':react-native-vector-icons')
     // this is for react-native itself
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation "com.android.support:appcompat-v7:26.1.0"
+    implementation "com.android.support:appcompat-v7:$ANDROID_SUPPORT_LIBRARY_VERSION"
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -171,8 +171,6 @@ android {
     configurations.all {
         resolutionStrategy.force 'com.android.support:appcompat-v7:26.1.0'
         resolutionStrategy.force 'com.android.support:customtabs:26.1.0'
-        resolutionStrategy.force 'com.google.android.gms:play-services-base:11.8.0'
-        resolutionStrategy.force 'com.google.android.gms:play-services-maps:11.8.0'
     }
 }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -5,6 +5,9 @@ include ':app'
 include ':bugsnag-react-native'
 project(':bugsnag-react-native').projectDir = new File(rootProject.projectDir, '../node_modules/bugsnag-react-native/android')
 
+include ':mapbox-react-native-mapbox-gl'
+project(':mapbox-react-native-mapbox-gl').projectDir = new File(rootProject.projectDir, '../node_modules/@mapbox/react-native-mapbox-gl/android/rctmgl')
+
 include ':react-native-calendar-events'
 project(':react-native-calendar-events').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-calendar-events/android')
 
@@ -22,9 +25,6 @@ project(':react-native-keychain').projectDir = new File(rootProject.projectDir, 
 
 include ':react-native-linear-gradient'
 project(':react-native-linear-gradient').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-linear-gradient/android')
-
-include ':mapbox-react-native-mapbox-gl'
-project(':mapbox-react-native-mapbox-gl').projectDir = new File(rootProject.projectDir, '../node_modules/@mapbox/react-native-mapbox-gl/android/rctmgl')
 
 include ':react-native-network-info'
 project(':react-native-network-info').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-network-info/android')


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/2465

## Overview

This was my resource that made me look at the version pinning things: https://rnfirebase.io/docs/v3.1.x/faqs#[Android]-Duplicate-Dex-Files-error-(build-time-error)

> A common build time error when using libraries that require google play services is of the form:
'Failed on android with com.android.dex.DexException: Multiple dex files… '
>
> This error (https://github.com/invertase/react-native-firebase/issues/48) occurs because different versions of google play services or google play services modules are being required by different libraries.
>
> The process to fix this is fairly manual and depends on your specific combination of external libraries. Essentially what's required is to check the app level build.gradle file of each external library and establish which ones have a Google Play Services dependency.
>
> You then need to find the lowest common version of each G.P.S module dependency, require that in the app level build.gradle file of your own project, and exclude it from being required by the modules themselves. This will force the use of a consistent version of the G.P.S module.
>
> It's not a good idea to modify the version within the library's build.gradle, as this will be overwritten when you update the library, which will lead to the build breaking again.
>
> A good break down of this process can be found here:
https://medium.com/@suchydan/how-to-solve-google-play-services-version-collision-in-gradle-dependencies-ef086ae5c75f

## Changes

- I added a separate "cache" step for rubygems, to separate it from the Android build. 
    - None of the other builds use it, but this way it can run and cache while yarn is caching too.
- I removed a bunch of `save_cache` steps from jobs that shouldn't be editing the caches
- I added `--console=plain` to the cradle invocation, to clean up the terminal output
    - This disables the fancy progress bar things
- I removed the `google-play-services` manual version resolutions, as we no longer have multiple projects with conflicting versions since we switched to Mapbox
- I added more manual version resolutions for Android support libraries, until Android Studio quit yelling at me
- `react-native-device-info` and `react-native-linear-gradient` both support external configuration for `compileSdkVersion` and `targetSdkVersion`, so I'm taking advantage of that to make them match our config