### PR TITLE
Update page link in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ If you are looking to get started with the project, issues tagged with [`good fi
 1. [Labels](#labels)
 2. [Keep It Running](#keep-it-running)
 3. [Maintainers](#maintainers)
-4. [Travis CI Notes](#travisci-notes)
+4. [CI Notes](#ci-notes)
 
 ## Labels
 We have a lot of labels! Even though they may seem unorganized, there's a method to the madness.


### PR DESCRIPTION
* Link the section back in so the hyperlink in the TOC works.
* Change title away from containing "Travis" as the section details more than one CI