### PR TITLE
npm: Make detox an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
     "bugsnag-sourcemaps": "1.0.4",
     "danger": "3.8.6",
     "danger-plugin-yarn": "1.3.0",
-    "detox": "8.1.6",
     "directory-tree": "2.1.0",
     "eslint": "5.0.1",
     "eslint-config-prettier": "3.0.1",
@@ -186,5 +185,8 @@
     "string-natural-compare": "2.0.2",
     "strip-ansi": "4.0.0",
     "xcode": "1.0.0"
+  },
+  "optionalDependencies": {
+    "detox": "8.1.6"
   }
 }


### PR DESCRIPTION
This will suppress total failures in `detox`'s postinstall script from breaking our npm installation cycle, and is a temporary fix until wix/detox#897 is resolved.

Resolves #2842. (kinda)