### PR TITLE
Update eslint-plugin-flowtype to the latest version (2.50.0) 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "eslint": "4.19.1",
     "eslint-config-prettier": "2.9.0",
     "eslint-plugin-babel": "5.1.0",
-    "eslint-plugin-flowtype": "2.49.3",
+    "eslint-plugin-flowtype": "2.50.0",
     "eslint-plugin-react": "7.10.0",
     "eslint-plugin-react-native": "3.2.0",
     "flow-bin": "0.67.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,9 +2473,9 @@ eslint-plugin-babel@5.1.0:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
-eslint-plugin-flowtype@2.49.3:
-  version "2.49.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.49.3.tgz#ccca6ee5ba2027eb3ed36bc2ec8c9a842feee841"
+eslint-plugin-flowtype@2.50.0:
+  version "2.50.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.0.tgz#953e262fa9b5d0fa76e178604892cf60dfb916da"
   dependencies:
     lodash "^4.17.10"
 


### PR DESCRIPTION
Closes #2688.