### PR TITLE
Remove attachEvent from radio player

### DIFF
--- a/source/views/streaming/radio/player.js
+++ b/source/views/streaming/radio/player.js
@@ -115,12 +115,6 @@ export class StreamPlayer extends React.PureComponent<Props> {
 	        fn();
 	      } else if (document.addEventListener) {
 	        document.addEventListener('DOMContentLoaded', fn);
-	      } else {
-	        document.attachEvent('onreadystatechange', function () {
-	          if (document.readyState !== 'loading') {
-	            fn();
-	          }
-	        });
 	      }
 	    };
 


### PR DESCRIPTION
Removing `document.attachEvent` as it is highly recommended to not include it in any production code.

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/attachEvent

<img width="703" alt="screen shot 2018-04-25 at 8 07 15 pm" src="https://user-images.githubusercontent.com/5240843/39281909-47779096-48c4-11e8-8e63-2e8c92249d16.png">


**Mobile**

Feature | Android | Firefox Mobile (Gecko) | IE Phone | Opera Mobile | Safari Mobile
-- | -- | -- | -- | -- | --
Basic support | No support | No support | ? | ? | No support

**Desktop**

Feature | Chrome | Firefox (Gecko) | Internet Explorer | Opera | Safari (WebKit)
-- | -- | -- | -- | -- | --
Basic support | No support | No support | 6 thru 10 [1] | ? | No support
