### PR TITLE
Remove links section from ios calendar detail

### DIFF
--- a/source/views/calendar/event-detail.ios.js
+++ b/source/views/calendar/event-detail.ios.js
@@ -2,7 +2,6 @@
 import * as React from 'react'
 import {ScrollView} from 'react-native'
 import {
-	Cell,
 	Section,
 	TableView,
 	ButtonCell,
@@ -11,7 +10,6 @@ import {
 import type {EventType, PoweredBy} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {ShareButton} from '@frogpond/navigation-buttons'
-import {openUrl} from '@frogpond/open-url'
 import {ListFooter} from '@frogpond/lists'
 import {shareEvent, getTimes} from './calendar-util'
 import {AddToCalendar} from '../../components/add-to-calendar'
@@ -20,21 +18,6 @@ function MaybeSection({header, content}: {header: string, content: string}) {
 	return content.trim() ? (
 		<Section header={header}>
 			<SelectableCell text={content} />
-		</Section>
-	) : null
-}
-
-function Links({header, event}: {header: string, event: EventType}) {
-	return event.links.length ? (
-		<Section header={header}>
-			{event.links.map(url => (
-				<Cell
-					key={url}
-					accessory="DisclosureIndicator"
-					onPress={() => openUrl(url)}
-					title={url}
-				/>
-			))}
 		</Section>
 	) : null
 }
@@ -64,7 +47,6 @@ export class EventDetail extends React.Component<Props> {
 					<MaybeSection content={getTimes(event)} header="TIME" />
 					<MaybeSection content={event.location} header="LOCATION" />
 					<MaybeSection content={event.description} header="DESCRIPTION" />
-					<Links event={event} header="LINKS" />
 
 					<AddToCalendar
 						event={event}


### PR DESCRIPTION
Followup to #3023. Removes the link row parsing because `SelectableCell` uses `TextInput`.