### PR TITLE
Move bonapp to https

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -77,11 +77,6 @@
 		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>legacy.cafebonappetit.com</key>
-			<dict>
-				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
 			<key>localhost</key>
 			<dict>
 				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -30,8 +30,8 @@ import delay from 'delay'
 import retry from 'p-retry'
 const CENTRAL_TZ = 'America/Winnipeg'
 
-const bonappMenuBaseUrl = 'http://legacy.cafebonappetit.com/api/2/menus'
-const bonappCafeBaseUrl = 'http://legacy.cafebonappetit.com/api/2/cafes'
+const bonappMenuBaseUrl = 'https://legacy.cafebonappetit.com/api/2/menus'
+const bonappCafeBaseUrl = 'https://legacy.cafebonappetit.com/api/2/cafes'
 const fetchJsonQuery = (url, query) =>
 	fetchJson(`${url}?${qs.stringify(query)}`)
 const entities = new AllHtmlEntities()


### PR DESCRIPTION
Seeing as http://legacy.cafebonappetit.com/api/2/menus?cafe=34 now automatically redirects to https://legacy.cafebonappetit.com/api/2/menus?cafe=34

I've also removed them from the `NSAppTransportSecurity` exceptions list.