### PR TITLE
BadgeDetail component

### DIFF
--- a/source/components/badge-detail.js
+++ b/source/components/badge-detail.js
@@ -15,7 +15,7 @@ const BGCOLORS = {
 
 type Props = {status: string}
 
-export class Badge extends React.PureComponent<Props> {
+export class BadgeDetail extends React.PureComponent<Props> {
 	render() {
 		const {status} = this.props
 		const bgColor = BGCOLORS[status] || c.goldenrod

--- a/source/components/outline-badge.js
+++ b/source/components/outline-badge.js
@@ -1,8 +1,4 @@
-/**
- * @flow
- *
- * <Badge/> renders the [Open] / [Closed] / [IDK] badge on the detai view
- */
+// @flow
 
 import * as React from 'react'
 import {View, Text, StyleSheet, Platform} from 'react-native'
@@ -15,7 +11,7 @@ const BGCOLORS = {
 
 type Props = {status: string}
 
-export class BadgeDetail extends React.PureComponent<Props> {
+export class OutlineBadge extends React.PureComponent<Props> {
 	render() {
 		const {status} = this.props
 		const bgColor = BGCOLORS[status] || c.goldenrod

--- a/source/components/solid-badge.js
+++ b/source/components/solid-badge.js
@@ -24,7 +24,7 @@ let styles = StyleSheet.create({
 	},
 })
 
-export function Badge({
+export function SolidBadge({
 	text,
 	style,
 	textStyle,

--- a/source/views/building-hours/detail/building.js
+++ b/source/views/building-hours/detail/building.js
@@ -8,7 +8,7 @@ import moment from 'moment-timezone'
 import * as c from '@frogpond/colors'
 import {getShortBuildingStatus} from '../lib'
 
-import {Badge} from './badge'
+import {BadgeDetail} from '../../../components/badge-detail'
 import {Header} from './header'
 import {ScheduleTable} from './schedule-table'
 import {ListFooter} from '@frogpond/lists'
@@ -63,7 +63,7 @@ export class BuildingDetail extends React.Component<Props> {
 				) : null}
 
 				<Header building={info} />
-				<Badge status={openStatus} />
+				<BadgeDetail status={openStatus} />
 				<ScheduleTable
 					now={now}
 					onProblemReport={onProblemReport}

--- a/source/views/building-hours/detail/building.js
+++ b/source/views/building-hours/detail/building.js
@@ -8,7 +8,7 @@ import moment from 'moment-timezone'
 import * as c from '@frogpond/colors'
 import {getShortBuildingStatus} from '../lib'
 
-import {BadgeDetail} from '../../../components/badge-detail'
+import {OutlineBadge} from '../../../components/outline-badge'
 import {Header} from './header'
 import {ScheduleTable} from './schedule-table'
 import {ListFooter} from '@frogpond/lists'
@@ -63,7 +63,7 @@ export class BuildingDetail extends React.Component<Props> {
 				) : null}
 
 				<Header building={info} />
-				<BadgeDetail status={openStatus} />
+				<OutlineBadge status={openStatus} />
 				<ScheduleTable
 					now={now}
 					onProblemReport={onProblemReport}

--- a/source/views/building-hours/row.js
+++ b/source/views/building-hours/row.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import {View, Text, StyleSheet} from 'react-native'
-import {Badge} from '../../components/badge'
+import {SolidBadge} from '../../components/solid-badge'
 import isEqual from 'lodash/isEqual'
 import type momentT from 'moment'
 import type {BuildingType} from './types'
@@ -122,7 +122,7 @@ export class BuildingRow extends React.Component<Props, State> {
 					</Title>
 
 					{!info.isNotice ? (
-						<Badge
+						<SolidBadge
 							accentColor={accentBg}
 							style={styles.accessoryBadge}
 							text={openStatus}

--- a/source/views/sis/course-search/detail/index.js
+++ b/source/views/sis/course-search/detail/index.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import {StyleSheet, Text, Platform} from 'react-native'
 import type {CourseType} from '../../../../lib/course-search'
 import glamorous from 'glamorous-native'
-import {Badge} from '../../../building-hours/detail/badge'
+import {BadgeDetail} from '../../../../components/badge-detail'
 import moment from 'moment-timezone'
 import {formatDay} from '../lib/format-day'
 import {
@@ -204,7 +204,7 @@ export class CourseDetailView extends React.PureComponent<Props> {
 			<Container>
 				<Header>{course.title || course.name}</Header>
 				<SubHeader>{deptNum(course)}</SubHeader>
-				<Badge status={status} />
+				<BadgeDetail status={status} />
 				<TableView>
 					<Information course={course} />
 					<Schedule course={course} />

--- a/source/views/sis/course-search/detail/index.js
+++ b/source/views/sis/course-search/detail/index.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import {StyleSheet, Text, Platform} from 'react-native'
 import type {CourseType} from '../../../../lib/course-search'
 import glamorous from 'glamorous-native'
-import {BadgeDetail} from '../../../../components/badge-detail'
+import {OutlineBadge} from '../../../../components/outline-badge'
 import moment from 'moment-timezone'
 import {formatDay} from '../lib/format-day'
 import {
@@ -204,7 +204,7 @@ export class CourseDetailView extends React.PureComponent<Props> {
 			<Container>
 				<Header>{course.title || course.name}</Header>
 				<SubHeader>{deptNum(course)}</SubHeader>
-				<BadgeDetail status={status} />
+				<OutlineBadge status={status} />
 				<TableView>
 					<Information course={course} />
 					<Schedule course={course} />


### PR DESCRIPTION
* Kills `Course Search`'s dependence on `Building Hours`' badge component.
* ~We already have a `<Badge />` component, so this introduces a `<BadgeDetail />`.~
* Renames `<Badge />` to `<SolidBadge/>` and adds a co-located `<OutlineBadge />`.