### PR TITLE
Set up library to allow importing from @app / @frogpond in a monorepo

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    "react-native"
+  ],
+  "env": {
+    "production": {
+      "plugins": [
+        "transform-remove-console"
+      ]
+    }
+  }
+}

--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,18 @@
   "presets": [
     "react-native"
   ],
+  "plugins": [
+    [
+      "module-resolver",
+      {
+        "alias": {
+          "^@app/(.+)": "source/\\1",
+          "^@frogpond/(.+)": "modules/\\1"
+        },
+        "extensions": [".ios.js", ".android.js", ".js", ".json"]
+      }
+    ]
+  ],
   "env": {
     "production": {
       "plugins": [

--- a/.flowconfig
+++ b/.flowconfig
@@ -42,6 +42,9 @@ module.file_ext=.json
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
 
+module.name_mapper='^@app\/\(.*\)$' -> '<PROJECT_ROOT>/source/\1'
+module.name_mapper='^@frogpond\/\(.*\)$' -> '<PROJECT_ROOT>/modules/\1'
+
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "babel-core": "6.26.3",
     "babel-eslint": "8.2.6",
     "babel-jest": "23.4.2",
+    "babel-plugin-module-resolver": "3.1.1",
     "babel-plugin-transform-remove-console": "6.9.4",
     "babel-preset-react-native": "4.0.0",
     "bugsnag-sourcemaps": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -27,18 +27,6 @@
     "validate-bus-data": "node scripts/validate-bus-schedules.js",
     "validate-data": "node scripts/validate-data.js"
   },
-  "babel": {
-    "presets": [
-      "react-native"
-    ],
-    "env": {
-      "production": {
-        "plugins": [
-          "transform-remove-console"
-        ]
-      }
-    }
-  },
   "greenkeeper": {
     "ignore": [
       "flow-bin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,6 +1139,16 @@ babel-plugin-jest-hoist@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
+babel-plugin-module-resolver@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.1.1.tgz#881cf67e3d4b8400d5eaaefc1be44d2dc1fe404f"
+  dependencies:
+    find-babel-config "^1.1.0"
+    glob "^7.1.2"
+    pkg-up "^2.0.0"
+    reselect "^3.0.1"
+    resolve "^1.4.0"
+
 babel-plugin-react-transform@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-transform/-/babel-plugin-react-transform-3.0.0.tgz#402f25137b7bb66e9b54ead75557dfbc7ecaaa74"
@@ -3072,6 +3082,13 @@ finalhandler@1.1.0:
     parseurl "~1.3.2"
     statuses "~1.3.1"
     unpipe "~1.0.0"
+
+find-babel-config@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
 
 find-cache-dir@^1.0.0:
   version "1.0.0"
@@ -5716,6 +5733,12 @@ pkg-dir@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  dependencies:
+    find-up "^2.1.0"
+
 plist@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/plist/-/plist-2.0.1.tgz#0a32ca9481b1c364e92e18dc55c876de9d01da8b"
@@ -6506,6 +6529,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+reselect@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -6528,7 +6555,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.3.2, resolve@^1.5.0:
+resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:


### PR DESCRIPTION
There are no real changes to the code base here.

---

So! This is part of a refurbished, repolished https://github.com/StoDevX/AAO-React-Native/pull/1537 (the giant reorganization PR). That one tried to do three separate things (move `components`/ to the top level, reorganize app initialization, and restructure the app views); I've decided to break the changes into smaller chunks for review 😸 

This PR sets up the infrastructure to allow us to do `import * as c from '@app/components/colors'` instead of `import * as c from '../../../../../components/colors'`, in both Flow and Babel.

Code movements are coming up next.

## Timeline
- [x] Move components to `source/`
- [x] Rename `flux/` to `redux/`
- [x] Reorganize app initialization
- [x] Set up things to we can do `import … from '@app/components/colors'` instead of `import … from '../../../../components/colors'`
- [ ] Extract reusable views from `views/` into `modules/`
- [ ] Automate-ish the loading of views from `views/` and deprecate the `views.js` object