### PR TITLE
Remove course times from course search rows

### DIFF
--- a/source/views/sis/course-search/row.js
+++ b/source/views/sis/course-search/row.js
@@ -5,13 +5,7 @@ import {StyleSheet} from 'react-native'
 import type {CourseType} from '../../../lib/course-search/types'
 import {ListRow, Title, Detail} from '@frogpond/lists'
 import {deptNum} from './lib/format-dept-num'
-import moment from 'moment-timezone'
-import {convertTimeStringsToOfferings} from 'sto-sis-time-parser'
-import {formatDayAbbrev} from './lib/format-day'
-import sortBy from 'lodash/sortBy'
 import {Row} from '@frogpond/layout'
-const CENTRAL_TZ = 'America/Winnipeg'
-const fmt = 'h:mm A'
 
 type Props = {
 	course: CourseType,
@@ -25,24 +19,6 @@ export class CourseRow extends React.PureComponent<Props> {
 
 	render() {
 		const {course} = this.props
-		const groupings = convertTimeStringsToOfferings(course, {groupBy: 'sis'})
-		const formattedGroupings = groupings.map(grouping => {
-			const times = grouping.times
-				.map(time => {
-					const start = moment.tz(time.start, 'hmm', CENTRAL_TZ).format(fmt)
-					const end = moment.tz(time.end, 'hmm', CENTRAL_TZ).format(fmt)
-					return `${start} – ${end}`
-				})
-				.join(', ')
-			const dayOrder = ['Mo', 'Tu', 'We', 'Th', 'Fr']
-			let days = sortBy(grouping.days, d => dayOrder.indexOf(d))
-				.map(formatDayAbbrev)
-				.join('')
-			if (days === 'MTWThF') {
-				days = 'M-F'
-			}
-			return `${days} ${times}`
-		})
 
 		return (
 			<ListRow arrowPosition="center" onPress={this.onPress}>
@@ -59,8 +35,6 @@ export class CourseRow extends React.PureComponent<Props> {
 				{course.instructors && (
 					<Detail style={styles.row}>{course.instructors.join(', ')}</Detail>
 				)}
-
-				{course.times && <Detail>{formattedGroupings.join('\n')}</Detail>}
 
 				{course.notes && (
 					<Detail lines={1} style={[styles.italics, styles.row]}>


### PR DESCRIPTION
So, this is currently broken -- `course.times` is now `course.offerings` and the dependency that parses these also looks for the old prop. That being said, even if it were fixed, I believe there are things to be gained by not listing course times on the rows.

* Creates a less-congested course list, which I've grown to like.
* Faster renderings of the rows without running the day-groupings on each row (our largest dataset by far)
* They're still available on each course in the detail
* Closes #2967

<hr>

Conversation between @hannesmcman and @hawkrives 

> **hawkrives**: At some point, we need to quit sticking stuff in the list view lol. Not saying this is the line, but just saying. I prefer notes at the bottom.

> **hannesmcman**: I agree, but I think the course schedule is a pretty important thing to have in the listview, since it may be a deal-breaker for some people in terms of whether or not they can take a class
>
> **hawkrives**: That's what the detail view is for
"oh, this looks interesting… let's get more information"
Again, not saying "no" to the schedules here
Just noting that these cells are getting pretty long(edited)
carleton is at the other end of information density from Olaf's SIS. I hope to take some inspiration from it this fall.
>
> **hannesmcman**: Agreed. Although the vast majority of classes will only have one line of text for their schedule this way...only classes with weird schedules (interim) will have long rows