### PR TITLE
Android switcher color

### DIFF
--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Change the color value for your need -->
+    <color name="colorPrimary">#ffc107</color>
+    <color name="colorPrimaryDark">#c79100</color>
+    <color name="colorAccent">#6E3A5D</color>
+    <color name="textColorPrimary">#ffffff</color>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,8 +1,9 @@
 <resources>
-
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
     </style>
-
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0-alpha09'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/2580

<img src="https://user-images.githubusercontent.com/464441/39826749-4c92f202-537b-11e8-962a-cca91c84b3e4.png" width=350 />

Also, we changed the accent color for check boxes and switches:

<img src="https://user-images.githubusercontent.com/464441/39826775-6ecc9af8-537b-11e8-93af-edc8ba9e9bfb.png" width=350 />

It's now purple, from the list of approved St. Olaf colors.