### PR TITLE
Remove the @app namespace

### DIFF
--- a/source/components/add-to-calendar.js
+++ b/source/components/add-to-calendar.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
-import type {EventType} from '@app/views/calendar/types'
-import {addToCalendar} from '@app/views/calendar/calendar-util'
+import type {EventType} from '../views/calendar/types'
+import {addToCalendar} from '../views/calendar/calendar-util'
 import delay from 'delay'
 
 type Props = {

--- a/source/redux/parts/homescreen.js
+++ b/source/redux/parts/homescreen.js
@@ -6,7 +6,7 @@ import {
 	trackHomescreenOrder,
 	trackHomescreenDisabledItem,
 	trackHomescreenReenabledItem,
-} from '@app/lib/analytics'
+} from '../../lib/analytics'
 import * as storage from '../../lib/storage'
 import {type ReduxState} from '../index'
 import isEqual from 'lodash/isEqual'

--- a/source/views/building-hours/report/submit.js
+++ b/source/views/building-hours/report/submit.js
@@ -4,7 +4,7 @@ import jsYaml from 'js-yaml'
 import type {BuildingType} from '../types'
 import {sendEmail} from '../../../components/send-email'
 import querystring from 'query-string'
-import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
+import {GH_NEW_ISSUE_URL} from '../../../lib/constants'
 
 export function submitReport(current: BuildingType, suggestion: BuildingType) {
 	// calling trim() on these to remove the trailing newlines

--- a/source/views/contacts/detail.js
+++ b/source/views/contacts/detail.js
@@ -11,7 +11,7 @@ import {trackScreenView} from '@frogpond/analytics'
 import {Button} from '@frogpond/button'
 import {openUrl} from '@frogpond/open-url'
 import type {ContactType} from './types'
-import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
+import {GH_NEW_ISSUE_URL} from '../../lib/constants'
 
 const Title = glamorous.text({
 	fontSize: 36,

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -7,7 +7,7 @@ import {Button} from '@frogpond/button'
 import glamorous from 'glamorous-native'
 import type {WordType} from './types'
 import type {TopLevelViewPropsType} from '../types'
-import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
+import {GH_NEW_ISSUE_URL} from '../../lib/constants'
 
 // TODO: This doesn't point at the SA dictionary because they don't have an
 // overview page.

--- a/source/views/dictionary/report/submit.js
+++ b/source/views/dictionary/report/submit.js
@@ -4,7 +4,7 @@ import jsYaml from 'js-yaml'
 import type {WordType} from '../types'
 import {sendEmail} from '../../../components/send-email'
 import querystring from 'query-string'
-import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
+import {GH_NEW_ISSUE_URL} from '../../../lib/constants'
 import wrap from 'wordwrap'
 
 export function submitReport(current: WordType, suggestion: WordType) {

--- a/source/views/settings/sections/miscellany.js
+++ b/source/views/settings/sections/miscellany.js
@@ -5,7 +5,7 @@ import type {TopLevelViewPropsType} from '../../types'
 import {trackedOpenUrl} from '@frogpond/open-url'
 import * as Icons from '@hawkrives/react-native-alternate-icons'
 import {sectionBgColor} from '@frogpond/colors'
-import {GH_BASE_URL} from '@app/lib/constants'
+import {GH_BASE_URL} from '../../../lib/constants'
 
 type Props = TopLevelViewPropsType
 

--- a/source/views/stoprint/components/error.js
+++ b/source/views/stoprint/components/error.js
@@ -5,7 +5,7 @@ import type {TopLevelViewPropsType} from '../../types'
 import {ScrollView, RefreshControl, StyleSheet, Platform} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {NoticeView} from '@frogpond/notice'
-import {sto} from '@app/lib/colors'
+import {sto} from '../../../lib/colors'
 import delay from 'delay'
 
 const ERROR_MESSAGE =

--- a/source/views/stoprint/components/notice.js
+++ b/source/views/stoprint/components/notice.js
@@ -10,7 +10,7 @@ import {
 } from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {NoticeView} from '@frogpond/notice'
-import {sto} from '@app/lib/colors'
+import {sto} from '../../../lib/colors'
 import delay from 'delay'
 
 type Props = {

--- a/source/views/streaming/radio/station-ksto.js
+++ b/source/views/streaming/radio/station-ksto.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {sto} from '@app/lib/colors'
+import {sto} from '../../../lib/colors'
 import {TabBarIcon} from '@frogpond/navigation-tabs'
 import {type TopLevelViewPropsType} from '../../types'
 import * as logos from '../../../../images/streaming'

--- a/source/views/transportation/other-modes/detail.js
+++ b/source/views/transportation/other-modes/detail.js
@@ -8,7 +8,7 @@ import {trackScreenView} from '@frogpond/analytics'
 import {Button} from '@frogpond/button'
 import {openUrl} from '@frogpond/open-url'
 import type {OtherModeType} from '../types'
-import {GH_NEW_ISSUE_URL} from '@app/lib/constants'
+import {GH_NEW_ISSUE_URL} from '../../../lib/constants'
 
 const Title = glamorous.text({
 	fontSize: 36,


### PR DESCRIPTION
phase 1 of 4

I never even got this in consistently, and I think I would like to redo how this worked anyway (like, `@lib` to load just the lib/ folder, instead of `@app` being /source.)