### PR TITLE
Remove font boldening from selectable text

### DIFF
--- a/source/views/components/cells/selectable.js
+++ b/source/views/components/cells/selectable.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {Platform, TextInput, StyleSheet} from 'react-native'
+import {TextInput, StyleSheet} from 'react-native'
 import * as c from '../../components/colors'
 import {AllHtmlEntities} from 'html-entities'
 
@@ -13,14 +13,6 @@ const styles = StyleSheet.create({
 		paddingHorizontal: 15,
 		paddingTop: 10,
 		paddingBottom: 10,
-		...Platform.select({
-			ios: {
-				fontWeight: '500',
-			},
-			android: {
-				fontWeight: '600',
-			},
-		}),
 	},
 })
 


### PR DESCRIPTION
Font weight slipped in by accident. This brings these fields back to normal. This is one example as they are spread around the app.

Before | After
--|--
<img width="480" alt="screen shot 2018-08-04 at 7 46 05 pm" src="https://user-images.githubusercontent.com/5240843/43681914-69da7248-981f-11e8-820f-252edd198002.png"> | <img width="480" alt="screen shot 2018-08-04 at 7 46 13 pm" src="https://user-images.githubusercontent.com/5240843/43681913-69c14dc2-981f-11e8-9c77-5c1caf45e7a9.png">