### PR TITLE
Correct valid times data url

### DIFF
--- a/source/lib/course-search/urls.js
+++ b/source/lib/course-search/urls.js
@@ -11,4 +11,4 @@ export const DEPT_DATA =
 	'https://stodevx.github.io/course-data/data-lists/valid_departments.json'
 
 export const TIMES_DATA =
-	'https://stodevx.github.io/course-data/data-lists/valid-times.json'
+	'https://stodevx.github.io/course-data/data-lists/valid_times.json'


### PR DESCRIPTION
The file names within the `course-data` repo are separated with underscores rather than hyphens