### PR TITLE
Course Search: Save recent filter combinations on unmount

### DIFF
--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -83,6 +83,12 @@ class CourseSearchView extends React.Component<Props, State> {
 		this.resetFilters()
 	}
 
+	componentWillUnmount() {
+		if (this.state.mode === 'browsing') {
+			this.props.updateRecentFilters(this.state.filters)
+		}
+	}
+
 	loadData = async () => {
 		this.setState(() => ({mode: 'loading'}))
 


### PR DESCRIPTION
This PR ensures that when a user is in browsing mode and leaves the SIS View, their current filter combination will be saved to their recent filter combinations. Resolves #2769.