### PR TITLE
Allow testflight uploading to fail the build

### DIFF
--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -85,14 +85,10 @@ platform :ios do
   desc 'Submit a new nightly Beta Build to Testflight'
   lane :nightly do
     build
-    # TestFlight is returning 500 errors when we upload changelogs again.
-    begin
-      testflight(changelog: make_changelog,
-                 distribute_external: false)
-    rescue => error
-      puts 'Changelog failed to upload:'
-      puts error
-    end
+
+    testflight(changelog: make_changelog,
+               distribute_external: false)
+
     generate_sourcemap
     upload_sourcemap_to_bugsnag
   end


### PR DESCRIPTION
Last night's nightly, for instance, failed to upload, but is green on circle.

I remember doing this, because it kept failing when it would upload changelogs… but I want to see if that's fixed now or anything. I need failures to be failures lol.