### PR TITLE
Update danger to the latest version (3.8.0) 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "babel-plugin-transform-remove-console": "6.9.4",
     "babel-preset-react-native": "4.0.0",
     "bugsnag-sourcemaps": "1.0.3",
-    "danger": "3.7.18",
+    "danger": "3.8.0",
     "danger-plugin-yarn": "1.3.0",
     "directory-tree": "2.1.0",
     "eslint": "5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2086,9 +2086,9 @@ danger-plugin-yarn@1.3.0:
   optionalDependencies:
     esdoc "^0.5.2"
 
-danger@3.7.18:
-  version "3.7.18"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-3.7.18.tgz#944e0e2786b3f40c044345f8185c0e2e61131cdc"
+danger@3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-3.8.0.tgz#04d61683195ddd98e9395342d9d1985a4aacacef"
   dependencies:
     "@octokit/rest" "^15.5.0"
     babel-polyfill "^6.23.0"
@@ -2096,6 +2096,7 @@ danger@3.7.18:
     commander "^2.13.0"
     debug "^3.1.0"
     get-stdin "^6.0.0"
+    https-proxy-agent "^2.2.1"
     hyperlinker "^1.0.0"
     jsome "^2.3.25"
     json5 "^1.0.0"
@@ -3383,7 +3384,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^2.2.0:
+https-proxy-agent@^2.2.0, https-proxy-agent@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   dependencies:


### PR DESCRIPTION
Closes #2687. (Superseded.)