### PR TITLE
Remove html-entity stripping from SelectableCell

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,7 @@
-/package.json
+package.json
 *.md
+node_modules/
 /flow-typed/
-/node_modules/
 /docs/
 /android/
 /ios/

--- a/modules/food-menu/lib/build-filters.js
+++ b/modules/food-menu/lib/build-filters.js
@@ -11,11 +11,8 @@ import filter from 'lodash/filter'
 import map from 'lodash/map'
 import uniq from 'lodash/uniq'
 import type {FilterType} from '@frogpond/filter'
-import {fastGetTrimmedText} from '../../../source/lib/html'
-import {AllHtmlEntities} from 'html-entities'
+import {fastGetTrimmedText, entities} from '@frogpond/html-lib'
 import {chooseMeal} from './choose-meal'
-
-const entities = new AllHtmlEntities()
 
 export function buildFilters(
 	foodItems: MenuItemType[],

--- a/modules/html-lib/index.js
+++ b/modules/html-lib/index.js
@@ -3,6 +3,10 @@ import htmlparser from 'htmlparser2'
 import cssSelect from 'css-select'
 export {cssSelect}
 
+import {AllHtmlEntities} from 'html-entities'
+
+export const entities = new AllHtmlEntities()
+
 export function parseHtml(string: string): Object {
 	return htmlparser.parseDOM(string, {
 		withDomLvl1: true,

--- a/modules/html-lib/package.json
+++ b/modules/html-lib/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@frogpond/html-lib",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC",
+  "scripts": {
+    "test": "jest"
+  },
+  "dependencies": {
+    "css-select": "2.0.0",
+    "html-entities": "1.2.1",
+    "htmlparser2": "3.9.2"
+  }
+}

--- a/modules/tableview/cells/selectable.js
+++ b/modules/tableview/cells/selectable.js
@@ -2,9 +2,6 @@
 import * as React from 'react'
 import {TextInput, StyleSheet} from 'react-native'
 import * as c from '@frogpond/colors'
-import {AllHtmlEntities} from 'html-entities'
-
-const entities = new AllHtmlEntities()
 
 const styles = StyleSheet.create({
 	text: {
@@ -22,6 +19,6 @@ export const SelectableCell = ({text}: {text: string}) => (
 		editable={false}
 		multiline={true}
 		style={styles.text}
-		value={entities.decode(text)}
+		value={text}
 	/>
 )

--- a/source/views/calendar/event-row.js
+++ b/source/views/calendar/event-row.js
@@ -5,7 +5,7 @@ import type {EventType} from './types'
 import * as c from '@frogpond/colors'
 import {Row, Column} from '@frogpond/layout'
 import {ListRow, Detail, Title} from '@frogpond/lists'
-import {fastGetTrimmedText} from '../../lib/html'
+import {fastGetTrimmedText} from '@frogpond/html-lib'
 import {Bar} from './vertical-bar'
 import {times} from './times'
 

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -19,8 +19,7 @@ import toPairs from 'lodash/toPairs'
 import type momentT from 'moment'
 import moment from 'moment-timezone'
 import {trimStationName, trimItemLabel} from './lib/trim-names'
-import {getTrimmedTextWithSpaces, parseHtml} from '../../lib/html'
-import {AllHtmlEntities} from 'html-entities'
+import {getTrimmedTextWithSpaces, parseHtml, entities} from '@frogpond/html-lib'
 import {toLaxTitleCase} from 'titlecase'
 import {reportNetworkProblem} from '@frogpond/analytics'
 import delay from 'delay'
@@ -28,7 +27,6 @@ import retry from 'p-retry'
 import {API} from '@frogpond/api'
 
 const CENTRAL_TZ = 'America/Winnipeg'
-const entities = new AllHtmlEntities()
 const BONAPP_HTML_ERROR_CODE = 'bonapp-html'
 
 const DEFAULT_MENU = [

--- a/source/views/sis/student-work/detail.ios.js
+++ b/source/views/sis/student-work/detail.ios.js
@@ -9,6 +9,9 @@ import type {JobType} from './types'
 import glamorous from 'glamorous-native'
 import {ShareButton} from '../../../components/nav-buttons'
 import {shareJob} from './lib'
+import {AllHtmlEntities} from 'html-entities'
+
+const entities = new AllHtmlEntities()
 
 const styles = StyleSheet.create({
 	lastUpdated: {
@@ -79,7 +82,7 @@ function Information({job}: {job: JobType}) {
 function Description({job}: {job: JobType}) {
 	return job.description ? (
 		<Section header="DESCRIPTION">
-			<SelectableCell text={job.description} />
+			<SelectableCell text={entities.decode(job.description)} />
 		</Section>
 	) : null
 }
@@ -87,7 +90,7 @@ function Description({job}: {job: JobType}) {
 function Skills({job}: {job: JobType}) {
 	return job.skills ? (
 		<Section header="SKILLS">
-			<SelectableCell text={job.skills} />
+			<SelectableCell text={entities.decode(job.skills)} />
 		</Section>
 	) : null
 }
@@ -95,7 +98,7 @@ function Skills({job}: {job: JobType}) {
 function Comments({job}: {job: JobType}) {
 	return job.comments ? (
 		<Section header="COMMENTS">
-			<SelectableCell text={job.comments} />
+			<SelectableCell text={entities.decode(job.comments)} />
 		</Section>
 	) : null
 }

--- a/source/views/sis/student-work/detail.ios.js
+++ b/source/views/sis/student-work/detail.ios.js
@@ -9,9 +9,7 @@ import type {JobType} from './types'
 import glamorous from 'glamorous-native'
 import {ShareButton} from '../../../components/nav-buttons'
 import {shareJob} from './lib'
-import {AllHtmlEntities} from 'html-entities'
-
-const entities = new AllHtmlEntities()
+import {entities} from '@frogpond/html-lib'
 
 const styles = StyleSheet.create({
 	lastUpdated: {

--- a/source/views/sis/student-work/job-row.js
+++ b/source/views/sis/student-work/job-row.js
@@ -3,7 +3,7 @@
 import * as React from 'react'
 import {Column, Row} from '@frogpond/layout'
 import {ListRow, Detail, Title} from '@frogpond/lists'
-import {fastGetTrimmedText} from '../../../lib/html'
+import {fastGetTrimmedText} from '@frogpond/html-lib'
 import type {JobType} from './types'
 
 type Props = {

--- a/source/views/streaming/streams/row.js
+++ b/source/views/streaming/streams/row.js
@@ -5,7 +5,7 @@ import {StyleSheet, Image} from 'react-native'
 
 import {ListRow, Detail, Title} from '@frogpond/lists'
 import {Column, Row} from '@frogpond/layout'
-import {getTrimmedTextWithSpaces, parseHtml} from '../../../lib/html'
+import {getTrimmedTextWithSpaces, parseHtml} from '@frogpond/html-lib'
 import {trackedOpenUrl} from '@frogpond/open-url'
 import moment from 'moment'
 import type {StreamType} from './types'

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -9,9 +9,7 @@ import type {TopLevelViewPropsType} from '../types'
 import {openUrl} from '@frogpond/open-url'
 import {sendEmail} from '../../components/send-email'
 import {showNameOrEmail} from './util'
-import {AllHtmlEntities} from 'html-entities'
-
-const entities = new AllHtmlEntities()
+import {entities} from '@frogpond/html-lib'
 
 const styles = StyleSheet.create({
 	name: {

--- a/source/views/student-orgs/detail.ios.js
+++ b/source/views/student-orgs/detail.ios.js
@@ -9,6 +9,9 @@ import type {TopLevelViewPropsType} from '../types'
 import {openUrl} from '@frogpond/open-url'
 import {sendEmail} from '../../components/send-email'
 import {showNameOrEmail} from './util'
+import {AllHtmlEntities} from 'html-entities'
+
+const entities = new AllHtmlEntities()
 
 const styles = StyleSheet.create({
 	name: {
@@ -72,7 +75,7 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
 
 					{meetings ? (
 						<Section header="MEETINGS">
-							<SelectableCell text={meetings} />
+							<SelectableCell text={entities.decode(meetings)} />
 						</Section>
 					) : null}
 
@@ -118,7 +121,7 @@ export class StudentOrgsDetailView extends React.PureComponent<Props> {
 
 					{description ? (
 						<Section header="DESCRIPTION">
-							<SelectableCell text={description} />
+							<SelectableCell text={entities.decode(description)} />
 						</Section>
 					) : null}
 


### PR DESCRIPTION
the first module with a package.json!

phase 2 of 4

`<SelectableCell>` should never have been in charge of removing HTML entities.

This PR moves that responsibility to the call sites, instead.

It also introduces the `@frogpond/html-lib` module, centralizing html parsing, entity removal, and cssSelect exports.