### PR TITLE
Make danger fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,7 @@ jobs:
             touch logs/prettier  # to ensure that the file exists
             if ! git diff --quiet *.js source/ scripts/; then
               git diff *.js source/ scripts/ | tee logs/prettier
+              exit 1
             fi
       - run: *run-danger
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ios": "react-native run-ios",
     "ios:release": "react-native run-ios --configuration Release",
     "ios-simulator": "xcrun instruments -s devices | peco --select-1 --query 'Simulator iPhone' --on-cancel error | sed  's~.*\\[\\(.*\\)\\].*~\\1~' | xargs open -n -a Simulator --args -CurrentDeviceUDID",
-    "lint": "eslint --cache source/ modules/ scripts/ *.js",
+    "lint": "eslint --report-unused-disable-directives --max-warnings=0 --cache source/ modules/ scripts/ *.js",
     "prepare": "sed -i.bak 's/\\(_backedTextInputView.scrollEnabled = \\)YES;/\\1NO;/' node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m",
     "prettier": "prettier --write '{source,modules,scripts,e2e}/**/*.{js,json}' 'data/**/*.css' '*.js'",
     "prettier:changed": "pretty-quick",

--- a/source/views/news/index.js
+++ b/source/views/news/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 // @flow
 
 import * as React from 'react'


### PR DESCRIPTION
Closes #2993 

Prettier and ESLint's Circle jobs both would never exit with a non-0 status code, which meant that the jobs would never fail.

Danger does not run if a PR hasn't been opened when it runs, because it would have nowhere to comment.

## Solutions:

1. Enable this Circle option:
    > **Only build pull requests**
    > By default, we will build all the commits for this project. Once turned on, we will only build branches that have associated pull requests open. Note: For your default branch, we will always build all commits.

    I don't really want to do that, as it delays the build start time by how long it takes you to write a PR.

2. Make ESLint and Prettier exit with non-0 status codes

    This is the option I chose, with the `--max-warnings=0` flag to ensure that all warnings are dealt with before merging. (I don't want to just make them errors, because they get colored differently in my editor and I find the two colors helpful).

You can see and compare a [failing build][f] with a [passing build][p].

[f]: https://circleci.com/workflow-run/27e1cbad-4a67-4c6b-8b78-07e1cc59c6ef
[p]: https://circleci.com/workflow-run/23e9f9b8-d871-4124-a37e-bce1507fdb51