### PR TITLE
Update JSC on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -183,6 +183,8 @@ android {
         resolutionStrategy.force "com.android.support:customtabs:$ANDROID_SUPPORT_LIBRARY_VERSION"
         resolutionStrategy.force "com.android.support:support-media-compat:$ANDROID_SUPPORT_LIBRARY_VERSION"
         resolutionStrategy.force "com.android.support:support-v4:$ANDROID_SUPPORT_LIBRARY_VERSION"
+
+        resolutionStrategy.force 'org.webkit:android-jsc:r224109'
     }
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -104,7 +104,7 @@ android {
     defaultConfig {
         applicationId "com.allaboutolaf"
 
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion TARGET_SDK_VERSION
 
         versionCode 1

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ allprojects {
             url "https://jitpack.io"
         }
         maven {
-            // Local Maven repo containing AARs with JSC library built for Android
+            // Local Maven repo containing AARs with JSC library built for Android, like RN
             url "$rootDir/../node_modules/jsc-android/dist"
         }
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,10 @@ allprojects {
             // react-native-custom-tabs requires this maven repository
             url "https://jitpack.io"
         }
+        maven {
+            // Local Maven repo containing AARs with JSC library built for Android
+            url "$rootDir/../node_modules/jsc-android/dist"
+        }
         google()
     }
 }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "glamorous-native": "1.4.0",
     "html-entities": "1.2.1",
     "htmlparser2": "3.9.2",
+    "jsc-android": "224109.x.x",
     "keyword-search": "0.1.1",
     "lodash": "4.17.10",
     "moment": "2.22.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4354,6 +4354,10 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jsc-android@224109.x.x:
+  version "224109.1.0"
+  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-224109.1.0.tgz#9749ec92f1e284b3c09befe7c47cc6e60b1f0cdf"
+
 jsdom@^11.5.1:
   version "11.5.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.5.1.tgz#5df753b8d0bca20142ce21f4f6c039f99a992929"


### PR DESCRIPTION
Closes #2569 

React-Native made the decision (many years ago) to standardize on the JSC (Javascript Core, part of WebKit) JS engine, instead of linking against and exposing separate APIs for each platform's JS engine (v8, chakracore, webkit, etc). So, on iOS the app uses the system-native JSC library, but it's bundled with the app on Android.

That's all well and good (and debatable, but there's no easy way to link against v8 on Android), but RN hasn't done a good job of keeping JSC on Android up to date.

> This project is based on `facebook/android-jsc`, but instead of rewriting JSC's build scripts into BUCK files, it relies on CMake build scripts maintained in a GTK branch of WebKit maintained by the WebKitGTK team […] Thanks to that, with just a small amount of work we should be able to build not only current but also future releases of JSC. 
>
> An obvious benefit for everyone using React Native is that this will allow us to update JSC for React Native on Android much more often than before (**note that facebook/android-jsc uses JSC version from Nov 2014**), which is especially helpful since React Native on iOS uses the built-in copy of JSC that is updated with each major iOS release (see this as a reference).

(emphasis mine.)

The [react-community/jsc-android-buildscripts](https://github.com/react-community/jsc-android-buildscripts) repository usually releases updates every few months, so Android can be kept much more up to date.

## Upsides

Keeping JSC up to date is good for many reasons¹, but going from the 2014-era bundled JSC to this version should bring a general __30%__ performance improvement (according to one issue on the issue tracker.)

Now, I don't know how much of our app is actually JS/CPU-bound, but I'd expect/hope to see a startup time improvement. (Honestly, our app doesn't do a whole lot, so there's not a ton that's CPU-bound. We've been moving HTML parsing out of the app entirely, and that's usually our biggest user of CPU time.)

The `jsc-android` repository includes a [set of benchmarks](), which I've trimmed and included below:

> - All timings in milliseconds (lower is better)
> - Size in MB (arm32/arm64)
> - Render is measured with 1000 elements, flat or deep. The timing is taken after a full render roundtrip (after onLayout)

| Npm Version | Publish Date | Config | WebkitGTK Revision | WebkitGTK Date | TTI | SunSpider | Jetstream Hashmap | Octane2 | SixSpeed | Render Flat | Render Deep | Size |
| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| - | - | Stock RN44 (x32 only, non-i18n) | 174650 | 2014-10-13 | 579 | 519 | 4087 | 2545 | 1386 | 844 | 1162 | 2.7/- |
| 216113.0.3 | 2017-11-17 | webkitGTK:2.17.1<br/>androidICU:7.1.2_r11<br/>i18n:false<br/> | 216113 | 2017-05-03 | 557 | 448 | 3151 | 1938 | 426 | 893 | 1084 | 5.9/8.8 |
| 224109.0.0 | 2018-06-04 | webkitGTK:2.18.2<br/>androidICU:8.0.0_r34<br/>i18n:false<br/> | 224109 | 2017-10-27 | 575 | 461 | 3148 | 1884 | 423 | 899 | 1182 | 6.1/9.3 |
| 224109.1.0 | 2018-07-29 | webkitGTK:2.18.2<br/>chromiumICUCommit:b34251f<br/>i18n:false<br/> | 224109 | 2017-10-27 | 522 | 461 | 3045 | 1946 | 428 | 859 | 1041 | 5.1/7.7 |


## Downsides

- We'll have to drop Android 4.4 support. This is still about 12 people, as of May of 2018, and they probably can't upgrade their Android, or afford a new phone. 
    - I don't feel as bad about this as I might, because we'll just be cutting off new feature updates; I fully intend to keep the data flowing to our older app versions.
- The app size will inflate by ~2.3MB on Android
    - However, this release will also allow people to put the app on external storage, which doesn't really change the effect there, but we're still < 20MB IIRC


---

_fn 1:_ citation needed