### PR TITLE
Switch Streams endpoint to ccc-server

### DIFF
--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -90,7 +90,9 @@ export class StreamListView extends React.PureComponent<Props, State> {
 				.map(stream => {
 					const date = moment(stream.starttime)
 					const group =
-						stream.status !== 'live' ? date.format('dddd, MMMM Do') : 'Live'
+						stream.status.toLowerCase() !== 'live'
+							? date.format('dddd, MMMM Do')
+							: 'Live'
 
 					return {
 						...stream,

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -78,10 +78,8 @@ export class StreamListView extends React.PureComponent<Props, State> {
 
 			let params = {
 				sort: 'ascending',
-				// eslint-disable-next-line camelcase
-				date_from: dateFrom,
-				// eslint-disable-next-line camelcase
-				date_to: dateTo,
+				dateFrom,
+				dateTo,
 			}
 
 			const data = await fetchJson(API('/streams/upcoming', params))
@@ -90,7 +88,7 @@ export class StreamListView extends React.PureComponent<Props, State> {
 			const processed = data
 				.filter(stream => stream.category !== 'athletics')
 				.map(stream => {
-					const date = moment(stream.starttime, 'YYYY-MM-DD HH:mm')
+					const date = moment(stream.starttime)
 					const group =
 						stream.status !== 'live' ? date.format('dddd, MMMM Do') : 'Live'
 

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -12,13 +12,12 @@ import {StreamRow} from './row'
 import toPairs from 'lodash/toPairs'
 import groupBy from 'lodash/groupBy'
 import moment from 'moment-timezone'
-import qs from 'querystring'
 import {toLaxTitleCase as titleCase} from 'titlecase'
 import type {StreamType} from './types'
 import delay from 'delay'
+import {API} from '../../../globals'
 
 const CENTRAL_TZ = 'America/Winnipeg'
-const url = 'https://www.stolaf.edu/multimedia/api/collection'
 
 const styles = StyleSheet.create({
 	listContainer: {
@@ -74,11 +73,10 @@ export class StreamListView extends React.PureComponent<Props, State> {
 			const dateFrom = date.format('YYYY-MM-DD')
 			const dateTo = date
 				.clone()
-				.add(1, 'month')
+				.add(2, 'month')
 				.format('YYYY-MM-DD')
 
 			let params = {
-				class: 'current',
 				sort: 'ascending',
 				// eslint-disable-next-line camelcase
 				date_from: dateFrom,
@@ -86,19 +84,15 @@ export class StreamListView extends React.PureComponent<Props, State> {
 				date_to: dateTo,
 			}
 
-			const streamsAPI = `${url}?${qs.stringify(params)}`
-			const data = await fetchJson(streamsAPI)
-			const streams = data.results
+			const data = await fetchJson(API('/streams/upcoming', params))
 
 			// force title-case on the stream types, to prevent not-actually-duplicate headings
-			const processed = streams
+			const processed = data
 				.filter(stream => stream.category !== 'athletics')
 				.map(stream => {
 					const date = moment(stream.starttime, 'YYYY-MM-DD HH:mm')
 					const group =
-						stream.status.toLowerCase() !== 'live'
-							? date.format('dddd, MMMM Do')
-							: 'Live'
+						stream.status !== 'live' ? date.format('dddd, MMMM Do') : 'Live'
 
 					return {
 						...stream,

--- a/source/views/streaming/streams/row.js
+++ b/source/views/streaming/streams/row.js
@@ -7,6 +7,7 @@ import {ListRow, Detail, Title} from '../../components/list'
 import {Column, Row} from '../../components/layout'
 import {getTrimmedTextWithSpaces, parseHtml} from '../../../lib/html'
 import {trackedOpenUrl} from '../../components/open-url'
+import moment from 'moment'
 import type {StreamType} from './types'
 
 const styles = StyleSheet.create({
@@ -30,9 +31,10 @@ function Info({item}: {item: StreamType}) {
 }
 
 function Time({item}: {item: StreamType}) {
+	const streamDate = moment(item.date)
 	const showTime = item.status !== 'archived'
 	return showTime ? (
-		<Detail>{item.date.format('h:mm A – ddd, MMM. Do, YYYY')}</Detail>
+		<Detail>{streamDate.format('h:mm A – ddd, MMM. Do, YYYY')}</Detail>
 	) : null
 }
 

--- a/source/views/streaming/streams/row.js
+++ b/source/views/streaming/streams/row.js
@@ -31,10 +31,9 @@ function Info({item}: {item: StreamType}) {
 }
 
 function Time({item}: {item: StreamType}) {
-	const streamDate = moment(item.date)
 	const showTime = item.status !== 'archived'
 	return showTime ? (
-		<Detail>{streamDate.format('h:mm A – ddd, MMM. Do, YYYY')}</Detail>
+		<Detail>{moment(item.date).format('h:mm A – ddd, MMM. Do, YYYY')}</Detail>
 	) : null
 }
 

--- a/source/views/streaming/streams/types.js
+++ b/source/views/streaming/streams/types.js
@@ -1,6 +1,4 @@
 // @flow
-import type momentT from 'moment'
-
 export type StreamType = {
 	category: string,
 	eid: string,
@@ -15,5 +13,5 @@ export type StreamType = {
 	subtitle: ?string,
 	thumb: string,
 	title: string,
-	date: momentT,
+	date: string,
 }


### PR DESCRIPTION
Uses a controlled API so that we have flexibility over the streams data.

Changes to the server are in review, but I thought I'd get this going in parallel.

Server PR: https://github.com/frog-pond/ccc-server/pull/64