### PR TITLE
Move google repo to top of the list on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,20 +21,20 @@ ext {
 
 allprojects {
     repositories {
-        google()
-        mavenLocal()
-        jcenter()
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
         maven {
-            // react-native-custom-tabs requires this maven repository
-            url "https://jitpack.io"
-        }
-        maven {
             // Local Maven repo containing AARs with JSC library built for Android, like RN
             url "$rootDir/../node_modules/jsc-android/dist"
+        }
+        mavenLocal()
+        google()
+        jcenter()
+        maven {
+            // react-native-custom-tabs requires this maven repository
+            url "https://jitpack.io"
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,6 +21,7 @@ ext {
 
 allprojects {
     repositories {
+        google()
         mavenLocal()
         jcenter()
         maven {
@@ -35,6 +36,5 @@ allprojects {
             // Local Maven repo containing AARs with JSC library built for Android, like RN
             url "$rootDir/../node_modules/jsc-android/dist"
         }
-        google()
     }
 }


### PR DESCRIPTION
I have no idea why this might work besides priority being messed up? All I know is that I don't like it at the bottom of the list.  We'll see if `react-native android` can finally resolve `com.android.tools.lint.lint-gradle`.