### PR TITLE
[stoPrint] how-to screen tweaks

### DIFF
--- a/source/views/stoprint/components/notice.js
+++ b/source/views/stoprint/components/notice.js
@@ -83,7 +83,9 @@ export class StoPrintNoticeView extends React.PureComponent<Props, State> {
 					style={styles.notice}
 					text={text}
 				/>
-				<Text style={styles.description}>{description}</Text>
+				{description ? (
+					<Text style={styles.description}>{description}</Text>
+				) : null}
 			</ScrollView>
 		)
 	}

--- a/source/views/stoprint/components/notice.js
+++ b/source/views/stoprint/components/notice.js
@@ -1,7 +1,13 @@
 // @flow
 
 import React from 'react'
-import {Platform, ScrollView, StyleSheet, RefreshControl} from 'react-native'
+import {
+	Platform,
+	Text,
+	ScrollView,
+	StyleSheet,
+	RefreshControl,
+} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {NoticeView} from '../../components/notice'
 import * as c from '../../components/colors'
@@ -9,6 +15,7 @@ import delay from 'delay'
 
 type Props = {
 	buttonText: string,
+	description?: string,
 	header: string,
 	onPress: () => any,
 	refresh: () => any,
@@ -52,7 +59,7 @@ export class StoPrintNoticeView extends React.PureComponent<Props, State> {
 	}
 
 	render() {
-		const {buttonText, header, onPress, text} = this.props
+		const {buttonText, description, header, onPress, text} = this.props
 		return (
 			<ScrollView
 				contentContainerStyle={styles.content}
@@ -76,6 +83,7 @@ export class StoPrintNoticeView extends React.PureComponent<Props, State> {
 					style={styles.notice}
 					text={text}
 				/>
+				<Text style={styles.description}>{description}</Text>
 			</ScrollView>
 		)
 	}
@@ -89,6 +97,11 @@ const styles = StyleSheet.create({
 		flex: 1,
 		alignItems: 'center',
 		justifyContent: 'center',
+	},
+	description: {
+		marginHorizontal: 30,
+		marginVertical: 20,
+		textAlign: 'center',
 	},
 	notice: {
 		flex: 0,

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -103,7 +103,17 @@ class PrintJobsView extends React.PureComponent<Props> {
 				/>
 			)
 		}
-		if (this.props.jobs.length === 0) {
+		if (this.props.loginState !== 'logged-in') {
+			return (
+				<StoPrintNoticeView
+					buttonText="Open Settings"
+					header="You are not logged in"
+					onPress={this.openSettings}
+					refresh={this.fetchData}
+					text="You must be logged in to your St. Olaf account to access this feature"
+				/>
+			)
+		} else if (this.props.jobs.length === 0) {
 			const instructions =
 				Platform.OS === 'android'
 					? 'using the Mobility Print app'

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react'
-import {SectionList} from 'react-native'
+import {Platform, SectionList} from 'react-native'
 import {connect} from 'react-redux'
 import {type ReduxState} from '../../flux'
 import {updatePrintJobs} from '../../flux/parts/stoprint'
@@ -103,20 +103,17 @@ class PrintJobsView extends React.PureComponent<Props> {
 				/>
 			)
 		}
-		if (this.props.loginState !== 'logged-in') {
-			return (
-				<StoPrintNoticeView
-					buttonText="Open Settings"
-					header="You are not logged in"
-					onPress={this.openSettings}
-					refresh={this.fetchData}
-					text="You must be logged in to your St. Olaf account to access this feature"
-				/>
-			)
-		} else if (this.props.jobs.length === 0) {
+		if (this.props.jobs.length === 0) {
+			const instructions =
+				Platform.OS === 'android'
+					? 'using the Mobility Print app'
+					: 'using the Print option in the Share Sheet'
+			const descriptionText = `You can print from a computer, or by ${instructions}.`
+
 			return (
 				<StoPrintNoticeView
 					buttonText="Learn how to use stoPrint"
+					description={descriptionText}
 					header="Nothing to Print!"
 					onPress={() => openUrl(STOPRINT_HELP_PAGE)}
 					refresh={this.fetchData}

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -116,7 +116,7 @@ class PrintJobsView extends React.PureComponent<Props> {
 		} else if (this.props.jobs.length === 0) {
 			return (
 				<StoPrintNoticeView
-					buttonText="Install stoPrint"
+					buttonText="Learn how to use stoPrint"
 					header="Nothing to Print!"
 					onPress={() => openUrl(STOPRINT_HELP_PAGE)}
 					refresh={this.fetchData}


### PR DESCRIPTION
* Adds a `description` prop to provide more text on the stoPrint notice view
* Adds per-platform text for a better hint on what's left to do before printing
* Tweaks the stoPrint button text to read "Learn how to use stoPrint" for clarity
* Closes #2824

**Portrait**

Platform | Before | After
--|--|--|
iOS | <img alt="ios-old-portrait" src="https://user-images.githubusercontent.com/5240843/44378550-13a3a280-a4bf-11e8-9092-3006686c532f.png"> | <img alt="ios-new-portrait" src="https://user-images.githubusercontent.com/5240843/44378604-5796a780-a4bf-11e8-8d48-041abed2552b.png">
Android | ![android-old-portrait](https://user-images.githubusercontent.com/5240843/44378871-819c9980-a4c0-11e8-95e2-2dea749f030c.png) | ![android-new-portrait](https://user-images.githubusercontent.com/5240843/44378522-fb338800-a4be-11e8-9143-d459918b8554.png) 

**Landscape**

Platform | Before | After
--|--|--|
iOS | <img alt="ios-old-landscape" src="https://user-images.githubusercontent.com/5240843/44378564-21592800-a4bf-11e8-8538-a75408eb0f99.png"> | <img alt="image" src="https://user-images.githubusercontent.com/5240843/44378812-4732fc80-a4c0-11e8-9a94-23548ed2eb2d.png">
Android | ![android-old-landscape](https://user-images.githubusercontent.com/5240843/44378783-223e8980-a4c0-11e8-9d1b-c85cf79da4f0.png) | ![android-new-landscape](https://user-images.githubusercontent.com/5240843/44378536-07b7e080-a4bf-11e8-858b-e81c33a57c35.png)
