### PR TITLE
Remove insecure http load exception for oleville

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -87,11 +87,6 @@
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
-			<key>oleville.com</key>
-			<dict>
-				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 		</dict>
 	</dict>
 	<key>NSCalendarsUsageDescription</key>


### PR DESCRIPTION
This is part two of and closes #2545. We no longer need the insecure exception for oleville.
