### PR TITLE
Rename calendar back button to "Back" to fix overlapping titles

### DIFF
--- a/source/views/calendar/index.js
+++ b/source/views/calendar/index.js
@@ -62,6 +62,7 @@ const CalendarView = TabNavigator({
 
 CalendarView.navigationOptions = {
 	title: 'Calendar',
+	headerBackTitle: 'Back',
 }
 
 export default CalendarView


### PR DESCRIPTION
before | after
--- | ---
<img width="320" alt="screen shot 2018-09-10 at 11 47 21 pm" src="https://user-images.githubusercontent.com/464441/45338681-04f75b00-b554-11e8-83c1-8285fd98f8ee.png"> | <img width="320" alt="screen shot 2018-09-10 at 11 47 09 pm" src="https://user-images.githubusercontent.com/464441/45338682-058ff180-b554-11e8-8a06-410a21835443.png">

I don't like hiding the back context, but sometimes you just need to.