### PR TITLE
ccc-calendar: Upgrade delay peer dependency to 4.1.0

### DIFF
--- a/modules/ccc-calendar/package.json
+++ b/modules/ccc-calendar/package.json
@@ -12,7 +12,7 @@
     "react": "^16.0.0",
     "react-navigation": "^2.13.0",
     "moment-timezone": "^0.5.21",
-    "delay": "4.0.1"
+    "delay": "4.1.0"
   },
   "dependencies": {
     "@frogpond/analytics": "^1.0.0",


### PR DESCRIPTION
This resolves a warning by Yarn about incorrect peer dependency versions.