### PR TITLE
Fix get-urls@8 crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "tinycolor2": "1.4.1",
     "titlecase": "1.1.2",
     "url": "0.11.0",
+    "whatwg-url": "7.0.0",
     "wordwrap": "1.0.0"
   },
   "devDependencies": {

--- a/source/app.js
+++ b/source/app.js
@@ -1,5 +1,9 @@
 // @flow
 
+// monkey-patches
+import './init/global--buffer'
+
+// initialization
 import './init/constants'
 import './init/fetch'
 import './init/moment'

--- a/source/app.js
+++ b/source/app.js
@@ -2,6 +2,7 @@
 
 // monkey-patches
 import './init/global--buffer'
+import './init/monkey-patch--url'
 
 // initialization
 import './init/constants'

--- a/source/init/global--buffer.js
+++ b/source/init/global--buffer.js
@@ -1,0 +1,10 @@
+// @flow
+
+/*
+ * Put `Buffer` into the global namespace for nodejs code that expects it to
+ * exist there.
+ */
+
+import {Buffer} from 'buffer'
+
+global.Buffer = Buffer

--- a/source/init/monkey-patch--url.js
+++ b/source/init/monkey-patch--url.js
@@ -1,0 +1,26 @@
+// @flow
+
+/*
+ * Monkey-patch RN's URL global.
+ *
+ * A history: get-urls@8 requires normalize-url@2, which uses the new
+ * window.URL global object for URL parsing.
+ *
+ * RN provides a global URL object… but only puts two things into it.
+ *
+ * The JSDOM project maintains a browser-compatible URL module.
+ *
+ * Thus, we stick that into the global namespace, and monkey-patch RN's
+ * two non-standard methods onto it so as to not break either things that
+ * expect web!URL or RN!URL objects.
+ */
+
+import {URL, URLSearchParams} from 'whatwg-url'
+
+let RNURL = global.URL;
+
+URL.createObjectURL = RNURL.createObjectURL;
+URL.revokeObjectURL = RNURL.revokeObjectURL;
+
+global.URL = URL;
+global.URLSearchParams = URLSearchParams;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7226,7 +7226,7 @@ tough-cookie@>=2.3.3, tough-cookie@^2.2.0, tough-cookie@^2.3.3, tough-cookie@~2.
     psl "^1.1.24"
     punycode "^1.4.1"
 
-tr46@^1.0.0:
+tr46@^1.0.0, tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   dependencies:
@@ -7450,6 +7450,14 @@ whatwg-url-compat@~0.6.5:
   resolved "https://registry.yarnpkg.com/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz#00898111af689bb097541cd5a45ca6c8798445bf"
   dependencies:
     tr46 "~0.0.1"
+
+whatwg-url@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 whatwg-url@^6.3.0:
   version "6.4.0"


### PR DESCRIPTION
Supercedes #2989 

A summary of my journey:
- get-urls@8 depends on normalize-url@2, which uses the [URL global](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)
- React Native [creates an URL global](https://github.com/facebook/react-native/blob/master/Libraries/Blob/URL.js)… but only populates it with two methods
- JSDOM maintains a [whatwg-url](https://www.npmjs.com/package/whatwg-url) package, which is a spec-compliant URL global
- Because it's intended for JSDOM/Node, it happens to depend on the global `Buffer` object

What I wound up doing: 
- add `global.Buffer` so that whatwg-url can use it
- replace `global.URL` with whatwg-url
- monkey-patch the two non-standard RN methods onto whatwg-url's URL export

This fixes the issue, according to my manual testing.

I have not written a test for this simply because we don't have the infrastructure for that quite yet. I can't just use Jest, because that runs in either a JSDOM-compatible or Node-compatible environment, both of which have appropriate URL globals, and we don't yet have any "testing" screens in Detox for an e2e test, which is approximately what we'd need for this to be accurately tested.