### PR TITLE
Move Student Orgs to ccc-server

### DIFF
--- a/source/views/student-orgs/detail.android.js
+++ b/source/views/student-orgs/detail.android.js
@@ -8,7 +8,7 @@ import type {StudentOrgType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {sendEmail} from '../components/send-email'
 import {openUrl} from '../components/open-url'
-import {cleanOrg, showNameOrEmail} from './util'
+import {showNameOrEmail} from './util'
 
 const styles = StyleSheet.create({
 	name: {
@@ -76,7 +76,7 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
 			advisors,
 			description,
 			lastUpdated: orgLastUpdated,
-		} = cleanOrg(this.props.navigation.state.params.org)
+		} = this.props.navigation.state.params.org
 
 		return (
 			<ScrollView>

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -8,7 +8,7 @@ import type {StudentOrgType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {openUrl} from '../components/open-url'
 import {sendEmail} from '../components/send-email'
-import {cleanOrg, showNameOrEmail} from './util'
+import {showNameOrEmail} from './util'
 import {SelectableCell} from '../components/cells/selectable'
 
 const styles = StyleSheet.create({
@@ -56,7 +56,7 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
 			advisors,
 			description,
 			lastUpdated: orgLastUpdated,
-		} = cleanOrg(this.props.navigation.state.params.org)
+		} = this.props.navigation.state.params.org
 
 		return (
 			<ScrollView>

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -25,9 +25,9 @@ import deburr from 'lodash/deburr'
 import startCase from 'lodash/startCase'
 import * as c from '../components/colors'
 import type {StudentOrgType} from './types'
+import {API} from '../../globals'
 
-const orgsUrl =
-	'https://www.stolaf.edu/orgs/list/index.cfm?fuseaction=getall&nostructure=1'
+const orgsUrl = API('/orgs')
 const leftSideSpacing = 20
 const ROW_HEIGHT = Platform.OS === 'ios' ? 58 : 74
 const SECTION_HEADER_HEIGHT = Platform.OS === 'ios' ? 33 : 41

--- a/source/views/student-orgs/util.js
+++ b/source/views/student-orgs/util.js
@@ -1,44 +1,5 @@
 // @flow
-import type {StudentOrgType} from './types'
 import type {ContactPersonType} from './types'
-import {fastGetTrimmedText} from '../../lib/html'
-
-export function cleanOrg(org: StudentOrgType): StudentOrgType {
-	const name = org.name.trim()
-
-	const advisors = org.advisors
-		.map(c => ({
-			...c,
-			name: c.name.trim(),
-		}))
-		.filter(c => c.name.length)
-
-	const contacts = org.contacts.map(c => ({
-		...c,
-		title: c.title.trim(),
-		firstName: c.firstName.trim(),
-		lastName: c.lastName.trim(),
-	}))
-
-	const category = org.category.trim()
-	const meetings = org.meetings.trim()
-	const description = fastGetTrimmedText(org.description)
-	let website = org.website.trim()
-	if (website && !/^https?:\/\//.test(website)) {
-		website = `http://${website}`
-	}
-
-	return {
-		...org,
-		name,
-		advisors,
-		contacts,
-		category,
-		meetings,
-		description,
-		website,
-	}
-}
 
 export function showNameOrEmail(c: ContactPersonType) {
 	if (!c.firstName.trim() && !c.lastName.trim()) {


### PR DESCRIPTION
Closes #2812 

Tested and verified that it's fetching from the server.

The "org cleaning" was [already on the server](https://github.com/frog-pond/ccc-server/blob/39b49b959cc2812cee78a4df29a94496a2dfeb0d/modules/node_modules/%40frogpond/ccci-stolaf-college/v1/orgs/index.mjs#L8-L41), so I removed it from here.

```
  <-- GET /v1/orgs
  --> GET /v1/orgs 200 28ms 67.02kb
  <-- GET /ping
  --> GET /ping 200 0ms 4b
  <-- GET /v1/orgs
  --> GET /v1/orgs 304 12ms
```