### PR TITLE
Next bottom tab bar iteration

### DIFF
--- a/source/views/components/colors.js
+++ b/source/views/components/colors.js
@@ -49,7 +49,7 @@ export const semitransparentGray = 'rgba(0,0,0,0.2)'
 
 // MARK: Oleville colors
 export const theLatest = '#00BFFF'
-export const olevilleGold = '#ffc107'
+export const olevilleGold = '#FFC107'
 export const darkGold = '#c79100'
 export const olevilleBackground = '#F0F0E1'
 

--- a/source/views/components/tabbed-view/index.js
+++ b/source/views/components/tabbed-view/index.js
@@ -25,9 +25,7 @@ export const TabNavigator: ComponentType = (screens, options = {}) =>
 	createTabNavigator(screens, {
 		backBehavior: 'none',
 		lazy: true,
-		activeTintColor: c.olevilleGold,
 		tabBarOptions: {
-			activeTintColor: c.black,
 			...(options.tabBarOptions || {}),
 			labelStyle: {
 				...Platform.select({

--- a/source/views/components/tabbed-view/index.js
+++ b/source/views/components/tabbed-view/index.js
@@ -25,6 +25,8 @@ export const TabNavigator: ComponentType = (screens, options = {}) =>
 	createTabNavigator(screens, {
 		backBehavior: 'none',
 		lazy: true,
+		activeTintColor: c.black,
+		inactiveTintColor: c.black25Percent,
 		tabBarOptions: {
 			...(options.tabBarOptions || {}),
 			labelStyle: {

--- a/source/views/components/tabbed-view/index.js
+++ b/source/views/components/tabbed-view/index.js
@@ -27,6 +27,11 @@ export const TabNavigator: ComponentType = (screens, options = {}) =>
 		lazy: true,
 		activeTintColor: c.black,
 		inactiveTintColor: c.black25Percent,
+		theme: {
+			colors: {
+				primary: c.olevilleGold,
+			},
+		},
 		tabBarOptions: {
 			...(options.tabBarOptions || {}),
 			labelStyle: {

--- a/source/views/components/tabbed-view/index.js
+++ b/source/views/components/tabbed-view/index.js
@@ -33,6 +33,8 @@ export const TabNavigator: ComponentType = (screens, options = {}) =>
 			},
 		},
 		tabBarOptions: {
+			activeTintColor: c.black,
+			inactiveTintColor: c.black25Percent,
 			...(options.tabBarOptions || {}),
 			labelStyle: {
 				...Platform.select({

--- a/source/views/components/tabbed-view/index.js
+++ b/source/views/components/tabbed-view/index.js
@@ -34,7 +34,6 @@ export const TabNavigator: ComponentType = (screens, options = {}) =>
 		},
 		tabBarOptions: {
 			activeTintColor: c.black,
-			inactiveTintColor: c.black25Percent,
 			...(options.tabBarOptions || {}),
 			labelStyle: {
 				...Platform.select({


### PR DESCRIPTION
TODO: Screenshots (later)

Changes to `c.black` active tint/`c.black25Percent` inactive tint on a `c.olevilleGold` background.