### PR TITLE
Wrap <FilterPopover> in <Viewport>

### DIFF
--- a/source/views/components/filter/filter-popover.js
+++ b/source/views/components/filter/filter-popover.js
@@ -39,7 +39,7 @@ export class FilterPopover extends React.PureComponent<Props, State> {
 
 		return (
 			<Viewport
-				render={viewport => (
+				render={() => (
 					<Popover
 						arrowStyle={arrowStyle}
 						fromView={anchor}

--- a/source/views/components/filter/filter-popover.js
+++ b/source/views/components/filter/filter-popover.js
@@ -4,6 +4,7 @@ import Popover from 'react-native-popover-view'
 import {FilterSection} from './section'
 import type {FilterType} from './types'
 import {type TouchableUnion} from '../touchable'
+import {Viewport} from '../viewport'
 import * as c from '../colors'
 
 type Props = {
@@ -37,16 +38,20 @@ export class FilterPopover extends React.PureComponent<Props, State> {
 		const {anchor, onClosePopover, visible} = this.props
 
 		return (
-			<Popover
-				arrowStyle={arrowStyle}
-				fromView={anchor}
-				isVisible={visible}
-				onClose={() => onClosePopover(filter)}
-				placement="bottom"
-				popoverStyle={popoverContainer}
-			>
-				<FilterSection filter={filter} onChange={this.onFilterChanged} />
-			</Popover>
+			<Viewport
+				render={viewport => (
+					<Popover
+						arrowStyle={arrowStyle}
+						fromView={anchor}
+						isVisible={visible}
+						onClose={() => onClosePopover(filter)}
+						placement="bottom"
+						popoverStyle={popoverContainer}
+					>
+						<FilterSection filter={filter} onChange={this.onFilterChanged} />
+					</Popover>
+				)}
+			/>
 		)
 	}
 }


### PR DESCRIPTION
This PR is a simple solution to #2773, forcing the `<FilterPopover>` component to re-render when the screen rotates. Resolves #2773.