### PR TITLE
Update timer interval to 5 seconds across the board

### DIFF
--- a/source/views/building-hours/detail/index.js
+++ b/source/views/building-hours/detail/index.js
@@ -32,7 +32,7 @@ export class BuildingHoursDetailView extends React.Component<Props> {
 
 		return (
 			<Timer
-				interval={60000}
+				interval={5000}
 				moment={true}
 				render={({now}) => (
 					<BuildingDetail

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -112,7 +112,7 @@ export class BuildingHoursView extends React.PureComponent<Props, State> {
 
 		return (
 			<Timer
-				interval={60000}
+				interval={5000}
 				moment={true}
 				render={({now}) => (
 					<BuildingHoursList

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -97,7 +97,7 @@ class PrintJobsView extends React.PureComponent<Props, State> {
 
 	renderItem = ({item}: {item: PrintJob}) => (
 		<Timer
-			interval={60000}
+			interval={5000}
 			moment={true}
 			render={({now}) => (
 				<ListRow onPress={() => this.handleJobPress(item)}>

--- a/source/views/transportation/bus/map.js
+++ b/source/views/transportation/bus/map.js
@@ -32,7 +32,7 @@ export function BusMap(props: WrapperProps) {
 
 	return (
 		<Timer
-			interval={60000}
+			interval={5000}
 			moment={true}
 			render={({now}) => <Map line={lineToDisplay} now={now} />}
 			timezone={TIMEZONE}

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -73,7 +73,7 @@ export class BusView extends React.PureComponent<Props, State> {
 
 		return (
 			<Timer
-				interval={60000}
+				interval={5000}
 				moment={true}
 				render={({now, refresh, loading}) => (
 					<BusLine


### PR DESCRIPTION
In #2943, a `Timer` component was introduced to make intervals friendlier. Some of the views had their intervals changed to intervals of a minute. This does not work so well when they depend upon "near instant" updates.

Rather than update views like `BuildingHours` and `BusSchedules` at an interval of a minute or every second (which is what we had prior to the `Timer` component), I propose to set the interval across the board to 5 seconds.

I do not think 20 checks a minute is out of the question, and it does not feel like overkill.

Thoughts? Concerns? Approvals?