### PR TITLE
use "an approximation of the default behavior for iOS" for header transitions

### DIFF
--- a/source/navigation.js
+++ b/source/navigation.js
@@ -105,6 +105,10 @@ export const AppNavigator = createStackNavigator(
 			headerStyle: styles.header,
 			headerTintColor: c.navigationForeground,
 		},
+		headerTransitionPreset: Platform.select({
+			ios: 'uikit',
+			android: undefined,
+		}),
 		cardStyle: styles.card,
 	},
 )


### PR DESCRIPTION
before | after
--- | ---
![before](https://user-images.githubusercontent.com/464441/43691551-d2b259f6-98e3-11e8-9076-1e78e2105825.gif) | ![after](https://user-images.githubusercontent.com/464441/43691524-77e3f1a6-98e3-11e8-874b-e1d27e43b850.gif)

From the docs for `StackNavigator`:
> `headerTransitionPreset` - Specifies how the header should transition from one screen to another when `headerMode: float` is enabled.
> - `fade-in-place` - Header components cross-fade without moving, similar to the Twitter, Instagram, and Facebook app for iOS. This is the default value.
> - `uikit` - An approximation of the default behavior for iOS.