### PR TITLE
Tweak filter buttons to be closable on entire button

### DIFF
--- a/modules/filter/active-filter-button.js
+++ b/modules/filter/active-filter-button.js
@@ -33,12 +33,12 @@ function ActiveFilterButton({filter, label, onRemove, style, theme}: Props) {
 	const iconColor = white
 
 	return (
-		<View style={[styles.badge, background, style]}>
-			<Text style={[styles.text, foreground]}>{label}</Text>
-			<TouchableWithoutFeedback onPress={() => onRemove(filter)}>
+		<TouchableWithoutFeedback onPress={() => onRemove(filter)}>
+			<View style={[styles.badge, background, style]}>
+				<Text style={[styles.text, foreground]}>{label}</Text>
 				<Icon color={iconColor} name={iconName} size={20} />
-			</TouchableWithoutFeedback>
-		</View>
+			</View>
+		</TouchableWithoutFeedback>
 	)
 }
 


### PR DESCRIPTION
Makes it a bit easter to manage the list of active filters as the touch target seems too small. Instead of the close button serving as the only surface to close an active filter button, the whole button now can be used to dismiss.