### PR TITLE
Dedupe yarn lockfile

### DIFF
--- a/modules/button/package.json
+++ b/modules/button/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {

--- a/modules/datepicker/package.json
+++ b/modules/datepicker/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4",
     "moment-timezone": "^0.5.21"
   },

--- a/modules/filter/package.json
+++ b/modules/filter/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4",
     "react-native-vector-icons": "^4.0.0",
     "react-native-popover-view": "^1.0.7"

--- a/modules/food-menu/package.json
+++ b/modules/food-menu/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4",
     "react-native-vector-icons": "^4.0.0",
     "moment": "^2.22.2",

--- a/modules/html-content/package.json
+++ b/modules/html-content/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {

--- a/modules/info-header/package.json
+++ b/modules/info-header/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {

--- a/modules/layout/package.json
+++ b/modules/layout/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {}

--- a/modules/lists/package.json
+++ b/modules/lists/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4",
     "react-native-vector-icons": "^4.0.0"
   },

--- a/modules/listview/package.json
+++ b/modules/listview/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {

--- a/modules/markdown/package.json
+++ b/modules/markdown/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "glamorous-native": "^1.4.0",
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {

--- a/modules/navigation-tabs/package.json
+++ b/modules/navigation-tabs/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "@frogpond/app-theme": "^1.0.0",
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4",
     "react-native-vector-icons": "^4.0.0",
     "react-navigation": "^2.11.2",

--- a/modules/notice/package.json
+++ b/modules/notice/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {

--- a/modules/searchbar/package.json
+++ b/modules/searchbar/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4",
     "react-native-search-bar": "^3.4.2",
     "react-native-searchbar-controlled": "^1.0.0",

--- a/modules/separator/package.json
+++ b/modules/separator/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {

--- a/modules/tableview/package.json
+++ b/modules/tableview/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {

--- a/modules/timer/package.json
+++ b/modules/timer/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "moment-timezone": "^0.5.21"
   }
 }

--- a/modules/toolbar/package.json
+++ b/modules/toolbar/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   },
   "dependencies": {

--- a/modules/touchable/package.json
+++ b/modules/touchable/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   }
 }

--- a/modules/viewport/package.json
+++ b/modules/viewport/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react": "^16.4.2",
+    "react": "^16.0.0",
     "react-native": "^0.55.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "p-retry": "2.0.0",
     "query-string": "6.1.0",
     "querystring": "0.2.0",
-    "react": "16.4.2",
+    "react": "16.3.1",
     "react-markdown": "2.5.1",
     "react-native": "0.55.4",
     "react-native-button": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "wordwrap": "1.0.0"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0-beta.44",
     "ajv": "6.5.3",
     "babel-core": "6.26.3",
     "babel-eslint": "8.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,7 +618,7 @@ ajv-keywords@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
-ajv@6.5.3:
+ajv@6.5.3, ajv@^6.0.1, ajv@^6.5.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.3.tgz#71a569d189ecf4f4f321224fecb166f071dd90f9"
   dependencies:
@@ -635,15 +635,6 @@ ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
-
-ajv@^6.0.1, ajv@^6.5.0:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
-  dependencies:
-    fast-deep-equal "^2.0.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -7283,7 +7274,7 @@ upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
-uri-js@^4.2.1, uri-js@^4.2.2:
+uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -856,13 +856,7 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.4:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
-  dependencies:
-    lodash "^4.14.0"
-
-async@^2.4.0:
+async@^2.1.4, async@^2.4.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
@@ -4746,7 +4740,7 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
 
-lodash@4.17.10, lodash@4.x.x, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.17.10, lodash@4.x.x, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,26 +14,6 @@
   dependencies:
     "@babel/highlight" "7.0.0-rc.1"
 
-"@babel/core@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-beta.44.tgz#90bb9e897427e7ebec2a1b857f458ff74ca28057"
-  dependencies:
-    "@babel/code-frame" "7.0.0-beta.44"
-    "@babel/generator" "7.0.0-beta.44"
-    "@babel/helpers" "7.0.0-beta.44"
-    "@babel/template" "7.0.0-beta.44"
-    "@babel/traverse" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
-    babylon "7.0.0-beta.44"
-    convert-source-map "^1.1.0"
-    debug "^3.1.0"
-    json5 "^0.5.0"
-    lodash "^4.2.0"
-    micromatch "^2.3.11"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
-
 "@babel/core@^7.0.0-beta":
   version "7.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0-rc.1.tgz#53c84fd562e13325f123d5951184eec97b958204"
@@ -231,14 +211,6 @@
     "@babel/template" "7.0.0-rc.1"
     "@babel/traverse" "7.0.0-rc.1"
     "@babel/types" "7.0.0-rc.1"
-
-"@babel/helpers@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.0.0-beta.44.tgz#b1cc87fdc3b77351c0a4860bcd9d4ef457919bfd"
-  dependencies:
-    "@babel/template" "7.0.0-beta.44"
-    "@babel/traverse" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
 
 "@babel/helpers@7.0.0-rc.1":
   version "7.0.0-rc.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,15 +2675,9 @@ eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz#ee1348bc2ceb912303ce6bdbd22e2f045ea86ea2"
 
-eslint-plugin-react-native@3.3.0:
+eslint-plugin-react-native@3.3.0, eslint-plugin-react-native@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-3.3.0.tgz#77135f1b9d69058c5612777aac90d9cd6d35af33"
-  dependencies:
-    eslint-plugin-react-native-globals "^0.1.1"
-
-eslint-plugin-react-native@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-3.2.1.tgz#04fcadd3285b7cd2f27146e640c941b00acc4e7e"
   dependencies:
     eslint-plugin-react-native-globals "^0.1.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6207,9 +6207,9 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@16.4.2:
-  version "16.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
+react@16.3.1:
+  version "16.3.1"
+  resolved "http://registry.npmjs.org/react/-/react-16.3.1.tgz#4a2da433d471251c69b6033ada30e2ed1202cfd8"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4582,13 +4582,9 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-left-pad@^1.1.3:
+left-pad@^1.1.3, left-pad@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
-
-left-pad@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
 
 leven@^2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4290,16 +4290,9 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@3.12.0, js-yaml@^3.11.0:
+js-yaml@3.12.0, js-yaml@^3.11.0, js-yaml@^3.7.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.7.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6629,11 +6629,7 @@ schedule@^0.3.0:
   dependencies:
     object-assign "^4.1.1"
 
-"semver@2 || 3 || 4 || 5", semver@5.x, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
-
-semver@5.5.1:
+"semver@2 || 3 || 4 || 5", semver@5.5.1, semver@5.x, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 


### PR DESCRIPTION
This was facilitated by running `yarn check` and fixing the issues.

## Before

```
warning "react-native#eslint-plugin-react-native@^3.2.1" could be deduped from "3.3.0" to "eslint-plugin-react-native@3.3.0"
warning "react-native#semver@^5.0.3" could be deduped from "5.5.1" to "semver@5.5.1"
error "react-native#react@16.3.1" doesn't satisfy found match of "react@16.4.2"
warning "@babel/core#semver@^5.4.1" could be deduped from "5.5.1" to "semver@5.5.1"
warning "babel-eslint#@babel/code-frame@7.0.0-beta.44" could be deduped from "7.0.0-beta.44" to "@babel/code-frame@7.0.0-beta.44"
warning "danger-plugin-yarn#semver@^5.4.1" could be deduped from "5.5.1" to "semver@5.5.1"
warning "eslint#ajv@^6.5.0" could be deduped from "6.5.3" to "ajv@6.5.3"
warning "eslint#semver@^5.5.0" could be deduped from "5.5.1" to "semver@5.5.1"
warning "babel-eslint#@babel/traverse#@babel/code-frame@7.0.0-beta.44" could be deduped from "7.0.0-beta.44" to "@babel/code-frame@7.0.0-beta.44"
warning "eslint#cross-spawn#semver@^5.5.0" could be deduped from "5.5.1" to "semver@5.5.1"
warning "react-native#fbjs-scripts#semver@^5.1.0" could be deduped from "5.5.1" to "semver@5.5.1"
warning "react-native#node-notifier#semver@^5.4.1" could be deduped from "5.5.1" to "semver@5.5.1"
warning "eslint#table#ajv@^6.0.1" could be deduped from "6.5.3" to "ajv@6.5.3"
error "react-native#eslint-plugin-react-native#eslint@^3.17.0 || ^4.0.0" doesn't satisfy found match of "eslint@5.0.1"
warning "metro#@babel/core#semver@^5.4.1" could be deduped from "5.5.1" to "semver@5.5.1"
warning "metro#babel-preset-es2015-node#semver@5.x" could be deduped from "5.5.1" to "semver@5.5.1"
warning "sane#fsevents#node-pre-gyp@^0.10.0" could be deduped from "0.10.3" to "node-pre-gyp@0.10.3"
warning "jest-cli#istanbul-api#async@^2.1.4" could be deduped from "2.6.1" to "async@2.6.1"
warning "jest-cli#istanbul-api#js-yaml@^3.7.0" could be deduped from "3.12.0" to "js-yaml@3.12.0"
warning "babel-plugin-istanbul#istanbul-lib-instrument#semver@^5.3.0" could be deduped from "5.5.1" to "semver@5.5.1"
warning "jest-cli#jest-snapshot#semver@^5.5.0" could be deduped from "5.5.1" to "semver@5.5.1"
warning "read-pkg#normalize-package-data#semver@2 || 3 || 4 || 5" could be deduped from "5.5.1" to "semver@5.5.1"
warning "table#ajv-keywords#ajv@^6.0.0" could be deduped from "6.5.3" to "ajv@6.5.3"
warning "babel-eslint#@babel/helper-function-name#@babel/template#@babel/code-frame@7.0.0-beta.44" could be deduped from "7.0.0-beta.44" to "@babel/code-frame@7.0.0-beta.44"
warning "jest-environment-jsdom#jsdom#left-pad@^1.2.0" could be deduped from "1.3.0" to "left-pad@1.3.0"
warning "os-name#win-release#semver@^5.0.1" could be deduped from "5.5.1" to "semver@5.5.1"
```

## After

```
warning "sane#fsevents#node-pre-gyp@^0.10.0" could be deduped from "0.10.3" to "node-pre-gyp@0.10.3"
```

(I'm not sure how to accomplish that one. We only have one `node-pre-gyp` in the lockfile, so I think it's a yarn bug.)

The only contentious item may be the React downgrade, but I think that it's OK:

1. The `react` package is tied together closely with the react-dom/react-native packages (it's actually co-versioned with `react-dom`, and there's probably a reason that `react-native` uses a fixed peerDependency version instead of a caret-range.)

    > The `react` package contains only the functionality necessary to define React components. It is typically used together with a React renderer like react-dom for the web, or react-native for the native environments.

2. Nearly all of the changes to `react` since 16.3.1 have been React DOM specific. The ones that weren't include:

    - Improve the error message when passing null or undefined to React.cloneElement.
    - Add a new experimental React.unstable_Profiler component for measuring performance. 
    - You can now assign propTypes to components returned by React.ForwardRef.
    - Add a warning if React.forwardRef render function doesn't take exactly two arguments
    - Improve the error message when passing an element to createElement by mistake
    - Don't call profiler onRender until after mutations

    So, there's not really any _bugfixes_, even, that we're missing out on.

3. There's probably a reason that react-native depends on react@16.3.1, without even a tilde-range depdendency, and I'd really like to silence the warning when I run `yarn install`.