### PR TITLE
Add stoPrint View!

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "moment-timezone": "0.5.21",
     "p-props": "1.2.0",
     "p-retry": "2.0.0",
-    "querystring": "0.2.0",
+    "query-string": "6.1.0",
     "react": "16.4.2",
     "react-markdown": "2.5.1",
     "react-native": "0.55.4",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "p-props": "1.2.0",
     "p-retry": "2.0.0",
     "query-string": "6.1.0",
+    "querystring": "0.2.0",
     "react": "16.4.2",
     "react-markdown": "2.5.1",
     "react-native": "0.55.4",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@hawkrives/react-native-alternate-icons": "0.4.7",
     "@hawkrives/react-native-sortable-list": "1.0.1",
     "@mapbox/react-native-mapbox-gl": "6.1.2",
+    "base-64": "0.1.0",
     "buffer": "5.2.0",
     "bugsnag-react-native": "2.10.2",
     "css-select": "2.0.0",

--- a/source/flux/index.js
+++ b/source/flux/index.js
@@ -12,6 +12,7 @@ import {balances, type State as BalancesState} from './parts/balances'
 import {buildings, type State as BuildingsState} from './parts/buildings'
 import {help, type State as HelpState} from './parts/help'
 import {courses, type State as CoursesState} from './parts/courses'
+import {stoprint, type State as StoprintState} from './parts/stoprint'
 
 export {init as initRedux} from './init'
 
@@ -23,6 +24,7 @@ export type ReduxState = {
 	balances?: BalancesState,
 	buildings?: BuildingsState,
 	help?: HelpState,
+	stoprint?: StoprintState,
 }
 
 export const makeStore = () => {
@@ -34,6 +36,7 @@ export const makeStore = () => {
 		balances,
 		buildings,
 		help,
+		stoprint,
 	})
 
 	const middleware = [reduxPromise, reduxThunk]

--- a/source/flux/index.js
+++ b/source/flux/index.js
@@ -12,7 +12,7 @@ import {balances, type State as BalancesState} from './parts/balances'
 import {buildings, type State as BuildingsState} from './parts/buildings'
 import {help, type State as HelpState} from './parts/help'
 import {courses, type State as CoursesState} from './parts/courses'
-import {stoprint, type State as StoprintState} from './parts/stoprint'
+import {stoprint, type State as StoPrintState} from './parts/stoprint'
 
 export {init as initRedux} from './init'
 
@@ -24,7 +24,7 @@ export type ReduxState = {
 	balances?: BalancesState,
 	buildings?: BuildingsState,
 	help?: HelpState,
-	stoprint?: StoprintState,
+	stoprint?: StoPrintState,
 }
 
 export const makeStore = () => {

--- a/source/flux/parts/stoprint.js
+++ b/source/flux/parts/stoprint.js
@@ -135,7 +135,7 @@ const initialState: State = {
 export function stoprint(state: State = initialState, action: Action) {
 	switch (action.type) {
 		case UPDATE_PRINT_JOBS_START:
-			return {...state, loadingJobs: true, error: null}
+			return {...state, loadingJobs: true}
 
 		case UPDATE_PRINT_JOBS_FAILURE:
 			return {...state, loadingJobs: false, error: action.payload}
@@ -149,7 +149,7 @@ export function stoprint(state: State = initialState, action: Action) {
 			}
 
 		case UPDATE_ALL_PRINTERS_START:
-			return {...state, loadingPrinters: true, error: null}
+			return {...state, loadingPrinters: true}
 
 		case UPDATE_ALL_PRINTERS_FAILURE:
 			return {...state, loadingPrinters: false, error: action.payload}

--- a/source/flux/parts/stoprint.js
+++ b/source/flux/parts/stoprint.js
@@ -1,15 +1,14 @@
 // @flow
 
 import {loadLoginCredentials} from '../../lib/login'
-import {encode} from 'base-64'
 import {type ReduxState} from '../index'
-import type {
-	HeldJob,
-	PrintJob,
-	Printer,
-	RecentPopularPrintersResponse as RecentPrinters,
-} from '../../views/stoprint/types'
-import {fetchAllPrinters, fetchJobs, fetchRecentPrinters, logIn} from '../../lib/stoprint'
+import type {PrintJob, Printer} from '../../lib/stoprint'
+import {
+	fetchAllPrinters,
+	fetchJobs,
+	fetchRecentPrinters,
+	logIn,
+} from '../../lib/stoprint'
 
 type Dispatch<A: Action> = (action: A | Promise<A> | ThunkAction<A>) => any
 type GetState = () => ReduxState

--- a/source/flux/parts/stoprint.js
+++ b/source/flux/parts/stoprint.js
@@ -92,7 +92,7 @@ async function logIn(
 	}
 }
 
-const mobileRelease = `${PAPERCUT}/mobilerelease/api`
+const mobileRelease = `${PAPERCUT_API}/mobilerelease/api`
 
 const fetchAllPrinters = (username: string): Promise<Array<Printer>> =>
 	fetchJson(`${mobileRelease}/all-printers?username=${username}`)

--- a/source/flux/parts/stoprint.js
+++ b/source/flux/parts/stoprint.js
@@ -10,7 +10,8 @@ import type {
 	RecentPopularPrintersResponse as RecentPrinters,
 } from '../../views/stoprint/types'
 
-const PAPERCUT = 'https://papercut.stolaf.edu:9192/rpc/api/rest/internal'
+const PAPERCUT = 'https://papercut.stolaf.edu'
+const PAPERCUT_API = 'https://papercut.stolaf.edu/rpc/api/rest/internal'
 
 type Dispatch<A: Action> = (action: A | Promise<A> | ThunkAction<A>) => any
 type GetState = () => ReduxState
@@ -72,9 +73,10 @@ async function logIn(
 ): Promise<'success' | string> {
 	try {
 		const now = new Date().getTime()
-		const url = `${PAPERCUT}/webclient/users/${username}/log-in?nocache=${now}`
+		const url = `${PAPERCUT_API}/webclient/users/${username}/log-in?nocache=${now}`
 		const headers = new Headers({
 			'Content-Type': 'application/x-www-form-urlencoded',
+			'Origin': PAPERCUT,
 		})
 		const body = querystring.stringify({password: encode(password)})
 		const result = await fetchJson(url, {method: 'POST', body, headers})
@@ -102,7 +104,7 @@ const heldJobsAvailableAtPrinterForUser = (
 	printerName: string,
 	username: string,
 ): Promise<{}> =>
-	// https://papercut.stolaf.edu/rpc/api/rest/internal/mobilerelease/api/held-jobs/?username=rives&printerName=printers%5Cmfc-it
+	// https://PAPERCUT_API.stolaf.edu/rpc/api/rest/internal/mobilerelease/api/held-jobs/?username=rives&printerName=printers%5Cmfc-it
 	fetchJson(
 		`${mobileRelease}/held-jobs/?username=${username}&printerName=printers%5c\\${printerName}`,
 	)
@@ -183,7 +185,7 @@ export function updatePrintJobs(): ThunkAction<UpdatePrintJobsAction> {
 			return dispatch({type: UPDATE_PRINT_JOBS_FAILURE, payload: successMsg})
 		}
 
-		const url = `https://papercut.stolaf.edu:9192/rpc/api/rest/internal/webclient/users/${username}/jobs/status`
+		const url = `${PAPERCUT_API}/webclient/users/${username}/jobs/status`
 		const {jobs} = await fetchJson(url)
 
 		dispatch({type: UPDATE_PRINT_JOBS_SUCCESS, payload: jobs})

--- a/source/flux/parts/stoprint.js
+++ b/source/flux/parts/stoprint.js
@@ -1,0 +1,248 @@
+// @flow
+
+import {loadLoginCredentials} from '../../lib/login'
+import querystring from 'querystring'
+import {encode} from 'base-64'
+import {type ReduxState} from '../index'
+import type {
+	PrintJob,
+	Printer,
+	RecentPopularPrintersResponse as RecentPrinters,
+} from '../../views/stoprint/types'
+
+const PAPERCUT = 'https://papercut.stolaf.edu:9192/rpc/api/rest/internal'
+
+type Dispatch<A: Action> = (action: A | Promise<A> | ThunkAction<A>) => any
+type GetState = () => ReduxState
+type ThunkAction<A: Action> = (dispatch: Dispatch<A>, getState: GetState) => any
+type Action = UpdateAllPrintersAction | UpdatePrintJobsAction
+
+const UPDATE_ALL_PRINTERS_START = 'stoprint/UPDATE_ALL_PRINTERS/START'
+const UPDATE_ALL_PRINTERS_FAILURE = 'stoprint/UPDATE_ALL_PRINTERS/FAILURE'
+const UPDATE_ALL_PRINTERS_SUCCESS = 'stoprint/UPDATE_ALL_PRINTERS/SUCCESS'
+const UPDATE_PRINT_JOBS_START = 'stoprint/UPDATE_PRINT_JOBS/START'
+const UPDATE_PRINT_JOBS_FAILURE = 'stoprint/UPDATE_PRINT_JOBS/FAILURE'
+const UPDATE_PRINT_JOBS_SUCCESS = 'stoprint/UPDATE_PRINT_JOBS/SUCCESS'
+
+type UpdateAllPrintersStartAction = {
+	type: 'stoprint/UPDATE_ALL_PRINTERS/START',
+}
+
+type UpdateAllPrintersFailureAction = {
+	type: 'stoprint/UPDATE_ALL_PRINTERS/FAILURE',
+	payload: string,
+}
+
+type UpdateAllPrintersSuccessAction = {
+	type: 'stoprint/UPDATE_ALL_PRINTERS/SUCCESS',
+	payload: {
+		allPrinters: Array<Printer>,
+		popularPrinters: Array<Printer>,
+		recentPrinters: Array<Printer>,
+	},
+}
+
+type UpdateAllPrintersAction =
+	| UpdateAllPrintersSuccessAction
+	| UpdateAllPrintersFailureAction
+	| UpdateAllPrintersStartAction
+
+type UpdatePrintJobsStartAction = {
+	type: 'stoprint/UPDATE_PRINT_JOBS/START',
+}
+
+type UpdatePrintJobsFailureAction = {
+	type: 'stoprint/UPDATE_PRINT_JOBS/FAILURE',
+	payload: string,
+}
+
+type UpdatePrintJobsSuccessAction = {
+	type: 'stoprint/UPDATE_PRINT_JOBS/SUCCESS',
+	payload: Array<PrintJob>,
+}
+
+type UpdatePrintJobsAction =
+	| UpdatePrintJobsSuccessAction
+	| UpdatePrintJobsFailureAction
+	| UpdatePrintJobsStartAction
+
+async function logIn(
+	username: string,
+	password: string,
+): Promise<'success' | string> {
+	try {
+		const now = new Date().getTime()
+		const url = `${PAPERCUT}/webclient/users/${username}/log-in?nocache=${now}`
+		const headers = new Headers({
+			'Content-Type': 'application/x-www-form-urlencoded',
+		})
+		const body = querystring.stringify({password: encode(password)})
+		const result = await fetchJson(url, {method: 'POST', body, headers})
+
+		if (!result.success) {
+			return 'The username and password appear to be invalid'
+		}
+
+		return 'success'
+	} catch (err) {
+		console.error(err)
+		return 'The print server seems to be having some issues'
+	}
+}
+
+const mobileRelease = `${PAPERCUT}/mobilerelease/api`
+
+const fetchAllPrinters = (username: string): Promise<Array<Printer>> =>
+	fetchJson(`${mobileRelease}/all-printers?username=${username}`)
+
+const fetchRecentPrinters = (username: string): Promise<RecentPrinters> =>
+	fetchJson(`${mobileRelease}/recent-popular-printers?username=${username}`)
+
+const heldJobsAvailableAtPrinterForUser = (
+	printerName: string,
+	username: string,
+): Promise<{}> =>
+	// https://papercut.stolaf.edu/rpc/api/rest/internal/mobilerelease/api/held-jobs/?username=rives&printerName=printers%5Cmfc-it
+	fetchJson(
+		`${mobileRelease}/held-jobs/?username=${username}&printerName=printers%5c\\${printerName}`,
+	)
+
+const cancelPrintJobForUser = (jobId, username) =>
+	// url: '/rpc/api/rest/internal/mobilerelease/api/held-jobs/cancel?username=' + MRApp.session.get('username'),
+	// data: {
+	//   jobIds: selectedJobIds
+	// },
+	fetchJson(`${mobileRelease}/held-jobs/cancel?username=${username}`, {
+		method: 'POST',
+		body: JSON.stringify({
+			jobIds: [jobId],
+		}),
+	})
+
+const releasePrintJobToPrinterForUser = ({
+	jobId,
+	printerName,
+	username,
+}: {
+	jobId: any,
+	printerName: string,
+	username: string,
+}) =>
+	// url: '/rpc/api/rest/internal/mobilerelease/api/held-jobs/release?username=' + MRApp.session.get('username'),
+	// data: {
+	//   printerName: this.model._printerName,
+	//   jobIds: selectedJobIds
+	// },
+	fetchJson(`${mobileRelease}/held-jobs/release?username=${username}`, {
+		method: 'POST',
+		body: JSON.stringify({
+			printerName,
+			jobIds: [jobId],
+		}),
+	})
+
+export function updatePrinters(): ThunkAction<UpdateAllPrintersAction> {
+	return async dispatch => {
+		const {username, password} = await loadLoginCredentials()
+		if (!username || !password) {
+			return false
+		}
+
+		dispatch({type: UPDATE_ALL_PRINTERS_START})
+
+		const successMsg = await logIn(username, password)
+		if (successMsg !== 'success') {
+			return dispatch({type: UPDATE_ALL_PRINTERS_FAILURE, payload: successMsg})
+		}
+
+		const [allPrinters, recentAndPopularPrinters] = await Promise.all([
+			fetchAllPrinters(username),
+			fetchRecentPrinters(username),
+		])
+
+		const {recentPrinters, popularPrinters} = recentAndPopularPrinters
+
+		dispatch({
+			type: UPDATE_ALL_PRINTERS_SUCCESS,
+			payload: {allPrinters, recentPrinters, popularPrinters},
+		})
+	}
+}
+
+export function updatePrintJobs(): ThunkAction<UpdatePrintJobsAction> {
+	return async dispatch => {
+		const {username, password} = await loadLoginCredentials()
+		if (!username || !password) {
+			return false
+		}
+
+		dispatch({type: UPDATE_PRINT_JOBS_START})
+
+		const successMsg = await logIn(username, password)
+		if (successMsg !== 'success') {
+			return dispatch({type: UPDATE_PRINT_JOBS_FAILURE, payload: successMsg})
+		}
+
+		const url = `https://papercut.stolaf.edu:9192/rpc/api/rest/internal/webclient/users/${username}/jobs/status`
+		const {jobs} = await fetchJson(url)
+
+		dispatch({type: UPDATE_PRINT_JOBS_SUCCESS, payload: jobs})
+	}
+}
+
+export type State = {|
+	jobs: Array<PrintJob>,
+	printers: Array<Printer>,
+	recentPrinters: Array<Printer>, // printer names
+	popularPrinters: Array<Printer>, // printer names
+	error: ?string,
+	loadingPrinters: boolean,
+	loadingJobs: boolean,
+|}
+
+const initialState: State = {
+	error: null,
+	jobs: [],
+	printers: [],
+	recentPrinters: [],
+	popularPrinters: [],
+	loadingPrinters: false,
+	loadingJobs: false,
+}
+
+export function stoprint(state: State = initialState, action: Action) {
+	switch (action.type) {
+		case UPDATE_PRINT_JOBS_START:
+			return {...state, loadingJobs: true, error: null}
+
+		case UPDATE_PRINT_JOBS_FAILURE:
+			return {...state, loadingJobs: false, error: action.payload}
+
+		case UPDATE_PRINT_JOBS_SUCCESS:
+			return {
+				...state,
+				jobs: action.payload,
+				error: null,
+				loadingJobs: false,
+			}
+
+		case UPDATE_ALL_PRINTERS_START:
+			return {...state, loadingPrinters: true, error: null}
+
+		case UPDATE_ALL_PRINTERS_FAILURE:
+			return {...state, loadingPrinters: false, error: action.payload}
+
+		case UPDATE_ALL_PRINTERS_SUCCESS:
+			return {
+				...state,
+				printers: action.payload.allPrinters,
+				recentPrinters: action.payload.recentPrinters,
+				popularPrinters: action.payload.popularPrinters,
+				error: null,
+				loadingPrinters: false,
+			}
+
+		default:
+			return state
+	}
+}

--- a/source/globals.js
+++ b/source/globals.js
@@ -1,6 +1,6 @@
 // @flow
 
-import qs from 'querystring'
+import qs from 'query-string'
 
 const root = 'https://stolaf.api.frogpond.tech/v1'
 export const API = (pth: string, query: ?Object = null) => {

--- a/source/lib/stoprint/api.js
+++ b/source/lib/stoprint/api.js
@@ -1,0 +1,96 @@
+// @flow
+
+import {PAPERCUT_MOBILE_RELEASE_API, PAPERCUT_API, PAPERCUT} from './urls'
+import querystring from 'query-string'
+import {encode} from 'base-64'
+
+const PAPERCUT_API_HEADERS = new Headers({
+	'Content-Type': 'application/x-www-form-urlencoded',
+	Origin: PAPERCUT,
+})
+
+export async function logIn(
+	username: string,
+	password: string,
+): Promise<'success' | string> {
+	try {
+		const now = new Date().getTime()
+		const url = `${PAPERCUT_API}/webclient/users/${username}/log-in?nocache=${now}`
+		const body = querystring.stringify({password: encode(password)})
+		const result = await fetchJson(url, {
+			method: 'POST',
+			body: body,
+			headers: PAPERCUT_API_HEADERS,
+		})
+
+		if (!result.success) {
+			return 'The username and password appear to be invalid'
+		}
+
+		return 'success'
+	} catch (err) {
+		console.error(err)
+		return 'The print server seems to be having some issues'
+	}
+}
+
+export const fetchJobs = (username: string): Promise<Array<PrintJob>> =>
+  fetchJson(`${PAPERCUT_API}/webclient/users/${username}/jobs/status`)
+
+export const fetchAllPrinters = (username: string): Promise<Array<Printer>> =>
+	fetchJson(`${PAPERCUT_MOBILE_RELEASE_API}/all-printers?username=${username}`)
+
+export const fetchRecentPrinters = (
+	username: string,
+): Promise<RecentPrinters> =>
+	fetchJson(
+		`${PAPERCUT_MOBILE_RELEASE_API}/recent-popular-printers?username=${username}`,
+	)
+
+export const heldJobsAvailableAtPrinterForUser = (
+	printerName: string,
+	username: string,
+): Promise<Array<HeldJob>> =>
+	// https://PAPERCUT_API.stolaf.edu/rpc/api/rest/internal/mobilerelease/api/held-jobs/?username=rives&printerName=printers%5Cmfc-it
+	fetchJson(
+		`${PAPERCUT_MOBILE_RELEASE_API}/held-jobs/?username=${username}&printerName=printers%5C${printerName}`,
+	)
+
+export const cancelPrintJobForUser = (jobId, username) =>
+	fetchJson(
+		`${PAPERCUT_MOBILE_RELEASE_API}/held-jobs/cancel?username=${username}`,
+		{
+			method: 'POST',
+			body: querystring.stringify({
+				jobIds: [jobId],
+			},
+      {arrayFormat: 'bracket'},
+    ),
+    headers: PAPERCUT_API_HEADERS,
+		},
+	)
+
+export const releasePrintJobToPrinterForUser = ({
+	jobId,
+	printerName,
+	username,
+}: {
+	jobId: any,
+	printerName: string,
+	username: string,
+}) => {
+	fetchJson(
+		`${PAPERCUT_MOBILE_RELEASE_API}/held-jobs/release?username=${username}`,
+		{
+			method: 'POST',
+			body: querystring.stringify(
+				{
+					printerName: `printers\\${printerName}`,
+					jobIds: [jobId],
+				},
+				{arrayFormat: 'bracket'},
+			),
+			headers: PAPERCUT_API_HEADERS,
+		},
+	)
+}

--- a/source/lib/stoprint/api.js
+++ b/source/lib/stoprint/api.js
@@ -10,6 +10,7 @@ import type {
 	ReleaseResponseOrErrorType,
 	CancelResponseOrErrorType,
 	HeldJobsResponseOrErrorType,
+	LoginResponseOrErrorType,
 } from './types'
 
 const PAPERCUT_API_HEADERS = new Headers({
@@ -21,25 +22,30 @@ export async function logIn(
 	username: string,
 	password: string,
 ): Promise<'success' | string> {
-	try {
-		const now = new Date().getTime()
-		const url = `${PAPERCUT_API}/webclient/users/${username}/log-in?nocache=${now}`
-		const body = querystring.stringify({password: encode(password)})
-		const result = await fetchJson(url, {
-			method: 'POST',
-			body: body,
-			headers: PAPERCUT_API_HEADERS,
-		})
+	const now = new Date().getTime()
+	const url = `${PAPERCUT_API}/webclient/users/${username}/log-in?nocache=${now}`
+	const body = querystring.stringify({password: encode(password)})
+	const result : LoginResponseOrErrorType = await fetchJson(url, {
+		method: 'POST',
+		body: body,
+		headers: PAPERCUT_API_HEADERS,
+	}).then(response => ({
+		error: false,
+		value: response
+	})).catch((error) => ({
+		error: true,
+		value: error
+	}))
 
-		if (!result.success) {
-			return 'The username and password appear to be invalid'
-		}
-
-		return 'success'
-	} catch (err) {
-		console.error(err)
+	if (result.error) {
 		return 'The print server seems to be having some issues'
 	}
+
+	if (!result.value.success) {
+		return 'The username and password appear to be invalid'
+	}
+
+	return 'success'
 }
 
 export const fetchJobs = (username: string): Promise<{jobs: Array<PrintJob>}> =>

--- a/source/lib/stoprint/api.js
+++ b/source/lib/stoprint/api.js
@@ -28,7 +28,7 @@ export async function logIn(
 	const result: LoginResponseOrErrorType = await fetchJson(url, {
 		method: 'POST',
 		body: body,
-		headers: Headers(PAPERCUT_API_HEADERS),
+		headers: new Headers(PAPERCUT_API_HEADERS),
 	})
 		.then(response => ({
 			error: false,
@@ -94,7 +94,7 @@ export const cancelPrintJobForUser = (
 				},
 				{arrayFormat: 'bracket'},
 			),
-			headers: Headers(PAPERCUT_API_HEADERS),
+			headers: new Headers(PAPERCUT_API_HEADERS),
 		},
 	)
 		.then(response => ({
@@ -126,7 +126,7 @@ export const releasePrintJobToPrinterForUser = ({
 				},
 				{arrayFormat: 'bracket'},
 			),
-			headers: Headers(PAPERCUT_API_HEADERS),
+			headers: new Headers(PAPERCUT_API_HEADERS),
 		},
 	)
 		.then(response => {

--- a/source/lib/stoprint/api.js
+++ b/source/lib/stoprint/api.js
@@ -25,17 +25,19 @@ export async function logIn(
 	const now = new Date().getTime()
 	const url = `${PAPERCUT_API}/webclient/users/${username}/log-in?nocache=${now}`
 	const body = querystring.stringify({password: encode(password)})
-	const result : LoginResponseOrErrorType = await fetchJson(url, {
+	const result: LoginResponseOrErrorType = await fetchJson(url, {
 		method: 'POST',
 		body: body,
 		headers: PAPERCUT_API_HEADERS,
-	}).then(response => ({
-		error: false,
-		value: response
-	})).catch((error) => ({
-		error: true,
-		value: error
-	}))
+	})
+		.then(response => ({
+			error: false,
+			value: response,
+		}))
+		.catch(error => ({
+			error: true,
+			value: error,
+		}))
 
 	if (result.error) {
 		return 'The print server seems to be having some issues'

--- a/source/lib/stoprint/api.js
+++ b/source/lib/stoprint/api.js
@@ -13,10 +13,10 @@ import type {
 	LoginResponseOrErrorType,
 } from './types'
 
-const PAPERCUT_API_HEADERS = new Headers({
+const PAPERCUT_API_HEADERS = {
 	'Content-Type': 'application/x-www-form-urlencoded',
 	Origin: PAPERCUT,
-})
+}
 
 export async function logIn(
 	username: string,
@@ -28,7 +28,7 @@ export async function logIn(
 	const result: LoginResponseOrErrorType = await fetchJson(url, {
 		method: 'POST',
 		body: body,
-		headers: PAPERCUT_API_HEADERS,
+		headers: Headers(PAPERCUT_API_HEADERS),
 	})
 		.then(response => ({
 			error: false,
@@ -94,7 +94,7 @@ export const cancelPrintJobForUser = (
 				},
 				{arrayFormat: 'bracket'},
 			),
-			headers: PAPERCUT_API_HEADERS,
+			headers: Headers(PAPERCUT_API_HEADERS),
 		},
 	)
 		.then(response => ({
@@ -126,7 +126,7 @@ export const releasePrintJobToPrinterForUser = ({
 				},
 				{arrayFormat: 'bracket'},
 			),
-			headers: PAPERCUT_API_HEADERS,
+			headers: Headers(PAPERCUT_API_HEADERS),
 		},
 	)
 		.then(response => {

--- a/source/lib/stoprint/errors.js
+++ b/source/lib/stoprint/errors.js
@@ -1,0 +1,11 @@
+// @flow
+
+import {Alert} from 'react-native'
+
+export const showGeneralError = (onDismiss: () => any) => {
+	Alert.alert(
+		'An unexpected error occurred',
+		"We're sorry, but we have lost communication with Papercut. Please try again.",
+		[{text: 'OK', onPress: onDismiss}],
+	)
+}

--- a/source/lib/stoprint/index.js
+++ b/source/lib/stoprint/index.js
@@ -1,12 +1,27 @@
 // @flow
 
-export {PAPERCUT, PAPERCUT_API, PAPERCUT_MOBILE_RELEASE_API} from './urls'
+export {
+	PAPERCUT,
+	PAPERCUT_API,
+	PAPERCUT_MOBILE_RELEASE_API,
+	STOPRINT_HELP_PAGE,
+} from './urls'
 export {
 	cancelPrintJobForUser,
 	fetchAllPrinters,
-  fetchJobs,
+	fetchJobs,
 	fetchRecentPrinters,
 	heldJobsAvailableAtPrinterForUser,
 	logIn,
 	releasePrintJobToPrinterForUser,
 } from './api'
+export type {
+	HeldJob,
+	Printer,
+	PrintJob,
+	RecentPopularPrintersResponse,
+	ReleaseResponseOrErrorType,
+	CancelResponseOrErrorType,
+	HeldJobsResponseOrErrorType,
+} from './types'
+export {showGeneralError} from './errors'

--- a/source/lib/stoprint/index.js
+++ b/source/lib/stoprint/index.js
@@ -1,0 +1,12 @@
+// @flow
+
+export {PAPERCUT, PAPERCUT_API, PAPERCUT_MOBILE_RELEASE_API} from './urls'
+export {
+	cancelPrintJobForUser,
+	fetchAllPrinters,
+  fetchJobs,
+	fetchRecentPrinters,
+	heldJobsAvailableAtPrinterForUser,
+	logIn,
+	releasePrintJobToPrinterForUser,
+} from './api'

--- a/source/lib/stoprint/types.js
+++ b/source/lib/stoprint/types.js
@@ -77,3 +77,15 @@ export type HeldJobsResponse = Array<HeldJob>
 export type HeldJobsResponseOrErrorType =
 	| {error: true, value: Error}
 	| {error: false, value: HeldJobsResponse}
+
+type LoginResponse = {
+	authCookie: string,
+	isMobileReleaseEnabled: boolean,
+	realName: string,
+	rememberMeEnabled: boolean,
+	success: true,
+}
+
+export type LoginResponseOrErrorType =
+	| {error: true, value: Error}
+	| {error: false, value: LoginResponse}

--- a/source/lib/stoprint/types.js
+++ b/source/lib/stoprint/types.js
@@ -10,7 +10,7 @@ export type PrintJob = {
 	printerName: string,
 	serverName: string,
 	status: string | 'DENIED',
-	statusDetail?: string,
+	statusDetail: string,
 	statusFormatted: string,
 	totalPages: number,
 	usageCostFormatted: string,
@@ -20,7 +20,18 @@ export type PrintJob = {
 export type HeldJob = {
 	canRelease: boolean,
 	client: string,
-} & PrintJob
+	isDenied: boolean,
+	copies: number,
+	documentName: string,
+	deniedReasonFormatted?: string,
+	grayscaleFormatted: 'Yes' | 'No',
+	id: string,
+	paperSizeFormatted: string,
+	printerName: string,
+	serverName: string,
+	usageCostFormatted: string,
+	usageTimeFormatted: string,
+}
 
 // https://papercut.stolaf.edu:9192/rpc/api/rest/internal/webclient/users/rives/jobs/status
 export type StatusResponse = {
@@ -42,6 +53,19 @@ export type RecentPopularPrintersResponse = {
 	recentPrinters: Array<Printer>,
 }
 
+export type ReleaseResponse = {
+	numJobsReleased: number,
+	statusMessage: string,
+}
+
+export type ReleaseResponseOrErrorType =
+	| {error: true, value: Error}
+	| {error: false, value: ReleaseResponse}
+
+export type CancelResponseOrErrorType =
+	| {error: true, value: Error}
+	| {error: false, value: Response}
+
 // https://papercut.stolaf.edu:9192/rpc/api/rest/internal/mobilerelease/api/all-printers
 // ?username=rives
 export type AllPrintersResponse = Array<Printer>
@@ -50,3 +74,6 @@ export type AllPrintersResponse = Array<Printer>
 // ?username=rives
 // &printerName=printers\mfc-it
 export type HeldJobsResponse = Array<HeldJob>
+export type HeldJobsResponseOrErrorType =
+	| {error: true, value: Error}
+	| {error: false, value: HeldJobsResponse}

--- a/source/lib/stoprint/urls.js
+++ b/source/lib/stoprint/urls.js
@@ -1,0 +1,5 @@
+// @flow
+
+export const PAPERCUT = 'https://papercut.stolaf.edu'
+export const PAPERCUT_API = 'https://papercut.stolaf.edu/rpc/api/rest/internal'
+export const PAPERCUT_MOBILE_RELEASE_API = `${PAPERCUT_API}/mobilerelease/api`

--- a/source/lib/stoprint/urls.js
+++ b/source/lib/stoprint/urls.js
@@ -3,3 +3,5 @@
 export const PAPERCUT = 'https://papercut.stolaf.edu'
 export const PAPERCUT_API = 'https://papercut.stolaf.edu/rpc/api/rest/internal'
 export const PAPERCUT_MOBILE_RELEASE_API = `${PAPERCUT_API}/mobilerelease/api`
+
+export const STOPRINT_HELP_PAGE = 'https://wp.stolaf.edu/it/stoprint/'

--- a/source/navigation.js
+++ b/source/navigation.js
@@ -47,7 +47,11 @@ import {IconSettingsView} from './views/settings/icon'
 import {StudentOrgsView, StudentOrgsDetailView} from './views/student-orgs'
 import {FaqView} from './views/faqs'
 import HelpView from './views/help'
-import {PrintJobsView, PrinterListView, PrintJobReleaseView} from './views/stoprint'
+import {
+	PrintJobsView,
+	PrinterListView,
+	PrintJobReleaseView,
+} from './views/stoprint'
 
 const styles = StyleSheet.create({
 	header: {

--- a/source/navigation.js
+++ b/source/navigation.js
@@ -47,7 +47,7 @@ import {IconSettingsView} from './views/settings/icon'
 import {StudentOrgsView, StudentOrgsDetailView} from './views/student-orgs'
 import {FaqView} from './views/faqs'
 import HelpView from './views/help'
-import PrintReleaseView, {PrintJobReleaseView} from './views/stoprint'
+import {PrintJobsView, PrinterListView, PrintJobReleaseView} from './views/stoprint'
 
 const styles = StyleSheet.create({
 	header: {
@@ -101,7 +101,8 @@ export const AppNavigator = createStackNavigator(
 		CarletonLDCMenuView: {screen: CarletonLDCMenuScreen},
 		CarletonWeitzMenuView: {screen: CarletonWeitzMenuScreen},
 		CarletonSaylesMenuView: {screen: CarletonSaylesMenuScreen},
-		PrintReleaseView: {screen: PrintReleaseView},
+		PrintJobsView: {screen: PrintJobsView},
+		PrinterListView: {screen: PrinterListView},
 		PrintJobReleaseView: {screen: PrintJobReleaseView},
 	},
 	{

--- a/source/navigation.js
+++ b/source/navigation.js
@@ -47,6 +47,7 @@ import {IconSettingsView} from './views/settings/icon'
 import {StudentOrgsView, StudentOrgsDetailView} from './views/student-orgs'
 import {FaqView} from './views/faqs'
 import HelpView from './views/help'
+import PrintReleaseView, {PrintJobReleaseView} from './views/stoprint'
 
 const styles = StyleSheet.create({
 	header: {
@@ -100,6 +101,8 @@ export const AppNavigator = createStackNavigator(
 		CarletonLDCMenuView: {screen: CarletonLDCMenuScreen},
 		CarletonWeitzMenuView: {screen: CarletonWeitzMenuScreen},
 		CarletonSaylesMenuView: {screen: CarletonSaylesMenuScreen},
+		PrintReleaseView: {screen: PrintReleaseView},
+		PrintJobReleaseView: {screen: PrintJobReleaseView},
 	},
 	{
 		navigationOptions: {

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -3,7 +3,7 @@
 import jsYaml from 'js-yaml'
 import type {BuildingType} from '../types'
 import {sendEmail} from '../../components/send-email'
-import querystring from 'querystring'
+import querystring from 'query-string'
 import {GH_NEW_ISSUE_URL} from '../../../globals'
 
 export function submitReport(current: BuildingType, suggestion: BuildingType) {

--- a/source/views/components/__tests__/__snapshots__/button.test.js.snap
+++ b/source/views/components/__tests__/__snapshots__/button.test.js.snap
@@ -49,15 +49,18 @@ exports[`calls the callback 2`] = `
 exports[`can change the title 1`] = `
 <Button
   containerStyle={
-    Object {
-      "alignSelf": "center",
-      "backgroundColor": "#E3A025",
-      "borderRadius": 6,
-      "marginVertical": 10,
-      "overflow": "hidden",
-      "paddingHorizontal": 20,
-      "paddingVertical": 10,
-    }
+    Array [
+      Object {
+        "alignSelf": "center",
+        "backgroundColor": "#E3A025",
+        "borderRadius": 6,
+        "marginVertical": 10,
+        "overflow": "hidden",
+        "paddingHorizontal": 20,
+        "paddingVertical": 10,
+      },
+      null,
+    ]
   }
   disabled={false}
   disabledContainerStyle={
@@ -67,26 +70,29 @@ exports[`can change the title 1`] = `
   }
   onPress={[Function]}
   style={
-    Object {
-      "backgroundColor": "transparent",
-      "color": Object {
-        "_a": 1,
-        "_b": 33,
-        "_format": "hex",
-        "_g": 33,
-        "_gradientType": undefined,
-        "_ok": true,
-        "_originalInput": "#242121",
-        "_r": 36,
-        "_roundA": 1,
-        "_tc_id": 3,
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "color": Object {
+          "_a": 1,
+          "_b": 33,
+          "_format": "hex",
+          "_g": 33,
+          "_gradientType": undefined,
+          "_ok": true,
+          "_originalInput": "#242121",
+          "_r": 36,
+          "_roundA": 1,
+          "_tc_id": 3,
+        },
+        "fontFamily": "System",
+        "fontSize": 16,
+        "fontWeight": "400",
+        "letterSpacing": -0.32,
+        "lineHeight": 21,
       },
-      "fontFamily": "System",
-      "fontSize": 16,
-      "fontWeight": "400",
-      "letterSpacing": -0.32,
-      "lineHeight": 21,
-    }
+      null,
+    ]
   }
   styleDisabled={
     Object {
@@ -101,15 +107,18 @@ exports[`can change the title 1`] = `
 exports[`renders 1`] = `
 <Button
   containerStyle={
-    Object {
-      "alignSelf": "center",
-      "backgroundColor": "#E3A025",
-      "borderRadius": 6,
-      "marginVertical": 10,
-      "overflow": "hidden",
-      "paddingHorizontal": 20,
-      "paddingVertical": 10,
-    }
+    Array [
+      Object {
+        "alignSelf": "center",
+        "backgroundColor": "#E3A025",
+        "borderRadius": 6,
+        "marginVertical": 10,
+        "overflow": "hidden",
+        "paddingHorizontal": 20,
+        "paddingVertical": 10,
+      },
+      null,
+    ]
   }
   disabled={false}
   disabledContainerStyle={
@@ -119,26 +128,29 @@ exports[`renders 1`] = `
   }
   onPress={[Function]}
   style={
-    Object {
-      "backgroundColor": "transparent",
-      "color": Object {
-        "_a": 1,
-        "_b": 33,
-        "_format": "hex",
-        "_g": 33,
-        "_gradientType": undefined,
-        "_ok": true,
-        "_originalInput": "#242121",
-        "_r": 36,
-        "_roundA": 1,
-        "_tc_id": 3,
+    Array [
+      Object {
+        "backgroundColor": "transparent",
+        "color": Object {
+          "_a": 1,
+          "_b": 33,
+          "_format": "hex",
+          "_g": 33,
+          "_gradientType": undefined,
+          "_ok": true,
+          "_originalInput": "#242121",
+          "_r": 36,
+          "_roundA": 1,
+          "_tc_id": 3,
+        },
+        "fontFamily": "System",
+        "fontSize": 16,
+        "fontWeight": "400",
+        "letterSpacing": -0.32,
+        "lineHeight": 21,
       },
-      "fontFamily": "System",
-      "fontSize": 16,
-      "fontWeight": "400",
-      "letterSpacing": -0.32,
-      "lineHeight": 21,
-    }
+      null,
+    ]
   }
   styleDisabled={
     Object {

--- a/source/views/components/button.js
+++ b/source/views/components/button.js
@@ -36,20 +36,24 @@ type Props = {
 	title?: string,
 	onPress?: () => any,
 	disabled?: boolean,
+	buttonStyle?: any,
+	textStyle?: any,
 }
 
 export function Button({
 	title = 'Push me!',
 	onPress = noop,
 	disabled = false,
+	buttonStyle = null,
+	textStyle = null,
 }: Props) {
 	return (
 		<BasicButton
-			containerStyle={styles.button}
+			containerStyle={[styles.button, buttonStyle]}
 			disabled={disabled}
 			disabledContainerStyle={styles.disabled}
 			onPress={onPress}
-			style={styles.text}
+			style={[styles.text, textStyle]}
 			styleDisabled={styles.textDisabled}
 		>
 			{Platform.OS === 'android' ? title.toUpperCase() : title}

--- a/source/views/components/cells/button.js
+++ b/source/views/components/cells/button.js
@@ -36,7 +36,10 @@ export function ButtonCell({
 			onPress={onPress}
 			title={
 				<Text
-					style={[indeterminate || disabled ? styles.disabled : styles.active, textStyle]}
+					style={[
+						indeterminate || disabled ? styles.disabled : styles.active,
+						textStyle,
+					]}
 				>
 					{title}
 				</Text>

--- a/source/views/components/cells/button.js
+++ b/source/views/components/cells/button.js
@@ -21,11 +21,13 @@ export function ButtonCell({
 	indeterminate,
 	disabled,
 	onPress,
+	textStyle,
 	title,
 }: {
 	indeterminate?: boolean,
 	disabled?: boolean,
 	onPress: () => any,
+	textStyle?: any,
 	title: string,
 }) {
 	return (
@@ -34,7 +36,7 @@ export function ButtonCell({
 			onPress={onPress}
 			title={
 				<Text
-					style={[indeterminate || disabled ? styles.disabled : styles.active]}
+					style={[indeterminate || disabled ? styles.disabled : styles.active, textStyle]}
 				>
 					{title}
 				</Text>

--- a/source/views/components/cells/index.js
+++ b/source/views/components/cells/index.js
@@ -2,3 +2,4 @@
 
 export {MultiLineDetailCell} from './multi-line-detail'
 export {MultiLineLeftDetailCell} from './multi-line-left-detail'
+export {ButtonCell} from './button'

--- a/source/views/dictionary/report/submit.js
+++ b/source/views/dictionary/report/submit.js
@@ -3,7 +3,7 @@
 import jsYaml from 'js-yaml'
 import type {WordType} from '../types'
 import {sendEmail} from '../../components/send-email'
-import querystring from 'querystring'
+import querystring from 'query-string'
 import {GH_NEW_ISSUE_URL} from '../../../globals'
 import wrap from 'wordwrap'
 

--- a/source/views/stoprint/components/error.js
+++ b/source/views/stoprint/components/error.js
@@ -7,25 +7,43 @@ import Icon from 'react-native-vector-icons/Ionicons'
 import {NoticeView} from '../../components/notice'
 import * as c from '../../components/colors'
 
-type Props = TopLevelViewPropsType
+const ERROR_MESSAGE = 'Make sure you are connected to the St. Olaf WiFi \
+ Network via eduroam or VPN. If you are, please report this so we can make\
+ sure it doesn\'t happen again.'
 
-export function StoprintErrorView(props: Props) {
-	const iconName = Platform.select({
-		ios: 'ios-bug',
-		android: 'md-bug',
-	})
-	return (
-		<View style={styles.container}>
-			<Icon color={c.sto.black} name={iconName} size={100} />
-			<NoticeView
-				buttonText="Report"
-				header="Look! A bug!"
-				onPress={() => props.navigation.navigate('HelpView')}
-				style={styles.notice}
-				text="We're sorry, but an unexpected error occurred when trying to connect to Stoprint. Please report this so we can make sure it doesn't happen again."
-			/>
-		</View>
-	)
+type Props = TopLevelViewPropsType & {
+	refresh: () => any,
+}
+
+export class StoprintErrorView extends React.PureComponent<Props> {
+	_timer : any
+
+	componentDidMount() {
+		this._timer = setInterval(this.props.refresh, 5000)
+	}
+
+	componentWillUnmount() {
+		clearInterval(this._timer)
+	}
+
+	render() {
+		const iconName = Platform.select({
+			ios: 'ios-bug',
+			android: 'md-bug',
+		})
+		return (
+			<View style={styles.container}>
+				<Icon color={c.sto.black} name={iconName} size={100} />
+				<NoticeView
+					buttonText="Report"
+					header="Connection Issue"
+					onPress={() => this.props.navigation.navigate('HelpView')}
+					style={styles.notice}
+					text={ERROR_MESSAGE}
+				/>
+			</View>
+		)
+	}
 }
 
 const styles = StyleSheet.create({

--- a/source/views/stoprint/components/error.js
+++ b/source/views/stoprint/components/error.js
@@ -1,0 +1,41 @@
+// @flow
+
+import React from 'react'
+import type {TopLevelViewPropsType} from '../../types'
+import {View, StyleSheet, Platform} from 'react-native'
+import Icon from 'react-native-vector-icons/Ionicons'
+import {NoticeView} from '../../components/notice'
+import * as c from '../../components/colors'
+
+type Props = TopLevelViewPropsType
+
+export function StoprintErrorView(props: Props) {
+	const iconName = Platform.select({
+		ios: 'ios-bug',
+		android: 'md-bug',
+	})
+	return (
+		<View style={styles.container}>
+			<Icon color={c.sto.black} name={iconName} size={100} />
+			<NoticeView
+				buttonText="Report"
+				header="Look! A bug!"
+				onPress={() => props.navigation.navigate('HelpView')}
+				style={styles.notice}
+				text="We're sorry, but an unexpected error occurred when trying to connect to Stoprint. Please report this so we can make sure it doesn't happen again."
+			/>
+		</View>
+	)
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: c.sto.white,
+	},
+	notice: {
+		flex: 0,
+	},
+})

--- a/source/views/stoprint/components/error.js
+++ b/source/views/stoprint/components/error.js
@@ -7,16 +7,17 @@ import Icon from 'react-native-vector-icons/Ionicons'
 import {NoticeView} from '../../components/notice'
 import * as c from '../../components/colors'
 
-const ERROR_MESSAGE = 'Make sure you are connected to the St. Olaf WiFi \
+const ERROR_MESSAGE =
+	"Make sure you are connected to the St. Olaf WiFi \
  Network via eduroam or VPN. If you are, please report this so we can make\
- sure it doesn\'t happen again.'
+ sure it doesn't happen again."
 
 type Props = TopLevelViewPropsType & {
 	refresh: () => any,
 }
 
 export class StoprintErrorView extends React.PureComponent<Props> {
-	_timer : any
+	_timer: any
 
 	componentDidMount() {
 		this._timer = setInterval(this.props.refresh, 5000)

--- a/source/views/stoprint/components/error.js
+++ b/source/views/stoprint/components/error.js
@@ -8,23 +8,23 @@ import {NoticeView} from '../../components/notice'
 import * as c from '../../components/colors'
 
 const ERROR_MESSAGE =
-	"Make sure you are connected to the St. Olaf \
- Network via eduroam or the VPN. If you are, please report this so we can make\
- sure it doesn't happen again."
+	"Make sure you are connected to the St. Olaf Network via eduroam or the VPN. If you are, please report this so we can make sure it doesn't happen again."
 
 type Props = TopLevelViewPropsType & {
 	refresh: () => any,
 }
 
 export class StoPrintErrorView extends React.PureComponent<Props> {
-	_timer: any
+	_timer: ?IntervalID
 
 	componentDidMount() {
 		this._timer = setInterval(this.props.refresh, 5000)
 	}
 
 	componentWillUnmount() {
-		clearInterval(this._timer)
+		if (this._timer) {
+			clearInterval(this._timer)
+		}
 	}
 
 	render() {

--- a/source/views/stoprint/components/error.js
+++ b/source/views/stoprint/components/error.js
@@ -16,7 +16,7 @@ type Props = TopLevelViewPropsType & {
 	refresh: () => any,
 }
 
-export class StoprintErrorView extends React.PureComponent<Props> {
+export class StoPrintErrorView extends React.PureComponent<Props> {
 	_timer: any
 
 	componentDidMount() {

--- a/source/views/stoprint/components/error.js
+++ b/source/views/stoprint/components/error.js
@@ -8,8 +8,8 @@ import {NoticeView} from '../../components/notice'
 import * as c from '../../components/colors'
 
 const ERROR_MESSAGE =
-	"Make sure you are connected to the St. Olaf WiFi \
- Network via eduroam or VPN. If you are, please report this so we can make\
+	"Make sure you are connected to the St. Olaf \
+ Network via eduroam or the VPN. If you are, please report this so we can make\
  sure it doesn't happen again."
 
 type Props = TopLevelViewPropsType & {

--- a/source/views/stoprint/components/index.js
+++ b/source/views/stoprint/components/index.js
@@ -1,4 +1,4 @@
 // @flow
 
-export {StoprintErrorView} from './error'
-export {StoprintNoticeView} from './notice'
+export {StoPrintErrorView} from './error'
+export {StoPrintNoticeView} from './notice'

--- a/source/views/stoprint/components/index.js
+++ b/source/views/stoprint/components/index.js
@@ -1,3 +1,4 @@
 // @flow
 
 export {StoprintErrorView} from './error'
+export {StoprintNoticeView} from './notice'

--- a/source/views/stoprint/components/index.js
+++ b/source/views/stoprint/components/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export {StoprintErrorView} from './error'

--- a/source/views/stoprint/components/notice.js
+++ b/source/views/stoprint/components/notice.js
@@ -7,54 +7,57 @@ import {NoticeView} from '../../components/notice'
 import * as c from '../../components/colors'
 
 type Props = {
-  buttonText: string,
-  header: string,
-  onPress: () => any,
-  refresh?: () => any,
-  text: string,
+	buttonText: string,
+	header: string,
+	onPress: () => any,
+	refresh?: () => any,
+	text: string,
 }
 
 export class StoprintNoticeView extends React.PureComponent<Props> {
+	_timer: any
 
-  _timer : any
+	componentDidMount() {
+		if (this.props.refresh) {
+			this._timer = setInterval(this.props.refresh, 5000)
+		}
+	}
 
-  componentDidMount() {
-    if (this.props.refresh) {
-      this._timer = setInterval(this.props.refresh, 5000)
-    }
-  }
+	componentWillUnmount() {
+		if (this.props.refresh) {
+			clearInterval(this._timer)
+		}
+	}
 
-  componentWillUnmount() {
-    if (this.props.refresh) {
-      clearInterval(this._timer)
-    }
-  }
-
-  render() {
-    const {buttonText, header, onPress, text} = this.props
-    return (
-      <View style={styles.container}>
-        <Icon color={c.sto.black} name={Platform.OS === 'ios' ? 'ios-print' : 'md-print'} size={100} />
-        <NoticeView
-          buttonText={buttonText}
-          header={header}
-          onPress={onPress}
-          style={styles.notice}
-          text={text}
-        />
-      </View>
-    )
-  }
+	render() {
+		const {buttonText, header, onPress, text} = this.props
+		return (
+			<View style={styles.container}>
+				<Icon
+					color={c.sto.black}
+					name={Platform.OS === 'ios' ? 'ios-print' : 'md-print'}
+					size={100}
+				/>
+				<NoticeView
+					buttonText={buttonText}
+					header={header}
+					onPress={onPress}
+					style={styles.notice}
+					text={text}
+				/>
+			</View>
+		)
+	}
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: c.sto.white,
-  },
-  notice: {
-    flex: 0,
-  },
+	container: {
+		flex: 1,
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: c.sto.white,
+	},
+	notice: {
+		flex: 0,
+	},
 })

--- a/source/views/stoprint/components/notice.js
+++ b/source/views/stoprint/components/notice.js
@@ -14,7 +14,7 @@ type Props = {
 	text: string,
 }
 
-export class StoprintNoticeView extends React.PureComponent<Props> {
+export class StoPrintNoticeView extends React.PureComponent<Props> {
 	_timer: any
 
 	componentDidMount() {

--- a/source/views/stoprint/components/notice.js
+++ b/source/views/stoprint/components/notice.js
@@ -15,16 +15,16 @@ type Props = {
 }
 
 export class StoPrintNoticeView extends React.PureComponent<Props> {
-	_timer: any
+	_timer: ?IntervalID
 
 	componentDidMount() {
-		if (this.props.refresh) {
+		if (this._timer && this.props.refresh) {
 			this._timer = setInterval(this.props.refresh, 5000)
 		}
 	}
 
 	componentWillUnmount() {
-		if (this.props.refresh) {
+		if (this._timer && this.props.refresh) {
 			clearInterval(this._timer)
 		}
 	}

--- a/source/views/stoprint/components/notice.js
+++ b/source/views/stoprint/components/notice.js
@@ -1,0 +1,60 @@
+// @flow
+
+import React from 'react'
+import {Platform, View, StyleSheet} from 'react-native'
+import Icon from 'react-native-vector-icons/Ionicons'
+import {NoticeView} from '../../components/notice'
+import * as c from '../../components/colors'
+
+type Props = {
+  buttonText: string,
+  header: string,
+  onPress: () => any,
+  refresh?: () => any,
+  text: string,
+}
+
+export class StoprintNoticeView extends React.PureComponent<Props> {
+
+  _timer : any
+
+  componentDidMount() {
+    if (this.props.refresh) {
+      this._timer = setInterval(this.props.refresh, 5000)
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.refresh) {
+      clearInterval(this._timer)
+    }
+  }
+
+  render() {
+    const {buttonText, header, onPress, text} = this.props
+    return (
+      <View style={styles.container}>
+        <Icon color={c.sto.black} name={Platform.OS === 'ios' ? 'ios-print' : 'md-print'} size={100} />
+        <NoticeView
+          buttonText={buttonText}
+          header={header}
+          onPress={onPress}
+          style={styles.notice}
+          text={text}
+        />
+      </View>
+    )
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: c.sto.white,
+  },
+  notice: {
+    flex: 0,
+  },
+})

--- a/source/views/stoprint/index.js
+++ b/source/views/stoprint/index.js
@@ -1,4 +1,5 @@
 // @flow
 
-export {default} from './print-jobs'
-export {default as PrintJobReleaseView} from './printers'
+export {ConnectedPrintJobsView as PrintJobsView} from './print-jobs'
+export {ConnectedPrinterListView as PrinterListView} from './printers'
+export {PrintJobReleaseView} from './print-release'

--- a/source/views/stoprint/index.js
+++ b/source/views/stoprint/index.js
@@ -1,0 +1,4 @@
+// @flow
+
+export {default} from './print-jobs'
+export {default as PrintJobReleaseView} from './printers'

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -36,12 +36,13 @@ type ReduxDispatchProps = {
 
 type Props = ReactProps & ReduxDispatchProps & ReduxStateProps
 
-class PrintReleaseView extends React.PureComponent<Props> {
+class PrintJobsView extends React.PureComponent<Props> {
 	static navigationOptions = {
 		title: 'Print Jobs',
+		headerBackTitle: 'Jobs',
 	}
 
-	componentWillMount = () => {
+	componentDidMount = () => {
 		this.refresh()
 	}
 
@@ -64,15 +65,15 @@ class PrintReleaseView extends React.PureComponent<Props> {
 
 	openSettings = () => this.props.navigation.navigate('SettingsView')
 
-	releaseJob = (id: any) =>
-		this.props.navigation.navigate('PrintJobReleaseView', {id})
+	releaseJob = (job: PrintJob) =>
+		this.props.navigation.navigate('PrinterListView', {job: job})
 
 	renderItem = ({item}: {item: PrintJob}) => (
-		<ListRow onPress={() => this.releaseJob(item.id)}>
+		<ListRow onPress={() => this.releaseJob(item)}>
 			<Title>{item.documentName}</Title>
 			<Detail>
-				{item.usageCostFormatted} • {item.totalPages} pages •{' '}
-				{item.statusFormatted} • {item.grayscaleFormatted}
+				{item.usageTimeFormatted} • {item.usageCostFormatted} • {item.totalPages} pages •{' '}
+				{item.statusFormatted}
 			</Detail>
 		</ListRow>
 	)
@@ -121,7 +122,7 @@ function mapDispatchToProps(dispatch): ReduxDispatchProps {
 	}
 }
 
-export default connect(
+export const ConnectedPrintJobsView = connect(
 	mapStateToProps,
 	mapDispatchToProps,
-)(PrintReleaseView)
+)(PrintJobsView)

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -43,7 +43,7 @@ class PrintJobsView extends React.PureComponent<Props> {
 	}
 
 	componentDidMount() {
-		this.refresh()
+		this.fetchData()
 	}
 
 	refresh = async (): any => {

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {SectionList, StyleSheet, View, Platform} from 'react-native'
+import {SectionList} from 'react-native'
 import {connect} from 'react-redux'
 import {type ReduxState} from '../../flux'
 import {updatePrintJobs} from '../../flux/parts/stoprint'
@@ -15,26 +15,11 @@ import {
 } from '../components/list'
 import type {TopLevelViewPropsType} from '../types'
 import delay from 'delay'
-import {NoticeView} from '../components/notice'
-import * as c from '../components/colors'
 import openUrl from '../components/open-url'
 import {StoprintErrorView, StoprintNoticeView} from './components'
 import groupBy from 'lodash/groupBy'
 import toPairs from 'lodash/toPairs'
 import sortBy from 'lodash/sortBy'
-
-const styles = StyleSheet.create({
-	list: {},
-	container: {
-		flex: 1,
-		alignItems: 'center',
-		justifyContent: 'center',
-		backgroundColor: c.sto.white,
-	},
-	notice: {
-		flex: 0,
-	},
-})
 
 type ReactProps = TopLevelViewPropsType
 
@@ -104,7 +89,12 @@ class PrintJobsView extends React.PureComponent<Props> {
 
 	render() {
 		if (this.props.error) {
-			return <StoprintErrorView refresh={this.refresh} navigation={this.props.navigation} />
+			return (
+				<StoprintErrorView
+					navigation={this.props.navigation}
+					refresh={this.refresh}
+				/>
+			)
 		}
 		if (this.props.loginState !== 'logged-in') {
 			return (
@@ -143,7 +133,6 @@ class PrintJobsView extends React.PureComponent<Props> {
 				renderItem={this.renderItem}
 				renderSectionHeader={this.renderSectionHeader}
 				sections={sortedGroupedJobs}
-				style={styles.list}
 			/>
 		)
 	}

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -1,0 +1,127 @@
+// @flow
+
+import React from 'react'
+import {FlatList, StyleSheet, View, Text, Button} from 'react-native'
+import {connect} from 'react-redux'
+import {type ReduxState} from '../../flux'
+import {ListEmpty} from '../components/list'
+import {updatePrintJobs} from '../../flux/parts/stoprint'
+import type {PrintJob} from './types'
+import {
+	ListRow,
+	ListSeparator,
+	ListSectionHeader,
+	Detail,
+	Title,
+} from '../components/list'
+import type {TopLevelViewPropsType} from '../types'
+import delay from 'delay'
+
+const styles = StyleSheet.create({
+	list: {},
+})
+
+type ReactProps = TopLevelViewPropsType
+
+type ReduxStateProps = {
+	jobs: Array<PrintJob>,
+	error: ?string,
+	loading: boolean,
+	loginState: string,
+}
+
+type ReduxDispatchProps = {
+	updatePrintJobs: () => Promise<any>,
+}
+
+type Props = ReactProps & ReduxDispatchProps & ReduxStateProps
+
+class PrintReleaseView extends React.PureComponent<Props> {
+	static navigationOptions = {
+		title: 'Print Jobs',
+	}
+
+	componentWillMount = () => {
+		this.refresh()
+	}
+
+	refresh = async (): any => {
+		let start = Date.now()
+
+		await this.fetchData()
+		// console.log('data returned')
+
+		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
+		let elapsed = start - Date.now()
+		if (elapsed < 500) {
+			await delay(500 - elapsed)
+		}
+	}
+
+	fetchData = () => this.props.updatePrintJobs()
+
+	keyExtractor = (item: PrintJob) => item.id
+
+	openSettings = () => this.props.navigation.navigate('SettingsView')
+
+	releaseJob = (id: any) =>
+		this.props.navigation.navigate('PrintJobReleaseView', {id})
+
+	renderItem = ({item}: {item: PrintJob}) => (
+		<ListRow onPress={() => this.releaseJob(item.id)}>
+			<Title>{item.documentName}</Title>
+			<Detail>
+				{item.usageCostFormatted} • {item.totalPages} pages •{' '}
+				{item.statusFormatted} • {item.grayscaleFormatted}
+			</Detail>
+		</ListRow>
+	)
+
+	renderSectionHeader = ({section: {title}}: any) => (
+		<ListSectionHeader title={title} />
+	)
+
+	render() {
+		if (this.props.loginState !== 'logged-in') {
+			return (
+				<View>
+					<Text>You are not logged in.</Text>
+					<Button onPress={this.openSettings} title="Open Settings" />
+				</View>
+			)
+		}
+
+		return (
+			<FlatList
+				ItemSeparatorComponent={ListSeparator}
+				ListEmptyComponent={<ListEmpty mode="bug" />}
+				data={this.props.jobs}
+				keyExtractor={this.keyExtractor}
+				onRefresh={this.refresh}
+				refreshing={this.props.loading}
+				renderItem={this.renderItem}
+				style={styles.list}
+			/>
+		)
+	}
+}
+
+function mapStateToProps(state: ReduxState): ReduxStateProps {
+	return {
+		jobs: state.stoprint ? state.stoprint.jobs : [],
+		error: state.stoprint ? state.stoprint.error : null,
+		loading: state.stoprint ? state.stoprint.loadingJobs : false,
+		loginState: state.settings ? state.settings.loginState : 'logged-out',
+	}
+}
+
+function mapDispatchToProps(dispatch): ReduxDispatchProps {
+	return {
+		updatePrintJobs: () => dispatch(updatePrintJobs()),
+	}
+}
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)(PrintReleaseView)

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -102,7 +102,7 @@ class PrintJobsView extends React.PureComponent<Props> {
 					buttonText="Open Settings"
 					header="You are not logged in"
 					onPress={this.openSettings}
-					text="You must be logged in to your St. Olaf student account to access this feature"
+					text="You must be logged in to your St. Olaf account to access this feature"
 				/>
 			)
 		} else if (this.props.jobs.length === 0) {

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -77,8 +77,9 @@ class PrintJobsView extends React.PureComponent<Props> {
 		<ListRow onPress={() => this.handleJobPress(item)}>
 			<Title>{item.documentName}</Title>
 			<Detail>
-				{item.usageTimeFormatted} • {item.usageCostFormatted} •{' '}
-				{item.totalPages} pages • {item.statusFormatted}
+				{item.usageTimeFormatted} {' • '} {item.usageCostFormatted} {' •  '}
+				{item.totalPages} {item.totalPages === 1 ? 'page' : 'pages'} {'\n'}
+				{item.statusFormatted}
 			</Detail>
 		</ListRow>
 	)

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -92,7 +92,7 @@ class PrintJobsView extends React.PureComponent<Props> {
 			return (
 				<StoprintErrorView
 					navigation={this.props.navigation}
-					refresh={this.refresh}
+					refresh={this.fetchData}
 				/>
 			)
 		}
@@ -111,7 +111,7 @@ class PrintJobsView extends React.PureComponent<Props> {
 					buttonText="Install Stoprint"
 					header="Nothing to Print!"
 					onPress={() => openUrl(STOPRINT_HELP_PAGE)}
-					refresh={this.refresh}
+					refresh={this.fetchData}
 					text="Need help getting started?"
 				/>
 			)

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -104,6 +104,9 @@ class PrintJobsView extends React.PureComponent<Props> {
 	)
 
 	render() {
+		if (this.props.error) {
+			return <StoprintErrorView refresh={this.refresh} navigation={this.props.navigation} />
+		}
 		if (this.props.loginState !== 'logged-in') {
 			return (
 				<NoticeView
@@ -130,8 +133,6 @@ class PrintJobsView extends React.PureComponent<Props> {
 					/>
 				</View>
 			)
-		} else if (this.props.error) {
-			return <StoprintErrorView navigation={this.props.navigation} />
 		}
 		const grouped = groupBy(this.props.jobs, j => j.statusFormatted || 'Other')
 		let groupedJobs = toPairs(grouped).map(([title, data]) => ({

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -16,10 +16,9 @@ import {
 import type {TopLevelViewPropsType} from '../types'
 import delay from 'delay'
 import {NoticeView} from '../components/notice'
-import Icon from 'react-native-vector-icons/Ionicons'
 import * as c from '../components/colors'
 import openUrl from '../components/open-url'
-import {StoprintErrorView} from './components'
+import {StoprintErrorView, StoprintNoticeView} from './components'
 import groupBy from 'lodash/groupBy'
 import toPairs from 'lodash/toPairs'
 import sortBy from 'lodash/sortBy'
@@ -109,7 +108,7 @@ class PrintJobsView extends React.PureComponent<Props> {
 		}
 		if (this.props.loginState !== 'logged-in') {
 			return (
-				<NoticeView
+				<StoprintNoticeView
 					buttonText="Open Settings"
 					header="You are not logged in"
 					onPress={this.openSettings}
@@ -117,21 +116,14 @@ class PrintJobsView extends React.PureComponent<Props> {
 				/>
 			)
 		} else if (this.props.jobs.length === 0) {
-			const iconName = Platform.select({
-				ios: 'ios-print',
-				android: 'md-print',
-			})
 			return (
-				<View style={styles.container}>
-					<Icon color={c.sto.black} name={iconName} size={100} />
-					<NoticeView
-						buttonText="Install Stoprint"
-						header="Nothing to Print!"
-						onPress={() => openUrl(STOPRINT_HELP_PAGE)}
-						style={styles.notice}
-						text="Need help getting started?"
-					/>
-				</View>
+				<StoprintNoticeView
+					buttonText="Install Stoprint"
+					header="Nothing to Print!"
+					onPress={() => openUrl(STOPRINT_HELP_PAGE)}
+					refresh={this.refresh}
+					text="Need help getting started?"
+				/>
 			)
 		}
 		const grouped = groupBy(this.props.jobs, j => j.statusFormatted || 'Other')
@@ -140,7 +132,7 @@ class PrintJobsView extends React.PureComponent<Props> {
 			data,
 		}))
 		let sortedGroupedJobs = sortBy(groupedJobs, [
-			group => group.title !== 'Pending Release',
+			group => group.title !== 'Pending Release', // puts 'Pending Release' jobs at the top
 		])
 		return (
 			<SectionList

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -16,7 +16,7 @@ import {
 import type {TopLevelViewPropsType} from '../types'
 import delay from 'delay'
 import openUrl from '../components/open-url'
-import {StoprintErrorView, StoprintNoticeView} from './components'
+import {StoPrintErrorView, StoPrintNoticeView} from './components'
 import groupBy from 'lodash/groupBy'
 import toPairs from 'lodash/toPairs'
 import sortBy from 'lodash/sortBy'
@@ -90,7 +90,7 @@ class PrintJobsView extends React.PureComponent<Props> {
 	render() {
 		if (this.props.error) {
 			return (
-				<StoprintErrorView
+				<StoPrintErrorView
 					navigation={this.props.navigation}
 					refresh={this.fetchData}
 				/>
@@ -98,7 +98,7 @@ class PrintJobsView extends React.PureComponent<Props> {
 		}
 		if (this.props.loginState !== 'logged-in') {
 			return (
-				<StoprintNoticeView
+				<StoPrintNoticeView
 					buttonText="Open Settings"
 					header="You are not logged in"
 					onPress={this.openSettings}
@@ -107,8 +107,8 @@ class PrintJobsView extends React.PureComponent<Props> {
 			)
 		} else if (this.props.jobs.length === 0) {
 			return (
-				<StoprintNoticeView
-					buttonText="Install Stoprint"
+				<StoPrintNoticeView
+					buttonText="Install stoPrint"
 					header="Nothing to Print!"
 					onPress={() => openUrl(STOPRINT_HELP_PAGE)}
 					refresh={this.fetchData}

--- a/source/views/stoprint/print-release.js
+++ b/source/views/stoprint/print-release.js
@@ -1,12 +1,11 @@
 // @flow
 
 import * as React from 'react'
-import {Alert, StyleSheet, View, ScrollView} from 'react-native'
+import {Alert, StyleSheet, ScrollView} from 'react-native'
 import type {TopLevelViewPropsType} from '../types'
 import glamorous from 'glamorous-native'
 import {TableView, Section, Cell} from 'react-native-tableview-simple'
 import * as c from '../components/colors'
-import {Button} from '../components/button'
 import {ButtonCell} from '../components/cells'
 import {
 	type Printer,
@@ -21,28 +20,12 @@ import {
 } from '../../lib/stoprint'
 
 const styles = StyleSheet.create({
-	button: {
-		width: 150,
-	},
-	buttonContainer: {
-		alignContent: 'center',
-		backgroundColor: c.sto.black,
-		flex: 1,
-		flexDirection: 'row',
-		justifyContent: 'center',
-	},
-	buttonText: {
-		color: c.white,
-	},
 	cancelButton: {
 		color: c.red,
 	},
-	printButton: {
-		backgroundColor: c.green,
-	},
 	buttonCell: {
 		textAlign: 'center',
-	}
+	},
 })
 
 const Container = glamorous.view({
@@ -234,7 +217,7 @@ export class PrintJobReleaseView extends React.PureComponent<Props, State> {
 					<Header>{job.documentName}</Header>
 					<TableView>
 						<JobInformation job={job} />
-						{actionAvailable &&
+						{actionAvailable && (
 							<React.Fragment>
 								<PrinterInformation printer={printer} />
 								<Section sectionPaddingBottom={0}>
@@ -252,7 +235,7 @@ export class PrintJobReleaseView extends React.PureComponent<Props, State> {
 									/>
 								</Section>
 							</React.Fragment>
-						}
+						)}
 					</TableView>
 				</ScrollView>
 			</Container>

--- a/source/views/stoprint/print-release.js
+++ b/source/views/stoprint/print-release.js
@@ -170,7 +170,7 @@ export class PrintJobReleaseView extends React.PureComponent<Props, State> {
 		} else {
 			Alert.alert(
 				'Job Successfully Released',
-				`Document ${job.documentName} is printing at ${printer.printerName}`,
+				`Document ${job.documentName} is printing at ${printer.printerName}.`,
 				[{text: 'OK', onPress: this.returnToJobsView}],
 			)
 		}

--- a/source/views/stoprint/print-release.js
+++ b/source/views/stoprint/print-release.js
@@ -23,13 +23,12 @@ const styles = StyleSheet.create({
 	cancelButton: {
 		color: c.red,
 	},
+	container: {
+		flex: 1,
+	},
 	buttonCell: {
 		textAlign: 'center',
 	},
-})
-
-const Container = glamorous.view({
-	flex: 1,
 })
 
 const Header = glamorous.text({
@@ -212,33 +211,31 @@ export class PrintJobReleaseView extends React.PureComponent<Props, State> {
 		const {status} = this.state
 		const actionAvailable = status !== 'complete' && printer
 		return (
-			<Container>
-				<ScrollView>
-					<Header>{job.documentName}</Header>
-					<TableView>
-						<JobInformation job={job} />
-						{actionAvailable && (
-							<React.Fragment>
-								<PrinterInformation printer={printer} />
-								<Section sectionPaddingBottom={0}>
-									<ButtonCell
-										onPress={this.requestRelease}
-										textStyle={styles.buttonCell}
-										title={status === 'printing' ? 'Printing…' : 'Print'}
-									/>
-								</Section>
-								<Section>
-									<ButtonCell
-										onPress={this.requestCancel}
-										textStyle={[styles.buttonCell, styles.cancelButton]}
-										title={status === 'cancelling' ? 'Cancelling…' : 'Cancel'}
-									/>
-								</Section>
-							</React.Fragment>
-						)}
-					</TableView>
-				</ScrollView>
-			</Container>
+			<ScrollView contentContainerStyle={styles.container}>
+				<Header>{job.documentName}</Header>
+				<TableView>
+					<JobInformation job={job} />
+					{actionAvailable && (
+						<React.Fragment>
+							<PrinterInformation printer={printer} />
+							<Section sectionPaddingBottom={0}>
+								<ButtonCell
+									onPress={this.requestRelease}
+									textStyle={styles.buttonCell}
+									title={status === 'printing' ? 'Printing…' : 'Print'}
+								/>
+							</Section>
+							<Section>
+								<ButtonCell
+									onPress={this.requestCancel}
+									textStyle={[styles.buttonCell, styles.cancelButton]}
+									title={status === 'cancelling' ? 'Cancelling…' : 'Cancel'}
+								/>
+							</Section>
+						</React.Fragment>
+					)}
+				</TableView>
+			</ScrollView>
 		)
 	}
 }

--- a/source/views/stoprint/print-release.js
+++ b/source/views/stoprint/print-release.js
@@ -1,12 +1,13 @@
 // @flow
 
-import React from 'react'
+import * as React from 'react'
 import {Alert, StyleSheet, View, ScrollView} from 'react-native'
 import type {TopLevelViewPropsType} from '../types'
 import glamorous from 'glamorous-native'
 import {TableView, Section, Cell} from 'react-native-tableview-simple'
 import * as c from '../components/colors'
 import {Button} from '../components/button'
+import {ButtonCell} from '../components/cells'
 import {
 	type Printer,
 	type PrintJob,
@@ -34,12 +35,14 @@ const styles = StyleSheet.create({
 		color: c.white,
 	},
 	cancelButton: {
-		backgroundColor: c.red,
-		marginRight: 20,
+		color: c.red,
 	},
 	printButton: {
 		backgroundColor: c.green,
 	},
+	buttonCell: {
+		textAlign: 'center',
+	}
 })
 
 const Container = glamorous.view({
@@ -47,7 +50,7 @@ const Container = glamorous.view({
 })
 
 const Header = glamorous.text({
-	fontSize: 36,
+	fontSize: 30,
 	textAlign: 'center',
 	marginTop: 20,
 	marginHorizontal: 10,
@@ -231,25 +234,27 @@ export class PrintJobReleaseView extends React.PureComponent<Props, State> {
 					<Header>{job.documentName}</Header>
 					<TableView>
 						<JobInformation job={job} />
-						{actionAvailable && <PrinterInformation printer={printer} />}
+						{actionAvailable &&
+							<React.Fragment>
+								<PrinterInformation printer={printer} />
+								<Section sectionPaddingBottom={0}>
+									<ButtonCell
+										onPress={this.requestRelease}
+										textStyle={styles.buttonCell}
+										title={status === 'printing' ? 'Printing…' : 'Print'}
+									/>
+								</Section>
+								<Section>
+									<ButtonCell
+										onPress={this.requestCancel}
+										textStyle={[styles.buttonCell, styles.cancelButton]}
+										title={status === 'cancelling' ? 'Cancelling…' : 'Cancel'}
+									/>
+								</Section>
+							</React.Fragment>
+						}
 					</TableView>
 				</ScrollView>
-				{actionAvailable && (
-					<View style={styles.buttonContainer}>
-						<Button
-							buttonStyle={[styles.button, styles.cancelButton]}
-							onPress={this.requestCancel}
-							textStyle={styles.buttonText}
-							title={status === 'cancelling' ? 'Cancelling…' : 'Cancel'}
-						/>
-						<Button
-							buttonStyle={[styles.button, styles.printButton]}
-							onPress={this.requestRelease}
-							textStyle={styles.buttonText}
-							title={status === 'printing' ? 'Printing…' : 'Print'}
-						/>
-					</View>
-				)}
 			</Container>
 		)
 	}

--- a/source/views/stoprint/print-release.js
+++ b/source/views/stoprint/print-release.js
@@ -1,0 +1,79 @@
+// @flow
+
+import React from 'react'
+import {StyleSheet, Text, Platform} from 'react-native'
+import glamorous from 'glamorous-native'
+import {TableView, Section, Cell} from 'react-native-tableview-simple'
+import * as c from '../components/colors'
+import type {Printer, PrintJob} from './types'
+
+const Container = glamorous.scrollView({
+	paddingVertical: 6,
+})
+
+const Header = glamorous.text({
+	fontSize: 36,
+	textAlign: 'center',
+	marginTop: 20,
+	marginHorizontal: 10,
+	color: c.black,
+})
+
+const SubHeader = glamorous.text({
+	fontSize: 21,
+	textAlign: 'center',
+	marginTop: 5,
+})
+
+type Props = TopLevelViewPropsType & {
+	navigation: {state: {params: {job: PrintJob, printer: Printer}}},
+}
+
+function LeftDetailCell({detail, title}: {detail: string, title: string}) {
+  return (
+    <Cell cellStyle="LeftDetail" detail={detail} title={title}/>
+  )
+}
+
+function JobInformation({job}: {job: PrintJob}) {
+  return (
+    <Section header="JOB INFO" sectionTintColor={c.sectionBgColor}>
+      <LeftDetailCell detail="Status" title={job.statusFormatted}/>
+      <LeftDetailCell detail="Time" title={job.usageTimeFormatted}/>
+      <LeftDetailCell detail="Pages" title={job.totalPages}/>
+      <LeftDetailCell detail="Cost" title={job.usageCostFormatted}/>
+      <LeftDetailCell detail="Grayscale" title={job.grayscaleFormatted}/>
+      <LeftDetailCell detail="Paper Size" title={job.paperSizeFormatted}/>
+    </Section>
+  )
+}
+
+function PrinterInformation({printer}: {printer: Printer}) {
+  return (
+    <Section header="PRINTER INFO" sectionTintColor={c.sectionBgColor}>
+      <LeftDetailCell detail="Name" title={printer.printerName}/>
+      {printer.location &&
+        <LeftDetailCell detail="Location" title={printer.location}/>
+      }
+    </Section>
+  )
+}
+
+export class PrintJobReleaseView extends React.PureComponent<Props> {
+	static navigationOptions = {
+			title: 'Release Job',
+	}
+
+	render() {
+		const {job, printer} = this.props.navigation.state.params
+		return (
+			<Container>
+				<Header>{job.documentName}</Header>
+				<TableView>
+					<JobInformation job={job} />
+          <PrinterInformation printer={printer} />
+				</TableView>
+			</Container>
+		)
+	}
+}

--- a/source/views/stoprint/printers.js
+++ b/source/views/stoprint/printers.js
@@ -89,7 +89,12 @@ class PrinterListView extends React.PureComponent<Props> {
 
 	render() {
 		if (this.props.error) {
-			return <StoprintErrorView refresh={this.refresh} navigation={this.props.navigation} />
+			return (
+				<StoprintErrorView
+					navigation={this.props.navigation}
+					refresh={this.refresh}
+				/>
+			)
 		}
 
 		const allWithLocations = this.props.printers.map(j => ({

--- a/source/views/stoprint/printers.js
+++ b/source/views/stoprint/printers.js
@@ -92,7 +92,7 @@ class PrinterListView extends React.PureComponent<Props> {
 			return (
 				<StoPrintErrorView
 					navigation={this.props.navigation}
-					refresh={this.refresh}
+					refresh={this.fetchData}
 				/>
 			)
 		}

--- a/source/views/stoprint/printers.js
+++ b/source/views/stoprint/printers.js
@@ -17,7 +17,7 @@ import type {TopLevelViewPropsType} from '../types'
 import delay from 'delay'
 import toPairs from 'lodash/toPairs'
 import groupBy from 'lodash/groupBy'
-import {StoprintErrorView} from './components'
+import {StoPrintErrorView} from './components'
 
 const styles = StyleSheet.create({
 	list: {},
@@ -90,7 +90,7 @@ class PrinterListView extends React.PureComponent<Props> {
 	render() {
 		if (this.props.error) {
 			return (
-				<StoprintErrorView
+				<StoPrintErrorView
 					navigation={this.props.navigation}
 					refresh={this.refresh}
 				/>

--- a/source/views/stoprint/printers.js
+++ b/source/views/stoprint/printers.js
@@ -89,7 +89,7 @@ class PrinterListView extends React.PureComponent<Props> {
 
 	render() {
 		if (this.props.error) {
-			return <StoprintErrorView navigation={this.props.navigation} />
+			return <StoprintErrorView refresh={this.refresh} navigation={this.props.navigation} />
 		}
 
 		const allWithLocations = this.props.printers.map(j => ({

--- a/source/views/stoprint/printers.js
+++ b/source/views/stoprint/printers.js
@@ -1,0 +1,149 @@
+// @flow
+
+import React from 'react'
+import {SectionList, StyleSheet} from 'react-native'
+import {connect} from 'react-redux'
+import {type ReduxState} from '../../flux'
+import {ListEmpty} from '../components/list'
+import {updatePrinters} from '../../flux/parts/stoprint'
+import type {Printer} from './types'
+import {
+	ListRow,
+	ListSeparator,
+	ListSectionHeader,
+	Detail,
+	Title,
+} from '../components/list'
+import type {TopLevelViewPropsType} from '../types'
+import delay from 'delay'
+import toPairs from 'lodash/toPairs'
+import groupBy from 'lodash/groupBy'
+
+const styles = StyleSheet.create({
+	list: {},
+})
+
+type ReactProps = TopLevelViewPropsType
+
+type ReduxStateProps = {
+	+printers: Array<Printer>,
+	+recentPrinters: Array<Printer>,
+	+popularPrinters: Array<Printer>,
+	+error: ?string,
+	+loading: boolean,
+}
+
+type ReduxDispatchProps = {
+	updatePrinters: () => any,
+}
+
+type Props = ReactProps & ReduxDispatchProps & ReduxStateProps
+
+class PrintReleaseView extends React.PureComponent<Props> {
+	static navigationOptions = {
+		title: 'Printers',
+	}
+
+	componentWillMount = () => {
+		this.refresh()
+	}
+
+	refresh = async (): any => {
+		let start = Date.now()
+
+		await this.fetchData()
+		// console.log('data returned')
+
+		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
+		let elapsed = start - Date.now()
+		if (elapsed < 500) {
+			await delay(500 - elapsed)
+		}
+	}
+
+	fetchData = () => this.props.updatePrinters()
+
+	keyExtractor = (item: Printer) => item.printerName
+
+	openPrintConfirmation = () =>
+		this.props.navigation.navigate('PrintJobReleaseConfirmationView')
+
+	renderItem = ({item}: {item: Printer}) => (
+		<ListRow onPress={this.openPrintConfirmation}>
+			<Title>{item.printerName}</Title>
+			<Detail>{item.location}</Detail>
+		</ListRow>
+	)
+
+	renderSectionHeader = ({section: {title}}: any) => (
+		<ListSectionHeader title={title} />
+	)
+
+	render() {
+		const allWithLocations = this.props.printers.map(j => ({
+			...j,
+			location: j.location || 'Unknown Building',
+		}))
+
+		const allGrouped = groupBy(
+			allWithLocations,
+			j =>
+				/^[A-Z]+ \d+/.test(j.location)
+					? j.location.split(/\s+/)[0]
+					: j.location,
+		)
+
+		const groupedByBuilding = toPairs(allGrouped).map(([title, data]) => ({
+			title,
+			data,
+		}))
+
+		groupedByBuilding.sort(
+			(a, b) =>
+				a.title === '' && b.title !== '' ? 1 : a.title.localeCompare(b.title),
+		)
+
+		const grouped = this.props.printers.length
+			? [
+					{title: 'Recent', data: this.props.recentPrinters},
+					{title: 'Popular', data: this.props.popularPrinters},
+					...groupedByBuilding,
+			  ]
+			: []
+
+		return (
+			<SectionList
+				ItemSeparatorComponent={ListSeparator}
+				ListEmptyComponent={<ListEmpty mode="bug" />}
+				keyExtractor={this.keyExtractor}
+				onRefresh={this.refresh}
+				refreshing={this.props.loading}
+				renderItem={this.renderItem}
+				renderSectionHeader={this.renderSectionHeader}
+				sections={grouped}
+				style={styles.list}
+			/>
+		)
+	}
+}
+
+function mapStateToProps(state: ReduxState): ReduxStateProps {
+	return {
+		printers: state.stoprint ? state.stoprint.printers : [],
+		recentPrinters: state.stoprint ? state.stoprint.recentPrinters : [],
+		popularPrinters: state.stoprint ? state.stoprint.popularPrinters : [],
+		error: state.stoprint ? state.stoprint.error : null,
+		loading: state.stoprint ? state.stoprint.loadingPrinters : false,
+	}
+}
+
+function mapDispatchToProps(dispatch): ReduxDispatchProps {
+	return {
+		updatePrinters: () => dispatch(updatePrinters()),
+	}
+}
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)(PrintReleaseView)

--- a/source/views/stoprint/printers.js
+++ b/source/views/stoprint/printers.js
@@ -49,7 +49,7 @@ class PrinterListView extends React.PureComponent<Props> {
 	}
 
 	componentDidMount = () => {
-		this.refresh()
+		this.fetchData()
 	}
 
 	refresh = async (): any => {

--- a/source/views/stoprint/printers.js
+++ b/source/views/stoprint/printers.js
@@ -6,7 +6,7 @@ import {connect} from 'react-redux'
 import {type ReduxState} from '../../flux'
 import {ListEmpty} from '../components/list'
 import {updatePrinters} from '../../flux/parts/stoprint'
-import type {Printer} from './types'
+import type {Printer, PrintJob} from './types'
 import {
 	ListRow,
 	ListSeparator,
@@ -23,7 +23,9 @@ const styles = StyleSheet.create({
 	list: {},
 })
 
-type ReactProps = TopLevelViewPropsType
+type ReactProps = TopLevelViewPropsType & {
+	navigation: {state: {params: {job: PrintJob}}},
+}
 
 type ReduxStateProps = {
 	+printers: Array<Printer>,
@@ -39,9 +41,9 @@ type ReduxDispatchProps = {
 
 type Props = ReactProps & ReduxDispatchProps & ReduxStateProps
 
-class PrintReleaseView extends React.PureComponent<Props> {
+class PrinterListView extends React.PureComponent<Props> {
 	static navigationOptions = {
-		title: 'Printers',
+		title: 'Select Printer',
 	}
 
 	componentWillMount = () => {
@@ -65,11 +67,14 @@ class PrintReleaseView extends React.PureComponent<Props> {
 
 	keyExtractor = (item: Printer) => item.printerName
 
-	openPrintConfirmation = () =>
-		this.props.navigation.navigate('PrintJobReleaseConfirmationView')
+	openPrintRelease = (item: Printer) =>
+		this.props.navigation.navigate(
+			'PrintJobReleaseView',
+			{job: this.props.navigation.state.params.job, printer: item}
+		)
 
 	renderItem = ({item}: {item: Printer}) => (
-		<ListRow onPress={this.openPrintConfirmation}>
+		<ListRow onPress={() => this.openPrintRelease(item)}>
 			<Title>{item.printerName}</Title>
 			<Detail>{item.location}</Detail>
 		</ListRow>
@@ -143,7 +148,7 @@ function mapDispatchToProps(dispatch): ReduxDispatchProps {
 	}
 }
 
-export default connect(
+export const ConnectedPrinterListView = connect(
 	mapStateToProps,
 	mapDispatchToProps,
-)(PrintReleaseView)
+)(PrinterListView)

--- a/source/views/stoprint/types.js
+++ b/source/views/stoprint/types.js
@@ -29,7 +29,7 @@ export type StatusResponse = {
 }
 
 export type Printer = {
-	location: string,
+	location?: string,
 	serverName: string,
 	code: string,
 	printerName: string,

--- a/source/views/stoprint/types.js
+++ b/source/views/stoprint/types.js
@@ -1,0 +1,52 @@
+// @flow
+
+export type PrintJob = {
+	copies: number,
+	documentName: string,
+	deniedReasonFormatted?: string,
+	grayscaleFormatted: 'Yes' | 'No',
+	id: string | number, // maybe just "any"...
+	paperSizeFormatted: string,
+	printerName: string,
+	serverName: string,
+	status: string | 'DENIED',
+	statusDetail?: string,
+	statusFormatted: string,
+	totalPages: number,
+	usageCostFormatted: string,
+	usageTimeFormatted: string,
+}
+
+export type HeldJob = {
+	canRelease: boolean,
+	client: string,
+} & PrintJob
+
+// https://papercut.stolaf.edu:9192/rpc/api/rest/internal/webclient/users/rives/jobs/status
+export type StatusResponse = {
+	hashCode: number,
+	jobs: Array<PrintJob>,
+}
+
+export type Printer = {
+	location: string,
+	serverName: string,
+	code: string,
+	printerName: string,
+}
+
+// https://papercut.stolaf.edu:9192/rpc/api/rest/internal/mobilerelease/api/recent-popular-printers
+// ?username=rives
+export type RecentPopularPrintersResponse = {
+	popularPrinters: Array<Printer>,
+	recentPrinters: Array<Printer>,
+}
+
+// https://papercut.stolaf.edu:9192/rpc/api/rest/internal/mobilerelease/api/all-printers
+// ?username=rives
+export type AllPrintersResponse = Array<Printer>
+
+// https://papercut.stolaf.edu:9192/rpc/api/rest/internal/mobilerelease/api/held-jobs/
+// ?username=rives
+// &printerName=printers\mfc-it
+export type HeldJobsResponse = Array<HeldJob>

--- a/source/views/views.js
+++ b/source/views/views.js
@@ -156,7 +156,7 @@ export const allViews: ViewType[] = [
 	{
 		type: 'view',
 		view: 'PrintJobsView',
-		title: 'StoPrint',
+		title: 'stoPrint',
 		icon: 'print',
 		foreground: 'light',
 		tint: c.chartreuse,

--- a/source/views/views.js
+++ b/source/views/views.js
@@ -158,6 +158,7 @@ export const allViews: ViewType[] = [
 		view: 'PrintJobsView',
 		title: 'StoPrint',
 		icon: 'print',
+		foreground: 'light',
 		tint: c.chartreuse,
 		gradient: c.tealToSeafoam,
 	},

--- a/source/views/views.js
+++ b/source/views/views.js
@@ -153,6 +153,14 @@ export const allViews: ViewType[] = [
 		tint: c.lavender,
 		gradient: c.seafoamToGrass,
 	},
+	{
+		type: 'view',
+		view: 'PrintReleaseView',
+		title: 'StoPrint',
+		icon: 'print',
+		tint: c.chartreuse,
+		gradient: c.tealToSeafoam,
+	},
 ]
 
 export const allViewNames = allViews.map(v => v.view)

--- a/source/views/views.js
+++ b/source/views/views.js
@@ -155,7 +155,7 @@ export const allViews: ViewType[] = [
 	},
 	{
 		type: 'view',
-		view: 'PrintReleaseView',
+		view: 'PrintJobsView',
 		title: 'StoPrint',
 		icon: 'print',
 		tint: c.chartreuse,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,6 +1578,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base-64@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+
 base64-js@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5732,6 +5732,13 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
+query-string@6.1.0, query-string@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    strict-uri-encode "^2.0.0"
+
 query-string@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
@@ -5739,13 +5746,6 @@ query-string@^5.0.1:
     decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
-
-query-string@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
-  dependencies:
-    decode-uri-component "^0.2.0"
-    strict-uri-encode "^2.0.0"
 
 querystring@0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This PR adds a Stoprint View that allows users to release/cancel their print jobs at any Stoprint printer on campus (as long as they are on the campus wifi or VPN). 

# Screenshots: #

### Basic Flow ###

See Jobs | Select Printer for Job | Release or Cancel Job 
-- | -- | -- 
<img width="308" alt="screen shot 2018-08-19 at 9 01 43 pm" src="https://user-images.githubusercontent.com/24640726/44316853-aaa32880-a3f3-11e8-8ba5-b1632416cf39.png"> | <img width="308" alt="screen shot 2018-08-19 at 9 01 50 pm" src="https://user-images.githubusercontent.com/24640726/44316856-b131a000-a3f3-11e8-94e4-9f37f5f1cae5.png"> | <img width="307" alt="screen shot 2018-08-19 at 9 00 40 pm" src="https://user-images.githubusercontent.com/24640726/44316866-bbec3500-a3f3-11e8-9fdf-e7588d73fad9.png"> 

### Alerts ###
Before Printing | After Successful Print | Before Canceling | After Successful Print
-- | -- | -- | --
<img width="306" alt="screen shot 2018-08-19 at 9 01 02 pm" src="https://user-images.githubusercontent.com/24640726/44316934-138aa080-a3f4-11e8-9603-593236a4827a.png"> | <img width="308" alt="screen shot 2018-08-19 at 9 01 10 pm" src="https://user-images.githubusercontent.com/24640726/44316938-171e2780-a3f4-11e8-975c-d4f1df9226d3.png"> | <img width="306" alt="screen shot 2018-08-19 at 9 01 26 pm" src="https://user-images.githubusercontent.com/24640726/44316941-1b4a4500-a3f4-11e8-8260-59fcb9c27afe.png"> | <img width="306" alt="screen shot 2018-08-19 at 9 01 34 pm" src="https://user-images.githubusercontent.com/24640726/44316947-1d140880-a3f4-11e8-99fe-4c570f87286c.png">

### Other States ###
Error (can't connect to API) | No Print Jobs
-- | -- 
<img width="306" alt="screen shot 2018-08-19 at 8 38 03 pm" src="https://user-images.githubusercontent.com/24640726/44316983-606e7700-a3f4-11e8-8252-2a3787bfd127.png"> | <img width="308" alt="screen shot 2018-08-19 at 8 37 44 pm" src="https://user-images.githubusercontent.com/24640726/44316986-62383a80-a3f4-11e8-8948-441e8bc876dd.png">




