### PR TITLE
Fix "no items selected" state in OR-based list filters

### DIFF
--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -19,6 +19,11 @@ function updateAnyFilter(callback: FilterType => any) {
 			filter = updateToggleFilter(filter)
 		} else if (filter.type === 'list') {
 			filter = updateListFilter(filter, option)
+		} else if (filter.type === 'picker') {
+			filter = filter
+		} else {
+			// assert to flow that we have handled every case
+			;(filter.type: empty)
 		}
 		callback(filter)
 	}

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -20,7 +20,7 @@ function updateAnyFilter(callback: FilterType => any) {
 		} else if (filter.type === 'list') {
 			filter = updateListFilter(filter, option)
 		} else if (filter.type === 'picker') {
-			filter = filter
+			// we don't need to do anything for pickers?
 		} else {
 			// assert to flow that we have handled every case
 			;(filter.type: empty)

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -63,6 +63,15 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 				/>
 			)
 		} else if (filter.type === 'list') {
+			if (!filter.spec.selected.length) {
+				return <ActiveFilterButton
+					key={filter.spec.title}
+					filter={filter}
+					label={`No ${filter.spec.title}`}
+					onRemove={filter => updateFilter(filter)}
+				/>
+			}
+
 			return filter.spec.selected.map(selected => (
 				<ActiveFilterButton
 					key={selected.title}

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -17,7 +17,7 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 	function updateFilter(filter: FilterType, option?: ListItemSpecType) {
 		if (filter.type === 'toggle') {
 			updateToggleFilter(filter)
-		} else if (filter.type === 'list' && option) {
+		} else if (filter.type === 'list') {
 			updateListFilter(filter, option)
 		}
 	}
@@ -27,12 +27,17 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 		onPopoverDismiss(newFilter)
 	}
 
-	function updateListFilter(filter: ListType, option: ListItemSpecType) {
+	function updateListFilter(filter: ListType, option?: ListItemSpecType) {
 		// easier to just clone the filter and mutate than avoid mutations
 		let newFilter = cloneDeep(filter)
-		newFilter.spec.selected = filter.spec.selected.filter(
-			item => item.title !== option.title,
-		)
+
+		// if no option is given, then the "No Terms" button was pressed
+		if (option) {
+			newFilter.spec.selected = filter.spec.selected.filter(
+				item => item.title !== option.title,
+			)
+		}
+
 		if (newFilter.spec.selected.length === 0) {
 			if (filter.spec.mode === 'OR') {
 				newFilter.spec.selected = newFilter.spec.options

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -33,8 +33,9 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 
 		// if no option is given, then the "No Terms" button was pressed
 		if (option) {
+			let optionTitle = option.title
 			newFilter.spec.selected = filter.spec.selected.filter(
-				item => item.title !== option.title,
+				item => item.title !== optionTitle,
 			)
 		}
 

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -69,12 +69,14 @@ export function FilterToolbar({filters, onPopoverDismiss}: Props) {
 			)
 		} else if (filter.type === 'list') {
 			if (!filter.spec.selected.length) {
-				return <ActiveFilterButton
-					key={filter.spec.title}
-					filter={filter}
-					label={`No ${filter.spec.title}`}
-					onRemove={filter => updateFilter(filter)}
-				/>
+				return (
+					<ActiveFilterButton
+						key={filter.spec.title}
+						filter={filter}
+						label={`No ${filter.spec.title}`}
+						onRemove={filter => updateFilter(filter)}
+					/>
+				)
 			}
 
 			return filter.spec.selected.map(selected => (

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -13,40 +13,46 @@ type Props = {
 	onPopoverDismiss: (filter: FilterType) => any,
 }
 
-export function FilterToolbar({filters, onPopoverDismiss}: Props) {
-	function updateFilter(filter: FilterType, option?: ListItemSpecType) {
+function updateAnyFilter(callback: FilterType => any) {
+	return (filter: FilterType, option?: ListItemSpecType) => {
 		if (filter.type === 'toggle') {
-			updateToggleFilter(filter)
+			filter = updateToggleFilter(filter)
 		} else if (filter.type === 'list') {
-			updateListFilter(filter, option)
+			filter = updateListFilter(filter, option)
 		}
+		callback(filter)
+	}
+}
+
+function updateToggleFilter(filter: ToggleType) {
+	let newFilter: ToggleType = {...filter, enabled: false}
+	return newFilter
+}
+
+function updateListFilter(filter: ListType, option?: ListItemSpecType) {
+	// easier to just clone the filter and mutate than avoid mutations
+	let newFilter = cloneDeep(filter)
+
+	// if no option is given, then the "No Terms" button was pressed
+	if (option) {
+		let optionTitle = option.title
+		newFilter.spec.selected = filter.spec.selected.filter(
+			item => item.title !== optionTitle,
+		)
 	}
 
-	function updateToggleFilter(filter: ToggleType) {
-		let newFilter: ToggleType = {...filter, enabled: false}
-		onPopoverDismiss(newFilter)
+	if (newFilter.spec.selected.length === 0) {
+		if (filter.spec.mode === 'OR') {
+			newFilter.spec.selected = newFilter.spec.options
+		}
+		newFilter.enabled = false
 	}
 
-	function updateListFilter(filter: ListType, option?: ListItemSpecType) {
-		// easier to just clone the filter and mutate than avoid mutations
-		let newFilter = cloneDeep(filter)
+	return newFilter
+}
 
-		// if no option is given, then the "No Terms" button was pressed
-		if (option) {
-			let optionTitle = option.title
-			newFilter.spec.selected = filter.spec.selected.filter(
-				item => item.title !== optionTitle,
-			)
-		}
-
-		if (newFilter.spec.selected.length === 0) {
-			if (filter.spec.mode === 'OR') {
-				newFilter.spec.selected = newFilter.spec.options
-			}
-			newFilter.enabled = false
-		}
-		onPopoverDismiss(newFilter)
-	}
+export function FilterToolbar({filters, onPopoverDismiss}: Props) {
+	let updateFilter = updateAnyFilter(onPopoverDismiss)
 
 	const filterToggles = filters.map(filter => (
 		<FilterToolbarButton


### PR DESCRIPTION
Closes the rest of #2859 

Built on top of #2863 

You can turn off every item in an OR-based list filter, which means that you essentially don't want anything to show up.

Technically, the filter is still enabled, so the button is gold, but there's no "active" button to remove it.

This PR adds such an "active" button.

<img width="487" alt="screen shot 2018-08-23 at 8 07 23 pm" src="https://user-images.githubusercontent.com/464441/44559777-c0755e00-a711-11e8-9c26-32a332fb8765.png">
