### PR TITLE
remove sudo:false from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ jobs:
 
     # Deploy the gh-pages data
     - os: linux
-      sudo: false
       distro: trusty
       language: node_js
       node_js: $TRAVIS_NODE_VERSION


### PR DESCRIPTION
See: https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures

> Starting in the second week of November (we’ll post another blog post), we will start to migrate repositories that use sudo: false to the virtual machine-based infrastructure. Open source repositories will be rerouted first, with closed-source to follow. We’ll keep you posted via this blog and the changelog and twitter - have a look out for updates!