### PR TITLE
Keyboard dismiss props on course search list

### DIFF
--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -91,6 +91,8 @@ export class CourseResultsList extends React.PureComponent<Props> {
 				ListHeaderComponent={header}
 				contentContainerStyle={styles.container}
 				extraData={this.props}
+				keyboardDismissMode="on-drag"
+				keyboardShouldPersistTaps="never"
 				keyExtractor={this.keyExtractor}
 				renderItem={this.renderItem}
 				renderSectionHeader={this.renderSectionHeader}

--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -91,9 +91,9 @@ export class CourseResultsList extends React.PureComponent<Props> {
 				ListHeaderComponent={header}
 				contentContainerStyle={styles.container}
 				extraData={this.props}
+				keyExtractor={this.keyExtractor}
 				keyboardDismissMode="on-drag"
 				keyboardShouldPersistTaps="never"
-				keyExtractor={this.keyExtractor}
 				renderItem={this.renderItem}
 				renderSectionHeader={this.renderSectionHeader}
 				sections={(results: any)}


### PR DESCRIPTION
Sometimes the keyboard gets in the way. This allows for us to dismiss
it if we swipe the view.