### PR TITLE
Fix dictionary updates

### DIFF
--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
 type Props = TopLevelViewPropsType
 
 type State = {
-	results: Array<WordType>,
+	query: string,
 	allTerms: Array<WordType>,
 	refreshing: boolean,
 }
@@ -60,7 +60,7 @@ export class DictionaryView extends React.PureComponent<Props, State> {
 	}
 
 	state = {
-		results: defaultData.data,
+		query: '',
 		allTerms: defaultData.data,
 		refreshing: false,
 	}
@@ -126,17 +126,7 @@ export class DictionaryView extends React.PureComponent<Props, State> {
 	)
 
 	performSearch = (text: ?string) => {
-		if (!text) {
-			this.setState(state => ({results: state.allTerms}))
-			return
-		}
-
-		const query = text.toLowerCase()
-		this.setState(state => ({
-			results: state.allTerms.filter(term =>
-				termToArray(term).some(word => word.startsWith(query)),
-			),
-		}))
+		this.setState(() => ({query: text ? text.toLowerCase() : ''}))
 	}
 
 	render() {
@@ -147,6 +137,14 @@ export class DictionaryView extends React.PureComponent<Props, State> {
 			/>
 		)
 
+		let results = this.state.allTerms
+		if (this.state.query) {
+			const {query, allTerms} = this.state
+			results = allTerms.filter(term =>
+				termToArray(term).some(word => word.startsWith(query)),
+			)
+		}
+
 		return (
 			<SearchableAlphabetListView
 				cell={this.renderRow}
@@ -154,7 +152,7 @@ export class DictionaryView extends React.PureComponent<Props, State> {
 					ROW_HEIGHT +
 					(Platform.OS === 'ios' ? 11 / 12 * StyleSheet.hairlineWidth : 0)
 				}
-				data={groupBy(this.state.results, item => item.word[0])}
+				data={groupBy(results, item => item.word[0])}
 				onSearch={this.performSearch}
 				refreshControl={refreshControl}
 				renderSeparator={this.renderSeparator}

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -17,13 +17,11 @@ import {
 } from '../components/list'
 import {trackOrgOpen} from '../../analytics'
 import {reportNetworkProblem} from '../../lib/report-network-problem'
-import size from 'lodash/size'
 import sortBy from 'lodash/sortBy'
 import groupBy from 'lodash/groupBy'
 import uniq from 'lodash/uniq'
 import words from 'lodash/words'
 import deburr from 'lodash/deburr'
-import filter from 'lodash/filter'
 import startCase from 'lodash/startCase'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
@@ -70,7 +68,7 @@ type Props = TopLevelViewPropsType
 
 type State = {
 	orgs: Array<StudentOrgType>,
-	results: {[key: string]: StudentOrgType[]},
+	query: string,
 	refreshing: boolean,
 	error: boolean,
 	loading: boolean,
@@ -86,7 +84,7 @@ export class StudentOrgsView extends React.PureComponent<Props, State> {
 
 	state = {
 		orgs: [],
-		results: {},
+		query: '',
 		refreshing: false,
 		loading: true,
 		error: false,
@@ -119,8 +117,7 @@ export class StudentOrgsView extends React.PureComponent<Props, State> {
 		})
 
 		const sorted = sortBy(withSortableNames, '$sortableName')
-		const grouped = groupBy(sorted, '$groupableName')
-		this.setState(() => ({orgs: sorted, results: grouped}))
+		this.setState(() => ({orgs: sorted}))
 	}
 
 	refresh = async () => {
@@ -178,20 +175,7 @@ export class StudentOrgsView extends React.PureComponent<Props, State> {
 	}
 
 	performSearch = (text: ?string) => {
-		if (!text) {
-			this.setState(state => ({
-				results: groupBy(state.orgs, '$groupableName'),
-			}))
-			return
-		}
-
-		const query = text.toLowerCase()
-		this.setState(state => {
-			const filteredResults = filter(state.orgs, org =>
-				orgToArray(org).some(word => word.startsWith(query)),
-			)
-			return {results: groupBy(filteredResults, '$groupableName')}
-		})
+		this.setState(() => ({query: text ? text.toLowerCase() : ''}))
 	}
 
 	render() {
@@ -199,7 +183,7 @@ export class StudentOrgsView extends React.PureComponent<Props, State> {
 			return <LoadingView />
 		}
 
-		if (!size(this.state.orgs)) {
+		if (!this.state.orgs.length) {
 			return <NoticeView text="No organizations found." />
 		}
 
@@ -210,6 +194,15 @@ export class StudentOrgsView extends React.PureComponent<Props, State> {
 			/>
 		)
 
+		let results = this.state.orgs
+		if (this.state.query) {
+			let {query, orgs} = this.state
+			results = orgs.filter(org =>
+				orgToArray(org).some(word => word.startsWith(query)),
+			)
+		}
+		let groupedResults = groupBy(results, '$groupableName')
+
 		return (
 			<SearchableAlphabetListView
 				cell={this.renderRow}
@@ -217,7 +210,7 @@ export class StudentOrgsView extends React.PureComponent<Props, State> {
 					ROW_HEIGHT +
 					(Platform.OS === 'ios' ? 11 / 12 * StyleSheet.hairlineWidth : 0)
 				}
-				data={this.state.results}
+				data={groupedResults}
 				onSearch={this.performSearch}
 				refreshControl={refreshControl}
 				renderSeparator={this.renderSeparator}


### PR DESCRIPTION
~WIP; needs to be applied to Orgs as well, although the bug is invisible there. ~ This has been applied to Orgs as well.

This is a bug we found on CARLS; Drew diagnosed it. 

- Change the remote dictionary file
- Open the app and open Dictionary
- See the lack of the updated definition
- Search the list
- See the updated definition

This is caused by the list only rendering the result of performSearch, and performSearch not being called when the remote data is loaded. 

So, rather than call performSearch, I propose that we just do the filtering in render() itself. 

I think this is OK because it's a fast operation, for our scales, and render() won't be invoked unnecessarily for this top-level View.  