### PR TITLE
Remove unnecessary viewport

### DIFF
--- a/modules/filter/filter-popover.js
+++ b/modules/filter/filter-popover.js
@@ -4,7 +4,6 @@ import Popover from 'react-native-popover-view'
 import {FilterSection} from './section'
 import type {FilterType} from './types'
 import {type TouchableUnion} from '@frogpond/touchable'
-import {Viewport} from '@frogpond/viewport'
 import * as c from '@frogpond/colors'
 
 type Props = {
@@ -38,20 +37,16 @@ export class FilterPopover extends React.PureComponent<Props, State> {
 		const {anchor, onClosePopover, visible} = this.props
 
 		return (
-			<Viewport
-				render={() => (
-					<Popover
-						arrowStyle={arrowStyle}
-						fromView={anchor}
-						isVisible={visible}
-						onClose={() => onClosePopover(filter)}
-						placement="bottom"
-						popoverStyle={popoverContainer}
-					>
-						<FilterSection filter={filter} onChange={this.onFilterChanged} />
-					</Popover>
-				)}
-			/>
+			<Popover
+				arrowStyle={arrowStyle}
+				fromView={anchor}
+				isVisible={visible}
+				onClose={() => onClosePopover(filter)}
+				placement="bottom"
+				popoverStyle={popoverContainer}
+			>
+				<FilterSection filter={filter} onChange={this.onFilterChanged} />
+			</Popover>
 		)
 	}
 }


### PR DESCRIPTION
Since `react-native-popover-view` updated to v1.0.7, we no longer need the Viewport wrapper around the Popover component, as the upstream component handles device rotation by itself. Tested on ios and android simulators to be certain.