### PR TITLE
Replace outline with empty favorites icon

### DIFF
--- a/source/views/components/nav-buttons/favorite.js
+++ b/source/views/components/nav-buttons/favorite.js
@@ -15,7 +15,8 @@ export class FavoriteButton extends React.PureComponent<Props> {
 	render() {
 		// (ios|md)-heart(-outline)
 		const iconPlatform = Platform.OS === 'ios' ? 'ios' : 'md'
-		const icon = `${iconPlatform}-heart`
+		const icon =
+			`${iconPlatform}-heart` + (this.props.favorited ? '' : '-empty')
 
 		return (
 			<Touchable


### PR DESCRIPTION
When we were fixing the icons we lost the outline for the favorites/heart in Building Hours. This adds the `empty` icon in its place so that we once again have a visual difference in button states.

Non-Favorite | Favorite
--|--
<img width="375" alt="screen shot 2018-08-04 at 1 38 29 pm" src="https://user-images.githubusercontent.com/5240843/43679925-b40c82fe-97eb-11e8-9d9a-5e3cf76d44b6.png"> | <img width="375" alt="screen shot 2018-08-04 at 1 38 33 pm" src="https://user-images.githubusercontent.com/5240843/43679924-b3f41070-97eb-11e8-8865-8bf47d788535.png">
