### PR TITLE
Temporarily migrate to Fastlane's Git as our installation source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'fastlane'
+gem 'fastlane', git: 'https://github.com/fastlane/fastlane.git'
 gem 'json'
 gem 'xcodeproj'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,7 @@
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/fastlane/fastlane.git
+  revision: a9b78cfd5cfabf18727e165bbfe38c27ba2e23ef
   specs:
-    CFPropertyList (3.0.0)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    ast (2.4.0)
-    atomos (0.1.3)
-    babosa (1.0.2)
-    claide (1.0.2)
-    colored (1.2)
-    colored2 (3.1.2)
-    commander-fastlane (4.4.6)
-      highline (~> 1.7.2)
-    declarative (0.0.10)
-    declarative-option (0.1.0)
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.5.0)
-    emoji_regex (0.1.1)
-    excon (0.62.0)
-    faraday (0.15.2)
-      multipart-post (>= 1.2, < 3)
-    faraday-cookie_jar (0.0.6)
-      faraday (>= 0.7.4)
-      http-cookie (~> 1.0.0)
-    faraday_middleware (0.12.2)
-      faraday (>= 0.7.4, < 1.0)
-    fastimage (2.1.3)
     fastlane (2.101.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
@@ -63,6 +38,36 @@ GEM
       xcodeproj (>= 1.5.7, < 2.0.0)
       xcpretty (~> 0.2.8)
       xcpretty-travis-formatter (>= 0.0.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
+    atomos (0.1.3)
+    babosa (1.0.2)
+    claide (1.0.2)
+    colored (1.2)
+    colored2 (3.1.2)
+    commander-fastlane (4.4.6)
+      highline (~> 1.7.2)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.5.0)
+    emoji_regex (0.1.1)
+    excon (0.62.0)
+    faraday (0.15.2)
+      multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.6)
+      faraday (>= 0.7.4)
+      http-cookie (~> 1.0.0)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
+    fastimage (2.1.3)
     fastlane-plugin-bugsnag (1.3.4)
       git
       xml-simple
@@ -162,7 +167,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane
+  fastlane!
   fastlane-plugin-bugsnag
   json
   rubocop (~> 0.58)


### PR DESCRIPTION
Here be dragons! It might break stuff, we'll have to see.

Besides poking people upstream, I can't think of a way of getting a new version released faster. We need functioning Android builds.

Obviously, every new commit is going to require a `bundle up`, but this won't _break_ things. We're just pinning to a specific Git revision.

I'll keep an eye on the repository to make sure we don't miss anything. Once the fix gets released upstream, we can switch back.