### PR TITLE
Change navigation icons back

### DIFF
--- a/source/components/nav-buttons/favorite.js
+++ b/source/components/nav-buttons/favorite.js
@@ -16,7 +16,7 @@ export class FavoriteButton extends React.PureComponent<Props> {
 		// (ios|md)-heart(-outline)
 		const iconPlatform = Platform.OS === 'ios' ? 'ios' : 'md'
 		const icon =
-			`${iconPlatform}-heart` + (this.props.favorited ? '' : '-empty')
+			`${iconPlatform}-heart` + (this.props.favorited ? '' : '-outline')
 
 		return (
 			<Touchable

--- a/source/components/nav-buttons/share.js
+++ b/source/components/nav-buttons/share.js
@@ -10,7 +10,7 @@ type Props = {
 	onPress: () => any,
 }
 
-const iconName = Platform.OS === 'ios' ? 'ios-share' : 'md-share'
+const iconName = Platform.OS === 'ios' ? 'ios-share-outline' : 'md-share'
 
 export class ShareButton extends React.PureComponent<Props> {
 	render() {


### PR DESCRIPTION
Revert icons to follow-up pinning rn-vector-icons. This somehow slipped through.

* Revert back to an outlined version of the favorites icon
* Revert back to an outlined version of the share icon