### PR TITLE
use SelectableCell in Calendar

### DIFF
--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -1,7 +1,13 @@
 // @flow
 import * as React from 'react'
 import {ScrollView} from 'react-native'
-import {Cell, Section, TableView, ButtonCell, SelectableCell} from '@frogpond/tableview'
+import {
+	Cell,
+	Section,
+	TableView,
+	ButtonCell,
+	SelectableCell,
+} from '@frogpond/tableview'
 import type {EventType, PoweredBy} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {ShareButton} from '../../components/nav-buttons'

--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react'
-import {Text, ScrollView, StyleSheet} from 'react-native'
-import {Cell, Section, TableView, ButtonCell} from '@frogpond/tableview'
+import {ScrollView} from 'react-native'
+import {Cell, Section, TableView, ButtonCell, SelectableCell} from '@frogpond/tableview'
 import type {EventType, PoweredBy} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {ShareButton} from '../../components/nav-buttons'
@@ -10,22 +10,10 @@ import {ListFooter} from '@frogpond/lists'
 import {getLinksFromEvent, shareEvent, getTimes} from './calendar-util'
 import {AddToCalendar} from '../../components/add-to-calendar'
 
-const styles = StyleSheet.create({
-	chunk: {
-		paddingVertical: 10,
-	},
-})
-
 function MaybeSection({header, content}: {header: string, content: string}) {
 	return content.trim() ? (
 		<Section header={header}>
-			<Cell
-				cellContentView={
-					<Text selectable={true} style={styles.chunk}>
-						{content}
-					</Text>
-				}
-			/>
+			<SelectableCell text={content} />
 		</Section>
 	) : null
 }


### PR DESCRIPTION
Before | After
--- | ---
<img width="487" alt="screen shot 2018-09-10 at 11 25 44 pm" src="https://user-images.githubusercontent.com/464441/45338039-dc219680-b550-11e8-8fba-ff4a8c6d0044.png"> | <img width="487" alt="screen shot 2018-09-10 at 11 25 18 pm" src="https://user-images.githubusercontent.com/464441/45338038-dc219680-b550-11e8-8fb0-404dce8ba1a4.png">

let the data detectors run loose on the calendar.

this allows iOS to select arbitrary text in the fields, in addition to allowing the data detectors to hyperlink random stuff.