### PR TITLE
API: Rename an argument and dedupe logic

### DIFF
--- a/modules/api/index.js
+++ b/modules/api/index.js
@@ -2,6 +2,8 @@
 
 import qs from 'query-string'
 
+import {IS_PRODUCTION} from '@frogpond/constants'
+
 let root: string
 
 export function setApiRoot(url: string) {
@@ -9,7 +11,7 @@ export function setApiRoot(url: string) {
 }
 
 export const API = (path: string, query: ?Object = null) => {
-	if (process.env.NODE_ENV !== 'production') {
+	if (!IS_PRODUCTION) {
 		if (!path.startsWith('/')) {
 			throw new Error('invalid path requested from the api!')
 		}

--- a/modules/api/index.js
+++ b/modules/api/index.js
@@ -8,13 +8,13 @@ export function setApiRoot(url: string) {
 	root = url
 }
 
-export const API = (pth: string, query: ?Object = null) => {
+export const API = (path: string, query: ?Object = null) => {
 	if (process.env.NODE_ENV !== 'production') {
-		if (!pth.startsWith('/')) {
+		if (!path.startsWith('/')) {
 			throw new Error('invalid path requested from the api!')
 		}
 	}
-	let url = root + pth
+	let url = root + path
 	if (query) {
 		url += `?${qs.stringify(query)}`
 	}

--- a/modules/api/index.js
+++ b/modules/api/index.js
@@ -14,9 +14,12 @@ export const API = (path: string, query: ?Object = null) => {
 			throw new Error('invalid path requested from the api!')
 		}
 	}
+
 	let url = root + path
+
 	if (query) {
 		url += `?${qs.stringify(query)}`
 	}
+
 	return url
 }


### PR DESCRIPTION
Instead of doing our own comparison with `process.env.NODE_ENV !== 'production'`, I figured it was better to use the constant that is already set to that value.

Also renames `pth` to `path`. Words are cool.

Oh and adds whitespace too.