### PR TITLE
Update the version of yarn in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
       node_js: $TRAVIS_NODE_VERSION
       stage: Greenkeeper
       env: [task=GREENKEEPER]
+      before_install: npm i -g yarn
       install: npm install -g greenkeeper-lockfile@1
       script: greenkeeper-lockfile-update
       after_script: greenkeeper-lockfile-upload
@@ -45,6 +46,7 @@ jobs:
       node_js: $TRAVIS_NODE_VERSION
       stage: Deploy Data
       env: [task=GH_PAGES]
+      before_install: npm i -g yarn
       install: yarn || yarn
       script:
         - npm run validate-bus-data


### PR DESCRIPTION
```
$ yarn --version
1.3.2
1.40s$ yarn || yarn
yarn install v1.3.2
(node:3418) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
error An unexpected error occurred: "patterns.map is not a function".
info If you think this is a bug, please open a bug report with the information provided in "/home/travis/build/StoDevX/AAO-React-Native/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
yarn install v1.3.2
(node:3438) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
error An unexpected error occurred: "patterns.map is not a function".
info If you think this is a bug, please open a bug report with the information provided in "/home/travis/build/StoDevX/AAO-React-Native/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command "yarn || yarn" failed and exited with 1 during .
```

We just need to upgrade yarn.