### PR TITLE
Remove right navigation button's margin

### DIFF
--- a/source/components/nav-buttons/styles.js
+++ b/source/components/nav-buttons/styles.js
@@ -41,7 +41,6 @@ export const rightButtonStyles = StyleSheet.create({
 		...Platform.select({
 			ios: {
 				paddingRight: 16,
-				marginTop: 7,
 			},
 			android: {
 				paddingVertical: 16,


### PR DESCRIPTION
At one time this was needed. It no longer appears to be needed.

Before | After
--|--
<img width="890" alt="broken" src="https://user-images.githubusercontent.com/5240843/45338398-2fdcb180-b54a-11e8-9ae4-7ac1d1d5dfb0.png"> | <img width="890" alt="pause-fixed" src="https://user-images.githubusercontent.com/5240843/45338394-2eab8480-b54a-11e8-8863-4d9648823b79.png">
<img width="736" alt="bug" src="https://user-images.githubusercontent.com/5240843/45338400-2fdcb180-b54a-11e8-94f7-0aae352cf1a2.png">| <img width="736" alt="fixed" src="https://user-images.githubusercontent.com/5240843/45338399-2fdcb180-b54a-11e8-92a8-52019826252e.png" />