### PR TITLE
Split out odds/ends and misc settings into separate files

### DIFF
--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -6,6 +6,7 @@ import {TableView} from 'react-native-tableview-simple'
 import type {TopLevelViewPropsType} from '../types'
 
 import CredentialsLoginSection from './sections/login-credentials'
+import MiscellanySection from './sections/miscellany'
 import OddsAndEndsSection from './sections/odds-and-ends'
 import SupportSection from './sections/support'
 
@@ -26,6 +27,8 @@ export default function SettingsView(props: TopLevelViewPropsType) {
 				<CredentialsLoginSection />
 
 				<SupportSection navigation={props.navigation} />
+
+				<MiscellanySection navigation={props.navigation} />
 
 				<OddsAndEndsSection navigation={props.navigation} />
 			</TableView>

--- a/source/views/settings/sections/miscellany.js
+++ b/source/views/settings/sections/miscellany.js
@@ -1,0 +1,69 @@
+// @flow
+import * as React from 'react'
+import {Section} from 'react-native-tableview-simple'
+import type {TopLevelViewPropsType} from '../../types'
+import {PushButtonCell} from '../../components/cells/push-button'
+import {trackedOpenUrl} from '../../components/open-url'
+import * as Icons from '@hawkrives/react-native-alternate-icons'
+import {sectionBgColor} from '../../components/colors'
+
+type Props = TopLevelViewPropsType
+
+type State = {
+	supported: boolean,
+}
+
+export default class MiscellanySection extends React.PureComponent<
+	Props,
+	State,
+> {
+	state = {
+		supported: false,
+	}
+
+	componentDidMount() {
+		this.checkIfCustomIconsSupported()
+	}
+
+	checkIfCustomIconsSupported = async () => {
+		const supported = await Icons.isSupported()
+		this.setState(() => ({supported}))
+	}
+
+	onPressButton = (id: string) => {
+		this.props.navigation.navigate(id)
+	}
+
+	onCreditsButton = () => this.onPressButton('CreditsView')
+	onPrivacyButton = () => this.onPressButton('PrivacyView')
+	onLegalButton = () => this.onPressButton('LegalView')
+	onSourceButton = () =>
+		trackedOpenUrl({
+			url: 'https://github.com/StoDevX/AAO-React-Native',
+			id: 'ContributingView',
+		})
+	onAppIconButton = () => this.onPressButton('IconSettingsView')
+
+	render() {
+		return (
+			<React.Fragment>
+				<Section header="MISCELLANY" sectionTintColor={sectionBgColor}>
+					{this.state.supported ? (
+						<PushButtonCell
+							onPress={this.onAppIconButton}
+							title="Change App Icon"
+						/>
+					) : null}
+
+					<PushButtonCell onPress={this.onCreditsButton} title="Credits" />
+					<PushButtonCell
+						onPress={this.onPrivacyButton}
+						title="Privacy Policy"
+					/>
+					<PushButtonCell onPress={this.onLegalButton} title="Legal" />
+					<PushButtonCell onPress={this.onSourceButton} title="Contributing" />
+				</Section>
+			</React.Fragment>
+		)
+	}
+}

--- a/source/views/settings/sections/odds-and-ends.js
+++ b/source/views/settings/sections/odds-and-ends.js
@@ -6,9 +6,6 @@ import type {TopLevelViewPropsType} from '../../types'
 import {setFeedbackStatus} from '../../../flux/parts/settings'
 import {connect} from 'react-redux'
 import {CellToggle} from '../../components/cells/toggle'
-import {PushButtonCell} from '../../components/cells/push-button'
-import {trackedOpenUrl} from '../../components/open-url'
-import * as Icons from '@hawkrives/react-native-alternate-icons'
 import {sectionBgColor} from '../../components/colors'
 
 type Props = TopLevelViewPropsType & {
@@ -16,58 +13,10 @@ type Props = TopLevelViewPropsType & {
 	feedbackDisabled: boolean,
 }
 
-type State = {
-	supported: boolean,
-}
-
-class OddsAndEndsSection extends React.PureComponent<Props, State> {
-	state = {
-		supported: false,
-	}
-
-	componentDidMount() {
-		this.checkIfCustomIconsSupported()
-	}
-
-	checkIfCustomIconsSupported = async () => {
-		const supported = await Icons.isSupported()
-		this.setState(() => ({supported}))
-	}
-
-	onPressButton = (id: string) => {
-		this.props.navigation.navigate(id)
-	}
-
-	onCreditsButton = () => this.onPressButton('CreditsView')
-	onPrivacyButton = () => this.onPressButton('PrivacyView')
-	onLegalButton = () => this.onPressButton('LegalView')
-	onSourceButton = () =>
-		trackedOpenUrl({
-			url: 'https://github.com/StoDevX/AAO-React-Native',
-			id: 'ContributingView',
-		})
-	onAppIconButton = () => this.onPressButton('IconSettingsView')
-
+class OddsAndEndsSection extends React.PureComponent<Props> {
 	render() {
 		return (
 			<React.Fragment>
-				<Section header="MISCELLANY" sectionTintColor={sectionBgColor}>
-					{this.state.supported ? (
-						<PushButtonCell
-							onPress={this.onAppIconButton}
-							title="Change App Icon"
-						/>
-					) : null}
-
-					<PushButtonCell onPress={this.onCreditsButton} title="Credits" />
-					<PushButtonCell
-						onPress={this.onPrivacyButton}
-						title="Privacy Policy"
-					/>
-					<PushButtonCell onPress={this.onLegalButton} title="Legal" />
-					<PushButtonCell onPress={this.onSourceButton} title="Contributing" />
-				</Section>
-
 				<Section header="ODDS &amp; ENDS" sectionTintColor={sectionBgColor}>
 					<Cell cellStyle="RightDetail" detail={version} title="Version" />
 


### PR DESCRIPTION
No visual changes. I noticed that the `odds-and-ends` file contained the `miscellany` section. This splits it into its own file.