### PR TITLE
Run [iOS] Detox in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,6 +299,8 @@ jobs:
       - restore_cache: *restore-cache-bundler
       - run: bundle check || bundle install --frozen --path ./vendor/bundle
       - save_cache: *save-cache-bundler
+      - run: brew tap wix/brew
+      - run: brew install applesimutils
       - run: mkdir -p logs/
       - run: *embed-env-vars
       - run:
@@ -306,6 +308,8 @@ jobs:
           command: bundle exec fastlane ios ci-run | tee ./logs/build
           environment:
             GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $CIRCLE_SHA1)
+      - run: yarn detox build --configuration ios.sim.release
+      - run: yarn detox test --configuration ios.sim.release --cleanup
       - store_artifacts:
           path: ./ios/build/
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,40 +52,40 @@ workflows:
     # different CIRCLE_WORKFLOW_ID, which should allow us to only deploy
     # nightlies from that branch.
     jobs: &basic-jobs
-      - cache-yarn-linux:
-          filters: &filters {tags: {only: /.*/}}
-      - cache-bundler-linux:
-          filters: &filters {tags: {only: /.*/}}
-      - danger:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - flow:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - jest:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - prettier:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - eslint:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - data:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - ios:
-          filters: *filters
-          requires: [danger, flow, jest, prettier, eslint, data]
-      - android:
-          filters: *filters
-          requires: [danger, flow, jest, prettier, eslint, data, cache-bundler-linux]
-      - ios-bundle:
-          filters: *filters
-          requires: [danger, flow, jest, prettier, eslint, data]
-      - android-bundle:
-          filters: *filters
-          requires: [danger, flow, jest, prettier, eslint, data]
+      # - cache-yarn-linux:
+      #     filters: &filters {tags: {only: /.*/}}
+      # - cache-bundler-linux:
+      #     filters: &filters {tags: {only: /.*/}}
+      # - danger:
+      #     filters: *filters
+      #     requires: [cache-yarn-linux]
+      # - flow:
+      #     filters: *filters
+      #     requires: [cache-yarn-linux]
+      # - jest:
+      #     filters: *filters
+      #     requires: [cache-yarn-linux]
+      # - prettier:
+      #     filters: *filters
+      #     requires: [cache-yarn-linux]
+      # - eslint:
+      #     filters: *filters
+      #     requires: [cache-yarn-linux]
+      # - data:
+      #     filters: *filters
+      #     requires: [cache-yarn-linux]
+      - ios: {}
+      #     filters: *filters
+      #     requires: [danger, flow, jest, prettier, eslint, data]
+      # - android:
+      #     filters: *filters
+      #     requires: [danger, flow, jest, prettier, eslint, data, cache-bundler-linux]
+      # - ios-bundle:
+      #     filters: *filters
+      #     requires: [danger, flow, jest, prettier, eslint, data]
+      # - android-bundle:
+      #     filters: *filters
+      #     requires: [danger, flow, jest, prettier, eslint, data]
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,7 +300,7 @@ jobs:
       - run: bundle check || bundle install --frozen --path ./vendor/bundle
       - save_cache: *save-cache-bundler
       - run: HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew
-      - run: brew install applesimutils
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils
       - run: mkdir -p logs/
       - run: *embed-env-vars
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,40 +52,40 @@ workflows:
     # different CIRCLE_WORKFLOW_ID, which should allow us to only deploy
     # nightlies from that branch.
     jobs: &basic-jobs
-      # - cache-yarn-linux:
-      #     filters: &filters {tags: {only: /.*/}}
-      # - cache-bundler-linux:
-      #     filters: &filters {tags: {only: /.*/}}
-      # - danger:
-      #     filters: *filters
-      #     requires: [cache-yarn-linux]
-      # - flow:
-      #     filters: *filters
-      #     requires: [cache-yarn-linux]
-      # - jest:
-      #     filters: *filters
-      #     requires: [cache-yarn-linux]
-      # - prettier:
-      #     filters: *filters
-      #     requires: [cache-yarn-linux]
-      # - eslint:
-      #     filters: *filters
-      #     requires: [cache-yarn-linux]
-      # - data:
-      #     filters: *filters
-      #     requires: [cache-yarn-linux]
-      - ios: {}
-      #     filters: *filters
-      #     requires: [danger, flow, jest, prettier, eslint, data]
-      # - android:
-      #     filters: *filters
-      #     requires: [danger, flow, jest, prettier, eslint, data, cache-bundler-linux]
-      # - ios-bundle:
-      #     filters: *filters
-      #     requires: [danger, flow, jest, prettier, eslint, data]
-      # - android-bundle:
-      #     filters: *filters
-      #     requires: [danger, flow, jest, prettier, eslint, data]
+      - cache-yarn-linux:
+          filters: &filters {tags: {only: /.*/}}
+      - cache-bundler-linux:
+          filters: &filters {tags: {only: /.*/}}
+      - danger:
+          filters: *filters
+          requires: [cache-yarn-linux]
+      - flow:
+          filters: *filters
+          requires: [cache-yarn-linux]
+      - jest:
+          filters: *filters
+          requires: [cache-yarn-linux]
+      - prettier:
+          filters: *filters
+          requires: [cache-yarn-linux]
+      - eslint:
+          filters: *filters
+          requires: [cache-yarn-linux]
+      - data:
+          filters: *filters
+          requires: [cache-yarn-linux]
+      - ios:
+          filters: *filters
+          requires: [danger, flow, jest, prettier, eslint, data]
+      - android:
+          filters: *filters
+          requires: [danger, flow, jest, prettier, eslint, data, cache-bundler-linux]
+      - ios-bundle:
+          filters: *filters
+          requires: [danger, flow, jest, prettier, eslint, data]
+      - android-bundle:
+          filters: *filters
+          requires: [danger, flow, jest, prettier, eslint, data]
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ jobs:
       - run: yarn detox build --configuration ios.sim.release
       - run: yarn detox test --configuration ios.sim.release --cleanup
       - store_artifacts:
-          path: ./ios/build/
+          path: ./ios/build/Build/Products/
       - run:
           name: Analyze Fastlane Logfile
           command: python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,8 +310,8 @@ jobs:
             GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $CIRCLE_SHA1)
       - run: yarn detox build --configuration ios.sim.release
       - run: yarn detox test --configuration ios.sim.release --cleanup
-      - store_artifacts:
-          path: ./ios/build/Build/Products/
+      - store_artifacts: {path: ./ios/build/AllAboutOlaf.app.dSYM.zip}
+      - store_artifacts: {path: ./ios/build/AllAboutOlaf.ipa}
       - run:
           name: Analyze Fastlane Logfile
           command: python2 ./scripts/analyze-gym.py -s 20 < ./logs/build | tee ./logs/analysis || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ jobs:
       - restore_cache: *restore-cache-bundler
       - run: bundle check || bundle install --frozen --path ./vendor/bundle
       - save_cache: *save-cache-bundler
-      - run: brew tap wix/brew
+      - run: HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew
       - run: brew install applesimutils
       - run: mkdir -p logs/
       - run: *embed-env-vars

--- a/e2e/basic-smoke.spec.js
+++ b/e2e/basic-smoke.spec.js
@@ -12,7 +12,6 @@ describe('Basic smoke tests', () => {
 	})
 
 	it('should show home screen after tap to exit settings screen', async () => {
-		await device.reloadReactNative()
 		await element(by.id('button-open-settings')).tap()
 		await expect(element(by.id('screen-homescreen'))).toBeNotVisible()
 		await element(by.id('header-back')).tap()

--- a/e2e/basic-smoke.spec.js
+++ b/e2e/basic-smoke.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-/* global element, device, by */
+/* global element, by */
 
 describe('Basic smoke tests', () => {
 	it('should have homescreen', async () => {

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -10,11 +10,11 @@ jasmine.getEnv().addReporter(adapter)
 
 beforeAll(async () => {
 	await detox.init(config, {launchApp: false})
-	await device.launchApp({permissions: {notifications: 'YES'}})
 })
 
 beforeEach(async () => {
 	await adapter.beforeEach()
+	await device.relaunchApp({delete: true, permissions: {notifications: 'YES'}})
 })
 
 afterAll(async () => {

--- a/e2e/views/homescreen/edit.spec.js
+++ b/e2e/views/homescreen/edit.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-/* global element, device, by */
+/* global element, by */
 
 describe('Edit Home tests to reorganize the home screen.', () => {
 	it('should show home screen after tap to exit edit-home screen', async () => {

--- a/e2e/views/homescreen/edit.spec.js
+++ b/e2e/views/homescreen/edit.spec.js
@@ -3,7 +3,6 @@
 
 describe('Edit Home tests to reorganize the home screen.', () => {
 	it('should show home screen after tap to exit edit-home screen', async () => {
-		await device.reloadReactNative()
 		await element(by.id('button-open-edit-home')).tap()
 		await element(by.id('header-back')).tap()
 		await expect(element(by.id('screen-homescreen'))).toBeVisible()

--- a/package.json
+++ b/package.json
@@ -65,6 +65,12 @@
         "build": "xcodebuild -project ios/AllAboutOlaf.xcodeproj -scheme AllAboutOlaf -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "name": "iPhone 7"
+      },
+      "ios.sim.release": {
+        "binaryPath": "ios/build/Build/Products/Releast-iphonesimulator/AllAboutOlaf.app",
+        "build": "xcodebuild -project ios/AllAboutOlaf.xcodeproj -scheme AllAboutOlaf -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
+        "type": "ios.simulator",
+        "name": "iPhone 7"
       }
     },
     "test-runner": "jest"

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         "name": "iPhone 7"
       },
       "ios.sim.release": {
-        "binaryPath": "ios/build/Build/Products/Releast-iphonesimulator/AllAboutOlaf.app",
+        "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app",
         "build": "xcodebuild -project ios/AllAboutOlaf.xcodeproj -scheme AllAboutOlaf -configuration Release -sdk iphonesimulator -derivedDataPath ios/build",
         "type": "ios.simulator",
         "name": "iPhone 7"


### PR DESCRIPTION
> I have Detox (for iOS) running in CI now… the only thing is, it adds about 6 minutes to the iOS build. I can't run them in parallel, since we only get one macOS container at a time. Do we want to enable it for a while and see how annoying the extra time is, or just, say, only enable it on nightlies for a start?
>
> I'd vote for turning it on on all builds and seeing how annoying it is.
– _Hawken_

> I’m happy running them on nightlies but no strong feelings one way or the other
– _drew_

> My argument against only nightlies is that then we have to bisect back and fix it, vs waiting an extra ~6 minutes and fixing things before master breaks.
> (Especially on greenkeeper PRs. Those be really nice to have smoke tests on.)
– _Hawken_

---

As you can see, I'm still opting to run Detox on every PR. This may need to change in the future; we can see.