### PR TITLE
enforce usage of "===" operator in JS

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -34,6 +34,7 @@ rules:
   curly: [warn, multi-line]
   default-case: error
   guard-for-in: error
+  eqeqeq: [error, always, {'null': ignore}]
   linebreak-style: [error, unix]
   new-cap: off
   no-await-in-loop: warn

--- a/source/user-agent.js
+++ b/source/user-agent.js
@@ -5,9 +5,9 @@ import {Platform} from 'react-native'
 
 const aaoVersion = version || 'unknown'
 const platformString =
-	Platform.OS == 'ios'
+	Platform.OS === 'ios'
 		? 'iOS'
-		: Platform.OS == 'android' ? 'Android' : 'unknown'
+		: Platform.OS === 'android' ? 'Android' : 'unknown'
 const platformVersion = Platform.Version || 'unknown'
 
 export const AAO_USER_AGENT = `AllAboutOlaf/${aaoVersion} (${platformString}/${platformVersion})`

--- a/source/views/calendar/clean-event.js
+++ b/source/views/calendar/clean-event.js
@@ -18,7 +18,7 @@ export function cleanEvent(event: EventType) {
 function cleanDescription(desc: string) {
 	const description = fastGetTrimmedText(desc || '')
 
-	if (description == 'See more details') {
+	if (description === 'See more details') {
 		return ''
 	}
 

--- a/source/views/components/filter/apply-filters.js
+++ b/source/views/components/filter/apply-filters.js
@@ -32,7 +32,7 @@ export function applyToggleFilter(filter: ToggleType, item: any): boolean {
 	// Dereference the value-to-check
 	const itemValue = item[filter.apply.key]
 	return filter.apply.trueEquivalent
-		? itemValue == filter.apply.trueEquivalent
+		? itemValue === filter.apply.trueEquivalent
 		: Boolean(itemValue)
 }
 

--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -377,7 +377,7 @@ class CourseSearchView extends React.PureComponent<Props, State> {
 			return <LoadingView text="Loading Course Data…" />
 		}
 
-		if (this.props.courseDataState == 'not-loaded') {
+		if (this.props.courseDataState === 'not-loaded') {
 			const msg = this.props.isConnected
 				? PROMPT_TEXT
 				: PROMPT_TEXT.concat(`\n\n${NETWORK_WARNING}`)

--- a/source/views/sis/student-work/detail.android.js
+++ b/source/views/sis/student-work/detail.android.js
@@ -76,7 +76,7 @@ function Contact({job}: {job: JobType}) {
 }
 
 function Hours({job}: {job: JobType}) {
-	const ending = job.hoursPerWeek == 'Full-time' ? '' : ' hrs/week'
+	const ending = job.hoursPerWeek === 'Full-time' ? '' : ' hrs/week'
 	return job.timeOfHours && job.hoursPerWeek ? (
 		<Card header="Hours" style={styles.card}>
 			<Text style={styles.cardBody}>

--- a/source/views/sis/student-work/job-row.js
+++ b/source/views/sis/student-work/job-row.js
@@ -19,7 +19,7 @@ export class JobRow extends React.PureComponent<Props> {
 		const title = fastGetTrimmedText(job.title)
 		const office = fastGetTrimmedText(job.office)
 		const hours = fastGetTrimmedText(job.hoursPerWeek)
-		const ending = hours == 'Full-time' ? '' : 'hrs/week'
+		const ending = hours === 'Full-time' ? '' : 'hrs/week'
 
 		return (
 			<ListRow arrowPosition="top" onPress={this._onPress}>

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -96,7 +96,7 @@ export class StreamListView extends React.PureComponent<Props, State> {
 				.map(stream => {
 					const date = moment(stream.starttime, 'YYYY-MM-DD HH:mm')
 					const group =
-						stream.status.toLowerCase() != 'live'
+						stream.status.toLowerCase() !== 'live'
 							? date.format('dddd, MMMM Do')
 							: 'Live'
 

--- a/source/views/streaming/streams/row.js
+++ b/source/views/streaming/streams/row.js
@@ -30,7 +30,7 @@ function Info({item}: {item: StreamType}) {
 }
 
 function Time({item}: {item: StreamType}) {
-	const showTime = item.status != 'archived'
+	const showTime = item.status !== 'archived'
 	return showTime ? (
 		<Detail>{item.date.format('h:mm A – ddd, MMM. Do, YYYY')}</Detail>
 	) : null


### PR DESCRIPTION
from [ESLint's docs](https://eslint.org/docs/rules/eqeqeq):

> It is considered good practice to use the type-safe equality operators `===` and `!==` instead of their regular counterparts `==` and `!=`.
>
> The reason for this is that `==` and `!=` do type coercion which follows the rather obscure Abstract Equality Comparison Algorithm. For instance, the following statements are all considered true:
> 
> ```js
> [] == false
> [] == ![]
> 3 == "03"
> ```
> 
> If one of those occurs in an innocent-looking statement such as `a == b` the actual problem is very difficult to spot.

I thought I'd already blocked use of `==` and `!=`, but apparently not. This PR will block use of those two operators in our code.