### PR TITLE
CircleCI: Sleep for up to 600 seconds at start of nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ workflows:
 
 jobs:
   sleep-random:
-    docker: [{image: alpine:latest}]
+    docker: [{image: 'alpine:latest'}]
     steps:
       - run:
           name: Sleep for up to 10 minutes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,8 @@ workflows:
           cron: 0 10 * * *
           filters: {branches: {only: [master]}}
     jobs:
-      - sleep-random
-      - cache-yarn-linux: {requires: [sleep-random]}
-      - cache-bundler-linux: {requires: [sleep-random]}
+      - cache-yarn-linux
+      - cache-bundler-linux
       - danger: {requires: [cache-yarn-linux]}
       - flow: {requires: [cache-yarn-linux]}
       - jest: {requires: [cache-yarn-linux]}
@@ -108,14 +107,6 @@ workflows:
       - android-nightly: {requires: [danger, flow, jest, prettier, eslint, data, cache-bundler-linux]}
 
 jobs:
-  sleep-random:
-    docker: [{image: 'alpine:latest'}]
-    steps:
-      - run:
-          name: Sleep for up to 10 minutes
-          command: time=$((RANDOM % 600)) && echo "Sleeping for $time seconds..." && set -x && sleep ${time}s
-          no_output_timeout: 15m
-
   cache-yarn-linux:
     docker: *docker-node
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,10 @@ jobs:
   sleep-random:
     docker: [{image: alpine:latest}]
     steps:
-      - run: echo "Sleeping for a bit..."
+      - run:
+          name: Sleep for up to 10 minutes
+          command: time=$((RANDOM % 600)) && echo "Sleeping for $time seconds..." && set -x && sleep ${time}s
+          no_output_timeout: 15m
 
   cache-yarn-linux:
     docker: *docker-node

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,9 @@ workflows:
           cron: 0 10 * * *
           filters: {branches: {only: [master]}}
     jobs:
-      - cache-yarn-linux
-      - cache-bundler-linux
+      - sleep-random
+      - cache-yarn-linux: {requires: [sleep-random]}
+      - cache-bundler-linux: {requires: [sleep-random]}
       - danger: {requires: [cache-yarn-linux]}
       - flow: {requires: [cache-yarn-linux]}
       - jest: {requires: [cache-yarn-linux]}
@@ -107,6 +108,11 @@ workflows:
       - android-nightly: {requires: [danger, flow, jest, prettier, eslint, data, cache-bundler-linux]}
 
 jobs:
+  sleep-random:
+    docker: [{image: alpine:latest}]
+    steps:
+      - run: echo "Sleeping for a bit..."
+
   cache-yarn-linux:
     docker: *docker-node
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: 0 10 * * *
+          cron: 17 10 * * *
           filters: {branches: {only: [master]}}
     jobs:
       - cache-yarn-linux


### PR DESCRIPTION
Closes #3027.

This PR changes CircleCI nightlies to sleep for up to 600 seconds at the start of the nightly, by forcing `yarn` and `bundle` to wait for a sleep job to finish.

This shouldn't incur any complaints from CircleCI, because sleeping is a very low-impact kind of thing to do. Yes, it does build up some build minutes, but we are an open source project so it doesn't matter.

This is done primarily to avoid any nightly failures due to load spikes on the services we depend on.

Another choice we could make is to start the nightly at a non-start-of-the-hour time, or (even better) start our build at a random offset of up to 10 minutes from that non-start-of-the-hour time.

This additional change would just involve applying a diff like the following:

```diff
diff --git a/.circleci/config.yml b/.circleci/config.yml
index e1bb7333..a1a4529d 100644
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: 0 10 * * *
+          cron: 17 10 * * *
           filters: {branches: {only: [master]}}
     jobs:
       - sleep-random
```