### PR TITLE
Viewport width styles on toolbar

### DIFF
--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -100,6 +100,8 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 
 const styles = StyleSheet.create({
 	scroller: {
+		flex: 1,
+		flexDirection: 'column',
 		paddingLeft: 10,
 	},
 })

--- a/source/views/components/toolbar/toolbar.js
+++ b/source/views/components/toolbar/toolbar.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {StyleSheet, Platform, View} from 'react-native'
 import * as c from '../colors'
+import {Viewport} from '../../components/viewport'
 
 const toolbarStyles = StyleSheet.create({
 	shadow: {
@@ -28,8 +29,21 @@ type ToolbarPropsType = {
 
 export function Toolbar({children}: ToolbarPropsType) {
 	return (
-		<View style={[toolbarStyles.shadow, toolbarStyles.container]}>
-			{children}
-		</View>
+		<Viewport
+			render={({width}) => {
+				const toolbarWidth = {width: width}
+				return (
+					<View
+						style={[
+							toolbarStyles.shadow,
+							toolbarStyles.container,
+							toolbarWidth,
+						]}
+					>
+						{children}
+					</View>
+				)
+			}}
+		/>
 	)
 }

--- a/source/views/components/toolbar/toolbar.js
+++ b/source/views/components/toolbar/toolbar.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import {StyleSheet, Platform, View} from 'react-native'
 import * as c from '../colors'
-import {Viewport} from '../../components/viewport'
 
 const toolbarStyles = StyleSheet.create({
 	shadow: {
@@ -29,21 +28,8 @@ type ToolbarPropsType = {
 
 export function Toolbar({children}: ToolbarPropsType) {
 	return (
-		<Viewport
-			render={({width}) => {
-				const toolbarWidth = {width: width}
-				return (
-					<View
-						style={[
-							toolbarStyles.shadow,
-							toolbarStyles.container,
-							toolbarWidth,
-						]}
-					>
-						{children}
-					</View>
-				)
-			}}
-		/>
+		<View style={[toolbarStyles.shadow, toolbarStyles.container]}>
+			{children}
+		</View>
 	)
 }


### PR DESCRIPTION
Closes #2772

**Before** | **After Portrait**
--|--
<img width="363" src="https://camo.githubusercontent.com/4f892e8296aef0220fb0a976c9a77ad727f2549e/68747470733a2f2f692e696d6775722e636f6d2f35305952414a732e6a7067" /> | <img width="363" alt="portrait" src="https://user-images.githubusercontent.com/5240843/44005132-786bde7a-9e2b-11e8-88d4-2ba5cbd61f49.png">


**After Landscape**

<img width="680" alt="landscape" src="https://user-images.githubusercontent.com/5240843/44005141-a3dde314-9e2b-11e8-87f8-5799612b96a4.png">