### PR TITLE
Stop calling getTags on app resume in the settings screen

### DIFF
--- a/source/redux/parts/notifications.js
+++ b/source/redux/parts/notifications.js
@@ -108,6 +108,22 @@ export function hydrate(): ThunkAction<
 	}
 }
 
+export function refreshPushStatus(): ThunkAction<
+	SetPermissionsAction,
+> {
+	return dispatch => {
+		OneSignal.getPermissionSubscriptionState(permissions => {
+			dispatch({
+				type: SET_PERMISSIONS,
+				payload: {
+					enabled: permissions.notificationsEnabled,
+					hasPrompted: permissions.hasPrompted,
+				},
+			})
+		})
+	}
+}
+
 type DisableNotificationsAction = {|
 	type: 'notifications/DISABLE',
 |}

--- a/source/redux/parts/notifications.js
+++ b/source/redux/parts/notifications.js
@@ -108,9 +108,7 @@ export function hydrate(): ThunkAction<
 	}
 }
 
-export function refreshPushStatus(): ThunkAction<
-	SetPermissionsAction,
-> {
+export function refreshPushStatus(): ThunkAction<SetPermissionsAction> {
 	return dispatch => {
 		OneSignal.getPermissionSubscriptionState(permissions => {
 			dispatch({

--- a/source/views/settings/screens/push-notifications/on-resume.js
+++ b/source/views/settings/screens/push-notifications/on-resume.js
@@ -3,10 +3,10 @@
 import * as React from 'react'
 import {AppState} from 'react-native'
 import {connect} from 'react-redux'
-import {hydrate} from '../../../../redux/parts/notifications'
+import {refreshPushStatus} from '../../../../redux/parts/notifications'
 
 type Props = {
-	rehydrate: () => any,
+	refreshPushStatus: () => any,
 }
 
 type State = {
@@ -33,7 +33,7 @@ class _CheckForPushSettingsOnResume extends React.Component<Props, State> {
 			currentAppState !== 'active' && nextAppState === 'active'
 
 		if (shouldRehydrate) {
-			this.props.rehydrate()
+			this.props.refreshPushStatus()
 		}
 
 		this.setState(() => ({appState: nextAppState}))
@@ -47,6 +47,6 @@ class _CheckForPushSettingsOnResume extends React.Component<Props, State> {
 export const CheckForPushSettingsOnResume = connect(
 	null,
 	(dispatch): Props => ({
-		rehydrate: () => dispatch(hydrate()),
+		refreshPushStatus: () => dispatch(refreshPushStatus()),
 	}),
 )(_CheckForPushSettingsOnResume)


### PR DESCRIPTION
Part of #3012 

I think that the underlying issue in #3012 is that we were calling getTags before the server had processed the addTag call, as evidenced by the fact that tags eventually do show up. We don't even _need_ to call getTags here; it was just simpler to reuse the `hydrate` function.