### PR TITLE
Disable textinput scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ios:release": "react-native run-ios --configuration Release",
     "ios-simulator": "xcrun instruments -s devices | peco --select-1 --query 'Simulator iPhone' --on-cancel error | sed  's~.*\\[\\(.*\\)\\].*~\\1~' | xargs open -n -a Simulator --args -CurrentDeviceUDID",
     "lint": "eslint --cache source/ scripts/ *.js",
+    "prepare": "sed -i.bak 's/\\(_backedTextInputView.scrollEnabled = \\)YES;/\\1NO;/' node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m",
     "prettier": "prettier --write '{source,scripts}/**/*.js' 'data/**/*.css' '*.js'",
     "prettier:changed": "pretty-quick",
     "prettier:since-master": "pretty-quick",


### PR DESCRIPTION
Closes #2445

Globally disable scrolling on RN multiline TextInputs via npm prepare script, which is run after yarn install