### PR TITLE
Disable react-navigation session persistence on dev

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -30,6 +30,8 @@ function getCurrentRouteName(navigationState: NavigationState): ?string {
 
 type Props = {}
 
+const navigationPersistenceKey = __DEV__ ? null : 'NavState'
+
 export default class App extends React.Component<Props> {
 	componentDidMount() {
 		OneSignal.addEventListener('received', this.onReceived)
@@ -83,7 +85,7 @@ export default class App extends React.Component<Props> {
 			<Provider store={store}>
 				<AppNavigator
 					onNavigationStateChange={this.trackScreenChanges}
-					persistenceKey="NavState"
+					persistenceKey={navigationPersistenceKey}
 				/>
 			</Provider>
 		)


### PR DESCRIPTION
Extracted from #2810 

Disables React-Navigation session persistence when developing.

For posterity: if you want to enable this for a development session, you can just change `null` to some other value (but remember not to commit it!)