### PR TITLE
Fix iOS search bar colors

### DIFF
--- a/modules/colors/platform.js
+++ b/modules/colors/platform.js
@@ -1,7 +1,6 @@
 import {Platform} from 'react-native'
-import {silver} from './index'
 
-export const iosGray = silver
+export const iosGray = 'rgb(241, 241, 242)'
 
 export const androidLightBackground = 'rgb(244, 244, 244)'
 export const androidSeparator = 'rgb(224, 224, 224)'

--- a/modules/listview/searchable-alphabet-listview.js
+++ b/modules/listview/searchable-alphabet-listview.js
@@ -5,6 +5,7 @@ import {StyleSheet, Platform, View} from 'react-native'
 import {StyledAlphabetListView} from './alphabet-listview'
 import debounce from 'lodash/debounce'
 import {SearchBar} from '@frogpond/searchbar'
+import {white} from '@frogpond/colors'
 
 export const LIST_HEADER_HEIGHT = Platform.OS === 'ios' ? 42 : 0
 
@@ -26,7 +27,12 @@ export class SearchableAlphabetListView extends React.Component<Props> {
 	render() {
 		return (
 			<View style={styles.wrapper}>
-				<SearchBar onChange={this.performSearch} value={this.props.query} />
+				<SearchBar
+					onChange={this.performSearch}
+					textFieldBackgroundColor={white}
+					value={this.props.query}
+				/>
+
 				<StyledAlphabetListView
 					headerHeight={
 						Platform.OS === 'ios'

--- a/modules/searchbar/searchbar.ios.js
+++ b/modules/searchbar/searchbar.ios.js
@@ -14,7 +14,6 @@ const styles = StyleSheet.create({
 
 export class SearchBar extends React.Component<Props> {
 	static defaultProps = {
-		backgroundColor: c.iosGray,
 		onCancel: () => {},
 		onChange: () => {},
 		onFocus: () => {},
@@ -41,7 +40,6 @@ export class SearchBar extends React.Component<Props> {
 			<NativeSearchBar
 				ref={this.handleRef}
 				autoCorrect={false}
-				barTintColor={this.props.backgroundColor}
 				hideBackground={true}
 				onCancelButtonPress={this.props.onCancel}
 				onChangeText={this.props.onChange}

--- a/modules/searchbar/searchbar.ios.js
+++ b/modules/searchbar/searchbar.ios.js
@@ -19,7 +19,7 @@ export class SearchBar extends React.Component<Props> {
 		onFocus: () => {},
 		onSubmit: () => {},
 		placeholder: 'Search',
-		textFieldBackgroundColor: null,
+		textFieldBackgroundColor: c.iosGray,
 		value: '',
 	}
 


### PR DESCRIPTION
Closes #2926 

Courses | SearchableAlphabetListView
--- | ---
<img width="487" alt="screen shot 2018-09-01 at 11 10 15 am" src="https://user-images.githubusercontent.com/464441/44947755-ab669200-add7-11e8-93e2-6f08691f7541.png"> | <img width="487" alt="screen shot 2018-09-01 at 11 10 22 am" src="https://user-images.githubusercontent.com/464441/44947754-ab669200-add7-11e8-8161-216070f0e6a2.png">

I took the new color from the iOS 11 Files app's search bar, so it should be accurate.