### PR TITLE
Greenkeeper/react native 0.55.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "querystring": "0.2.0",
     "react": "16.3.2",
     "react-markdown": "2.5.1",
-    "react-native": "0.55.3",
+    "react-native": "0.55.4",
     "react-native-button": "2.3.0",
     "react-native-calendar-events": "1.5.0",
     "react-native-communications": "2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5353,9 +5353,9 @@ react-native-vector-icons@4.6.0, react-native-vector-icons@^4.4.2:
     prop-types "^15.5.10"
     yargs "^8.0.2"
 
-react-native@0.55.3:
-  version "0.55.3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.55.3.tgz#6ff1691bd0645d0480fba16377edb9dce5bd28c4"
+react-native@0.55.4:
+  version "0.55.4"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.55.4.tgz#eecffada3750a928e2ddd07cf11d857ae9751c30"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"


### PR DESCRIPTION
okay really greenkeeper

the old pr was closed

don't comment on it

---

## Version **0.55.4** just got published. 

<details>
<summary>Commits</summary>
<p>The new version differs by 4 commits.</p>
<ul>
<li><a href="https://urls.greenkeeper.io/facebook/react-native/commit/370bcffba748e895ad8afa825bfef40bff859c95"><code>370bcff</code></a> <code>[0.55.4] Bump version numbers</code></li>
<li><a href="https://urls.greenkeeper.io/facebook/react-native/commit/5bb2e83f65dfe8b6d016ab03a2e8f08221876cf2"><code>5bb2e83</code></a> <code>Switch equality check in BlobModule.java</code></li>
<li><a href="https://urls.greenkeeper.io/facebook/react-native/commit/f8091fac04728fb69a1fe452c3ff4cef6db6b17e"><code>f8091fa</code></a> <code>fix use of C++ syntax in an header file</code></li>
<li><a href="https://urls.greenkeeper.io/facebook/react-native/commit/e187b076904de5d283c80145f228fee0d3aa0ea5"><code>e187b07</code></a> <code>Properly tear down the reachabilityRef in RCTNetInfo</code></li>
</ul>
<p>See the <a href="https://urls.greenkeeper.io/facebook/react-native/compare/2845a8661cf1a3cbb8e6148b181a96f6a55b149d...370bcffba748e895ad8afa825bfef40bff859c95">full diff</a></p>
</details>