### PR TITLE
Fix course search crash on iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "htmlparser2": "3.9.2",
     "keyword-search": "0.1.1",
     "lodash": "4.17.10",
-    "mem": "3.0.1",
     "moment": "2.22.2",
     "moment-timezone": "0.5.21",
     "p-props": "1.2.0",

--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -74,7 +74,7 @@ export class CourseResultsList extends React.Component<Props> {
 		let {filters, browsing, query, courses, applyFilters} = this.props
 
 		let results = this.memoizedDoSearch({
-			query: query.toLowerCase(),
+			query,
 			filters,
 			courses,
 			applyFilters,

--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -7,7 +7,7 @@ import type {CourseType} from '../../../lib/course-search/types'
 import {ListSeparator, ListSectionHeader} from '../../components/list'
 import * as c from '../../components/colors'
 import {CourseRow} from './row'
-import memoize from 'mem'
+import memoize from 'lodash/memoize'
 import {parseTerm} from '../../../lib/course-search'
 import {NoticeView} from '../../components/notice'
 import {FilterToolbar} from '../components/filter-toolbar'
@@ -49,10 +49,8 @@ function doSearch (args: {
 	return sortAndGroupResults(results)
 }
 
-let memoizedDoSearch = memoize(doSearch, {
-	maxAge: 1000,
-	cacheKey: (...args) => args,
-})
+let memoizedDoSearch = memoize(doSearch)
+memoizedDoSearch.cache = new WeakMap()
 
 export class CourseResultsList extends React.Component<Props> {
 	keyExtractor = (item: CourseType) => item.clbid.toString()

--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -33,7 +33,7 @@ type Props = TopLevelViewPropsType & {
 	updateRecentFilters: (filters: FilterType[]) => any,
 }
 
-function doSearch (args: {
+function doSearch(args: {
 	query: string,
 	filters: Array<FilterType>,
 	courses: Array<CourseType>,

--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -73,12 +73,7 @@ export class CourseResultsList extends React.Component<Props> {
 	render() {
 		let {filters, browsing, query, courses, applyFilters} = this.props
 
-		let results = this.memoizedDoSearch({
-			query,
-			filters,
-			courses,
-			applyFilters,
-		})
+		let results = memoizedDoSearch({query, filters, courses, applyFilters})
 
 		const header = (
 			<FilterToolbar filters={filters} onPress={this.props.openFilterView} />

--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -33,6 +33,27 @@ type Props = TopLevelViewPropsType & {
 	updateRecentFilters: (filters: FilterType[]) => any,
 }
 
+function doSearch (args: {
+	query: string,
+	filters: Array<FilterType>,
+	courses: Array<CourseType>,
+	applyFilters: (filters: FilterType[], item: CourseType) => boolean,
+}) {
+	let {query, filters, courses, applyFilters} = args
+
+	let results = courses.filter(course => applyFilters(filters, course))
+	if (query) {
+		results = results.filter(course => applySearch(query, course))
+	}
+
+	return sortAndGroupResults(results)
+}
+
+let memoizedDoSearch = memoize(doSearch, {
+	maxAge: 1000,
+	cacheKey: (...args) => args,
+})
+
 export class CourseResultsList extends React.Component<Props> {
 	keyExtractor = (item: CourseType) => item.clbid.toString()
 
@@ -47,28 +68,6 @@ export class CourseResultsList extends React.Component<Props> {
 	onPressRow = (data: CourseType) => {
 		this.props.navigation.navigate('CourseDetailView', {course: data})
 	}
-
-	doSearch = (args: {
-		query: string,
-		filters: Array<FilterType>,
-		courses: Array<CourseType>,
-		applyFilters: (filters: FilterType[], item: CourseType) => boolean,
-	}) => {
-		let {query, filters, courses, applyFilters} = args
-		query = query.toLowerCase()
-
-		let results = courses.filter(course => applyFilters(filters, course))
-		if (query) {
-			results = results.filter(course => applySearch(query, course))
-		}
-
-		return sortAndGroupResults(results)
-	}
-
-	memoizedDoSearch = memoize(this.doSearch, {
-		maxAge: 1000,
-		cacheKey: (...args) => args,
-	})
 
 	render() {
 		let {filters, browsing, query, courses, applyFilters} = this.props

--- a/yarn.lock
+++ b/yarn.lock
@@ -4784,13 +4784,6 @@ marked@0.3.6:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
 
-mem@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-3.0.1.tgz#152410d0d7e835e4a4363e626238d9e5be3d6f5a"
-  dependencies:
-    mimic-fn "^1.0.0"
-    p-is-promise "^1.1.0"
-
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
@@ -5393,10 +5386,6 @@ osenv@^0.1.4:
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-
-p-is-promise@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
 
 p-limit@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Turns out that iOS was crashing as soon as you tapped the search bar, if you didn't have the debugger attached.

`mem`'s internals were trying to copy an object property onto something that iOS doesn't like.

I replaced it with Lodash and a [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap). This should be fine; Drew tested it on iOS 9 and Android, and I tested on iOS 11.