### PR TITLE
use sto.purple for the iOS tab bar

### DIFF
--- a/source/lib/theme.js
+++ b/source/lib/theme.js
@@ -70,10 +70,7 @@ export const androidTabBarForeground = firstReadable(androidTabBarBackground, [
 
 // not used in the gui; just used for calculations
 const iosTabBarBackground = '#F7F7F7'
-export const iosTabBarActiveColor = firstReadable(iosTabBarBackground, [
-	accent,
-	sto.black,
-])
+export const iosTabBarActiveColor = sto.purple
 
 export const androidStatusBarColor = tinycolor(navigationBackground)
 	.darken(20)


### PR DESCRIPTION
See https://github.com/StoDevX/AAO-React-Native/issues/2742

So. iOS tab bar colors.

<dl><dt>Black</dt>
<dd>somehow works for iBooks; after having measured their colors again, I think they're using a "vibrant" tab bar (which we can't currently do) that tints more white when on a white background than our grey one. 

Sadly, black icons become nigh-indistinguishable from the grey icons at night / with tired eyes, _especially_ with Night Shift enabled.</dd>

<dt>Gold</dt>
<dd>I want to like gold. I can even rationalize an excuse to use it, even given the accessibility focus: something something it's an icon, and it's bigger, and maybe the text being black in the inactive state helps too. (parenthetical: I would feel better about this if our tab bar actually responded to the iOS accessibility settings, like long press to zoom the icon, but it doesn't.)

Unfortunately, it's ~9pm right now, and I already have to look twice to read the text on the icon. And night shift isn't even on yet! I think that if we use gold, I'll have to re-open https://github.com/StoDevX/AAO-React-Native/issues/2252.</dd>

<dt>Purple</dt>
<dd>Pros: It's the new St. Olaf secondary accent color, more or less, as it's used for all links on the website.

Cons: It's not gold or black, which makes it not as heavily associated with the brand yet.

I think it's readable, it's not affected by night shift, and it's easily distinguishable from the dark grey ones. Really, my only problem with it is that it's _new_ (lol).</dd>
</dl>

black | gold | purple
--- | --- | ---
<img width="487" alt="screen shot 2018-08-31 at 9 09 13 pm" src="https://user-images.githubusercontent.com/464441/44941421-c21ed180-ad62-11e8-8eaf-e905ad2f3398.png"> | <img width="487" alt="screen shot 2018-08-31 at 9 09 25 pm" src="https://user-images.githubusercontent.com/464441/44941422-c21ed180-ad62-11e8-857b-c6dca72a4723.png"> | <img width="487" alt="screen shot 2018-08-31 at 9 09 05 pm" src="https://user-images.githubusercontent.com/464441/44941423-c21ed180-ad62-11e8-8459-1c071b3ba76a.png">

---

My vote: purple.

Thoughts? @rye, @hannesmcman, @drewvolz.