### PR TITLE
Circle: Use Ruby 2.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ x-config:
   x-commands:  # command shorthands
     - &set-ruby-version
       name: Set Ruby Version
-      command: echo "ruby-2.4.2" > ~/.ruby-version
+      command: echo "ruby-2.5.1" > ~/.ruby-version
     - &run-danger
       command: |
         if ! [[ $CIRCLE_PR_NUMBER ]]; then


### PR DESCRIPTION
This _might_ work? Otherwise we can keep 2.4, but upgrade to 2.4.4.

Should be perfectly fine to do this, though.  This only affects Fastlane-y stuff anyways.