### PR TITLE
Nutrition detail view for menu items

### DIFF
--- a/modules/food-menu/dietary-tags-detail.js
+++ b/modules/food-menu/dietary-tags-detail.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
-import {View, StyleSheet, Image} from 'react-native'
+import {View, Text, StyleSheet, Image} from 'react-native'
+import {Row} from '@frogpond/layout'
 
 import keys from 'lodash/keys'
 import pick from 'lodash/pick'
@@ -12,14 +13,17 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		justifyContent: 'flex-end',
 	},
-	iconsList: {
-		marginHorizontal: 3,
+	wrapper: {
+		marginVertical: 5,
+	},
+	iconsDetail: {
+		marginRight: 5,
 		width: 15,
 		height: 15,
 	},
 })
 
-export function DietaryTags({
+export function DietaryTagsDetail({
 	corIcons,
 	dietary,
 	style,
@@ -33,14 +37,13 @@ export function DietaryTags({
 		? pick(corIcons, [])
 		: pick(corIcons, keys(dietary))
 
-	// turn the remaining items into images
 	let tags = map(filtered, (dietaryIcon, key) => (
-		<Image
-			key={key}
-			source={{uri: dietaryIcon.image}}
-			style={styles.iconsList}
-		/>
+		<Row key={key} alignItems="center" style={styles.wrapper}>
+			<Row flex={1}>
+				<Image source={{uri: dietaryIcon.image}} style={styles.iconsDetail} />
+				<Text>{dietaryIcon.label}</Text>
+			</Row>
+		</Row>
 	))
-
 	return <View style={[styles.container, style]}>{tags}</View>
 }

--- a/modules/food-menu/dietary-tags.js
+++ b/modules/food-menu/dietary-tags.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
-import {View, StyleSheet, Image} from 'react-native'
+import {View, Text, StyleSheet, Image} from 'react-native'
+import {Row} from '@frogpond/layout'
 
 import keys from 'lodash/keys'
 import pick from 'lodash/pick'
@@ -12,8 +13,16 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		justifyContent: 'flex-end',
 	},
-	icons: {
+	wrapper: {
+		marginVertical: 5,
+	},
+	iconsList: {
 		marginHorizontal: 3,
+		width: 15,
+		height: 15,
+	},
+	iconsDetail: {
+		marginRight: 5,
 		width: 15,
 		height: 15,
 	},
@@ -22,10 +31,12 @@ const styles = StyleSheet.create({
 export function DietaryTags({
 	corIcons,
 	dietary,
+	isDetail,
 	style,
 }: {
 	corIcons: MasterCorIconMapType,
 	dietary: ItemCorIconMapType,
+	isDetail: boolean,
 	style?: any,
 }) {
 	// filter the mapping of all icons by just the icons provided by this item
@@ -33,10 +44,27 @@ export function DietaryTags({
 		? pick(corIcons, [])
 		: pick(corIcons, keys(dietary))
 
-	// turn the remaining items into images
-	let tags = map(filtered, (dietaryIcon, key) => (
-		<Image key={key} source={{uri: dietaryIcon.image}} style={styles.icons} />
-	))
+	let tags
+
+	if (isDetail) {
+		tags = map(filtered, (dietaryIcon, key) => (
+			<Row key={key} alignItems="center" style={styles.wrapper}>
+				<Row flex={1}>
+					<Image source={{uri: dietaryIcon.image}} style={styles.iconsDetail} />
+					<Text>{dietaryIcon.label}</Text>
+				</Row>
+			</Row>
+		))
+	} else {
+		// turn the remaining items into images
+		tags = map(filtered, (dietaryIcon, key) => (
+			<Image
+				key={key}
+				source={{uri: dietaryIcon.image}}
+				style={styles.iconsList}
+			/>
+		))
+	}
 
 	return <View style={[styles.container, style]}>{tags}</View>
 }

--- a/modules/food-menu/fancy-menu.js
+++ b/modules/food-menu/fancy-menu.js
@@ -97,10 +97,7 @@ export class FancyMenu extends React.Component<Props, State> {
 	}
 
 	onPressRow(item: MenuItem, icons: MasterCorIconMapType) {
-		this.props.navigation.navigate('MenuItemDetailView', {
-			item,
-			icons,
-		})
+		this.props.navigation.navigate('MenuItemDetailView', {item, icons})
 	}
 
 	groupMenuData = (args: {

--- a/modules/food-menu/fancy-menu.js
+++ b/modules/food-menu/fancy-menu.js
@@ -11,6 +11,7 @@ import type {
 	MenuItemContainerType,
 	StationMenuType,
 } from './types'
+import {type NavigationScreenProp} from 'react-navigation'
 import size from 'lodash/size'
 import values from 'lodash/values'
 import {ListSeparator, ListSectionHeader} from '@frogpond/lists'
@@ -36,6 +37,7 @@ type FilterFunc = (filters: Array<FilterType>, item: MenuItem) => boolean
 
 type DefaultProps = {
 	applyFilters: FilterFunc,
+	navigation: NavigationScreenProp<*>,
 }
 
 type Props = ReactProps & DefaultProps
@@ -94,6 +96,13 @@ export class FancyMenu extends React.Component<Props, State> {
 		})
 	}
 
+	onPressRow(item: MenuItem, icons: MasterCorIconMapType) {
+		this.props.navigation.navigate('MenuItemDetailView', {
+			item: item,
+			icons: icons,
+		})
+	}
+
 	groupMenuData = (args: {
 		filters: Array<FilterType>,
 		stations: Array<StationMenuType>,
@@ -143,6 +152,7 @@ export class FancyMenu extends React.Component<Props, State> {
 				badgeSpecials={!specialsFilterEnabled}
 				corIcons={this.props.menuCorIcons}
 				data={item}
+				onPress={() => this.onPressRow(item, this.props.menuCorIcons)}
 				spacing={{left: LEFT_MARGIN}}
 			/>
 		)

--- a/modules/food-menu/fancy-menu.js
+++ b/modules/food-menu/fancy-menu.js
@@ -98,8 +98,8 @@ export class FancyMenu extends React.Component<Props, State> {
 
 	onPressRow(item: MenuItem, icons: MasterCorIconMapType) {
 		this.props.navigation.navigate('MenuItemDetailView', {
-			item: item,
-			icons: icons,
+			item,
+			icons,
 		})
 	}
 

--- a/modules/food-menu/food-item-detail.js
+++ b/modules/food-menu/food-item-detail.js
@@ -8,11 +8,13 @@ import * as c from '@frogpond/colors'
 import map from 'lodash/map'
 import {DietaryTagsDetail} from './dietary-tags-detail'
 import {calculateAmount} from './lib/calculate-amount'
-import {type TopLevelViewPropsType} from '../../source/views/types'
+import type {NavigationScreenProp} from 'react-navigation'
 import type {MenuItemType as MenuItem, MasterCorIconMapType} from './types'
 
-type Props = TopLevelViewPropsType & {
-	navigation: {state: {params: {icons: MasterCorIconMapType, item: MenuItem}}},
+type Props = {
+	navigation: NavigationScreenProp<*> & {
+		state: {params: {icons: MasterCorIconMapType, item: MenuItem}},
+	},
 }
 
 export class MenuItemDetailView extends React.Component<Props> {

--- a/modules/food-menu/food-item-detail.js
+++ b/modules/food-menu/food-item-detail.js
@@ -19,10 +19,8 @@ type Props = TopLevelViewPropsType & {
 }
 
 export class MenuItemDetailView extends React.Component<Props> {
-	static navigationOptions = () => {
-		return {
-			title: 'Nutrition',
-		}
+	static navigationOptions = {
+		title: 'Nutrition',
 	}
 
 	render() {

--- a/modules/food-menu/food-item-detail.js
+++ b/modules/food-menu/food-item-detail.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {Text, ScrollView, View, StyleSheet} from 'react-native'
+import {Text, ScrollView, StyleSheet} from 'react-native'
 import {Column, Row} from '@frogpond/layout'
 import {ListRow, ListSeparator, Detail, Title} from '@frogpond/lists'
 import * as c from '@frogpond/colors'

--- a/modules/food-menu/food-item-detail.js
+++ b/modules/food-menu/food-item-detail.js
@@ -1,0 +1,120 @@
+// @flow
+
+import * as React from 'react'
+import {Text, ScrollView, View, StyleSheet} from 'react-native'
+import {Column, Row} from '@frogpond/layout'
+import {ListRow, ListSeparator, Detail, Title} from '@frogpond/lists'
+import * as c from '@frogpond/colors'
+import map from 'lodash/map'
+import {DietaryTags} from './dietary-tags'
+import {type TopLevelViewPropsType} from '../../source/views/types'
+import type {
+	MenuItemType as MenuItem,
+	NutritionDetailType,
+	MasterCorIconMapType,
+} from './types'
+
+type Props = TopLevelViewPropsType & {
+	navigation: {state: {params: {icons: MasterCorIconMapType, item: MenuItem}}},
+}
+
+export class MenuItemDetailView extends React.Component<Props> {
+	static navigationOptions = () => {
+		return {
+			title: 'Nutrition',
+		}
+	}
+
+	render() {
+		const item = this.props.navigation.state.params.item
+		const icons = this.props.navigation.state.params.icons
+
+		const calculateAmount = (nutrition: NutritionDetailType) => {
+			// turn "lessthang" and "lessthanmg" into "less than 1g", "less than 5mg", etc
+			return nutrition.unit.includes('lessthan')
+				? `less than ${nutrition.value}${nutrition.unit.split('lessthan')[1]}`
+				: `${nutrition.value}${nutrition.unit}`
+		}
+
+		return (
+			<ScrollView style={styles.container}>
+				<Text selectable={true} style={styles.title}>
+					{item.label}
+				</Text>
+
+				<DietaryTags
+					corIcons={icons}
+					dietary={item.cor_icon}
+					isDetail={true}
+					style={styles.iconContainer}
+				/>
+
+				{item.description ? (
+					<View>
+						<ListRow
+							arrowPosition="none"
+							contentContainerStyle={styles.container}
+							fullWidth={false}
+						>
+							<Row>
+								<Title>Description</Title>
+							</Row>
+							<Row>
+								<Detail>{item.description}</Detail>
+							</Row>
+						</ListRow>
+						<ListSeparator />
+					</View>
+				) : null}
+
+				{item.nutrition_details &&
+				Object.keys(item.nutrition_details).length > 1 ? (
+					map(item.nutrition_details, (nutrition, key: number) => {
+						return (
+							<View key={`${nutrition}-${key}`}>
+								<ListRow
+									arrowPosition="none"
+									fullWidth={false}
+									style={styles.container}
+								>
+									<Row>
+										<Column flex={1}>
+											<Title>{nutrition.label}</Title>
+										</Column>
+
+										<Detail>{calculateAmount(nutrition)}</Detail>
+									</Row>
+								</ListRow>
+
+								<ListSeparator />
+							</View>
+						)
+					})
+				) : (
+					<Detail style={styles.noInfo}>No nutritional information</Detail>
+				)}
+			</ScrollView>
+		)
+	}
+}
+
+const styles = StyleSheet.create({
+	container: {
+		backgroundColor: c.white,
+	},
+	title: {
+		fontSize: 36,
+		textAlign: 'center',
+		marginHorizontal: 18,
+		marginVertical: 10,
+	},
+	iconContainer: {
+		flexDirection: 'column',
+		marginHorizontal: 16,
+		marginVertical: 10,
+	},
+	noInfo: {
+		marginHorizontal: 16,
+		marginVertical: 10,
+	},
+})

--- a/modules/food-menu/food-item-detail.js
+++ b/modules/food-menu/food-item-detail.js
@@ -42,12 +42,8 @@ export class MenuItemDetailView extends React.Component<Props> {
 							contentContainerStyle={styles.container}
 							fullWidth={false}
 						>
-							<Row>
-								<Title>Description</Title>
-							</Row>
-							<Row>
-								<Detail>{item.description}</Detail>
-							</Row>
+							<Title>Description</Title>
+							<Detail>{item.description}</Detail>
 						</ListRow>
 						<ListSeparator />
 					</React.Fragment>

--- a/modules/food-menu/food-item-detail.js
+++ b/modules/food-menu/food-item-detail.js
@@ -21,8 +21,7 @@ export class MenuItemDetailView extends React.Component<Props> {
 	}
 
 	render() {
-		const item = this.props.navigation.state.params.item
-		const icons = this.props.navigation.state.params.icons
+		const {item, icons} = this.props.navigation.state.params
 
 		return (
 			<ScrollView style={styles.container}>

--- a/modules/food-menu/food-item-detail.js
+++ b/modules/food-menu/food-item-detail.js
@@ -7,12 +7,9 @@ import {ListRow, ListSeparator, Detail, Title} from '@frogpond/lists'
 import * as c from '@frogpond/colors'
 import map from 'lodash/map'
 import {DietaryTags} from './dietary-tags'
+import {calculateAmount} from './lib/calculate-amount'
 import {type TopLevelViewPropsType} from '../../source/views/types'
-import type {
-	MenuItemType as MenuItem,
-	NutritionDetailType,
-	MasterCorIconMapType,
-} from './types'
+import type {MenuItemType as MenuItem, MasterCorIconMapType} from './types'
 
 type Props = TopLevelViewPropsType & {
 	navigation: {state: {params: {icons: MasterCorIconMapType, item: MenuItem}}},
@@ -26,13 +23,6 @@ export class MenuItemDetailView extends React.Component<Props> {
 	render() {
 		const item = this.props.navigation.state.params.item
 		const icons = this.props.navigation.state.params.icons
-
-		const calculateAmount = (nutrition: NutritionDetailType) => {
-			// turn "lessthang" and "lessthanmg" into "less than 1g", "less than 5mg", etc
-			return nutrition.unit.includes('lessthan')
-				? `less than ${nutrition.value}${nutrition.unit.split('lessthan')[1]}`
-				: `${nutrition.value}${nutrition.unit}`
-		}
 
 		return (
 			<ScrollView style={styles.container}>

--- a/modules/food-menu/food-item-detail.js
+++ b/modules/food-menu/food-item-detail.js
@@ -36,7 +36,7 @@ export class MenuItemDetailView extends React.Component<Props> {
 				/>
 
 				{item.description ? (
-					<View>
+					<React.Fragment>
 						<ListRow
 							arrowPosition="none"
 							contentContainerStyle={styles.container}
@@ -50,14 +50,14 @@ export class MenuItemDetailView extends React.Component<Props> {
 							</Row>
 						</ListRow>
 						<ListSeparator />
-					</View>
+					</React.Fragment>
 				) : null}
 
 				{item.nutrition_details &&
 				Object.keys(item.nutrition_details).length > 1 ? (
 					map(item.nutrition_details, (nutrition, key: number) => {
 						return (
-							<View key={`${nutrition}-${key}`}>
+							<React.Fragment key={`${nutrition}-${key}`}>
 								<ListRow
 									arrowPosition="none"
 									fullWidth={false}
@@ -73,7 +73,7 @@ export class MenuItemDetailView extends React.Component<Props> {
 								</ListRow>
 
 								<ListSeparator />
-							</View>
+							</React.Fragment>
 						)
 					})
 				) : (

--- a/modules/food-menu/food-item-detail.js
+++ b/modules/food-menu/food-item-detail.js
@@ -6,7 +6,7 @@ import {Column, Row} from '@frogpond/layout'
 import {ListRow, ListSeparator, Detail, Title} from '@frogpond/lists'
 import * as c from '@frogpond/colors'
 import map from 'lodash/map'
-import {DietaryTags} from './dietary-tags'
+import {DietaryTagsDetail} from './dietary-tags-detail'
 import {calculateAmount} from './lib/calculate-amount'
 import {type TopLevelViewPropsType} from '../../source/views/types'
 import type {MenuItemType as MenuItem, MasterCorIconMapType} from './types'
@@ -30,10 +30,9 @@ export class MenuItemDetailView extends React.Component<Props> {
 					{item.label}
 				</Text>
 
-				<DietaryTags
+				<DietaryTagsDetail
 					corIcons={icons}
 					dietary={item.cor_icon}
-					isDetail={true}
 					style={styles.iconContainer}
 				/>
 

--- a/modules/food-menu/food-item-row.js
+++ b/modules/food-menu/food-item-row.js
@@ -16,19 +16,22 @@ type FoodItemPropsType = {|
 	style?: any,
 	badgeSpecials?: boolean,
 	spacing: {left: number},
+	onPress: any,
 |}
 
 export function FoodItemRow({
 	data,
 	corIcons,
 	badgeSpecials = true,
+	onPress,
 	...props
 }: FoodItemPropsType) {
 	const {left = 0} = props.spacing
 	return (
 		<ListRow
-			arrowPosition="none"
+			arrowPosition="center"
 			fullWidth={true}
+			onPress={onPress}
 			style={[styles.container, props.style]}
 		>
 			<Row alignItems="center">
@@ -46,6 +49,7 @@ export function FoodItemRow({
 				<DietaryTags
 					corIcons={corIcons}
 					dietary={data.cor_icon}
+					isDetail={false}
 					style={styles.iconContainer}
 				/>
 			</Row>

--- a/modules/food-menu/food-item-row.js
+++ b/modules/food-menu/food-item-row.js
@@ -16,7 +16,7 @@ type FoodItemPropsType = {|
 	style?: any,
 	badgeSpecials?: boolean,
 	spacing: {left: number},
-	onPress: any,
+	onPress: () => any,
 |}
 
 export function FoodItemRow({

--- a/modules/food-menu/food-item-row.js
+++ b/modules/food-menu/food-item-row.js
@@ -49,7 +49,6 @@ export function FoodItemRow({
 				<DietaryTags
 					corIcons={corIcons}
 					dietary={data.cor_icon}
-					isDetail={false}
 					style={styles.iconContainer}
 				/>
 			</Row>

--- a/modules/food-menu/lib/calculate-amount.js
+++ b/modules/food-menu/lib/calculate-amount.js
@@ -1,0 +1,10 @@
+// @flow
+
+import type {NutritionDetailType} from '../types'
+
+export function calculateAmount(nutrition: NutritionDetailType) {
+	// turn "lessthang" and "lessthanmg" into "less than 1g", "less than 5mg", etc
+	return nutrition.unit.includes('lessthan')
+		? `less than ${nutrition.value}${nutrition.unit.split('lessthan')[1]}`
+		: `${nutrition.value}${nutrition.unit}`
+}

--- a/modules/food-menu/types.js
+++ b/modules/food-menu/types.js
@@ -27,6 +27,7 @@ export type MenuItemType = {
 				well_being: string,
 				well_being_image: string,
 		  },
+	nutrition_details: {} | NutritionDetailContainer,
 	nutrition_link: string,
 	options: any[],
 	price: CurrencyStringType,
@@ -38,6 +39,26 @@ export type MenuItemType = {
 	sub_station_order: NumericStringType,
 	tier3: boolean,
 	zero_entree: NumericStringType,
+}
+
+export type NutritionDetailContainer = {
+	calories: NutritionDetailType,
+	servingSize: NutritionDetailType,
+	fatContent: NutritionDetailType,
+	saturatedFatContent: NutritionDetailType,
+	transFatContent: NutritionDetailType,
+	cholesterolContent: NutritionDetailType,
+	sodiumContent: NutritionDetailType,
+	carbohydrateContent: NutritionDetailType,
+	fiberContent: NutritionDetailType,
+	sugarContent: NutritionDetailType,
+	proteinContent: NutritionDetailType,
+}
+
+export type NutritionDetailType = {
+	label: string,
+	value: number,
+	unit: string,
 }
 
 export type StationMenuType = {

--- a/source/navigation/routes.js
+++ b/source/navigation/routes.js
@@ -30,6 +30,7 @@ import {
 	CarletonWeitzMenuScreen,
 	MenusView,
 } from '../views/menus'
+import {MenuItemDetailView} from '@frogpond/food-menu/food-item-detail'
 import NewsView from '../views/news'
 import PrivacyView from '../views/settings/privacy'
 import SettingsView from '../views/settings'
@@ -89,6 +90,7 @@ export const routes = {
 	CarletonLDCMenuView: {screen: CarletonLDCMenuScreen},
 	CarletonWeitzMenuView: {screen: CarletonWeitzMenuScreen},
 	CarletonSaylesMenuView: {screen: CarletonSaylesMenuScreen},
+	MenuItemDetailView: {screen: MenuItemDetailView},
 	PrintJobsView: {screen: PrintJobsView},
 	PrinterListView: {screen: PrinterListView},
 	PrintJobReleaseView: {screen: PrintJobReleaseView},

--- a/source/views/menus/lib/__tests__/menu-item.mock.js
+++ b/source/views/menus/lib/__tests__/menu-item.mock.js
@@ -19,6 +19,7 @@ export const item: ({|
 	monotony: {},
 	nutrition_link: '',
 	nutrition: {},
+	nutrition_details: {},
 	options: [],
 	rating: '',
 	special: special,

--- a/source/views/menus/lib/process-menu-shorthands.js
+++ b/source/views/menus/lib/process-menu-shorthands.js
@@ -29,6 +29,7 @@ export function upgradeMenuItem(
 			well_being: '',
 			well_being_image: '',
 		},
+		nutrition_details: {},
 		nutrition_link: '',
 		price: '',
 		rating: '',


### PR DESCRIPTION
We had the data all along -- and now we're going to do something with it! The menu returns the nutritional information for quite a lot of items, and this PR provides a detail view for displaying an in-depth look into the makeup of those food items.

This adds calories, serving size, fat, saturated fat, trans fat, cholesterol, sodium, carbohydrates, fiber, sugar, and protein counts. I've also made it clear on what each dietary icon means underneath the item title. I do not count on everyone to have used the filters so this tries to make it more explicit.

Closes #1609 

<hr>

The types of screenshots
* title only
* title, icons, and description
* title, icons, description, and nutrition
* title, icons and nutrition

**iOS**

~ | ~
--|--
<img width="414" alt="nothing" src="https://user-images.githubusercontent.com/5240843/44762028-c482f080-ab02-11e8-9d5e-fa7a36f5f09d.png"> |<img width="414" alt="description-no-nutrition" src="https://user-images.githubusercontent.com/5240843/44762020-c1880000-ab02-11e8-80c7-7869fc4bd279.png">
<img width="414" alt="icons-description-nutrition" src="https://user-images.githubusercontent.com/5240843/44762024-c2b92d00-ab02-11e8-8c59-648d08988795.png"> | <img width="414" alt="icons-nutrition" src="https://user-images.githubusercontent.com/5240843/44762027-c351c380-ab02-11e8-9c56-9ed63f1ba26d.png">


**Android**

~ | ~
--|--
![android-nothing](https://user-images.githubusercontent.com/5240843/44761486-9a303380-ab00-11e8-8b4f-fb0b334d3bb3.png) | ![android-description-no-nutrition](https://user-images.githubusercontent.com/5240843/44761488-9a303380-ab00-11e8-93aa-c484f1e77c43.png)
![android-icons-description-nutrition](https://user-images.githubusercontent.com/5240843/44761965-7cfc6480-ab02-11e8-9745-19cb3a779eb6.png) | ![android-icons-nutrition](https://user-images.githubusercontent.com/5240843/44761490-9a303380-ab00-11e8-99a1-83b72dfe797c.png)