### PR TITLE
Remove Promise#finally from course search

### DIFF
--- a/source/lib/course-search/update-course-storage.js
+++ b/source/lib/course-search/update-course-storage.js
@@ -20,7 +20,7 @@ export async function areAnyTermsCached(): Promise<boolean> {
 export async function updateStoredCourses(): Promise<boolean> {
 	const outdatedTerms: Array<TermType> = await determineOutdatedTerms()
 	await Promise.all(outdatedTerms.map(term => storeTermCoursesFromServer(term)))
-	// returns ``true`` if any terms were updated
+	// returns `true` if any terms were updated
 	return outdatedTerms.length === 0 ? false : true
 }
 

--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -230,8 +230,6 @@ class CourseSearchView extends React.PureComponent<Props, State> {
 		this.setState(() => ({dataLoading: false}))
 	}
 
-	doneLoading = () => this.setState(() => ({dataLoading: false}))
-
 	onSearchButtonPress = text => {
 		if (Platform.OS === 'ios') {
 			this.searchBar.blur()

--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -191,13 +191,7 @@ class CourseSearchView extends React.PureComponent<Props, State> {
 	}
 
 	componentDidMount() {
-		areAnyTermsCached().then(anyTermsCached => {
-			if (anyTermsCached) {
-				this.loadData()
-			} else {
-				this.setState(() => ({dataLoading: false}))
-			}
-		})
+		this.loadData()
 		this.updateFilters(this.props)
 	}
 

--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -206,29 +206,28 @@ class CourseSearchView extends React.PureComponent<Props, State> {
 	searchBarTop = new Animated.Value(this.animations.searchBarTop.start)
 	containerHeight = new Animated.Value(this.animations.containerHeight.start)
 
-	loadData = () => {
+	loadData = async () => {
 		this.setState(() => ({dataLoading: true}))
 
+		// If the data has not been loaded into Redux State:
 		if (this.props.courseDataState !== 'ready') {
-			// If the data has not been loaded into Redux State:
 			// 1. load the cached courses
+			await this.props.loadCourseDataIntoMemory()
+
 			// 2. if any courses are cached, hide the spinner
+			if (await areAnyTermsCached()) {
+				this.setState(() => ({dataLoading: false}))
+			}
+
 			// 3. either way, start updating courses in the background
-			// 4. when everything is done, make sure the spinner is hidden
-			return this.props
-				.loadCourseDataIntoMemory()
-				.then(() => areAnyTermsCached())
-				.then(anyTermsCached => {
-					if (anyTermsCached) {
-						this.doneLoading()
-					}
-					return this.props.updateCourseData()
-				})
-				.finally(() => this.doneLoading())
+			await this.props.updateCourseData()
 		} else {
 			// If the course data is already in Redux State, check for update
-			return this.props.updateCourseData().then(() => this.doneLoading())
+			await this.props.updateCourseData()
 		}
+
+		// 4. when everything is done, make sure the spinner is hidden
+		this.setState(() => ({dataLoading: false}))
 	}
 
 	doneLoading = () => this.setState(() => ({dataLoading: false}))


### PR DESCRIPTION
Closes #2502 

There are two changes in here.

---

```diff
	componentDidMount() {
-		areAnyTermsCached().then(anyTermsCached => {
-			if (anyTermsCached) {
-				this.loadData()
-			} else {
-				this.setState(() => ({dataLoading: false}))
-			}
-		})
+		this.loadData()
```

This one … so far as I can tell, the check here is duplicated in `loadData`, both in the `if (this.props.courseDataState !== 'ready')` check and the `if (await areAnyTermsCached())`.

That is to say, we need to call `loadData` if the courses haven't been loaded into RAM (`courseDataState !== 'ready'`), and … well, TBH I can't quite tell why the `areAnyTermsCached` was there in `componentDidMount`.

---

The other change is to remove the `.finally(() => this.doneLoading())` line from `loadData`. I did this by converting it from a promise chain to an async function. My translation should be equivalent here, esp. the `this.setState(() => ({dataLoading: false}))` bit right after the if-else blocks.