### PR TITLE
Note about event locations on faqs

### DIFF
--- a/data/faqs.md
+++ b/data/faqs.md
@@ -1,3 +1,4 @@
 # Known Issues
 - Building Hours: It reports the 2am buildings as open too often; for instance, the Pause is open on Saturday at 2am, continuing from Friday, but the app reports it as being open on Friday at 2am, as well. This is incorrect.
 - Radio: The KSTO or KRLX radio player button can get stuck at "starting" and no music playing. The temporary solution is to hit play/pause _one_ more time.
+- Calendar: Events are listing duplicate locations. They are also listing "MN" at the end of the event locations. This is incorrect.


### PR DESCRIPTION
> Calendar: Events are listing duplicate locations. They are also listing "MN" at the end of the event locations. This is incorrect.