### PR TITLE
Push course search results onto the stack

### DIFF
--- a/source/navigation.js
+++ b/source/navigation.js
@@ -24,9 +24,11 @@ import {
 	CarletonSaylesMenuScreen,
 } from './views/menus'
 import NewsView from './views/news'
-import SISView from './views/sis'
-import {JobDetailView} from './views/sis/student-work/detail'
-import {CourseDetailView} from './views/sis/course-search/detail'
+import SISView, {
+	JobDetailView,
+	CourseDetailView,
+	CourseSearchResultsView,
+} from './views/sis'
 import {
 	BuildingHoursView,
 	BuildingHoursDetailView,
@@ -84,6 +86,7 @@ export const AppNavigator = createStackNavigator(
 		SettingsView: {screen: SettingsView},
 		IconSettingsView: {screen: IconSettingsView},
 		SISView: {screen: SISView},
+		CourseSearchResultsView: {screen: CourseSearchResultsView},
 		CourseDetailView: {screen: CourseDetailView},
 		StreamingView: {screen: StreamingView},
 		KSTOScheduleView: {screen: KSTOScheduleView},

--- a/source/views/components/searchbar/index.android.js
+++ b/source/views/components/searchbar/index.android.js
@@ -28,6 +28,7 @@ export class SearchBar extends React.Component<Props> {
 	static defaultProps = {
 		active: false,
 		backButtonAndroid: true,
+		androidIcon: null,
 		onCancel: () => {},
 		onChange: () => {},
 		onFocus: () => {},
@@ -41,17 +42,18 @@ export class SearchBar extends React.Component<Props> {
 	}
 
 	render() {
+		let {backButtonAndroid} = this.props
 		let backButton = this.props.active ? backIcon : searchIcon
 
 		return (
 			<NativeSearchBar
 				ref={this.handleRef}
 				autoCorrect={false}
-				backButton={backButton}
+				backButton={backButtonAndroid === 'search' ? searchIcon : backButton}
 				closeButton={this.props.active ? closeIcon : null}
 				focusOnLayout={false}
 				handleChangeText={this.props.onChange}
-				hideBack={!this.props.backButtonAndroid}
+				hideBack={!backButtonAndroid}
 				hideClose={!this.props.active}
 				input={this.props.value}
 				onBack={this.props.onCancel}

--- a/source/views/components/searchbar/index.android.js
+++ b/source/views/components/searchbar/index.android.js
@@ -27,6 +27,7 @@ const styles = StyleSheet.create({
 export class SearchBar extends React.Component<Props> {
 	static defaultProps = {
 		active: false,
+		backButtonAndroid: true,
 		onCancel: () => {},
 		onChange: () => {},
 		onFocus: () => {},
@@ -50,6 +51,7 @@ export class SearchBar extends React.Component<Props> {
 				closeButton={this.props.active ? closeIcon : null}
 				focusOnLayout={false}
 				handleChangeText={this.props.onChange}
+				hideBack={!this.props.backButtonAndroid}
 				hideClose={!this.props.active}
 				input={this.props.value}
 				onBack={this.props.onCancel}

--- a/source/views/components/searchbar/types.js
+++ b/source/views/components/searchbar/types.js
@@ -3,7 +3,7 @@
 export type Props = {
 	getRef?: any,
 	active?: boolean,
-	backButtonAndroid?: boolean,
+	backButtonAndroid?: "search" | boolean,
 	backgroundColor?: string,
 	onCancel: () => any,
 	onChange: string => any,

--- a/source/views/components/searchbar/types.js
+++ b/source/views/components/searchbar/types.js
@@ -3,7 +3,7 @@
 export type Props = {
 	getRef?: any,
 	active?: boolean,
-	backButtonAndroid?: "search" | boolean,
+	backButtonAndroid?: 'search' | boolean,
 	backgroundColor?: string,
 	onCancel: () => any,
 	onChange: string => any,

--- a/source/views/components/searchbar/types.js
+++ b/source/views/components/searchbar/types.js
@@ -3,6 +3,7 @@
 export type Props = {
 	getRef?: any,
 	active?: boolean,
+	backButtonAndroid?: boolean,
 	backgroundColor?: string,
 	onCancel: () => any,
 	onChange: string => any,

--- a/source/views/sis/components/animated-searchbox.js
+++ b/source/views/sis/components/animated-searchbox.js
@@ -118,7 +118,7 @@ export class AnimatedSearchbox extends React.Component<Props> {
 							<Animated.View style={searchStyle}>
 								<SearchBar
 									active={this.props.active}
-									backButtonAndroid={false}
+									backButtonAndroid="search"
 									onCancel={this.handleCancel}
 									onChange={this.props.onChange}
 									onFocus={this.handleFocus}

--- a/source/views/sis/components/animated-searchbox.js
+++ b/source/views/sis/components/animated-searchbox.js
@@ -118,6 +118,7 @@ export class AnimatedSearchbox extends React.Component<Props> {
 							<Animated.View style={searchStyle}>
 								<SearchBar
 									active={this.props.active}
+									backButtonAndroid={false}
 									onCancel={this.handleCancel}
 									onChange={this.props.onChange}
 									onFocus={this.handleFocus}

--- a/source/views/sis/components/animated-searchbox.js
+++ b/source/views/sis/components/animated-searchbox.js
@@ -80,23 +80,36 @@ export class AnimatedSearchbox extends React.Component<Props> {
 				render={viewport => {
 					let searchBarWidth = viewport.width - 20
 
+					let showTitle = Boolean(this.props.title)
+
 					let containerStyle = [
 						styles.searchContainer,
 						styles.common,
-						{height: this.containerHeight},
+						{
+							height: showTitle
+								? this.containerHeight
+								: this.containerHeightSpec.end,
+						},
 					]
 
 					let searchStyle = [
 						styles.searchBarWrapper,
 						{width: searchBarWidth},
-						{top: this.searchBarTop},
+						{top: showTitle ? this.searchBarTop : this.searchBarTopSpec.end},
 					]
 
-					let headerStyle = [styles.header, {opacity: this.headerOpacity}]
+					let headerStyle = [
+						styles.header,
+						{
+							opacity: showTitle
+								? this.headerOpacity
+								: this.headerOpacitySpec.end,
+						},
+					]
 
 					return (
 						<Animated.View style={containerStyle}>
-							{this.props.title ? (
+							{showTitle ? (
 								<Animated.Text style={headerStyle}>
 									{this.props.title}
 								</Animated.Text>

--- a/source/views/sis/course-search/index.js
+++ b/source/views/sis/course-search/index.js
@@ -1,3 +1,5 @@
 // @flow
 
-export {default} from './search'
+export {default as CourseSearchView} from './search'
+export {default as CourseSearchResultsView} from './results'
+export {CourseDetailView} from './detail'

--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {StyleSheet, SectionList} from 'react-native'
+import {StyleSheet, SectionList, ActivityIndicator} from 'react-native'
 import type {TopLevelViewPropsType} from '../../types'
 import type {CourseType} from '../../../lib/course-search/types'
 import {ListSeparator, ListSectionHeader} from '../../components/list'
@@ -21,15 +21,23 @@ const styles = StyleSheet.create({
 	message: {
 		paddingVertical: 16,
 	},
+	spinner: {
+		alignItems: 'center',
+		justifyContent: 'center',
+		padding: 8,
+	},
 })
 
 type Props = TopLevelViewPropsType & {
 	applyFilters: (filters: FilterType[], item: CourseType) => boolean,
-	browsing: boolean,
 	courses: Array<CourseType>,
 	filters: Array<FilterType>,
 	onPopoverDismiss: (filter: FilterType) => any,
+	onListItemPress?: CourseType => any,
 	query: string,
+	style?: any,
+	contentContainerStyle?: any,
+	filtersLoaded: boolean,
 }
 
 function doSearch(args: {
@@ -63,17 +71,22 @@ export class CourseResultsList extends React.PureComponent<Props> {
 	)
 
 	onPressRow = (data: CourseType) => {
+		if (this.props.onListItemPress) {
+			this.props.onListItemPress(data)
+		}
 		this.props.navigation.navigate('CourseDetailView', {course: data})
 	}
 
 	render() {
 		let {
 			filters,
-			browsing,
 			query,
 			courses,
 			applyFilters,
 			onPopoverDismiss,
+			contentContainerStyle,
+			style,
+			filtersLoaded,
 		} = this.props
 
 		// be sure to lowercase the query before calling doSearch, so that the memoization
@@ -81,11 +94,15 @@ export class CourseResultsList extends React.PureComponent<Props> {
 		query = query.toLowerCase()
 		let results = memoizedDoSearch({query, filters, courses, applyFilters})
 
-		const header = (
+		const header = filtersLoaded ? (
 			<FilterToolbar filters={filters} onPopoverDismiss={onPopoverDismiss} />
+		) : (
+			<ActivityIndicator style={styles.spinner} />
 		)
 
-		const message = browsing
+		const hasActiveFilter = filters.some(f => f.enabled)
+
+		const message = hasActiveFilter
 			? 'There were no courses that matched your selected filters. Try a different filter combination.'
 			: query.length
 				? 'There were no courses that matched your query. Please try again.'
@@ -98,14 +115,14 @@ export class CourseResultsList extends React.PureComponent<Props> {
 				ItemSeparatorComponent={ListSeparator}
 				ListEmptyComponent={messageView}
 				ListHeaderComponent={header}
-				contentContainerStyle={styles.container}
+				contentContainerStyle={[styles.container, contentContainerStyle]}
 				extraData={this.props}
 				keyExtractor={this.keyExtractor}
-				keyboardDismissMode="on-drag"
-				keyboardShouldPersistTaps="never"
+				keyboardDismissMode="interactive"
 				renderItem={this.renderItem}
 				renderSectionHeader={this.renderSectionHeader}
 				sections={(results: any)}
+				style={style}
 				windowSize={10}
 			/>
 		)

--- a/source/views/sis/course-search/results.js
+++ b/source/views/sis/course-search/results.js
@@ -1,0 +1,211 @@
+// @flow
+
+import * as React from 'react'
+import {StyleSheet, View} from 'react-native'
+import * as c from '../../components/colors'
+import {
+	updateRecentSearches,
+	updateRecentFilters,
+} from '../../../flux/parts/courses'
+import LoadingView from '../../components/loading'
+import {type CourseType} from '../../../lib/course-search'
+import type {ReduxState} from '../../../flux'
+import type {TopLevelViewPropsType} from '../../types'
+import {connect} from 'react-redux'
+import {CourseResultsList} from './list'
+import {AnimatedSearchbox} from '../components/animated-searchbox'
+import {applyFiltersToItem, type FilterType} from '../../components/filter'
+import {Separator} from '../../components/separator'
+import {buildFilters} from './lib/build-filters'
+
+type ReactProps = TopLevelViewPropsType
+
+type ReduxStateProps = {
+	allCourses: Array<CourseType>,
+	isConnected: boolean,
+	courseDataState: string,
+}
+
+type ReduxDispatchProps = {
+	updateRecentFilters: (filters: FilterType[]) => any,
+	updateRecentSearches: (query: string) => any,
+}
+
+type DefaultProps = {
+	applyFilters: (filters: FilterType[], item: CourseType) => boolean,
+}
+
+type NavigationProps = {
+	navigation: {
+		state: {
+			params: {
+				initialQuery?: string,
+				initialFilters?: Array<FilterType>,
+			},
+		},
+	},
+}
+
+type Props = ReactProps &
+	ReduxStateProps &
+	ReduxDispatchProps &
+	DefaultProps &
+	NavigationProps
+
+type State = {
+	filters: Array<FilterType>,
+	typedQuery: string,
+	searchQuery: string,
+	isSearchbarActive: boolean,
+	filtersLoaded: boolean,
+}
+
+class CourseSearchResultsView extends React.Component<Props, State> {
+	static navigationOptions = {
+		title: 'Course Search',
+	}
+
+	static defaultProps = {
+		applyFilters: applyFiltersToItem,
+	}
+
+	state = {
+		isSearchbarActive: false,
+		filtersLoaded: false,
+		filters: this.props.navigation.state.params.initialFilters || [],
+		typedQuery: this.props.navigation.state.params.initialQuery || '',
+		searchQuery: this.props.navigation.state.params.initialQuery || '',
+	}
+
+	componentDidMount() {
+		this.resetFilters()
+	}
+
+	handleSearchSubmit = () => {
+		this.setState(state => ({searchQuery: state.typedQuery}))
+	}
+
+	handleSearchCancel = () => {
+		this.setState(() => ({
+			typedQuery: '',
+			searchQuery: '',
+			isSearchbarActive: false,
+		}))
+		this.resetFilters()
+	}
+
+	handleSearchChange = (value: string) => {
+		this.setState(() => ({typedQuery: value}))
+
+		if (value === '') {
+			this.setState(() => ({searchQuery: value}))
+		}
+	}
+
+	handleSearchFocus = () => {
+		this.setState(() => ({isSearchbarActive: true}))
+	}
+
+	onRecentSearchPress = (text: string) => {
+		this.setState(() => ({
+			typedQuery: text,
+			searchQuery: text,
+		}))
+	}
+
+	handleListItemPress = () => {
+		if (this.state.searchQuery.length) {
+			// if there is text in the search bar, add the text to the Recent Searches list
+			this.props.updateRecentSearches(this.state.searchQuery)
+		} else if (this.state.filters.some(f => f.enabled)) {
+			// if there is at least one active filter, add the filter set to the Recent Filters list
+			this.props.updateRecentFilters(this.state.filters)
+		}
+	}
+
+	updateFilter = (filter: FilterType) => {
+		this.setState(state => {
+			let edited = state.filters.map(f => (f.key !== filter.key ? f : filter))
+			return {filters: edited}
+		})
+	}
+
+	resetFilters = async () => {
+		const newFilters = await buildFilters()
+		this.setState(() => ({filters: newFilters, filtersLoaded: true}))
+	}
+
+	render() {
+		let {
+			typedQuery,
+			searchQuery,
+			filters,
+			isSearchbarActive,
+			filtersLoaded,
+		} = this.state
+
+		if (this.props.courseDataState !== 'ready') {
+			return <LoadingView text="Loading Course Data…" />
+		}
+
+		return (
+			<View style={[styles.container, styles.common]}>
+				<AnimatedSearchbox
+					active={true}
+					onCancel={this.handleSearchCancel}
+					onChange={this.handleSearchChange}
+					onFocus={this.handleSearchFocus}
+					onSubmit={this.handleSearchSubmit}
+					placeholder="Search Class & Lab"
+					value={typedQuery}
+				/>
+
+				<Separator />
+
+				<CourseResultsList
+					applyFilters={this.props.applyFilters}
+					courses={this.props.allCourses}
+					filters={filters}
+					filtersLoaded={filtersLoaded}
+					navigation={this.props.navigation}
+					onListItemPress={this.handleListItemPress}
+					onPopoverDismiss={this.updateFilter}
+					query={searchQuery}
+					style={isSearchbarActive ? styles.darken : null}
+				/>
+			</View>
+		)
+	}
+}
+
+function mapState(state: ReduxState): ReduxStateProps {
+	return {
+		isConnected: state.app ? state.app.isConnected : false,
+		allCourses: state.courses ? state.courses.allCourses : [],
+		courseDataState: state.courses ? state.courses.readyState : '',
+	}
+}
+
+function mapDispatch(dispatch): ReduxDispatchProps {
+	return {
+		updateRecentSearches: (query: string) =>
+			dispatch(updateRecentSearches(query)),
+		updateRecentFilters: (filters: FilterType[]) =>
+			dispatch(updateRecentFilters(filters)),
+	}
+}
+
+export default connect(
+	mapState,
+	mapDispatch,
+)(CourseSearchResultsView)
+
+let styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	common: {
+		backgroundColor: c.white,
+	},
+	darken: {},
+})

--- a/source/views/sis/course-search/results.js
+++ b/source/views/sis/course-search/results.js
@@ -71,14 +71,16 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 
 	state = {
 		isSearchbarActive: false,
-		filtersLoaded: false,
+		filtersLoaded: Boolean(this.props.navigation.state.params.initialFilters),
 		filters: this.props.navigation.state.params.initialFilters || [],
 		typedQuery: this.props.navigation.state.params.initialQuery || '',
 		searchQuery: this.props.navigation.state.params.initialQuery || '',
 	}
 
 	componentDidMount() {
-		this.resetFilters()
+		if (!this.state.filters.length) {
+			this.resetFilters()
+		}
 	}
 
 	handleSearchSubmit = () => {

--- a/source/views/sis/course-search/results.js
+++ b/source/views/sis/course-search/results.js
@@ -86,9 +86,8 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 	}
 
 	handleSearchCancel = () => {
-		this.setState(() => ({
-			typedQuery: '',
-			searchQuery: '',
+		this.setState(state => ({
+			typedQuery: state.searchQuery,
 			isSearchbarActive: false,
 		}))
 	}

--- a/source/views/sis/course-search/results.js
+++ b/source/views/sis/course-search/results.js
@@ -91,7 +91,6 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 			searchQuery: '',
 			isSearchbarActive: false,
 		}))
-		this.resetFilters()
 	}
 
 	handleSearchChange = (value: string) => {

--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -68,7 +68,7 @@ class CourseSearchView extends React.Component<Props, State> {
 		this.loadData({userInitiated: false})
 	}
 
-	loadData = async ({userInitiated=true}={}) => {
+	loadData = async ({userInitiated = true} = {}) => {
 		let hasCache = await areAnyTermsCached()
 
 		if (!hasCache && !userInitiated) {

--- a/source/views/sis/course-search/search.js
+++ b/source/views/sis/course-search/search.js
@@ -75,7 +75,7 @@ class CourseSearchView extends React.Component<Props, State> {
 			// if no terms are cached, and the user didn't push the button,
 			// then don't download anything.
 			this.setState(() => ({mode: 'pending'}))
-			return;
+			return
 		}
 
 		this.setState(() => ({mode: 'loading'}))
@@ -102,10 +102,10 @@ class CourseSearchView extends React.Component<Props, State> {
 	}
 
 	handleSearchSubmit = () => {
-		this.setState(() => ({isSearchbarActive: false}))
 		this.props.navigation.push('CourseSearchResultsView', {
 			initialQuery: this.state.typedQuery,
 		})
+		this.setState(() => ({isSearchbarActive: false, typedQuery: ''}))
 	}
 
 	handleSearchCancel = () => {

--- a/source/views/sis/index.js
+++ b/source/views/sis/index.js
@@ -4,8 +4,11 @@ import {TabNavigator} from '../components/tabbed-view'
 
 import BalancesView from './balances'
 import StudentWorkView from './student-work'
-import CourseSearchView from './course-search'
+import {CourseSearchView} from './course-search'
 import TESView from './tes'
+
+export {JobDetailView} from './student-work/detail'
+export {CourseSearchResultsView, CourseDetailView} from './course-search'
 
 const SisView = TabNavigator({
 	BalancesView: {screen: BalancesView},


### PR DESCRIPTION
Yay behavioral changes 😭😆

Instead of transmogrifying the search overview into the search results, we'll just push the results view onto the stack. This better matches how searching works in YouTube, for instance, and makes logical sense to me since we don't do search-as-you-type.

We still hide the home's search box title when typing, and we show it again when you return from the results, since returning to the overview essentially resets the screen.

Tapping a search or filter will push the results view with the tapped item as the search or filter. 

We'll always show a Search icon on Android, which isn't quite platform-native, but since our search bar is separate from the titlebar the "back" button doesn't make sense IMO.

We now determine when to save a "recent" item in a nifty way: what's the best way to tell that someone found a query useful? IMO, it's that they interacted with the list, so we'll now only save the thing to the "recents" list if the person has tapped on a result row.

> IOW, to save a recent search, search for something, then tap on a row.
> To save a recent filter, browse for something, then tap on a row.

Bugfixes: 
- If the view is pushed while filters are loading, there will be a spinner to indicate that content will appear. This is impossible to trigger on master, because the filters will have loaded by the time you can search for something, but here they can be missing for up to ~1s.
- Dismissing the keyboard will now work based on your finger's position and won't dismiss by dragging on android, to better match Android conventions.
- Dismissing the keyboard on the home screen is now possible by dragging
- Course data loading now only makes network requests after the "Download" button is pressed (again; I broke it in #2737)

I haven't attached any screenshots because there really weren't any visual changes, aside from the Android back-to-search icon change.