### PR TITLE
bump package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AllAboutOlaf",
-  "version": "2.6.3",
+  "version": "2.6.4-pre",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
Apple won't let us upload nightlies with the same version as the currently released app.