### PR TITLE
Fix <Timer/>

### DIFF
--- a/flow-typed/npm/jest_v23.x.x.js
+++ b/flow-typed/npm/jest_v23.x.x.js
@@ -1,5 +1,5 @@
-// flow-typed signature: 18018da6c1a1d95b4ab1c64bb5fe86ca
-// flow-typed version: c1ad61e7d4/jest_v22.x.x/flow_>=v0.39.x
+// flow-typed signature: 268d738ecf65f4bcc4a5455efa90619f
+// flow-typed version: 0e8507a159/jest_v23.x.x/flow_>=v0.39.x
 
 type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   (...args: TArguments): TReturn,
@@ -17,7 +17,12 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
      * An array that contains all the object instances that have been
      * instantiated from this mock function.
      */
-    instances: Array<TReturn>
+    instances: Array<TReturn>,
+    /**
+     * An array that contains all the object results that have been
+     * returned by this mock function call
+     */
+    results: Array<{ isThrow: boolean, value: TReturn }>
   },
   /**
    * Resets all information stored in the mockFn.mock.calls and
@@ -56,17 +61,38 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
     fn: (...args: TArguments) => TReturn
   ): JestMockFn<TArguments, TReturn>,
   /**
+   * Accepts a string to use in test result output in place of "jest.fn()" to
+   * indicate which mock function is being referenced.
+   */
+  mockName(name: string): JestMockFn<TArguments, TReturn>,
+  /**
    * Just a simple sugar function for returning `this`
    */
   mockReturnThis(): void,
   /**
-   * Deprecated: use jest.fn(() => value) instead
+   * Accepts a value that will be returned whenever the mock function is called.
    */
   mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
   /**
    * Sugar for only returning a value once inside your mock
    */
-  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>
+  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
+   */
+  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  /**
+   * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
+   */
+  mockResolvedValueOnce(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  /**
+   * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))
+   */
+  mockRejectedValue(value: TReturn): JestMockFn<TArguments, Promise<any>>,
+  /**
+   * Sugar for jest.fn().mockImplementationOnce(() => Promise.reject(value))
+   */
+  mockRejectedValueOnce(value: TReturn): JestMockFn<TArguments, Promise<any>>
 };
 
 type JestAsymmetricEqualityType = {
@@ -98,7 +124,9 @@ type JestMatcherResult = {
   pass: boolean
 };
 
-type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
+type JestMatcher = (actual: any, expected: any) =>
+  | JestMatcherResult
+  | Promise<JestMatcherResult>;
 
 type JestPromiseType = {
   /**
@@ -120,20 +148,46 @@ type JestPromiseType = {
 type JestTestName = string | Function;
 
 /**
+ *  Plugin: jest-styled-components
+ */
+
+type JestStyledComponentsMatcherValue =
+  | string
+  | JestAsymmetricEqualityType
+  | RegExp
+  | typeof undefined;
+
+type JestStyledComponentsMatcherOptions = {
+  media?: string;
+  modifier?: string;
+  supports?: string;
+}
+
+type JestStyledComponentsMatchersType = {
+  toHaveStyleRule(
+    property: string,
+    value: JestStyledComponentsMatcherValue,
+    options?: JestStyledComponentsMatcherOptions
+  ): void,
+};
+
+/**
  *  Plugin: jest-enzyme
  */
 type EnzymeMatchersType = {
   toBeChecked(): void,
   toBeDisabled(): void,
   toBeEmpty(): void,
+  toBeEmptyRender(): void,
   toBePresent(): void,
   toContainReact(element: React$Element<any>): void,
+  toExist(): void,
   toHaveClassName(className: string): void,
   toHaveHTML(html: string): void,
-  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveProp: ((propKey: string, propValue?: any) => void) & ((props: Object) => void),
   toHaveRef(refName: string): void,
-  toHaveState(stateKey: string, stateValue?: any): void,
-  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveState: ((stateKey: string, stateValue?: any) => void) & ((state: Object) => void),
+  toHaveStyle: ((styleKey: string, styleValue?: any) => void) & ((style: Object) => void),
   toHaveTagName(tagName: string): void,
   toHaveText(text: string): void,
   toIncludeText(text: string): void,
@@ -142,8 +196,348 @@ type EnzymeMatchersType = {
   toMatchSelector(selector: string): void
 };
 
-type JestExpectType = {
-  not: JestExpectType & EnzymeMatchersType,
+// DOM testing library extensions https://github.com/kentcdodds/dom-testing-library#custom-jest-matchers
+type DomTestingLibraryType = {
+  toBeInTheDOM(): void,
+  toHaveTextContent(content: string): void,
+  toHaveAttribute(name: string, expectedValue?: string): void
+};
+
+// Jest JQuery Matchers: https://github.com/unindented/custom-jquery-matchers
+type JestJQueryMatchersType = {
+  toExist(): void,
+  toHaveLength(len: number): void,
+  toHaveId(id: string): void,
+  toHaveClass(className: string): void,
+  toHaveTag(tag: string): void,
+  toHaveAttr(key: string, val?: any): void,
+  toHaveProp(key: string, val?: any): void,
+  toHaveText(text: string | RegExp): void,
+  toHaveData(key: string, val?: any): void,
+  toHaveValue(val: any): void,
+  toHaveCss(css: {[key: string]: any}): void,
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBeHidden(): void,
+  toBeSelected(): void,
+  toBeVisible(): void,
+  toBeFocused(): void,
+  toBeInDom(): void,
+  toBeMatchedBy(sel: string): void,
+  toHaveDescendant(sel: string): void,
+  toHaveDescendantWithText(sel: string, text: string | RegExp): void
+};
+
+
+// Jest Extended Matchers: https://github.com/jest-community/jest-extended
+type JestExtendedMatchersType = {
+  /**
+     * Note: Currently unimplemented
+     * Passing assertion
+     *
+     * @param {String} message
+     */
+  //  pass(message: string): void;
+
+    /**
+     * Note: Currently unimplemented
+     * Failing assertion
+     *
+     * @param {String} message
+     */
+  //  fail(message: string): void;
+
+    /**
+     * Use .toBeEmpty when checking if a String '', Array [] or Object {} is empty.
+     */
+    toBeEmpty(): void;
+
+    /**
+     * Use .toBeOneOf when checking if a value is a member of a given Array.
+     * @param {Array.<*>} members
+     */
+    toBeOneOf(members: any[]): void;
+
+    /**
+     * Use `.toBeNil` when checking a value is `null` or `undefined`.
+     */
+    toBeNil(): void;
+
+    /**
+     * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
+     * @param {Function} predicate
+     */
+    toSatisfy(predicate: (n: any) => boolean): void;
+
+    /**
+     * Use `.toBeArray` when checking if a value is an `Array`.
+     */
+    toBeArray(): void;
+
+    /**
+     * Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
+     * @param {Number} x
+     */
+    toBeArrayOfSize(x: number): void;
+
+    /**
+     * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
+     * @param {Array.<*>} members
+     */
+    toIncludeAllMembers(members: any[]): void;
+
+    /**
+     * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
+     * @param {Array.<*>} members
+     */
+    toIncludeAnyMembers(members: any[]): void;
+
+    /**
+     * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
+     * @param {Function} predicate
+     */
+    toSatisfyAll(predicate: (n: any) => boolean): void;
+
+    /**
+     * Use `.toBeBoolean` when checking if a value is a `Boolean`.
+     */
+    toBeBoolean(): void;
+
+    /**
+     * Use `.toBeTrue` when checking a value is equal (===) to `true`.
+     */
+    toBeTrue(): void;
+
+    /**
+     * Use `.toBeFalse` when checking a value is equal (===) to `false`.
+     */
+    toBeFalse(): void;
+
+    /**
+     * Use .toBeDate when checking if a value is a Date.
+     */
+    toBeDate(): void;
+
+    /**
+     * Use `.toBeFunction` when checking if a value is a `Function`.
+     */
+    toBeFunction(): void;
+
+    /**
+     * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
+     *
+     * Note: Required Jest version >22
+     * Note: Your mock functions will have to be asynchronous to cause the timestamps inside of Jest to occur in a differentJS event loop, otherwise the mock timestamps will all be the same
+     *
+     * @param {Mock} mock
+     */
+    toHaveBeenCalledBefore(mock: JestMockFn<any, any>): void;
+
+    /**
+     * Use `.toBeNumber` when checking if a value is a `Number`.
+     */
+    toBeNumber(): void;
+
+    /**
+     * Use `.toBeNaN` when checking a value is `NaN`.
+     */
+    toBeNaN(): void;
+
+    /**
+     * Use `.toBeFinite` when checking if a value is a `Number`, not `NaN` or `Infinity`.
+     */
+    toBeFinite(): void;
+
+    /**
+     * Use `.toBePositive` when checking if a value is a positive `Number`.
+     */
+    toBePositive(): void;
+
+    /**
+     * Use `.toBeNegative` when checking if a value is a negative `Number`.
+     */
+    toBeNegative(): void;
+
+    /**
+     * Use `.toBeEven` when checking if a value is an even `Number`.
+     */
+    toBeEven(): void;
+
+    /**
+     * Use `.toBeOdd` when checking if a value is an odd `Number`.
+     */
+    toBeOdd(): void;
+
+    /**
+     * Use `.toBeWithin` when checking if a number is in between the given bounds of: start (inclusive) and end (exclusive).
+     *
+     * @param {Number} start
+     * @param {Number} end
+     */
+    toBeWithin(start: number, end: number): void;
+
+    /**
+     * Use `.toBeObject` when checking if a value is an `Object`.
+     */
+    toBeObject(): void;
+
+    /**
+     * Use `.toContainKey` when checking if an object contains the provided key.
+     *
+     * @param {String} key
+     */
+    toContainKey(key: string): void;
+
+    /**
+     * Use `.toContainKeys` when checking if an object has all of the provided keys.
+     *
+     * @param {Array.<String>} keys
+     */
+    toContainKeys(keys: string[]): void;
+
+    /**
+     * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
+     *
+     * @param {Array.<String>} keys
+     */
+    toContainAllKeys(keys: string[]): void;
+
+    /**
+     * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
+     *
+     * @param {Array.<String>} keys
+     */
+    toContainAnyKeys(keys: string[]): void;
+
+    /**
+     * Use `.toContainValue` when checking if an object contains the provided value.
+     *
+     * @param {*} value
+     */
+    toContainValue(value: any): void;
+
+    /**
+     * Use `.toContainValues` when checking if an object contains all of the provided values.
+     *
+     * @param {Array.<*>} values
+     */
+    toContainValues(values: any[]): void;
+
+    /**
+     * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
+     *
+     * @param {Array.<*>} values
+     */
+    toContainAllValues(values: any[]): void;
+
+    /**
+     * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
+     *
+     * @param {Array.<*>} values
+     */
+    toContainAnyValues(values: any[]): void;
+
+    /**
+     * Use `.toContainEntry` when checking if an object contains the provided entry.
+     *
+     * @param {Array.<String, String>} entry
+     */
+    toContainEntry(entry: [string, string]): void;
+
+    /**
+     * Use `.toContainEntries` when checking if an object contains all of the provided entries.
+     *
+     * @param {Array.<Array.<String, String>>} entries
+     */
+    toContainEntries(entries: [string, string][]): void;
+
+    /**
+     * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
+     *
+     * @param {Array.<Array.<String, String>>} entries
+     */
+    toContainAllEntries(entries: [string, string][]): void;
+
+    /**
+     * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
+     *
+     * @param {Array.<Array.<String, String>>} entries
+     */
+    toContainAnyEntries(entries: [string, string][]): void;
+
+    /**
+     * Use `.toBeExtensible` when checking if an object is extensible.
+     */
+    toBeExtensible(): void;
+
+    /**
+     * Use `.toBeFrozen` when checking if an object is frozen.
+     */
+    toBeFrozen(): void;
+
+    /**
+     * Use `.toBeSealed` when checking if an object is sealed.
+     */
+    toBeSealed(): void;
+
+    /**
+     * Use `.toBeString` when checking if a value is a `String`.
+     */
+    toBeString(): void;
+
+    /**
+     * Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.
+     *
+     * @param {String} string
+     */
+    toEqualCaseInsensitive(string: string): void;
+
+    /**
+     * Use `.toStartWith` when checking if a `String` starts with a given `String` prefix.
+     *
+     * @param {String} prefix
+     */
+    toStartWith(prefix: string): void;
+
+    /**
+     * Use `.toEndWith` when checking if a `String` ends with a given `String` suffix.
+     *
+     * @param {String} suffix
+     */
+    toEndWith(suffix: string): void;
+
+    /**
+     * Use `.toInclude` when checking if a `String` includes the given `String` substring.
+     *
+     * @param {String} substring
+     */
+    toInclude(substring: string): void;
+
+    /**
+     * Use `.toIncludeRepeated` when checking if a `String` includes the given `String` substring the correct number of times.
+     *
+     * @param {String} substring
+     * @param {Number} times
+     */
+    toIncludeRepeated(substring: string, times: number): void;
+
+    /**
+     * Use `.toIncludeMultiple` when checking if a `String` includes all of the given substrings.
+     *
+     * @param {Array.<String>} substring
+     */
+    toIncludeMultiple(substring: string[]): void;
+};
+
+interface JestExpectType {
+  not:
+    & JestExpectType
+    & EnzymeMatchersType
+    & DomTestingLibraryType
+    & JestJQueryMatchersType
+    & JestStyledComponentsMatchersType
+    & JestExtendedMatchersType,
   /**
    * If you have a mock function, you can use .lastCalledWith to test what
    * arguments it was last called with.
@@ -154,10 +548,6 @@ type JestExpectType = {
    * strict equality.
    */
   toBe(value: any): void,
-  /**
-   * Use .toHaveBeenCalled to ensure that a mock function got called.
-   */
-  toBeCalled(): void,
   /**
    * Use .toBeCalledWith to ensure that a mock function was called with
    * specific arguments.
@@ -233,21 +623,55 @@ type JestExpectType = {
    * Use .toHaveBeenCalled to ensure that a mock function got called.
    */
   toHaveBeenCalled(): void,
+  toBeCalled(): void;
   /**
    * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
    * number of times.
    */
   toHaveBeenCalledTimes(number: number): void,
+  toBeCalledTimes(number: number): void;
+  /**
+   *
+   */
+  toHaveBeenNthCalledWith(nthCall: number, ...args: Array<any>): void;
+  nthCalledWith(nthCall: number, ...args: Array<any>): void;
+  /**
+   *
+   */
+  toHaveReturned(): void;
+  toReturn(): void;
+  /**
+   *
+   */
+  toHaveReturnedTimes(number: number): void;
+  toReturnTimes(number: number): void;
+  /**
+   *
+   */
+  toHaveReturnedWith(value: any): void;
+  toReturnWith(value: any): void;
+  /**
+   *
+   */
+  toHaveLastReturnedWith(value: any): void;
+  lastReturnedWith(value: any): void;
+  /**
+   *
+   */
+  toHaveNthReturnedWith(nthCall: number, value: any): void;
+  nthReturnedWith(nthCall: number, value: any): void;
   /**
    * Use .toHaveBeenCalledWith to ensure that a mock function was called with
    * specific arguments.
    */
   toHaveBeenCalledWith(...args: Array<any>): void,
+  toBeCalledWith(...args: Array<any>): void,
   /**
    * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
    * with specific arguments.
    */
   toHaveBeenLastCalledWith(...args: Array<any>): void,
+  lastCalledWith(...args: Array<any>): void,
   /**
    * Check that an object has a .length property and it is set to a certain
    * numeric value.
@@ -266,9 +690,20 @@ type JestExpectType = {
    */
   toMatchObject(object: Object | Array<Object>): void,
   /**
-   * This ensures that a React component matches the most recent snapshot.
+   * Use .toStrictEqual to check that a javascript object matches a subset of the properties of an object.
    */
-  toMatchSnapshot(name?: string): void,
+  toStrictEqual(value: any): void,
+  /**
+   * This ensures that an Object matches the most recent snapshot.
+   */
+  toMatchSnapshot(propertyMatchers?: {[key: string]: JestAsymmetricEqualityType}, name?: string): void,
+  /**
+   * This ensures that an Object matches the most recent snapshot.
+   */
+  toMatchSnapshot(name: string): void,
+
+  toMatchInlineSnapshot(snapshot?: string): void,
+  toMatchInlineSnapshot(propertyMatchers?: {[key: string]: JestAsymmetricEqualityType}, snapshot?: string): void,
   /**
    * Use .toThrow to test that a function throws when it is called.
    * If you want to test that a specific error gets thrown, you can provide an
@@ -283,8 +718,9 @@ type JestExpectType = {
    * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
    * matching the most recent snapshot when it is called.
    */
-  toThrowErrorMatchingSnapshot(): void
-};
+  toThrowErrorMatchingSnapshot(): void,
+  toThrowErrorMatchingInlineSnapshot(snapshot?: string): void,
+}
 
 type JestObjectType = {
   /**
@@ -397,6 +833,13 @@ type JestObjectType = {
    * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
    * or setInterval() and setImmediate()).
    */
+  advanceTimersByTime(msToRun: number): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   *
+   * Renamed to `advanceTimersByTime`.
+   */
   runTimersToTime(msToRun: number): void,
   /**
    * Executes only the macro-tasks that are currently pending (i.e., only the
@@ -430,7 +873,7 @@ type JestObjectType = {
    * Creates a mock function similar to jest.fn but also tracks calls to
    * object[methodName].
    */
-  spyOn(object: Object, methodName: string): JestMockFn<any, any>,
+  spyOn(object: Object, methodName: string, accessType?: "get" | "set"): JestMockFn<any, any>,
   /**
    * Set the default timeout interval for tests and before/after hooks in milliseconds.
    * Note: The default timeout interval is 5 seconds if this method is not called.
@@ -478,7 +921,19 @@ declare var describe: {
   /**
    * Skip running this describe block
    */
-  skip(name: JestTestName, fn: () => void): void
+  skip(name: JestTestName, fn: () => void): void,
+
+  /**
+   * each runs this test against array of argument arrays per each run
+   *
+   * @param {table} table of Test
+   */
+  each(
+    table: Array<Array<mixed> | mixed>
+  ): (
+    name: JestTestName,
+    fn?: (...args: Array<any>) => ?Promise<mixed>
+  ) => void,
 };
 
 /** An individual test unit */
@@ -496,6 +951,17 @@ declare var it: {
     timeout?: number
   ): void,
   /**
+   * each runs this test against array of argument arrays per each run
+   *
+   * @param {table} table of Test
+   */
+  each(
+    table: Array<Array<mixed> | mixed>
+  ): (
+    name: JestTestName,
+    fn?: (...args: Array<any>) => ?Promise<mixed>
+  ) => void,
+  /**
    * Only run this test
    *
    * @param {JestTestName} Name of Test
@@ -506,7 +972,14 @@ declare var it: {
     name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
-  ): void,
+  ): {
+    each(
+      table: Array<Array<mixed> | mixed>
+    ): (
+      name: JestTestName,
+      fn?: (...args: Array<any>) => ?Promise<mixed>
+    ) => void,
+  },
   /**
    * Skip running this test
    *
@@ -530,7 +1003,18 @@ declare var it: {
     name: JestTestName,
     fn?: (done: () => void) => ?Promise<mixed>,
     timeout?: number
-  ): void
+  ): void,
+  /**
+   * each runs this test against array of argument arrays per each run
+   *
+   * @param {table} table of Test
+   */
+  each(
+    table: Array<Array<mixed> | mixed>
+  ): (
+    name: JestTestName,
+    fn?: (...args: Array<any>) => ?Promise<mixed>
+  ) => void,
 };
 declare function fit(
   name: JestTestName,
@@ -548,23 +1032,83 @@ declare var xit: typeof it;
 /** A disabled individual test */
 declare var xtest: typeof it;
 
+type JestPrettyFormatColors = {
+  comment: { close: string, open: string },
+  content: { close: string, open: string },
+  prop: { close: string, open: string },
+  tag: { close: string, open: string },
+  value: { close: string, open: string },
+};
+
+type JestPrettyFormatIndent = string => string;
+type JestPrettyFormatRefs = Array<any>;
+type JestPrettyFormatPrint = any => string;
+type JestPrettyFormatStringOrNull = string | null;
+
+type JestPrettyFormatOptions = {|
+  callToJSON: boolean,
+  edgeSpacing: string,
+  escapeRegex: boolean,
+  highlight: boolean,
+  indent: number,
+  maxDepth: number,
+  min: boolean,
+  plugins: JestPrettyFormatPlugins,
+  printFunctionName: boolean,
+  spacing: string,
+  theme: {|
+    comment: string,
+    content: string,
+    prop: string,
+    tag: string,
+    value: string,
+  |},
+|};
+
+type JestPrettyFormatPlugin = {
+  print: (
+    val: any,
+    serialize: JestPrettyFormatPrint,
+    indent: JestPrettyFormatIndent,
+    opts: JestPrettyFormatOptions,
+    colors: JestPrettyFormatColors,
+  ) => string,
+  test: any => boolean,
+};
+
+type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
+
 /** The expect function is used every time you want to test a value */
 declare var expect: {
   /** The object that you want to make assertions against */
-  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
+  (value: any):
+    & JestExpectType
+    & JestPromiseType
+    & EnzymeMatchersType
+    & DomTestingLibraryType
+    & JestJQueryMatchersType
+    & JestStyledComponentsMatchersType
+    & JestExtendedMatchersType,
+
   /** Add additional Jasmine matchers to Jest's roster */
   extend(matchers: { [name: string]: JestMatcher }): void,
   /** Add a module that formats application-specific data structures. */
-  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
   assertions(expectedAssertions: number): void,
   hasAssertions(): void,
   any(value: mixed): JestAsymmetricEqualityType,
-  anything(): void,
-  arrayContaining(value: Array<mixed>): void,
-  objectContaining(value: Object): void,
+  anything(): any,
+  arrayContaining(value: Array<mixed>): Array<mixed>,
+  objectContaining(value: Object): Object,
   /** Matches any received string that contains the exact expected string. */
-  stringContaining(value: string): void,
-  stringMatching(value: string | RegExp): void
+  stringContaining(value: string): string,
+  stringMatching(value: string | RegExp): string,
+  not: {
+    arrayContaining: (value: $ReadOnlyArray<mixed>) => Array<mixed>,
+    objectContaining: (value: {}) => Object,
+    stringContaining: (value: string) => string,
+    stringMatching: (value: string | RegExp) => string,
+  },
 };
 
 // TODO handle return type
@@ -581,14 +1125,14 @@ declare var jest: JestObjectType;
 declare var jasmine: {
   DEFAULT_TIMEOUT_INTERVAL: number,
   any(value: mixed): JestAsymmetricEqualityType,
-  anything(): void,
-  arrayContaining(value: Array<mixed>): void,
+  anything(): any,
+  arrayContaining(value: Array<mixed>): Array<mixed>,
   clock(): JestClockType,
   createSpy(name: string): JestSpyType,
   createSpyObj(
     baseName: string,
     methodNames: Array<string>
   ): { [methodName: string]: JestSpyType },
-  objectContaining(value: Object): void,
-  stringMatching(value: string): void
+  objectContaining(value: Object): Object,
+  stringMatching(value: string): string
 };

--- a/modules/timer/__tests__/timer.test.js
+++ b/modules/timer/__tests__/timer.test.js
@@ -5,13 +5,13 @@ import {msUntilIntervalRepeat} from '../index'
 describe('msUntilIntervalRepeat', () => {
 	test.each`
 		now              | interval | expected
-		${100}           | ${10}    | ${0}
-		${1536625260000} | ${60000} | ${0}
-		${60000}         | ${60000} | ${0}
+		${100}           | ${10}    | ${10}
+		${1536625260000} | ${60000} | ${60000}
+		${60000}         | ${60000} | ${60000}
 		${35}            | ${60}    | ${25}
 		${110}           | ${100}   | ${90}
 		${1}             | ${9}     | ${8}
-		${1000}          | ${20}    | ${0}
+		${1000}          | ${20}    | ${20}
 		${9}             | ${20}    | ${11}
 	`(
 		'returns remaining: $expected with now: $now and interval: $interval',

--- a/modules/timer/__tests__/timer.test.js
+++ b/modules/timer/__tests__/timer.test.js
@@ -1,0 +1,22 @@
+/* eslint-env jest */
+
+import {msUntilIntervalRepeat} from '../index'
+
+describe('msUntilIntervalRepeat', () => {
+	test.each`
+		now              | interval | expected
+		${100}           | ${10}    | ${0}
+		${1536625260000} | ${60000} | ${0}
+		${60000}         | ${60000} | ${0}
+		${35}            | ${60}    | ${25}
+		${110}           | ${100}   | ${90}
+		${1}             | ${9}     | ${8}
+		${1000}          | ${20}    | ${0}
+		${9}             | ${20}    | ${11}
+	`(
+		'returns remaining: $expected with now: $now and interval: $interval',
+		({now, interval, expected}) => {
+			expect(msUntilIntervalRepeat(now, interval)).toBe(expected)
+		},
+	)
+})

--- a/modules/timer/index.js
+++ b/modules/timer/index.js
@@ -4,6 +4,14 @@ import * as React from 'react'
 import moment from 'moment-timezone'
 import delay from 'delay'
 
+export function msUntilIntervalRepeat(now: number, interval: number) {
+	let next = now
+	while (next % interval !== 0) {
+		next += 1
+	}
+	return next - now
+}
+
 type Props = {
 	interval: number, // ms
 	timezone?: string,

--- a/modules/timer/index.js
+++ b/modules/timer/index.js
@@ -42,6 +42,7 @@ type State = {
 
 export class Timer extends React.Component<Props, State> {
 	_timeoutId: ?TimeoutID
+	_intervalId: ?IntervalID
 
 	state = {
 		now: new Date(),
@@ -49,25 +50,26 @@ export class Timer extends React.Component<Props, State> {
 	}
 
 	componentDidMount() {
-		this.queue()
-	}
-
-	componentWillUnmount() {
-		// eslint-disable-next-line no-eq-null
-		this._timeoutId != null && clearTimeout(this._timeoutId)
-	}
-
-	queue = () => {
 		// get the time remaining until the next $interval
 		let {interval} = this.props
 		let nowMs = this.state.now.getTime()
 		let untilNextInterval = msUntilIntervalRepeat(nowMs, interval)
 
-		this._timeoutId = setTimeout(this.updateTime, untilNextInterval)
+		this._timeoutId = setTimeout(() => {
+			this.updateTime()
+			this._intervalId = setInterval(this.updateTime, interval)
+		}, untilNextInterval)
+	}
+
+	componentWillUnmount() {
+		// eslint-disable-next-line no-eq-null
+		this._timeoutId != null && clearTimeout(this._timeoutId)
+		// eslint-disable-next-line no-eq-null
+		this._intervalId != null && clearInterval(this._intervalId)
 	}
 
 	updateTime = () => {
-		this.setState(() => ({now: new Date()}), this.queue)
+		this.setState(() => ({now: new Date()}))
 	}
 
 	refresh = async () => {

--- a/modules/timer/index.js
+++ b/modules/timer/index.js
@@ -41,7 +41,6 @@ type State = {
 }
 
 export class Timer extends React.Component<Props, State> {
-	_intervalId: ?IntervalID
 	_timeoutId: ?TimeoutID
 
 	state = {
@@ -50,29 +49,25 @@ export class Timer extends React.Component<Props, State> {
 	}
 
 	componentDidMount() {
-		// get the time remaining until the next $interval
-		let {interval} = this.props
-		let nowMs = this.state.now.getTime()
-		let untilNextInterval = interval - (nowMs % interval)
-
-		this._timeoutId = setTimeout(() => {
-			this.updateTime()
-			this._intervalId = setInterval(this.updateTime, this.props.interval)
-		}, untilNextInterval)
+		this.queue()
 	}
 
 	componentWillUnmount() {
-		if (this._timeoutId) {
-			clearTimeout(this._timeoutId)
-		}
+		// eslint-disable-next-line no-eq-null
+		this._timeoutId != null && clearTimeout(this._timeoutId)
+	}
 
-		if (this._intervalId) {
-			clearInterval(this._intervalId)
-		}
+	queue = () => {
+		// get the time remaining until the next $interval
+		let {interval} = this.props
+		let nowMs = this.state.now.getTime()
+		let untilNextInterval = msUntilIntervalRepeat(nowMs, interval)
+
+		this._timeoutId = setTimeout(this.updateTime, untilNextInterval)
 	}
 
 	updateTime = () => {
-		this.setState(() => ({now: new Date()}))
+		this.setState(() => ({now: new Date()}), this.queue)
 	}
 
 	refresh = async () => {

--- a/modules/timer/index.js
+++ b/modules/timer/index.js
@@ -5,11 +5,7 @@ import moment from 'moment-timezone'
 import delay from 'delay'
 
 export function msUntilIntervalRepeat(now: number, interval: number) {
-	let next = now
-	while (next % interval !== 0) {
-		next += 1
-	}
-	return next - now
+	return interval - (now % interval)
 }
 
 type Props = {


### PR DESCRIPTION
It was … doing not the right thing. I don't even want to try to explain what it was doing.

Now, however, it does the correct, intended thing: given `$interval`, it waits until the next even division of `$interval` into the current time (ie, the next top-of-the-minute if given 60,000), and then sets a `setInterval` to re-invoke itself every 60 seconds.

This also adds unit tests for the `msUntilIntervalRepeat` function. (As part of that, I had to update the Jest definition, which has been outdated for a while.)