### PR TITLE
Show the bonapp dev tool on beta/nightly

### DIFF
--- a/source/views/menus/index.js
+++ b/source/views/menus/index.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import {TabNavigator, TabBarIcon} from '@frogpond/navigation-tabs'
-import {IS_PRODUCTION} from '@frogpond/constants'
+import {isReleaseBuild} from '@frogpond/constants'
 
 import {BonAppHostedMenu} from './menu-bonapp'
 import {GitHubHostedMenu} from './menu-github'
@@ -89,7 +89,7 @@ export const MenusView = TabNavigator({
 		},
 	},
 
-	...(!IS_PRODUCTION ? {BonAppDevToolView: {screen: BonAppPickerView}} : {}),
+	...(!isReleaseBuild() ? {BonAppDevToolView: {screen: BonAppPickerView}} : {}),
 })
 MenusView.navigationOptions = {
 	title: 'Menus',


### PR DESCRIPTION
instead of only showing it when debugging on a simulator.