### PR TITLE
Update mime-types gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     memoist (0.16.0)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
     mini_magick (4.5.1)
     multi_json (1.13.1)
     multi_xml (0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     json (2.1.0)
     jwt (2.1.0)
     memoist (0.16.0)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_magick (4.5.1)


### PR DESCRIPTION
These got released a bit ago.

The `mime-types` update just removes some debugging code, and the `mime-types-data` update is just a refresh of more data.

This only affects the Ruby side of things.