### PR TITLE
Build the nightly at 04:00 rather than 00:00 (Zulu time)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: 0 6 * * *
+          cron: 0 10 * * *
           filters: {branches: {only: [master]}}
     jobs:
       - cache-yarn-linux


### PR DESCRIPTION
This gives us more time to work on things, as @hawkrives says.

Closes #2431.