### PR TITLE
Downgrade react-native-vector-icons to retain the outlined icons

### DIFF
--- a/modules/filter/package.json
+++ b/modules/filter/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "react": "^16.4.2",
     "react-native": "^0.55.4",
-    "react-native-vector-icons": "^5.0.0",
+    "react-native-vector-icons": "^4.0.0",
     "react-native-popover-view": "^1.0.7"
   },
   "dependencies": {

--- a/modules/food-menu/package.json
+++ b/modules/food-menu/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "react": "^16.4.2",
     "react-native": "^0.55.4",
-    "react-native-vector-icons": "^5.0.0",
+    "react-native-vector-icons": "^4.0.0",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.21"
   },

--- a/modules/lists/package.json
+++ b/modules/lists/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "react": "^16.4.2",
     "react-native": "^0.55.4",
-    "react-native-vector-icons": "^5.0.0"
+    "react-native-vector-icons": "^4.0.0"
   },
   "dependencies": {
     "@callstack/react-theme-provider": "^1.0.3",

--- a/modules/navigation-tabs/package.json
+++ b/modules/navigation-tabs/package.json
@@ -12,7 +12,7 @@
     "@frogpond/app-theme": "^1.0.0",
     "react": "^16.4.2",
     "react-native": "^0.55.4",
-    "react-native-vector-icons": "^5.0.0",
+    "react-native-vector-icons": "^4.0.0",
     "react-navigation": "^2.11.2",
     "react-navigation-material-bottom-tabs": "^0.3.0"
   }

--- a/modules/searchbar/package.json
+++ b/modules/searchbar/package.json
@@ -13,7 +13,7 @@
     "react-native": "^0.55.4",
     "react-native-search-bar": "^3.4.2",
     "react-native-searchbar-controlled": "^1.0.0",
-    "react-native-vector-icons": "^5.0.0"
+    "react-native-vector-icons": "^4.0.0"
   },
   "dependencies": {
     "@frogpond/colors": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "ignore": [
       "flow-bin",
       "react-markdown",
-      "react"
+      "react",
+      "react-test-renderer",
+      "react-native-vector-icons"
     ]
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "react-native-searchbar-controlled": "1.0.0",
     "react-native-tableview-simple": "0.17.5",
     "react-native-typography": "1.3.0",
-    "react-native-vector-icons": "5.0.0",
+    "react-native-vector-icons": "4.6.0",
     "react-navigation": "2.13.0",
     "react-navigation-material-bottom-tabs": "0.3.0",
     "react-redux": "5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6038,15 +6038,7 @@ react-native-typography@1.3.0, react-native-typography@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/react-native-typography/-/react-native-typography-1.3.0.tgz#ae921c141ab1dfdf4335ebc2b4a146bcf7919b36"
 
-react-native-vector-icons@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-5.0.0.tgz#d0bd6fdda01159db409810718dd04904951a98f5"
-  dependencies:
-    lodash "^4.0.0"
-    prop-types "^15.5.10"
-    yargs "^8.0.2"
-
-react-native-vector-icons@^4.4.2:
+react-native-vector-icons@4.6.0, react-native-vector-icons@^4.4.2:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.6.0.tgz#e4014311ffa6de397d914ffc31b7097a874cc8d5"
   dependencies:


### PR DESCRIPTION
Closes #2980 
Makes Hawken happy

---

`react-native-vector-icons@5` upgraded Ionicons to v4.0.

`ionicons@4` removed almost all of the outlined icons, because Apple's _starting_ to move away from them.

But… they removed too many. The iOS Share icon, for instance, should still be outlined, but they took it away 😭. 

We don't need any of the changes in rnvi@5, so I'm just downgrading to v4.6 to get back the outlined icons.

Before | After
--- | ---
![screen shot 2018-09-08 at 6 56 25 pm](https://user-images.githubusercontent.com/464441/45259739-ea2cb700-b398-11e8-8dab-9363fb587d52.png)| ![screen shot 2018-09-08 at 5 37 28 pm](https://user-images.githubusercontent.com/464441/45259720-8bffd400-b398-11e8-8379-0c5cd993ca68.png)
