### PR TITLE
Use _our_ build tools versions when compiling dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,3 +38,14 @@ allprojects {
         }
     }
 }
+
+subprojects {
+    afterEvaluate { project ->
+        if (project.hasProperty("android")) {
+            android {
+                compileSdkVersion 28
+                buildToolsVersion "27.0.3"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This explicitly forces each subproject to use our version of the build tools, and suppresses any warnings about out-of-date build tools versions.  It does so by redefining the compileSdkVersion and buildToolsVersion for each subproject after they have been evaluated.

For what it's worth, this does compile and run properly locally.

This _could_ go into `android/app/build.gradle` and use the defined constants from there? Something like that?