### PR TITLE
Fix formatting of recent filter combo with department filter

### DIFF
--- a/source/views/sis/course-search/lib/format-filter-combo.js
+++ b/source/views/sis/course-search/lib/format-filter-combo.js
@@ -43,9 +43,9 @@ function describeFilter(f: FilterType, filters: FilterType[]) {
 			const selectedGEs = geFilter ? geFilter.spec.selected : []
 			return selectedGEs.map(ge => ge.title).join('/')
 		}
-		case 'departments': {
+		case 'department': {
 			const deptFilter = filterListSpecs(filters).find(
-				f => f.key === 'departments',
+				f => f.key === 'department',
 			)
 			const selectedDepts = deptFilter ? deptFilter.spec.selected : []
 			return selectedDepts.map(dept => dept.title).join('/')


### PR DESCRIPTION
This PR fixes an issue with the formatting of recent filter combinations that include a department name. I simply forgot to update the key of the old "departments" filter to "department".