### PR TITLE
Allow unused variables prefixed with _

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -66,7 +66,7 @@ rules:
   no-unused-vars:
     - warn
     - args: 'after-used'
-      argsIgnorePattern: '^_$'
+      argsIgnorePattern: '^_'
   no-useless-constructor: error
   no-var: error
   prefer-promise-reject-errors: error


### PR DESCRIPTION
If you need to ignore an argument, for instance, you can do `(username, _password)` and Eslint won't complain.

This is a change I have intended to make for quite a long time.