### PR TITLE
Include development bonapp menu picker

### DIFF
--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -36,7 +36,7 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 		tabBarIcon: TabBarIcon('ionic'),
 	}
 
-	_ref: any
+	_ref: ?TextInput
 
 	state = {
 		cafeId: '34',
@@ -59,12 +59,16 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 					<TextInput
 						ref={this.setRef}
 						keyboardType="numeric"
-						onBlur={() => this.chooseCafe(this._ref._lastNativeText)}
+						onBlur={() =>
+							this._ref ? this.chooseCafe(this._ref._lastNativeText) : null
+						}
 						style={styles.default}
 						value={Platform.OS === 'ios' ? this.state.cafeId : null}
 					/>
 					<Button
-						onPress={() => this.chooseCafe(this._ref._lastNativeText)}
+						onPress={() =>
+							this._ref ? this.chooseCafe(this._ref._lastNativeText) : null
+						}
 						title="Go"
 					/>
 				</Toolbar>

--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react'
-import {View, TextInput, StyleSheet, Platform} from 'react-native'
+import {View, TextInput, StyleSheet} from 'react-native'
+import {NoticeView} from '@frogpond/notice'
 import {TabBarIcon} from '@frogpond/navigation-tabs'
 import * as c from '@frogpond/colors'
 import {Toolbar} from '@frogpond/toolbar'
@@ -35,7 +36,7 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 	}
 
 	state = {
-		cafeId: '34',
+		cafeId: '',
 	}
 
 	chooseCafe = (cafeId: string) => {
@@ -52,18 +53,22 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 					<TextInput
 						keyboardType="numeric"
 						onEndEditing={e => this.chooseCafe(e.nativeEvent.text)}
+						placeholder="id"
 						returnKeyType="done"
 						style={styles.default}
-						value={Platform.OS === 'ios' ? this.state.cafeId : null}
 					/>
 				</Toolbar>
-				<BonAppHostedMenu
-					key={this.state.cafeId}
-					cafe={{id: this.state.cafeId}}
-					loadingMessage={['Loading…']}
-					name="BonApp"
-					navigation={this.props.navigation}
-				/>
+				{this.state.cafeId ? (
+					<BonAppHostedMenu
+						key={this.state.cafeId}
+						cafe={{id: this.state.cafeId}}
+						loadingMessage={['Loading…']}
+						name="BonApp"
+						navigation={this.props.navigation}
+					/>
+				) : (
+					<NoticeView text="Please enter a Cafe ID." />
+				)}
 			</View>
 		)
 	}

--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -4,7 +4,6 @@ import {View, TextInput, StyleSheet, Platform} from 'react-native'
 import {TabBarIcon} from '@frogpond/navigation-tabs'
 import * as c from '@frogpond/colors'
 import {Toolbar} from '@frogpond/toolbar'
-import {Button} from '@frogpond/button'
 import type {TopLevelViewPropsType} from '../types'
 import {BonAppHostedMenu} from './menu-bonapp'
 
@@ -62,14 +61,9 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 						onBlur={() =>
 							this._ref ? this.chooseCafe(this._ref._lastNativeText) : null
 						}
+						returnKeyType="done"
 						style={styles.default}
 						value={Platform.OS === 'ios' ? this.state.cafeId : null}
-					/>
-					<Button
-						onPress={() =>
-							this._ref ? this.chooseCafe(this._ref._lastNativeText) : null
-						}
-						title="Go"
 					/>
 				</Toolbar>
 				<BonAppHostedMenu

--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -26,7 +26,6 @@ type Props = TopLevelViewPropsType
 
 type State = {
 	cafeId: string,
-	menu: ?any,
 }
 
 export class BonAppPickerView extends React.PureComponent<Props, State> {
@@ -37,7 +36,6 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 
 	state = {
 		cafeId: '34',
-		menu: null,
 	}
 
 	chooseCafe = (cafeId: string) => {

--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -3,7 +3,8 @@ import * as React from 'react'
 import {View, TextInput, StyleSheet} from 'react-native'
 import {TabBarIcon} from '@frogpond/navigation-tabs'
 import * as c from '@frogpond/colors'
-import {Toolbar, ToolbarButton} from '@frogpond/toolbar'
+import {Toolbar} from '@frogpond/toolbar'
+import {Button} from '@frogpond/button'
 import type {TopLevelViewPropsType} from '../types'
 import {BonAppHostedMenu} from './menu-bonapp'
 
@@ -35,6 +36,8 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 		tabBarIcon: TabBarIcon('ionic'),
 	}
 
+	_ref: any
+
 	state = {
 		cafeId: '34',
 		menu: null,
@@ -47,18 +50,23 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 		this.setState(() => ({cafeId}))
 	}
 
+	setRef = (ref: any) => (this._ref = ref)
+
 	render() {
 		return (
 			<View style={styles.container}>
 				<Toolbar onPress={() => {}}>
 					<TextInput
+						ref={this.setRef}
 						keyboardType="numeric"
-						onBlur={this.chooseCafe}
-						onChangeText={this.chooseCafe}
+						onBlur={() => this.chooseCafe(this._ref._lastNativeText)}
 						style={styles.default}
 						value={this.state.cafeId}
 					/>
-					<ToolbarButton isActive={true} title="Go" />
+					<Button
+						onPress={() => this.chooseCafe(this._ref._lastNativeText)}
+						title="Go"
+					/>
 				</Toolbar>
 				<BonAppHostedMenu
 					key={this.state.cafeId}

--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {View, TextInput, StyleSheet} from 'react-native'
+import {View, TextInput, StyleSheet, Platform} from 'react-native'
 import {TabBarIcon} from '@frogpond/navigation-tabs'
 import * as c from '@frogpond/colors'
 import {Toolbar} from '@frogpond/toolbar'
@@ -61,7 +61,7 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 						keyboardType="numeric"
 						onBlur={() => this.chooseCafe(this._ref._lastNativeText)}
 						style={styles.default}
-						value={this.state.cafeId}
+						value={Platform.OS === 'ios' ? this.state.cafeId : null}
 					/>
 					<Button
 						onPress={() => this.chooseCafe(this._ref._lastNativeText)}

--- a/source/views/menus/dev-bonapp-picker.js
+++ b/source/views/menus/dev-bonapp-picker.js
@@ -35,8 +35,6 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 		tabBarIcon: TabBarIcon('ionic'),
 	}
 
-	_ref: ?TextInput
-
 	state = {
 		cafeId: '34',
 		menu: null,
@@ -49,18 +47,13 @@ export class BonAppPickerView extends React.PureComponent<Props, State> {
 		this.setState(() => ({cafeId}))
 	}
 
-	setRef = (ref: any) => (this._ref = ref)
-
 	render() {
 		return (
 			<View style={styles.container}>
 				<Toolbar onPress={() => {}}>
 					<TextInput
-						ref={this.setRef}
 						keyboardType="numeric"
-						onBlur={() =>
-							this._ref ? this.chooseCafe(this._ref._lastNativeText) : null
-						}
+						onEndEditing={e => this.chooseCafe(e.nativeEvent.text)}
 						returnKeyType="done"
 						style={styles.default}
 						value={Platform.OS === 'ios' ? this.state.cafeId : null}

--- a/source/views/menus/index.js
+++ b/source/views/menus/index.js
@@ -2,11 +2,12 @@
 
 import * as React from 'react'
 import {TabNavigator, TabBarIcon} from '@frogpond/navigation-tabs'
+import {IS_PRODUCTION} from '@frogpond/constants'
 
 import {BonAppHostedMenu} from './menu-bonapp'
 import {GitHubHostedMenu} from './menu-github'
 import {CarletonCafeIndex} from './carleton-menus'
-// import {BonAppPickerView} from './dev-bonapp-picker'
+import {BonAppPickerView} from './dev-bonapp-picker'
 
 export {
 	CarletonBurtonMenuScreen,
@@ -88,7 +89,7 @@ export const MenusView = TabNavigator({
 		},
 	},
 
-	// BonAppDevToolView: {screen: BonAppPickerView},
+	...(!IS_PRODUCTION ? {BonAppDevToolView: {screen: BonAppPickerView}} : {}),
 })
 MenusView.navigationOptions = {
 	title: 'Menus',

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -16,6 +16,7 @@ import sample from 'lodash/sample'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
 import toPairs from 'lodash/toPairs'
+import isEmpty from 'lodash/isEmpty'
 import type momentT from 'moment'
 import moment from 'moment-timezone'
 import {trimStationName, trimItemLabel} from './lib/trim-names'
@@ -259,6 +260,11 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
 
 			const msg =
 				'Something went wrong. Email allaboutolaf@stolaf.edu to let them know?'
+			return <NoticeView text={msg} />
+		}
+
+		if (isEmpty(this.state.cafeMenu.items)) {
+			const msg = 'No items were found.'
 			return <NoticeView text={msg} />
 		}
 

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -16,7 +16,6 @@ import sample from 'lodash/sample'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
 import toPairs from 'lodash/toPairs'
-import isEmpty from 'lodash/isEmpty'
 import type momentT from 'moment'
 import moment from 'moment-timezone'
 import {trimStationName, trimItemLabel} from './lib/trim-names'
@@ -263,7 +262,7 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
 			return <NoticeView text={msg} />
 		}
 
-		if (isEmpty(this.state.cafeMenu.items)) {
+		if (Object.keys(this.state.cafeMenu.items).length === 0) {
 			const msg = 'No items were found.'
 			return <NoticeView text={msg} />
 		}


### PR DESCRIPTION
@hawkrives wrote the dev picker and I felt that it'd be nice to have as an exposed tab within dev. This tool lets us explore ~1980ish bonapp cafes available thru the API. 

* Check if there are any menu items to display as to handle all cafe types and menu states.
* Stop live searching as to cut down on the api calls while typing.
* Swap out the toolbar button to be an actual functioning button.

[One nuance of android](https://facebook.github.io/react-native/docs/textinput#value): it won't let you delete and type if the value is set, so opt for not setting it from state.

> The value to show for the text input. TextInput is a controlled component, which means the native value will be forced to match this value prop if provided. For most uses, this works great, but in some cases this may cause flickering - one common cause is preventing edits by keeping value the same.

Android | iOS
--|--
![android-empty](https://user-images.githubusercontent.com/5240843/45522259-25efc400-b77f-11e8-8511-970f1b090829.png) | <img width="877" alt="ios-empty" src="https://user-images.githubusercontent.com/5240843/45522260-26885a80-b77f-11e8-92b7-4460980a36ab.png">
![android-100](https://user-images.githubusercontent.com/5240843/45522282-520b4500-b77f-11e8-8387-1efa7489069f.png) | <img width="877" alt="ios-100" src="https://user-images.githubusercontent.com/5240843/45522281-5172ae80-b77f-11e8-97f4-7b63bced63f8.png">
![android-84](https://user-images.githubusercontent.com/5240843/45522293-5e8f9d80-b77f-11e8-8533-7683a2f8b7ee.png) | <img width="877" alt="ios-84" src="https://user-images.githubusercontent.com/5240843/45522294-5e8f9d80-b77f-11e8-82b5-3d1debd72dfd.png">


 