### PR TITLE
[modularization] Extract HtmlView to frogpond/html-view

### DIFF
--- a/modules/html-content/index.js
+++ b/modules/html-content/index.js
@@ -10,7 +10,7 @@ type Props = {
 	style?: number | Object | Array<number | Object>,
 }
 
-export class HtmlView extends React.Component<Props> {
+export class HtmlContent extends React.Component<Props> {
 	_webview: WebView
 
 	onNavigationStateChange = ({url}: {url: string}) => {


### PR DESCRIPTION
As opposed to frogpond/html-lib, which will be coming up soon.

HtmlView lets us render HTML in the app, and open links like they should be opened.

Part of the great #1537 redo.