### PR TITLE
Remove unused break schedules

### DIFF
--- a/data/building-hours/1-1-cage.yaml
+++ b/data/building-hours/1-1-cage.yaml
@@ -21,8 +21,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '3:00pm'}
-        - {days: [Fr], from: '7:30am', to: '1:00pm'}
+  summer: []

--- a/data/building-hours/1-2-pause-kitchen.yaml
+++ b/data/building-hours/1-2-pause-kitchen.yaml
@@ -29,7 +29,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      notes: The Pause Kitchen is closed for the summer.
-      hours: []
+  summer: []

--- a/data/building-hours/1-4-bag-lunch-line.yaml
+++ b/data/building-hours/1-4-bag-lunch-line.yaml
@@ -13,7 +13,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours: []
-      notes: The Bag Lunch line is closed for the summer.
+  summer: []

--- a/data/building-hours/10-admissions.yaml
+++ b/data/building-hours/10-admissions.yaml
@@ -16,8 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/10-business-office.yaml
+++ b/data/building-hours/10-business-office.yaml
@@ -15,8 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:00pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/10-cmie.yaml
+++ b/data/building-hours/10-cmie.yaml
@@ -16,7 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours: []
-      notes: The CMIE is closed for the summer.
+  summer: []

--- a/data/building-hours/10-conferences-camps-events.yaml
+++ b/data/building-hours/10-conferences-camps-events.yaml
@@ -15,8 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:00pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/10-financial-aid.yaml
+++ b/data/building-hours/10-financial-aid.yaml
@@ -15,8 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/10-osa.yaml
+++ b/data/building-hours/10-osa.yaml
@@ -16,8 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/10-pastor-office.yaml
+++ b/data/building-hours/10-pastor-office.yaml
@@ -15,8 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:00pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/10-piper-center.yaml
+++ b/data/building-hours/10-piper-center.yaml
@@ -16,8 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:00pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/10-registrar.yaml
+++ b/data/building-hours/10-registrar.yaml
@@ -15,8 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/2-1-bookstore.yaml
+++ b/data/building-hours/2-1-bookstore.yaml
@@ -15,7 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '8:00am', to: '4:30pm'}
+  summer: []

--- a/data/building-hours/2-2-convenience-store.yaml
+++ b/data/building-hours/2-2-convenience-store.yaml
@@ -16,7 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours: []
-      notes: The convenience store is closed for the summer? They should be open whenever the bookstore is open.
+  summer: []

--- a/data/building-hours/3-1-post-office.yaml
+++ b/data/building-hours/3-1-post-office.yaml
@@ -16,8 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '8:00am', to: '3:00pm'}
-        - {days: [Fr], from: '8:00am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/3-2-print-center.yaml
+++ b/data/building-hours/3-2-print-center.yaml
@@ -17,8 +17,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '8:00am', to: '3:00pm'}
-        - {days: [Fr], from: '8:00am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/4-1-disco.yaml
+++ b/data/building-hours/4-1-disco.yaml
@@ -21,8 +21,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/4-2-halvorson-music-library.yaml
+++ b/data/building-hours/4-2-halvorson-music-library.yaml
@@ -20,9 +20,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '10:00am', to: '12:00pm'}
-        - {days: [Mo, Tu, We, Th], from: '1:00pm', to: '3:00pm'}
-        - {days: [Fr], from: '10:00am', to: '1:00pm'}
+  summer: []

--- a/data/building-hours/4-3-rølvaag-library.yaml
+++ b/data/building-hours/4-3-rølvaag-library.yaml
@@ -19,8 +19,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '5:00pm'}
-        - {days: [Fr], from: '7:30am', to: '1:00pm'}
+  summer: []

--- a/data/building-hours/4-4-rølvaag-reference-desk.yaml
+++ b/data/building-hours/4-4-rølvaag-reference-desk.yaml
@@ -19,8 +19,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '5:00pm'}
-        - {days: [Fr], from: '7:30am', to: '1:00pm'}
+  summer: []

--- a/data/building-hours/5-1-it-helpdesk.yaml
+++ b/data/building-hours/5-1-it-helpdesk.yaml
@@ -17,8 +17,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-        - {days: [Fr], from: '7:45am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/5-2-asc.yaml
+++ b/data/building-hours/5-2-asc.yaml
@@ -17,8 +17,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:30am', to: '4:30pm'}
-        - {days: [Fr], from: '7:30am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/5-3-asc-speaking-space.yaml
+++ b/data/building-hours/5-3-asc-speaking-space.yaml
@@ -16,7 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours: []
-      notes: The Speaking Space is closed for the summer.
+  summer: []

--- a/data/building-hours/5-4-asc-writing-desk.yaml
+++ b/data/building-hours/5-4-asc-writing-desk.yaml
@@ -19,7 +19,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours: []
-      notes: The Writing Desk is closed for the summer.
+  summer: []

--- a/data/building-hours/6-1-skoglund.yaml
+++ b/data/building-hours/6-1-skoglund.yaml
@@ -17,8 +17,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '8:00am', to: '7:00pm'}
-        - {days: [Fr], from: '8:00am', to: '2:00pm'}
+  summer: []

--- a/data/building-hours/6-2-skoglund-pool.yaml
+++ b/data/building-hours/6-2-skoglund-pool.yaml
@@ -19,7 +19,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Lap Swim
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '6:00pm', to: '7:00pm'}
+  summer: []

--- a/data/building-hours/6-3-storp.yaml
+++ b/data/building-hours/6-3-storp.yaml
@@ -15,7 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Th], from: '4:00pm', to: '6:00pm'}
+  summer: []

--- a/data/building-hours/6-4-tom-porter.yaml
+++ b/data/building-hours/6-4-tom-porter.yaml
@@ -14,7 +14,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:30am', to: '5:15pm'}
+  summer: []

--- a/data/building-hours/6-5-tostrud-climbing-wall.yaml
+++ b/data/building-hours/6-5-tostrud-climbing-wall.yaml
@@ -17,7 +17,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, We], from: '4:30pm', to: '6:30pm'}
+  summer: []

--- a/data/building-hours/7-1-wellness-center.yaml
+++ b/data/building-hours/7-1-wellness-center.yaml
@@ -15,7 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours: []
-      notes: The Wellness Center is closed for the summer?
+  summer: []

--- a/data/building-hours/7-2-health-services.yaml
+++ b/data/building-hours/7-2-health-services.yaml
@@ -16,7 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours: []
-      notes: Health Services is closed for the summer.
+  summer: []

--- a/data/building-hours/7-3-sarn.yaml
+++ b/data/building-hours/7-3-sarn.yaml
@@ -23,7 +23,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Office
-      hours: []
-      notes: The SARN office is closed for the summer?
+  summer: []

--- a/data/building-hours/7-4-gender-sexuality-center.yaml
+++ b/data/building-hours/7-4-gender-sexuality-center.yaml
@@ -15,7 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Office
-      hours: []
-      notes: The Gender & Sexuality Center is closed for the summer?
+  summer: []

--- a/data/building-hours/8-alh.yaml
+++ b/data/building-hours/8-alh.yaml
@@ -14,8 +14,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:00am', to: '4:30pm'}
-        - {days: [Fr], from: '7:00am', to: '12:00pm'}
+  summer: []

--- a/data/building-hours/8-bc.yaml
+++ b/data/building-hours/8-bc.yaml
@@ -15,8 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:00am', to: '10:00pm'}
-        - {days: [Fr, Sa, Su], from: '7:00am', to: '7:00pm'}
+  summer: []

--- a/data/building-hours/8-boe.yaml
+++ b/data/building-hours/8-boe.yaml
@@ -16,9 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:00am', to: '10:00pm'}
-        - {days: [Fr], from: '7:00am', to: '8:00pm'}
-        - {days: [Sa], from: '9:00am', to: '8:00pm'}
+  summer: []

--- a/data/building-hours/8-cad.yaml
+++ b/data/building-hours/8-cad.yaml
@@ -16,8 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '8:00pm'}
-        - {days: [Sa], from: '9:00am', to: '3:00pm'}
+  summer: []

--- a/data/building-hours/8-chm.yaml
+++ b/data/building-hours/8-chm.yaml
@@ -17,8 +17,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '10:00pm'}
-        - {days: [Sa, Su], from: '12:00pm', to: '10:00pm'}
+  summer: []

--- a/data/building-hours/8-hh.yaml
+++ b/data/building-hours/8-hh.yaml
@@ -15,7 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
+  summer: []

--- a/data/building-hours/8-hom.yaml
+++ b/data/building-hours/8-hom.yaml
@@ -17,8 +17,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '10:00pm'}
-        - {days: [Sa, Su], from: '12:00pm', to: '10:00pm'}
+  summer: []

--- a/data/building-hours/8-omh.yaml
+++ b/data/building-hours/8-omh.yaml
@@ -15,7 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
+  summer: []

--- a/data/building-hours/8-rms.yaml
+++ b/data/building-hours/8-rms.yaml
@@ -15,10 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:00am', to: '10:00pm'}
-        - {days: [Fr], from: '7:00am', to: '8:00pm'}
-        - {days: [Sa], from: '9:00am', to: '8:00pm'}
-        - {days: [Su], from: '9:00am', to: '10:00pm'}
+  summer: []

--- a/data/building-hours/8-rns.yaml
+++ b/data/building-hours/8-rns.yaml
@@ -9,47 +9,10 @@ schedule:
       - {days: [Mo, Tu, We, Th, Fr, Sa, Su], from: '7:00am', to: '10:00pm'}
 
 breakSchedule:
-  fall:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '12:00am'}
-        - {days: [Sa, Su], from: '8:00am', to: '12:00am'}
-
-  thanksgiving:
-    - title: Hours
-      hours:
-        - {days: [Tu, We], from: '7:00am', to: '10:00pm'}
-        - {days: [Sa], from: '8:00pm', to: '5:00pm'}
-        - {days: [Su], from: '8:00am', to: '12:00am'}
-
-  winter:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '8:00pm'}
-
-  interim:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
-
-  spring:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
-        - {days: [Sa], from: '8:00pm', to: '5:00pm'}
-        - {days: [Su], from: '8:00am', to: '12:00am'}
-
-  easter:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '5:00pm'}
-        - {days: [Sa], from: '8:00pm', to: '5:00pm'}
-        - {days: [Su], from: '8:00am', to: '12:00am'}
-
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th], from: '7:00am', to: '10:00pm'}
-        - {days: [Fr], from: '7:00am', to: '8:00pm'}
-        - {days: [Sa], from: '9:00am', to: '8:00pm'}
-        - {days: [Su], from: '9:00am', to: '10:00pm'}
+  fall: []
+  thanksgiving: []
+  winter: []
+  interim: []
+  spring: []
+  easter: []
+  summer: []

--- a/data/building-hours/8-skifter.yaml
+++ b/data/building-hours/8-skifter.yaml
@@ -15,8 +15,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '10:00pm'}
-        - {days: [Sa, Su], from: '12:00pm', to: '10:00pm'}
+  summer: []

--- a/data/building-hours/8-tb.yaml
+++ b/data/building-hours/8-tb.yaml
@@ -16,7 +16,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours: []
-      notes: The Theater Building is closed for the summer.
+  summer: []

--- a/data/building-hours/8-toh.yaml
+++ b/data/building-hours/8-toh.yaml
@@ -17,8 +17,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours:
-        - {days: [Mo, Tu, We, Th, Fr], from: '7:30am', to: '5:30pm'}
-        - {days: [Sa, Su], from: '9:00am', to: '5:00pm'}
+  summer: []

--- a/data/building-hours/8-wlc.yaml
+++ b/data/building-hours/8-wlc.yaml
@@ -18,7 +18,4 @@ breakSchedule:
   interim: []
   spring: []
   easter: []
-  summer:
-    - title: Hours
-      hours: []
-      notes: 'World Language Center is closed for the summer?'
+  summer: []


### PR DESCRIPTION
A lot of them haven't been updated for a while or aren't truly accurate. I'd rather have one source of truth (and hence a smaller data bundle) than risk having someone just copy break hours for a break and have them be incorrect.

(Also think of this as part I of a new vision for hours.)