### PR TITLE
Speed up searching

### DIFF
--- a/source/views/components/alphabet-listview.js
+++ b/source/views/components/alphabet-listview.js
@@ -15,16 +15,20 @@ const styles = StyleSheet.create({
 	},
 })
 
-export function StyledAlphabetListView(props: Object) {
-	return (
-		<AlphabetListView
-			contentContainerStyle={styles.listView}
-			initialListSize={StyledAlphabetListView.initialListSize}
-			pageSize={StyledAlphabetListView.pageSize}
-			sectionListStyle={styles.sectionItems}
-			{...props}
-		/>
-	)
+type Props = {}
+
+export class StyledAlphabetListView extends React.PureComponent<Props> {
+	static initialListSize = 12
+	static pageSize = 8
+	render() {
+		return (
+			<AlphabetListView
+				contentContainerStyle={styles.listView}
+				initialListSize={StyledAlphabetListView.initialListSize}
+				pageSize={StyledAlphabetListView.pageSize}
+				sectionListStyle={styles.sectionItems}
+				{...this.props}
+			/>
+		)
+	}
 }
-StyledAlphabetListView.initialListSize = 12
-StyledAlphabetListView.pageSize = 8

--- a/source/views/components/searchable-alphabet-listview.js
+++ b/source/views/components/searchable-alphabet-listview.js
@@ -19,10 +19,9 @@ type Props = any & {query: string}
 export class SearchableAlphabetListView extends React.Component<Props> {
 	_performSearch = (text: string) => this.props.onSearch(text)
 
-	// We need to make the search run slightly behind the UI,
-	// so I'm slowing it down by 50ms. 0ms also works, but seems
-	// rather pointless.
-	performSearch = debounce(this._performSearch, 50)
+	// We don't need to search as-you-type; slightly delayed is more
+	// efficient and nearly as effective
+	performSearch = debounce(this._performSearch, 200)
 
 	render() {
 		return (

--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -52,7 +52,7 @@ function doSearch(args: {
 let memoizedDoSearch = memoize(doSearch)
 memoizedDoSearch.cache = new WeakMap()
 
-export class CourseResultsList extends React.Component<Props> {
+export class CourseResultsList extends React.PureComponent<Props> {
 	keyExtractor = (item: CourseType) => item.clbid.toString()
 
 	renderSectionHeader = ({section: {title}}: any) => (


### PR DESCRIPTION
I've been removing PureComponent as I wander because, as [this article](https://cdb.reacttraining.com/react-inline-functions-and-performance-bdff784f5578#f11e) points out, 

> If a component _usually_ changes when there’s an update, then a PureComponent will be doing two diffs instead of just one (props and state in `shouldComponentUpdate`, and then the normal element diff). Which means it’s going to be slower usually, but faster occasionally.

PureComponent's not _bad_, but it's not a panacea either. It's really, really useful in some situations, though. Like here.

Anyway. TL;DR: do less work and the app is faster.

before | after
--- | ---
![image](https://user-images.githubusercontent.com/464441/43681998-8dc47f4a-982a-11e8-8022-8dd0c6fbd4bd.png) | ![image](https://user-images.githubusercontent.com/464441/43681999-93bb208e-982a-11e8-806b-db123bc439aa.png)

After's screenshot is zoomed in significantly, _and_ I was typing more and faster.