### PR TITLE
Fix filter mutation in FilterToolbar

### DIFF
--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -19,6 +19,11 @@ function updateAnyFilter(callback: FilterType => any) {
 			filter = updateToggleFilter(filter)
 		} else if (filter.type === 'list') {
 			filter = updateListFilter(filter, option)
+		} else if (filter.type === 'picker') {
+			filter = filter
+		} else {
+			// assert to flow that we have handled every case
+			;(filter.type: empty)
 		}
 		callback(filter)
 	}

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -20,7 +20,7 @@ function updateAnyFilter(callback: FilterType => any) {
 		} else if (filter.type === 'list') {
 			filter = updateListFilter(filter, option)
 		} else if (filter.type === 'picker') {
-			filter = filter
+			// we don't need to do anything for pickers?
 		} else {
 			// assert to flow that we have handled every case
 			;(filter.type: empty)

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -63,6 +63,15 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 				/>
 			)
 		} else if (filter.type === 'list') {
+			if (!filter.spec.selected.length) {
+				return <ActiveFilterButton
+					key={filter.spec.title}
+					filter={filter}
+					label={`No ${filter.spec.title}`}
+					onRemove={filter => updateFilter(filter)}
+				/>
+			}
+
 			return filter.spec.selected.map(selected => (
 				<ActiveFilterButton
 					key={selected.title}

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -17,7 +17,7 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 	function updateFilter(filter: FilterType, option?: ListItemSpecType) {
 		if (filter.type === 'toggle') {
 			updateToggleFilter(filter)
-		} else if (filter.type === 'list' && option) {
+		} else if (filter.type === 'list') {
 			updateListFilter(filter, option)
 		}
 	}
@@ -27,12 +27,17 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 		onPopoverDismiss(newFilter)
 	}
 
-	function updateListFilter(filter: ListType, option: ListItemSpecType) {
+	function updateListFilter(filter: ListType, option?: ListItemSpecType) {
 		// easier to just clone the filter and mutate than avoid mutations
 		let newFilter = cloneDeep(filter)
-		newFilter.spec.selected = filter.spec.selected.filter(
-			item => item.title !== option.title,
-		)
+
+		// if no option is given, then the "No Terms" button was pressed
+		if (option) {
+			newFilter.spec.selected = filter.spec.selected.filter(
+				item => item.title !== option.title,
+			)
+		}
+
 		if (newFilter.spec.selected.length === 0) {
 			if (filter.spec.mode === 'OR') {
 				newFilter.spec.selected = newFilter.spec.options

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -23,7 +23,7 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 	}
 
 	function updateToggleFilter(filter: ToggleType) {
-		let newFilter = {...filter, enabled: false}
+		let newFilter: ToggleType = {...filter, enabled: false}
 		onPopoverDismiss(newFilter)
 	}
 

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -33,8 +33,9 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 
 		// if no option is given, then the "No Terms" button was pressed
 		if (option) {
+			let optionTitle = option.title
 			newFilter.spec.selected = filter.spec.selected.filter(
-				item => item.title !== option.title,
+				item => item.title !== optionTitle,
 			)
 		}
 

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -69,12 +69,14 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 			)
 		} else if (filter.type === 'list') {
 			if (!filter.spec.selected.length) {
-				return <ActiveFilterButton
-					key={filter.spec.title}
-					filter={filter}
-					label={`No ${filter.spec.title}`}
-					onRemove={filter => updateFilter(filter)}
-				/>
+				return (
+					<ActiveFilterButton
+						key={filter.spec.title}
+						filter={filter}
+						label={`No ${filter.spec.title}`}
+						onRemove={filter => updateFilter(filter)}
+					/>
+				)
 			}
 
 			return filter.spec.selected.map(selected => (

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -6,6 +6,7 @@ import {Toolbar} from '../toolbar'
 import {FilterToolbarButton} from './filter-toolbar-button'
 import {ActiveFilterButton} from './active-filter-button'
 import flatten from 'lodash/flatten'
+import cloneDeep from 'lodash/cloneDeep'
 
 type Props = {
 	filters: Array<FilterType>,
@@ -22,13 +23,13 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 	}
 
 	function updateToggleFilter(filter: ToggleType) {
-		let newFilter = filter
-		newFilter.enabled = false
+		let newFilter = {...filter, enabled: false}
 		onPopoverDismiss(newFilter)
 	}
 
 	function updateListFilter(filter: ListType, option: ListItemSpecType) {
-		let newFilter = filter
+		// easier to just clone the filter and mutate than avoid mutations
+		let newFilter = cloneDeep(filter)
 		newFilter.spec.selected = filter.spec.selected.filter(
 			item => item.title !== option.title,
 		)

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -13,40 +13,46 @@ type Props = {
 	onPopoverDismiss: (filter: FilterType) => any,
 }
 
-export function FilterToolbar({filters, onPopoverDismiss}: Props) {
-	function updateFilter(filter: FilterType, option?: ListItemSpecType) {
+function updateAnyFilter(callback: FilterType => any) {
+	return (filter: FilterType, option?: ListItemSpecType) => {
 		if (filter.type === 'toggle') {
-			updateToggleFilter(filter)
+			filter = updateToggleFilter(filter)
 		} else if (filter.type === 'list') {
-			updateListFilter(filter, option)
+			filter = updateListFilter(filter, option)
 		}
+		callback(filter)
+	}
+}
+
+function updateToggleFilter(filter: ToggleType) {
+	let newFilter: ToggleType = {...filter, enabled: false}
+	return newFilter
+}
+
+function updateListFilter(filter: ListType, option?: ListItemSpecType) {
+	// easier to just clone the filter and mutate than avoid mutations
+	let newFilter = cloneDeep(filter)
+
+	// if no option is given, then the "No Terms" button was pressed
+	if (option) {
+		let optionTitle = option.title
+		newFilter.spec.selected = filter.spec.selected.filter(
+			item => item.title !== optionTitle,
+		)
 	}
 
-	function updateToggleFilter(filter: ToggleType) {
-		let newFilter: ToggleType = {...filter, enabled: false}
-		onPopoverDismiss(newFilter)
+	if (newFilter.spec.selected.length === 0) {
+		if (filter.spec.mode === 'OR') {
+			newFilter.spec.selected = newFilter.spec.options
+		}
+		newFilter.enabled = false
 	}
 
-	function updateListFilter(filter: ListType, option?: ListItemSpecType) {
-		// easier to just clone the filter and mutate than avoid mutations
-		let newFilter = cloneDeep(filter)
+	return newFilter
+}
 
-		// if no option is given, then the "No Terms" button was pressed
-		if (option) {
-			let optionTitle = option.title
-			newFilter.spec.selected = filter.spec.selected.filter(
-				item => item.title !== optionTitle,
-			)
-		}
-
-		if (newFilter.spec.selected.length === 0) {
-			if (filter.spec.mode === 'OR') {
-				newFilter.spec.selected = newFilter.spec.options
-			}
-			newFilter.enabled = false
-		}
-		onPopoverDismiss(newFilter)
-	}
+export function FilterToolbar({filters, onPopoverDismiss}: Props) {
+	let updateFilter = updateAnyFilter(onPopoverDismiss)
 
 	const filterToggles = filters.map(filter => (
 		<FilterToolbarButton


### PR DESCRIPTION
Closes #2859 

For reference: `let x = y` only assigns a new name to an object; it's like doing `Type *point = anotherPointer` in C++.

If we want to actually copy the contents of an object, to prevent mutation, we need to either call `cloneDeep` (less preferable, because it's recursive, but good if we need to mutate an object later), or use Object Rest-Spread syntax (`{…x, key: newValue}`) to just change the value of a single key, which also returns a new overall object and avoids mutation.