### PR TITLE
Fix missing bar between username and password fields in login screen

### DIFF
--- a/source/views/settings/screens/overview/login-credentials.js
+++ b/source/views/settings/screens/overview/login-credentials.js
@@ -75,8 +75,9 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 				{loggedIn ? (
 					<Cell title={`Logged in as ${username}.`} />
 				) : (
-					<React.Fragment>
+					[
 						<CellTextField
+							key={0}
 							_ref={this.getUsernameRef}
 							disabled={loading}
 							label="Username"
@@ -86,10 +87,9 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 							returnKeyType="next"
 							secureTextEntry={false}
 							value={username}
-						/>
-
+						/>,
 						<CellTextField
-							key="password"
+							key={1}
 							_ref={this.getPasswordRef}
 							disabled={loading}
 							label="Password"
@@ -99,8 +99,8 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 							returnKeyType="done"
 							secureTextEntry={true}
 							value={password}
-						/>
-					</React.Fragment>
+						/>,
+					]
 				)}
 
 				<LoginButton


### PR DESCRIPTION
replace React.Fragment with an array, because Section is silly and iterates over `props.children` to insert the separators into the view… and a Fragment is a single child, wheras an array gets flattened before iteration.

Yay.

Before | After
--- | ---
<img width=320 src=https://user-images.githubusercontent.com/464441/45336978-84346100-b54b-11e8-8a71-03cbeac7832b.jpg> | <img width="320" alt="image" src="https://user-images.githubusercontent.com/464441/45336992-97dfc780-b54b-11e8-9744-822acf560287.png">
