### PR TITLE
[modularization] move IS_PRODUCTION constant to frogpond/constants

### DIFF
--- a/source/init/analytics.js
+++ b/source/init/analytics.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {initTracker, initBugsnag} from '@frogpond/analytics'
-import {IS_PRODUCTION} from '@app/lib/constants'
+import {IS_PRODUCTION} from '@frogpond/constants'
 
 const GOOGLE_ANALYTICS_PRODUCTION_ID = 'UA-90234209-2'
 const GOOGLE_ANALYTICS_DEVELOPMENT_ID = 'UA-90234209-1'

--- a/source/lib/constants.js
+++ b/source/lib/constants.js
@@ -2,5 +2,3 @@
 
 export const GH_BASE_URL = 'https://github.com/StoDevX/AAO-React-Native'
 export const GH_NEW_ISSUE_URL = `${GH_BASE_URL}/issues/new`
-
-export const IS_PRODUCTION = process.env.NODE_ENV === 'production'

--- a/source/navigation/constants.js
+++ b/source/navigation/constants.js
@@ -1,5 +1,5 @@
 // @flow
 
-import {IS_PRODUCTION} from '../lib/constants'
+import {IS_PRODUCTION} from '@frogpond/constants'
 
 export const persistenceKey = IS_PRODUCTION ? 'NavState' : null

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -4,7 +4,7 @@ import jsYaml from 'js-yaml'
 import type {BuildingType} from '../types'
 import {sendEmail} from '../../../components/send-email'
 import querystring from 'query-string'
-import {GH_NEW_ISSUE_URL} from '../../../lib/constants'
+import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
 
 export function submitReport(current: BuildingType, suggestion: BuildingType) {
 	// calling trim() on these to remove the trailing newlines

--- a/source/views/contacts/detail.js
+++ b/source/views/contacts/detail.js
@@ -11,7 +11,7 @@ import {trackScreenView} from '@frogpond/analytics'
 import {Button} from '../../components/button'
 import {openUrl} from '@frogpond/open-url'
 import type {ContactType} from './types'
-import {GH_NEW_ISSUE_URL} from '../../lib/constants'
+import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
 
 const Title = glamorous.text({
 	fontSize: 36,

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -7,7 +7,7 @@ import {Button} from '../../components/button'
 import glamorous from 'glamorous-native'
 import type {WordType} from './types'
 import type {TopLevelViewPropsType} from '../types'
-import {GH_NEW_ISSUE_URL} from '../../lib/constants'
+import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
 
 // TODO: This doesn't point at the SA dictionary because they don't have an
 // overview page.

--- a/source/views/dictionary/report/submit.js
+++ b/source/views/dictionary/report/submit.js
@@ -4,7 +4,7 @@ import jsYaml from 'js-yaml'
 import type {WordType} from '../types'
 import {sendEmail} from '../../../components/send-email'
 import querystring from 'query-string'
-import {GH_NEW_ISSUE_URL} from '../../../lib/constants'
+import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
 import wrap from 'wordwrap'
 
 export function submitReport(current: WordType, suggestion: WordType) {

--- a/source/views/settings/sections/miscellany.js
+++ b/source/views/settings/sections/miscellany.js
@@ -5,7 +5,7 @@ import type {TopLevelViewPropsType} from '../../types'
 import {trackedOpenUrl} from '@frogpond/open-url'
 import * as Icons from '@hawkrives/react-native-alternate-icons'
 import {sectionBgColor} from '@frogpond/colors'
-import {GH_BASE_URL} from '../../../lib/constants'
+import {GH_BASE_URL} from '@app/lib/constants'
 
 type Props = TopLevelViewPropsType
 

--- a/source/views/transportation/other-modes/detail.js
+++ b/source/views/transportation/other-modes/detail.js
@@ -8,7 +8,7 @@ import {trackScreenView} from '@frogpond/analytics'
 import {Button} from '../../../components/button'
 import {openUrl} from '@frogpond/open-url'
 import type {OtherModeType} from '../types'
-import {GH_NEW_ISSUE_URL} from '../../../lib/constants'
+import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
 
 const Title = glamorous.text({
 	fontSize: 36,


### PR DESCRIPTION
I figure that app-agnostic things can go here, like IS_PRODUCTION and IS_BETA.

Part of the great #1537 redo.