### PR TITLE
Navigation button cleanup

### DIFF
--- a/source/views/components/nav-buttons/open-settings.js
+++ b/source/views/components/nav-buttons/open-settings.js
@@ -4,10 +4,9 @@
  */
 
 import * as React from 'react'
-import {StyleSheet, Platform} from 'react-native'
-import * as c from '../colors'
 import {Touchable} from '../touchable'
 import Icon from 'react-native-vector-icons/Ionicons'
+import {commonStyles, leftButtonStyles} from './styles'
 import type {NavType} from '../../types'
 
 export function OpenSettingsButton({
@@ -22,22 +21,9 @@ export function OpenSettingsButton({
 			borderless={true}
 			highlight={false}
 			onPress={() => navigation.navigate('SettingsView')}
-			style={[styles.button, buttonStyle]}
+			style={[commonStyles.button, buttonStyle]}
 		>
-			<Icon name="ios-settings" style={styles.icon} />
+			<Icon name="ios-settings" style={leftButtonStyles.icon} />
 		</Touchable>
 	)
 }
-
-const styles = StyleSheet.create({
-	icon: {
-		color: c.white,
-		fontSize: 24,
-	},
-	button: {
-		flexDirection: 'row',
-		alignItems: 'center',
-		paddingVertical: Platform.OS === 'ios' ? 10 : 16,
-		paddingHorizontal: Platform.OS === 'ios' ? 18 : 16,
-	},
-})

--- a/source/views/components/nav-buttons/styles.js
+++ b/source/views/components/nav-buttons/styles.js
@@ -12,7 +12,6 @@ export const commonStyles = StyleSheet.create({
 		alignItems: 'center',
 		...Platform.select({
 			ios: {
-				paddingVertical: 11,
 				paddingHorizontal: 18,
 			},
 			android: {

--- a/source/views/components/nav-buttons/styles.js
+++ b/source/views/components/nav-buttons/styles.js
@@ -59,3 +59,10 @@ export const rightButtonStyles = StyleSheet.create({
 		}),
 	},
 })
+
+export const leftButtonStyles = StyleSheet.create({
+	icon: {
+		color: c.white,
+		fontSize: 24,
+	},
+})


### PR DESCRIPTION
The primary objective of this PR is to close #2483. This fixes the cutoff buttons. I removed the `paddingVertical` to fix that.

While I was here, I noticed that `open-settings` was not using `commonStyles` that the rest of our buttons use. I added those styles to the settings button.

I also created a `leftButtonStyles` in the `commonStyles` to co-locate the style for all-things-buttonlike. This is used to set the left icon styles for the home screen.

**Before**
<img width="849" alt="before" src="https://user-images.githubusercontent.com/5240843/38179674-36c0169a-35e3-11e8-80d8-16b045d20b58.png">

**After**
<img width="849" alt="after" src="https://user-images.githubusercontent.com/5240843/38179673-369a68be-35e3-11e8-8364-5bd860ba2a51.png">