### PR TITLE
FilterToolbar refactoring

### DIFF
--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -19,6 +19,11 @@ function updateAnyFilter(callback: FilterType => any) {
 			filter = updateToggleFilter(filter)
 		} else if (filter.type === 'list') {
 			filter = updateListFilter(filter, option)
+		} else if (filter.type === 'picker') {
+			filter = filter
+		} else {
+			// assert to flow that we have handled every case
+			;(filter.type: empty)
 		}
 		callback(filter)
 	}

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -20,7 +20,7 @@ function updateAnyFilter(callback: FilterType => any) {
 		} else if (filter.type === 'list') {
 			filter = updateListFilter(filter, option)
 		} else if (filter.type === 'picker') {
-			filter = filter
+			// we don't need to do anything for pickers?
 		} else {
 			// assert to flow that we have handled every case
 			;(filter.type: empty)

--- a/source/views/components/filter/filter-toolbar.js
+++ b/source/views/components/filter/filter-toolbar.js
@@ -13,40 +13,46 @@ type Props = {
 	onPopoverDismiss: (filter: FilterType) => any,
 }
 
-export function FilterToolbar({filters, onPopoverDismiss}: Props) {
-	function updateFilter(filter: FilterType, option?: ListItemSpecType) {
+function updateAnyFilter(callback: FilterType => any) {
+	return (filter: FilterType, option?: ListItemSpecType) => {
 		if (filter.type === 'toggle') {
-			updateToggleFilter(filter)
+			filter = updateToggleFilter(filter)
 		} else if (filter.type === 'list') {
-			updateListFilter(filter, option)
+			filter = updateListFilter(filter, option)
 		}
+		callback(filter)
+	}
+}
+
+function updateToggleFilter(filter: ToggleType) {
+	let newFilter: ToggleType = {...filter, enabled: false}
+	return newFilter
+}
+
+function updateListFilter(filter: ListType, option?: ListItemSpecType) {
+	// easier to just clone the filter and mutate than avoid mutations
+	let newFilter = cloneDeep(filter)
+
+	// if no option is given, then the "No Terms" button was pressed
+	if (option) {
+		let optionTitle = option.title
+		newFilter.spec.selected = filter.spec.selected.filter(
+			item => item.title !== optionTitle,
+		)
 	}
 
-	function updateToggleFilter(filter: ToggleType) {
-		let newFilter: ToggleType = {...filter, enabled: false}
-		onPopoverDismiss(newFilter)
+	if (newFilter.spec.selected.length === 0) {
+		if (filter.spec.mode === 'OR') {
+			newFilter.spec.selected = newFilter.spec.options
+		}
+		newFilter.enabled = false
 	}
 
-	function updateListFilter(filter: ListType, option?: ListItemSpecType) {
-		// easier to just clone the filter and mutate than avoid mutations
-		let newFilter = cloneDeep(filter)
+	return newFilter
+}
 
-		// if no option is given, then the "No Terms" button was pressed
-		if (option) {
-			let optionTitle = option.title
-			newFilter.spec.selected = filter.spec.selected.filter(
-				item => item.title !== optionTitle,
-			)
-		}
-
-		if (newFilter.spec.selected.length === 0) {
-			if (filter.spec.mode === 'OR') {
-				newFilter.spec.selected = newFilter.spec.options
-			}
-			newFilter.enabled = false
-		}
-		onPopoverDismiss(newFilter)
-	}
+export function FilterToolbar({filters, onPopoverDismiss}: Props) {
+	let updateFilter = updateAnyFilter(onPopoverDismiss)
 
 	const filterToggles = filters.map(filter => (
 		<FilterToolbarButton


### PR DESCRIPTION
Built on top of #2864 

Extracts the "update" functions from the rendering of FilterToolbar, for easier testing in the future.

If something doesn't depend on the state in `render`, I prefer to pull it out. Idk.

This diff looks better with whitespace changes hidden: https://github.com/StoDevX/AAO-React-Native/pull/2865/files?diff=unified&w=1