### PR TITLE
Fix course search scroll error

### DIFF
--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -38,7 +38,6 @@ type Props = TopLevelViewPropsType & {
 	style?: any,
 	contentContainerStyle?: any,
 	filtersLoaded: boolean,
-	getRef: (ref: any) => any,
 }
 
 function doSearch(args: {
@@ -88,7 +87,6 @@ export class CourseResultsList extends React.PureComponent<Props> {
 			contentContainerStyle,
 			style,
 			filtersLoaded,
-			getRef,
 		} = this.props
 
 		// be sure to lowercase the query before calling doSearch, so that the memoization
@@ -114,7 +112,6 @@ export class CourseResultsList extends React.PureComponent<Props> {
 
 		return (
 			<SectionList
-				ref={getRef}
 				ItemSeparatorComponent={ListSeparator}
 				ListEmptyComponent={messageView}
 				ListHeaderComponent={header}

--- a/source/views/sis/course-search/results.js
+++ b/source/views/sis/course-search/results.js
@@ -163,6 +163,7 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 				<Separator />
 
 				<CourseResultsList
+					key={searchQuery.toLowerCase()}
 					applyFilters={this.props.applyFilters}
 					courses={this.props.allCourses}
 					filters={filters}

--- a/source/views/sis/course-search/results.js
+++ b/source/views/sis/course-search/results.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {StyleSheet, View, Platform} from 'react-native'
+import {StyleSheet, View} from 'react-native'
 import * as c from '../../components/colors'
 import {
 	updateRecentSearches,
@@ -69,8 +69,6 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 		applyFilters: applyFiltersToItem,
 	}
 
-	resultsList: any
-
 	state = {
 		isSearchbarActive: false,
 		filtersLoaded: Boolean(this.props.navigation.state.params.initialFilters),
@@ -85,19 +83,8 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 		}
 	}
 
-	scrollResultsToTop = () => {
-		this.resultsList.scrollToLocation({
-			animated: false,
-			itemIndex: 0,
-			sectionIndex: 0,
-			viewOffset: Platform.OS === 'ios' ? 87 : 100,
-			viewPosition: 0,
-		})
-	}
-
 	handleSearchSubmit = () => {
 		this.setState(state => ({searchQuery: state.typedQuery}))
-		this.scrollResultsToTop()
 	}
 
 	handleSearchCancel = () => {
@@ -112,7 +99,6 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 
 		if (value === '') {
 			this.setState(() => ({searchQuery: value}))
-			this.scrollResultsToTop()
 		}
 	}
 
@@ -149,10 +135,6 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 		this.setState(() => ({filters: newFilters, filtersLoaded: true}))
 	}
 
-	getRef = (ref: any) => {
-		this.resultsList = ref
-	}
-
 	render() {
 		let {
 			typedQuery,
@@ -185,7 +167,6 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 					courses={this.props.allCourses}
 					filters={filters}
 					filtersLoaded={filtersLoaded}
-					getRef={this.getRef}
 					navigation={this.props.navigation}
 					onListItemPress={this.handleListItemPress}
 					onPopoverDismiss={this.updateFilter}


### PR DESCRIPTION
Closes #2849 

[My current favorite React blog post](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#recommendation-fully-uncontrolled-component-with-a-key):

> In order to reset the value when moving to a different item […], we can use the special React attribute called `key`. When a `key` changes, React will create a new component instance rather than update the current one.

By adding `key={searchQuery}`, we completely avoid the need to scroll back to the top manually, because our "results list" gets completely unmounted and recreated.

Furthermore, because the search cache is at the module level and not cached within an instance of the component, we don't incur a speed penalty for recreating the search list.

Thoughts? I think this seems elegant.