### PR TITLE
Circle: Update xcode version to 9.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ jobs:
       - run: *run-danger
 
   ios: &ios
-    macos: {xcode: '9.0'}
+    macos: {xcode: '9.4.1'}
     environment: &ios-env
       task: IOS
       FASTLANE_SKIP_UPDATE_CHECK: '1'


### PR DESCRIPTION
This might help to clear up some warnings about outdated versions of node.