### PR TITLE
Allow past events in list of streams

### DIFF
--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -71,7 +71,6 @@ export class StreamListView extends React.PureComponent<Props, State> {
 
 	getStreams = async (date: moment = moment.tz(CENTRAL_TZ)) => {
 		try {
-			const dateFrom = date.format('YYYY-MM-DD')
 			const dateTo = date
 				.clone()
 				.add(1, 'month')
@@ -80,8 +79,6 @@ export class StreamListView extends React.PureComponent<Props, State> {
 			let params = {
 				class: 'current',
 				sort: 'ascending',
-				// eslint-disable-next-line camelcase
-				date_from: dateFrom,
 				// eslint-disable-next-line camelcase
 				date_to: dateTo,
 			}


### PR DESCRIPTION
This queries the broadcast media streams for events so that we are able to see past events.

Closes #2702