### PR TITLE
[stoPrint]: Fix pull-to-refresh bug and fix loading states

### DIFF
--- a/source/flux/parts/stoprint.js
+++ b/source/flux/parts/stoprint.js
@@ -16,16 +16,10 @@ type GetState = () => ReduxState
 type ThunkAction<A: Action> = (dispatch: Dispatch<A>, getState: GetState) => any
 type Action = UpdateAllPrintersAction | UpdatePrintJobsAction
 
-const UPDATE_ALL_PRINTERS_START = 'stoprint/UPDATE_ALL_PRINTERS/START'
 const UPDATE_ALL_PRINTERS_FAILURE = 'stoprint/UPDATE_ALL_PRINTERS/FAILURE'
 const UPDATE_ALL_PRINTERS_SUCCESS = 'stoprint/UPDATE_ALL_PRINTERS/SUCCESS'
-const UPDATE_PRINT_JOBS_START = 'stoprint/UPDATE_PRINT_JOBS/START'
 const UPDATE_PRINT_JOBS_FAILURE = 'stoprint/UPDATE_PRINT_JOBS/FAILURE'
 const UPDATE_PRINT_JOBS_SUCCESS = 'stoprint/UPDATE_PRINT_JOBS/SUCCESS'
-
-type UpdateAllPrintersStartAction = {
-	type: 'stoprint/UPDATE_ALL_PRINTERS/START',
-}
 
 type UpdateAllPrintersFailureAction = {
 	type: 'stoprint/UPDATE_ALL_PRINTERS/FAILURE',
@@ -45,11 +39,6 @@ type UpdateAllPrintersSuccessAction = {
 type UpdateAllPrintersAction =
 	| UpdateAllPrintersSuccessAction
 	| UpdateAllPrintersFailureAction
-	| UpdateAllPrintersStartAction
-
-type UpdatePrintJobsStartAction = {
-	type: 'stoprint/UPDATE_PRINT_JOBS/START',
-}
 
 type UpdatePrintJobsFailureAction = {
 	type: 'stoprint/UPDATE_PRINT_JOBS/FAILURE',
@@ -64,7 +53,6 @@ type UpdatePrintJobsSuccessAction = {
 type UpdatePrintJobsAction =
 	| UpdatePrintJobsSuccessAction
 	| UpdatePrintJobsFailureAction
-	| UpdatePrintJobsStartAction
 
 export function updatePrinters(): ThunkAction<UpdateAllPrintersAction> {
 	return async dispatch => {
@@ -72,8 +60,6 @@ export function updatePrinters(): ThunkAction<UpdateAllPrintersAction> {
 		if (!username || !password) {
 			return false
 		}
-
-		dispatch({type: UPDATE_ALL_PRINTERS_START})
 
 		const successMsg = await logIn(username, password)
 		if (successMsg !== 'success') {
@@ -137,8 +123,6 @@ export function updatePrintJobs(): ThunkAction<UpdatePrintJobsAction> {
 			return false
 		}
 
-		dispatch({type: UPDATE_PRINT_JOBS_START})
-
 		const successMsg = await logIn(username, password)
 		if (successMsg !== 'success') {
 			return dispatch({type: UPDATE_PRINT_JOBS_FAILURE, payload: successMsg})
@@ -168,8 +152,6 @@ export type State = {|
 	colorPrinters: Array<Printer>,
 	jobsError: ?string,
 	printersError: ?string,
-	loadingPrinters: boolean,
-	loadingJobs: boolean,
 |}
 
 const initialState: State = {
@@ -180,31 +162,22 @@ const initialState: State = {
 	recentPrinters: [],
 	popularPrinters: [],
 	colorPrinters: [],
-	loadingPrinters: false,
-	loadingJobs: false,
 }
 
 export function stoprint(state: State = initialState, action: Action) {
 	switch (action.type) {
-		case UPDATE_PRINT_JOBS_START:
-			return {...state, loadingJobs: true}
-
 		case UPDATE_PRINT_JOBS_FAILURE:
-			return {...state, loadingJobs: false, jobsError: action.payload}
+			return {...state, jobsError: action.payload}
 
 		case UPDATE_PRINT_JOBS_SUCCESS:
 			return {
 				...state,
 				jobs: action.payload,
-				error: null,
-				loadingJobs: false,
+				jobsError: null,
 			}
 
-		case UPDATE_ALL_PRINTERS_START:
-			return {...state, loadingPrinters: true}
-
 		case UPDATE_ALL_PRINTERS_FAILURE:
-			return {...state, loadingPrinters: false, printersError: action.payload}
+			return {...state, printersError: action.payload}
 
 		case UPDATE_ALL_PRINTERS_SUCCESS:
 			return {
@@ -213,9 +186,7 @@ export function stoprint(state: State = initialState, action: Action) {
 				recentPrinters: action.payload.recentPrinters,
 				popularPrinters: action.payload.popularPrinters,
 				colorPrinters: action.payload.colorPrinters,
-				jobsError: null,
 				printersError: null,
-				loadingPrinters: false,
 			}
 
 		default:

--- a/source/views/stoprint/components/error.js
+++ b/source/views/stoprint/components/error.js
@@ -64,6 +64,7 @@ export class StoPrintErrorView extends React.PureComponent<Props, State> {
 						refreshing={this.state.refreshing}
 					/>
 				}
+				showsVerticalScrollIndicator={false}
 				style={styles.container}
 			>
 				<Icon color={c.sto.black} name={iconName} size={100} />

--- a/source/views/stoprint/components/notice.js
+++ b/source/views/stoprint/components/notice.js
@@ -34,9 +34,7 @@ export class StoPrintNoticeView extends React.PureComponent<Props, State> {
 	}
 
 	componentDidMount() {
-		if (this._timer) {
-			this._timer = setInterval(this.props.refresh, 5000)
-		}
+		this._timer = setInterval(this.props.refresh, 5000)
 	}
 
 	componentWillUnmount() {
@@ -69,6 +67,7 @@ export class StoPrintNoticeView extends React.PureComponent<Props, State> {
 						refreshing={this.state.refreshing}
 					/>
 				}
+				showsVerticalScrollIndicator={false}
 				style={styles.container}
 			>
 				<Icon

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -49,7 +49,7 @@ class PrintJobsView extends React.PureComponent<Props, State> {
 
 	state = {
 		initialLoadComplete: false,
-		loading: false,
+		loading: true,
 	}
 
 	componentDidMount() {
@@ -57,7 +57,6 @@ class PrintJobsView extends React.PureComponent<Props, State> {
 	}
 
 	initialLoad = async () => {
-		this.setState(() => ({loading: true}))
 		await this.fetchData()
 		this.setState(() => ({loading: false, initialLoadComplete: true}))
 	}

--- a/source/views/stoprint/printers.js
+++ b/source/views/stoprint/printers.js
@@ -56,7 +56,7 @@ class PrinterListView extends React.PureComponent<Props, State> {
 
 	state = {
 		initialLoadComplete: false,
-		loading: false,
+		loading: true,
 	}
 
 	componentDidMount = () => {
@@ -64,7 +64,6 @@ class PrinterListView extends React.PureComponent<Props, State> {
 	}
 
 	initialLoad = async () => {
-		this.setState(() => ({loading: true}))
 		await this.fetchData()
 		this.setState(() => ({loading: false, initialLoadComplete: true}))
 	}


### PR DESCRIPTION
Resolves #2826, #2855.
This PR resolves the pull-to-refresh bug by moving the loading status of the print jobs and the list of printers from Redux state to the state of the components themselves. This also allows us to distinguish between the loading state of these components when they are first mounted vs. when they have been refreshed via pull-to-refresh. This distinction allows us to present a `<LoadingView/>` only on the initial data load, while all data requests initiated by pull-to-refresh will lead to the expected behavior (with the loading icon above the SectionList or ScrollView itself). 

Bug | Before | After
-- | -- | --
#2826 | ![before-2](https://user-images.githubusercontent.com/24640726/44491361-9a26c400-a626-11e8-95f9-53ab190b3e1d.gif) | ![after-2](https://user-images.githubusercontent.com/24640726/44491367-9dba4b00-a626-11e8-964a-8b2ca2314d7d.gif)
#2855 | ![before](https://user-images.githubusercontent.com/24640726/44491942-677dcb00-a628-11e8-9a0d-424e76a492dd.gif) | ![after](https://user-images.githubusercontent.com/24640726/44491957-6ea4d900-a628-11e8-8614-e9641c01b5d8.gif)

