### PR TITLE
Fix toolbar widths when the toolbar isn't as wide as the screen

### DIFF
--- a/source/views/components/filter/active-filter-button.js
+++ b/source/views/components/filter/active-filter-button.js
@@ -42,7 +42,6 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		justifyContent: 'center',
 		marginRight: 10,
-		marginVertical: 10,
 		paddingHorizontal: 10,
 		paddingVertical: 5,
 	},

--- a/source/views/components/filter/filter-toolbar-button.js
+++ b/source/views/components/filter/filter-toolbar-button.js
@@ -14,7 +14,6 @@ const buttonStyles = StyleSheet.create({
 		marginRight: 10,
 		paddingHorizontal: 8,
 		paddingVertical: 5,
-		marginVertical: 8,
 		borderWidth: 1,
 		borderRadius: 2,
 	},

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -101,5 +101,6 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 const styles = StyleSheet.create({
 	scroller: {
 		paddingLeft: 10,
+		paddingVertical: 8,
 	},
 })

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -78,13 +78,15 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 
 	return (
 		<React.Fragment>
-			<ScrollView
-				contentContainerStyle={styles.scroller}
-				horizontal={true}
-				showsHorizontalScrollIndicator={false}
-			>
-				<Toolbar>{filterToggles}</Toolbar>
-			</ScrollView>
+			<Toolbar>
+				<ScrollView
+					contentContainerStyle={styles.scroller}
+					horizontal={true}
+					showsHorizontalScrollIndicator={false}
+				>
+					{filterToggles}
+				</ScrollView>
+			</Toolbar>
 			{anyFiltersEnabled && (
 				<ScrollView
 					contentContainerStyle={styles.scroller}

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -88,13 +88,15 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 				</ScrollView>
 			</Toolbar>
 			{anyFiltersEnabled && (
-				<ScrollView
-					contentContainerStyle={styles.scroller}
-					horizontal={true}
-					showsHorizontalScrollIndicator={false}
-				>
-					{activeFilterButtons}
-				</ScrollView>
+				<Toolbar>
+					<ScrollView
+						contentContainerStyle={styles.scroller}
+						horizontal={true}
+						showsHorizontalScrollIndicator={false}
+					>
+						{activeFilterButtons}
+					</ScrollView>
+				</Toolbar>
 			)}
 		</React.Fragment>
 	)

--- a/source/views/components/toolbar/toolbar.js
+++ b/source/views/components/toolbar/toolbar.js
@@ -19,6 +19,7 @@ const toolbarStyles = StyleSheet.create({
 	container: {
 		flexDirection: 'row',
 		paddingVertical: 3,
+		alignItems: 'center',
 	},
 })
 

--- a/source/views/menus/components/filter-menu-toolbar.js
+++ b/source/views/menus/components/filter-menu-toolbar.js
@@ -42,10 +42,8 @@ export function FilterMenuToolbar({
 		<React.Fragment>
 			<Toolbar>
 				<View style={[styles.toolbarSection, styles.today]}>
-					<Text>
-						<Text>{date.format('MMM. Do')}</Text>
-						{title ? <Text> — {title}</Text> : null}
-					</Text>
+					<Text>{date.format('MMM. Do')}</Text>
+					{title ? <Text> — {title}</Text> : null}
 				</View>
 				{mealFilter && multipleMeals ? (
 					<FilterToolbarButton


### PR DESCRIPTION
An alternative approach to #2776 
Closes #2772 

You'll want to view the diff without whitespace changes: https://github.com/StoDevX/AAO-React-Native/pull/2777/files?utf8=✓&diff=unified&w=1

In addition to fixing the width, I also fixed a height difference between views with a Menus button and views without, and I wrapped the "active" toolbar in a Toolbar so that it will always have a border even if we use it with something without a top border.

--- | Before | After
--- | --- | ---
Cage | <img width="320" alt="before-cage" src="https://user-images.githubusercontent.com/464441/44006489-e1f79b30-9e4a-11e8-99f3-a651bbe62ded.png"> | <img width="320" alt="after-cage" src="https://user-images.githubusercontent.com/464441/44006486-e183d376-9e4a-11e8-84d8-f39ff7d9e9f1.png">
Stav | <img width="320" alt="before-stav" src="https://user-images.githubusercontent.com/464441/44006490-e2360960-9e4a-11e8-97c3-3c40ffdc5c24.png"> | <img width="320" alt="after-stav" src="https://user-images.githubusercontent.com/464441/44006488-e1bf861e-9e4a-11e8-82ee-7f6a655f9936.png">