### PR TITLE
Lower-case Course search queries

### DIFF
--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -70,6 +70,9 @@ export class CourseResultsList extends React.PureComponent<Props> {
 	render() {
 		let {filters, browsing, query, courses, applyFilters} = this.props
 
+		// be sure to lowercase the query before calling doSearch, so that the memoization
+		// doesn't break when nothing's changed except case.
+		query = query.toLowerCase()
 		let results = memoizedDoSearch({query, filters, courses, applyFilters})
 
 		const header = (


### PR DESCRIPTION
Fixes a bug I noticed this morning, where I couldn't search for `ART 103` or `Art 103`.

Turns out that in all of the search operations, we're comparing the query to lowercased values from the course objects. Which is great, except that we (I) forgot to normalize the query to lowercase before searching.

This lowercases the query before searching, but without changing the typed values so as to not confuse the user.