### PR TITLE
NoticeView and TES tweaks

### DIFF
--- a/source/views/components/notice.js
+++ b/source/views/components/notice.js
@@ -9,7 +9,7 @@ import {Viewport} from './viewport'
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
-		paddingHorizontal: 16,
+		paddingHorizontal: 30,
 		justifyContent: 'center',
 		alignItems: 'center',
 		backgroundColor: c.white,

--- a/source/views/sis/tes.js
+++ b/source/views/sis/tes.js
@@ -1,11 +1,9 @@
 // @flow
 
 import * as React from 'react'
-import {View, StyleSheet} from 'react-native'
 import {TabBarIcon} from '../components/tabbar-icon'
 import openUrl from '../components/open-url'
 import type {TopLevelViewPropsType} from '../types'
-import * as c from '../components/colors'
 import {NoticeView} from '../components/notice'
 
 type Props = TopLevelViewPropsType
@@ -22,25 +20,12 @@ export default class TESView extends React.PureComponent<Props> {
 
 	render() {
 		return (
-			<View style={styles.container}>
-				<NoticeView
-					buttonText="Open TES"
-					header="Time Entry System"
-					onPress={this.launchSite}
-					text="The St. Olaf Time Entry System (TES) is the place to report your work hours, for both students and hourly staff."
-				/>
-			</View>
+			<NoticeView
+				buttonText="Open TES"
+				header="Time Entry System"
+				onPress={this.launchSite}
+				text="The St. Olaf Time Entry System (TES) is the place to report your work hours, for both students and hourly staff."
+			/>
 		)
 	}
 }
-
-const styles = StyleSheet.create({
-	container: {
-		alignItems: 'center',
-		flexGrow: 1,
-		flexDirection: 'column',
-		justifyContent: 'center',
-		backgroundColor: c.white,
-		padding: 20,
-	},
-})


### PR DESCRIPTION
* Remove a wrapping `<View />` on the TES component
* Remove styles, imports from TES view
* Increase `<NoticeView />` horizontal padding.

Before | After
--|--
<img width="420" alt="before-tes" src="https://user-images.githubusercontent.com/5240843/44485667-95561600-a60e-11e8-93a8-d6b47812855e.jpeg" > | <img alt="after-tes" src="https://user-images.githubusercontent.com/5240843/44485668-95561600-a60e-11e8-8c08-1321a4358d2b.png">
<img alt="before-course" src="https://user-images.githubusercontent.com/5240843/44485681-9e46e780-a60e-11e8-9502-8b2128440cd9.png"> | <img alt="after-course" src="https://user-images.githubusercontent.com/5240843/44485683-9e46e780-a60e-11e8-9d1e-6fe57b323489.png">