### PR TITLE
Ignore "ordinary" yellowbox warnings

### DIFF
--- a/source/root.js
+++ b/source/root.js
@@ -1,10 +1,17 @@
 // @flow
 
-import {AppRegistry} from 'react-native'
+import {AppRegistry, YellowBox} from 'react-native'
 import App from './app'
 
 // I'm not importing the exported variable because I just want to initialize
 // the file here.
 import './bugsnag'
+
+YellowBox.ignoreWarnings([
+	// TODO: remove me after upgrading to RN 0.56
+	'Warning: isMounted(...) is deprecated',
+	// TODO: remove me after upgrading to RN 0.56
+	'Module RCTImageLoader',
+])
 
 AppRegistry.registerComponent('AllAboutOlaf', () => App)


### PR DESCRIPTION
We keep having ~9 "Warning: isMounted(...) is deprecated" warnings pop up every time we launch the app in the simulator.

Turns out they're from React Native itself, and they'll be fixed in the next stable.

Until then, we can just ignore them.

We should revert this PR as part of the 0.56 upgrade.