### PR TITLE
Course Search: Enter browsing mode on empty search bar

### DIFF
--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -131,6 +131,9 @@ class CourseSearchView extends React.Component<Props, State> {
 
 	handleSearchChange = (value: string) => {
 		this.setState(() => ({typedQuery: value}))
+		if (value === '') {
+			this.setState(() => ({mode: 'browsing', searchQuery: value}))
+		}
 	}
 
 	handleSearchFocus = () => {


### PR DESCRIPTION
This PR makes the course search process more intuitive. When the search bar is cleared, browsing mode is entered and all the courses matching the selected filters are displayed in the results list. This resolves the last bullet point of #2771.