### PR TITLE
[modularization] Move the lib/api function into frogpond/api

### DIFF
--- a/modules/api/index.js
+++ b/modules/api/index.js
@@ -2,7 +2,12 @@
 
 import qs from 'query-string'
 
-const root = 'https://stolaf.api.frogpond.tech/v1'
+let root: string
+
+export function setApiRoot(url: string) {
+	root = url
+}
+
 export const API = (pth: string, query: ?Object = null) => {
 	if (process.env.NODE_ENV !== 'production') {
 		if (!pth.startsWith('/')) {

--- a/source/init/api.js
+++ b/source/init/api.js
@@ -1,0 +1,5 @@
+// @flow
+
+import {setApiRoot} from '@frogpond/api'
+
+setApiRoot('https://stolaf.api.frogpond.tech/v1')

--- a/source/lib/cache.js
+++ b/source/lib/cache.js
@@ -1,7 +1,7 @@
 // @flow
 import {AsyncStorage} from 'react-native'
 import moment from 'moment'
-import {API} from '../lib/api'
+import {API} from '@frogpond/api'
 
 type BaseCacheResultType<T> = {
 	isExpired: boolean,

--- a/source/lib/stoprint/api.js
+++ b/source/lib/stoprint/api.js
@@ -3,7 +3,7 @@
 import {PAPERCUT_MOBILE_RELEASE_API, PAPERCUT_API, PAPERCUT} from './urls'
 import querystring from 'query-string'
 import {encode} from 'base-64'
-import {API} from '../api'
+import {API} from '@frogpond/api'
 import type {
 	PrintJobsResponseOrErrorType,
 	AllPrintersResponseOrErrorType,

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -14,7 +14,7 @@ import toPairs from 'lodash/toPairs'
 import groupBy from 'lodash/groupBy'
 import delay from 'delay'
 import {CENTRAL_TZ} from './lib'
-import {API} from '../../lib/api'
+import {API} from '@frogpond/api'
 
 const buildingHoursUrl = API('/spaces/hours')
 

--- a/source/views/calendar/calendar-ccc.js
+++ b/source/views/calendar/calendar-ccc.js
@@ -9,7 +9,7 @@ import type {EventType, PoweredBy} from './types'
 import moment from 'moment-timezone'
 import delay from 'delay'
 import {LoadingView} from '@frogpond/notice'
-import {API} from '../../lib/api'
+import {API} from '@frogpond/api'
 const TIMEZONE = 'America/Winnipeg'
 
 type Props = TopLevelViewPropsType & {

--- a/source/views/contacts/list.js
+++ b/source/views/contacts/list.js
@@ -12,7 +12,7 @@ import toPairs from 'lodash/toPairs'
 import * as c from '@frogpond/colors'
 import type {ContactType} from './types'
 import type {TopLevelViewPropsType} from '../types'
-import {API} from '../../lib/api'
+import {API} from '@frogpond/api'
 
 const contactInfoUrl = API('/contacts')
 

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -21,7 +21,7 @@ import uniq from 'lodash/uniq'
 import words from 'lodash/words'
 import deburr from 'lodash/deburr'
 import * as defaultData from '../../../docs/dictionary.json'
-import {API} from '../../lib/api'
+import {API} from '@frogpond/api'
 
 const dictionaryUrl = API('/dictionary')
 

--- a/source/views/faqs/index.js
+++ b/source/views/faqs/index.js
@@ -8,7 +8,7 @@ import {reportNetworkProblem} from '../../lib/report-network-problem'
 import {LoadingView} from '@frogpond/notice'
 import * as defaultData from '../../../docs/faqs.json'
 import delay from 'delay'
-import {API} from '../../lib/api'
+import {API} from '@frogpond/api'
 
 const faqsUrl = API('/faqs')
 

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -26,7 +26,7 @@ import {tracker} from '../../lib/analytics'
 import bugsnag from '../../init/bugsnag'
 import delay from 'delay'
 import retry from 'p-retry'
-import {API} from '../../lib/api'
+import {API} from '@frogpond/api'
 
 const CENTRAL_TZ = 'America/Winnipeg'
 const entities = new AllHtmlEntities()

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -19,7 +19,7 @@ import {upgradeMenuItem, upgradeStation} from './lib/process-menu-shorthands'
 import {data as fallbackMenu} from '../../../docs/pause-menu.json'
 import {tracker} from '../../lib/analytics'
 import bugsnag from '../../init/bugsnag'
-import {API} from '../../lib/api'
+import {API} from '@frogpond/api'
 
 const CENTRAL_TZ = 'America/Winnipeg'
 

--- a/source/views/news/news-container.js
+++ b/source/views/news/news-container.js
@@ -6,7 +6,7 @@ import {NoticeView, LoadingView} from '@frogpond/notice'
 import type {TopLevelViewPropsType} from '../types'
 import {reportNetworkProblem} from '../../lib/report-network-problem'
 import {NewsList} from './news-list'
-import {API} from '../../lib/api'
+import {API} from '@frogpond/api'
 
 type Props = TopLevelViewPropsType & {
 	source: string | {url: string, type: 'rss' | 'wp-json'},

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -15,7 +15,7 @@ import orderBy from 'lodash/orderBy'
 import groupBy from 'lodash/groupBy'
 import {toLaxTitleCase as titleCase} from 'titlecase'
 import {JobRow} from './job-row'
-import {API} from '../../../lib/api'
+import {API} from '@frogpond/api'
 import type {JobType} from './types'
 
 const jobsUrl = API('/jobs')

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -14,7 +14,7 @@ import moment from 'moment-timezone'
 import {toLaxTitleCase as titleCase} from 'titlecase'
 import type {StreamType} from './types'
 import delay from 'delay'
-import {API} from '../../../lib/api'
+import {API} from '@frogpond/api'
 
 const CENTRAL_TZ = 'America/Winnipeg'
 

--- a/source/views/streaming/webcams/list.js
+++ b/source/views/streaming/webcams/list.js
@@ -10,7 +10,7 @@ import {Column} from '@frogpond/layout'
 import {partitionByIndex} from '../../../lib/partition-by-index'
 import type {Webcam} from './types'
 import {StreamThumbnail} from './thumbnail'
-import {API} from '../../../lib/api'
+import {API} from '@frogpond/api'
 import {Viewport} from '@frogpond/viewport'
 
 const webcamsUrl = API('/webcams')

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -24,7 +24,7 @@ import deburr from 'lodash/deburr'
 import startCase from 'lodash/startCase'
 import * as c from '@frogpond/colors'
 import type {StudentOrgType} from './types'
-import {API} from '../../lib/api'
+import {API} from '@frogpond/api'
 
 const orgsUrl = API('/orgs')
 const leftSideSpacing = 20

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -9,7 +9,7 @@ import type {TopLevelViewPropsType} from '../../types'
 import delay from 'delay'
 import {reportNetworkProblem} from '../../../lib/report-network-problem'
 import * as defaultData from '../../../../docs/bus-times.json'
-import {API} from '../../../lib/api'
+import {API} from '@frogpond/api'
 
 const TIMEZONE = 'America/Winnipeg'
 

--- a/source/views/transportation/other-modes/list.js
+++ b/source/views/transportation/other-modes/list.js
@@ -12,7 +12,7 @@ import groupBy from 'lodash/groupBy'
 import toPairs from 'lodash/toPairs'
 import type {TopLevelViewPropsType} from '../../types'
 import type {OtherModeType} from '../types'
-import {API} from '../../../lib/api'
+import {API} from '@frogpond/api'
 
 const transportationUrl = API('/transit/modes')
 


### PR DESCRIPTION
Moves the "frogpond api" file into a module, `@frogpond/api`.

This is the `import {API} from …` thing that I introduced for talking with ccc-server.

This PR also introduces a `setApiRoot` function, to be called as part of app initialization before the `API` function is ever called. This should allow the module to be agnostic between CARLS and AllAboutOlaf.

Part of the great #1537 redo.