### PR TITLE
Replace isReleaseBuild with isDevMode

### DIFF
--- a/modules/constants/index.js
+++ b/modules/constants/index.js
@@ -25,7 +25,8 @@ export const isPre = () => IS_PRE
 let IS_RC: boolean
 export const isRc = () => IS_RC
 
-export const isReleaseBuild = () => IS_ALPHA || IS_BETA || IS_PRE || IS_RC
+// checks if the build should show debugging tools
+export const isDevMode = () => !IS_PRODUCTION || (IS_ALPHA || IS_BETA || IS_PRE || IS_RC)
 
 export const setVersionInfo = (versionStr: string) => {
 	let [version, buildNum] = versionStr.split('+')

--- a/source/views/home/notice.js
+++ b/source/views/home/notice.js
@@ -5,7 +5,7 @@ import * as glamorous from 'glamorous-native'
 import * as c from '@frogpond/colors'
 import sample from 'lodash/sample'
 import {CELL_MARGIN} from './button'
-import {isReleaseBuild} from '@frogpond/constants'
+import {isDevMode} from '@frogpond/constants'
 
 let messages = [
 	'☃️ An Unofficial App Project ☃️',
@@ -18,7 +18,7 @@ let messages = [
 	'Made with ❤️ in Northfield, MN',
 ]
 
-if (!isReleaseBuild()) {
+if (isDevMode()) {
 	messages = [
 		...messages,
 		'made with  ⃟ in Ñ̸̞͖̘̱̰̥͇̗̂͌̇̎͊ͯ̎̓̎ͥ̋̐ͤͪͭ̚͘͢͢ø̸̛̞͊̎ͩ̍̉̑ͯͫͥ̚͟ͅ ̱̬̹̱̦®̵̬͖͙̻̩͓̖̠͉͈͍̈́̅͂͛̅̀͗ͤ̓́͡†̵̧͙̥̫̫͎̘̩̲̥̖̈̌͋̀ͨ̑̽̍̆̓̒̒̄̈́͒̓̕͜ ͍̩̫̼ͅ˙̶͕̰̗͓̯̫̲̮͕̪̝͎̩̬̺̔ͯ̌̈̽̌ͨ͊͊͐̀͆̽̐̓̃́̚͢͟ ̞̞̤ƒ͚͙̤ͭͪ͑̄͆͑ͯ̆͗̆ͨ̍̀͟͢ ̙͎̝͕͔̠͉̩̯͕͚̗̤ͅî̹̗̩̫̝̝͙̠̹̣̺̤̆ͭ̾̋ͬ̂ͫ̃̏ͥͬ́͜͠é̚ ̸͔͕̗̞̰́̅̅͒ ̪̩̞̰̫͓̞̱̫̞̭̯¬ͫ̾̆ ̍ͣ̎̀ͫͪͪ̋͌̂ ̪̘̯̝̤͌̆ͮ̕͜͜͡∂̢̛͕̻͖̈͌ͮ̂̾ͪͪ̑͋͂̂̂̂̈́̈́̓̌̍̌͜͞ ͙̫̤',

--- a/source/views/menus/index.js
+++ b/source/views/menus/index.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import {TabNavigator, TabBarIcon} from '@frogpond/navigation-tabs'
-import {IS_PRODUCTION} from '@frogpond/constants'
+import {isDevMode} from '@frogpond/constants'
 
 import {BonAppHostedMenu} from './menu-bonapp'
 import {GitHubHostedMenu} from './menu-github'
@@ -89,7 +89,7 @@ export const MenusView = TabNavigator({
 		},
 	},
 
-	...(!IS_PRODUCTION ? {BonAppDevToolView: {screen: BonAppPickerView}} : {}),
+	...(isDevMode() ? {BonAppDevToolView: {screen: BonAppPickerView}} : {}),
 })
 MenusView.navigationOptions = {
 	title: 'Menus',


### PR DESCRIPTION
Supplants #3061 

This allows us to use a positive conditional, instead of negating.

It also is clearer about our intent – we'd never want to build something that's on a beta/nightly but _not_ a simulator, for instance.

This PR replaces the `isReleaseBuild(): boolean` method from `@frogpond/constants` with `isDevMode(): boolean`.