### PR TITLE
Call dev mode constant in settings as a function

### DIFF
--- a/source/views/settings/screens/overview/odds-and-ends.js
+++ b/source/views/settings/screens/overview/odds-and-ends.js
@@ -34,7 +34,7 @@ export class OddsAndEndsSection extends React.Component<Props> {
 
 				<ConnectedNotificationsCell onPress={this.onNotificationsButton} />
 
-				{isDevMode && (
+				{isDevMode() && (
 					<PushButtonCell onPress={this.onDebugButton} title="Debug" />
 				)}
 			</Section>


### PR DESCRIPTION
The check wasn't being called as a function for exposing the redux settings.