### PR TITLE
Add new module: <Timer/>

### DIFF
--- a/modules/timer/index.js
+++ b/modules/timer/index.js
@@ -9,7 +9,7 @@ type Props = {
 	timezone?: string,
 } & (
 	| {
-			moment?: true,
+			moment: true,
 			render: ({
 				now: moment,
 				loading: boolean,
@@ -17,7 +17,7 @@ type Props = {
 			}) => React.Node,
 	  }
 	| {
-			moment?: false,
+			moment: false,
 			render: ({
 				now: Date,
 				loading: boolean,

--- a/modules/timer/index.js
+++ b/modules/timer/index.js
@@ -1,0 +1,65 @@
+// @flow
+
+import * as React from 'react'
+import moment from 'moment'
+
+type Props = {
+	interval: number, // ms
+	render: ({now: Date}) => React.Node,
+	moment?: boolean,
+	timezone?: string,
+}
+
+type State = {
+	now: Date,
+}
+
+export class Timer extends React.Component<Props, State> {
+	_intervalId: ?IntervalID
+	_timeoutId: ?TimeoutID
+
+	state = {
+		now: new Date(),
+	}
+
+	componentDidMount() {
+		this._intervalId = setInterval(this.updateTime, this.props.interval)
+		// get the time remaining until the next $interval
+		let {interval} = this.props
+		let nowMs = this.state.now.getTime()
+		let untilNextInterval = interval - (nowMs % interval)
+
+		this._timeoutId = setTimeout(() => {
+			this.updateTime()
+			this._intervalId = setInterval(this.updateTime, this.props.interval)
+		}, untilNextInterval)
+	}
+
+	componentWillUnmount() {
+		if (this._timeoutId) {
+			clearTimeout(this._timeoutId)
+		}
+
+		if (this._intervalId) {
+			clearInterval(this._intervalId)
+		}
+	}
+
+	updateTime = () => {
+		this.setState(() => ({now: new Date()}))
+	}
+
+	render() {
+		let {now} = this.state
+
+		if (this.props.moment) {
+			now = moment(now)
+		}
+
+		if (this.props.timezone) {
+			now = now.tz(this.props.timezone)
+		}
+
+		return this.props.render({now})
+	}
+}

--- a/modules/timer/index.js
+++ b/modules/timer/index.js
@@ -7,6 +7,7 @@ import delay from 'delay'
 type Props = {
 	interval: number, // ms
 	timezone?: string,
+	invoke?: () => mixed,
 } & (
 	| {
 			moment: true,
@@ -91,6 +92,10 @@ export class Timer extends React.Component<Props, State> {
 			if (this.props.timezone) {
 				now = now.tz(this.props.timezone)
 			}
+		}
+
+		if (this.props.invoke) {
+			this.props.invoke()
 		}
 
 		return this.props.render({now, loading, refresh: this.refresh})

--- a/modules/timer/package.json
+++ b/modules/timer/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@frogpond/timer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC",
+  "scripts": {
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "react": "^16.4.2"
+  }
+}

--- a/modules/timer/package.json
+++ b/modules/timer/package.json
@@ -9,6 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2"
+    "react": "^16.4.2",
+    "moment-timezone": "^0.5.21"
   }
 }

--- a/source/views/building-hours/detail/index.js
+++ b/source/views/building-hours/detail/index.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import type {BuildingType} from '../types'
-import moment from 'moment-timezone'
+import {Timer} from '@frogpond/timer'
 import {BuildingDetail} from './building'
 import {CENTRAL_TZ} from '../lib'
 import type {TopLevelViewPropsType} from '../../types'
@@ -12,36 +12,13 @@ type Props = TopLevelViewPropsType & {
 	navigation: {state: {params: {building: BuildingType}}},
 }
 
-type State = {now: moment}
-
-export class BuildingHoursDetailView extends React.PureComponent<Props, State> {
+export class BuildingHoursDetailView extends React.Component<Props> {
 	static navigationOptions = ({navigation}: any) => {
 		const building = navigation.state.params.building
 		return {
 			title: building.name,
 			headerRight: <FavoriteButton buildingName={building.name} />,
 		}
-	}
-
-	_intervalId: ?IntervalID
-
-	state = {
-		// now: moment.tz('Wed 7:25pm', 'ddd h:mma', null, CENTRAL_TZ),
-		now: moment.tz(CENTRAL_TZ),
-	}
-
-	componentDidMount() {
-		// This updates the screen every second, so that the building
-		// info statuses are updated without needing to leave and come back.
-		this._intervalId = setInterval(this.updateTime, 1000)
-	}
-
-	componentWillUnmount() {
-		this._intervalId && clearInterval(this._intervalId)
-	}
-
-	updateTime = () => {
-		this.setState(() => ({now: moment.tz(CENTRAL_TZ)}))
 	}
 
 	reportProblem = () => {
@@ -52,13 +29,19 @@ export class BuildingHoursDetailView extends React.PureComponent<Props, State> {
 
 	render() {
 		const info = this.props.navigation.state.params.building
-		const {now} = this.state
 
 		return (
-			<BuildingDetail
-				info={info}
-				now={now}
-				onProblemReport={this.reportProblem}
+			<Timer
+				interval={60000}
+				moment={true}
+				render={({now}) => (
+					<BuildingDetail
+						info={info}
+						now={now}
+						onProblemReport={this.reportProblem}
+					/>
+				)}
+				timezone={CENTRAL_TZ}
 			/>
 		)
 	}

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -43,12 +43,12 @@ type ReduxStateProps = {
 
 type Props = TopLevelViewPropsType & ReduxStateProps
 
-type State = {
+type State = {|
 	error: ?Error,
 	loading: boolean,
 	buildings: Array<{title: string, data: Array<BuildingType>}>,
 	allBuildings: Array<BuildingType>,
-}
+|}
 
 export class BuildingHoursView extends React.PureComponent<Props, State> {
 	static navigationOptions = {
@@ -61,7 +61,6 @@ export class BuildingHoursView extends React.PureComponent<Props, State> {
 		loading: false,
 		buildings: groupBuildings(defaultData.data, this.props.favoriteBuildings),
 		allBuildings: defaultData.data,
-		intervalId: null,
 	}
 
 	static getDerivedStateFromProps(nextProps: Props, prevState: State) {

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -113,7 +113,7 @@ export class BuildingHoursView extends React.PureComponent<Props, State> {
 
 		return (
 			<Timer
-				interval={1000}
+				interval={60000}
 				moment={true}
 				render={({now}) => (
 					<BuildingHoursList

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -5,7 +5,6 @@ import {NoticeView} from '@frogpond/notice'
 import {BuildingHoursList} from './list'
 import {type ReduxState} from '../../redux'
 import {connect} from 'react-redux'
-import moment from 'moment-timezone'
 import type {TopLevelViewPropsType} from '../types'
 import type {BuildingType} from './types'
 import * as defaultData from '../../../docs/building-hours.json'
@@ -15,6 +14,7 @@ import groupBy from 'lodash/groupBy'
 import delay from 'delay'
 import {CENTRAL_TZ} from './lib'
 import {API} from '@frogpond/api'
+import {Timer} from '@frogpond/timer'
 
 const buildingHoursUrl = API('/spaces/hours')
 
@@ -46,7 +46,6 @@ type Props = TopLevelViewPropsType & ReduxStateProps
 type State = {
 	error: ?Error,
 	loading: boolean,
-	now: moment,
 	buildings: Array<{title: string, data: Array<BuildingType>}>,
 	allBuildings: Array<BuildingType>,
 }
@@ -57,13 +56,9 @@ export class BuildingHoursView extends React.PureComponent<Props, State> {
 		headerBackTitle: 'Hours',
 	}
 
-	_intervalId: ?IntervalID
-
 	state = {
 		error: null,
 		loading: false,
-		// now: moment.tz('Wed 7:25pm', 'ddd h:mma', null, CENTRAL_TZ),
-		now: moment.tz(CENTRAL_TZ),
 		buildings: groupBuildings(defaultData.data, this.props.favoriteBuildings),
 		allBuildings: defaultData.data,
 		intervalId: null,
@@ -80,18 +75,6 @@ export class BuildingHoursView extends React.PureComponent<Props, State> {
 
 	componentDidMount() {
 		this.fetchData()
-
-		// This updates the screen every second, so that the building
-		// info statuses are updated without needing to leave and come back.
-		this._intervalId = setInterval(this.updateTime, 1000)
-	}
-
-	componentWillUnmount() {
-		this._intervalId && clearInterval(this._intervalId)
-	}
-
-	updateTime = () => {
-		this.setState(() => ({now: moment.tz(CENTRAL_TZ)}))
 	}
 
 	refresh = async (): any => {
@@ -120,7 +103,6 @@ export class BuildingHoursView extends React.PureComponent<Props, State> {
 		this.setState(() => ({
 			buildings: groupBuildings(buildings, this.props.favoriteBuildings),
 			allBuildings: buildings,
-			now: moment.tz(CENTRAL_TZ),
 		}))
 	}
 
@@ -130,12 +112,19 @@ export class BuildingHoursView extends React.PureComponent<Props, State> {
 		}
 
 		return (
-			<BuildingHoursList
-				buildings={this.state.buildings}
-				loading={this.state.loading}
-				navigation={this.props.navigation}
-				now={this.state.now}
-				onRefresh={this.refresh}
+			<Timer
+				interval={1000}
+				moment={true}
+				render={({now}) => (
+					<BuildingHoursList
+						buildings={this.state.buildings}
+						loading={this.state.loading}
+						navigation={this.props.navigation}
+						now={now}
+						onRefresh={this.refresh}
+					/>
+				)}
+				timezone={CENTRAL_TZ}
 			/>
 		)
 	}

--- a/source/views/stoprint/components/error.js
+++ b/source/views/stoprint/components/error.js
@@ -6,7 +6,7 @@ import {ScrollView, RefreshControl, StyleSheet, Platform} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {NoticeView} from '@frogpond/notice'
 import {sto} from '../../../lib/colors'
-import delay from 'delay'
+import {Timer} from '@frogpond/timer'
 
 const ERROR_MESSAGE =
 	"Make sure you are connected to the St. Olaf Network via eduroam or the VPN. If you are, please report this so we can make sure it doesn't happen again."
@@ -16,66 +16,38 @@ type Props = TopLevelViewPropsType & {
 	statusMessage: string,
 }
 
-type State = {
-	refreshing: boolean,
-}
-
-export class StoPrintErrorView extends React.PureComponent<Props, State> {
-	_timer: ?IntervalID
-
-	state = {
-		refreshing: false,
-	}
-
-	componentDidMount() {
-		this._timer = setInterval(this.props.refresh, 5000)
-	}
-
-	componentWillUnmount() {
-		if (this._timer) {
-			clearInterval(this._timer)
-		}
-	}
-
-	_refresh = async () => {
-		this.setState(() => ({refreshing: true}))
-		let start = Date.now()
-
-		await this.props.refresh()
-
-		let elapsed = start - Date.now()
-		if (elapsed < 500) {
-			await delay(500 - elapsed)
-		}
-		this.setState(() => ({refreshing: false}))
-	}
-
+export class StoPrintErrorView extends React.PureComponent<Props> {
 	render() {
 		const iconName = Platform.select({
 			ios: 'ios-bug',
 			android: 'md-bug',
 		})
+
 		return (
-			<ScrollView
-				contentContainerStyle={styles.content}
-				refreshControl={
-					<RefreshControl
-						onRefresh={this._refresh}
-						refreshing={this.state.refreshing}
-					/>
-				}
-				showsVerticalScrollIndicator={false}
-				style={styles.container}
-			>
-				<Icon color={sto.black} name={iconName} size={100} />
-				<NoticeView
-					buttonText="Report"
-					header="Connection Issue"
-					onPress={() => this.props.navigation.navigate('HelpView')}
-					style={styles.notice}
-					text={`${this.props.statusMessage} ${ERROR_MESSAGE}`}
-				/>
-			</ScrollView>
+			<Timer
+				interval={5000}
+				invoke={this.props.refresh}
+				moment={false}
+				render={({refresh, loading}) => (
+					<ScrollView
+						contentContainerStyle={styles.content}
+						refreshControl={
+							<RefreshControl onRefresh={refresh} refreshing={loading} />
+						}
+						showsVerticalScrollIndicator={false}
+						style={styles.container}
+					>
+						<Icon color={sto.black} name={iconName} size={100} />
+						<NoticeView
+							buttonText="Report"
+							header="Connection Issue"
+							onPress={() => this.props.navigation.navigate('HelpView')}
+							style={styles.notice}
+							text={`${this.props.statusMessage} ${ERROR_MESSAGE}`}
+						/>
+					</ScrollView>
+				)}
+			/>
 		)
 	}
 }

--- a/source/views/stoprint/components/notice.js
+++ b/source/views/stoprint/components/notice.js
@@ -11,7 +11,7 @@ import {
 import Icon from 'react-native-vector-icons/Ionicons'
 import {NoticeView} from '@frogpond/notice'
 import {sto} from '../../../lib/colors'
-import delay from 'delay'
+import {Timer} from '@frogpond/timer'
 
 type Props = {
 	buttonText: string,
@@ -22,70 +22,42 @@ type Props = {
 	text: string,
 }
 
-type State = {
-	refreshing: boolean,
-}
-
-export class StoPrintNoticeView extends React.PureComponent<Props, State> {
-	_timer: ?IntervalID
-
-	state = {
-		refreshing: false,
-	}
-
-	componentDidMount() {
-		this._timer = setInterval(this.props.refresh, 5000)
-	}
-
-	componentWillUnmount() {
-		if (this._timer) {
-			clearInterval(this._timer)
-		}
-	}
-
-	_refresh = async () => {
-		this.setState(() => ({refreshing: true}))
-		let start = Date.now()
-
-		await this.props.refresh()
-
-		let elapsed = start - Date.now()
-		if (elapsed < 500) {
-			await delay(500 - elapsed)
-		}
-		this.setState(() => ({refreshing: false}))
-	}
-
+export class StoPrintNoticeView extends React.PureComponent<Props> {
 	render() {
 		const {buttonText, description, header, onPress, text} = this.props
+
 		return (
-			<ScrollView
-				contentContainerStyle={styles.content}
-				refreshControl={
-					<RefreshControl
-						onRefresh={this._refresh}
-						refreshing={this.state.refreshing}
-					/>
-				}
-				showsVerticalScrollIndicator={false}
-				style={styles.container}
-			>
-				<Icon
-					color={sto.black}
-					name={Platform.OS === 'ios' ? 'ios-print' : 'md-print'}
-					size={100}
-				/>
-				<NoticeView
-					buttonText={buttonText}
-					header={header}
-					onPress={onPress}
-					style={styles.notice}
-					text={text}
-				/>
-				{description ? (
-					<Text style={styles.description}>{description}</Text>
-				) : null}
-			</ScrollView>
+			<Timer
+				interval={5000}
+				invoke={this.props.refresh}
+				moment={false}
+				render={({refresh, loading}) => (
+					<ScrollView
+						contentContainerStyle={styles.content}
+						refreshControl={
+							<RefreshControl onRefresh={refresh} refreshing={loading} />
+						}
+						showsVerticalScrollIndicator={false}
+						style={styles.container}
+					>
+						<Icon
+							color={sto.black}
+							name={Platform.OS === 'ios' ? 'ios-print' : 'md-print'}
+							size={100}
+						/>
+						<NoticeView
+							buttonText={buttonText}
+							header={header}
+							onPress={onPress}
+							style={styles.notice}
+							text={text}
+						/>
+						{description ? (
+							<Text style={styles.description}>{description}</Text>
+						) : null}
+					</ScrollView>
+				)}
+			/>
 		)
 	}
 }


### PR DESCRIPTION
Usage: 

```jsx
<Timer
    interval={60000} // ms
    moment={true} // if you want a moment instance
    render={({now, refresh, loading}) => <Text>{now.calendar()}</Text>}
    timezone="America/Central" // if you want a moment-timezone instance
/>
```

The only component that didn't get significantly smaller was the Bus Map; the others all shrank by ~30sloc.

For more usage descriptions, please see the diffs.

For StoPrint, I think we can do, like

```js
renderItem = ({item}: {item: PrintJob}) => (
		<ListRow onPress={() => this.handleJobPress(item)}>
			<Title>{item.documentName}</Title>
			<Detail>
				<Timer interval={60000} moment={true} render={({now}) => <Text>{now.diff(moment(item.usageTimeFormatted, etc))}</Text>} timezone={CENTRAL_TZ} /> {' • '} {item.usageCostFormatted} {' • '}
				{item.totalPages} {item.totalPages === 1 ? 'page' : 'pages'} {'\n'}
				{item.statusFormatted}
			</Detail>
		</ListRow>
	)
```

or something.