### PR TITLE
add-to-device-calendar: Update delay to version 4.1.0

### DIFF
--- a/modules/add-to-device-calendar/package.json
+++ b/modules/add-to-device-calendar/package.json
@@ -9,13 +9,13 @@
     "test": "jest"
   },
   "peerDependencies": {
+    "delay": "^4.1.0",
     "react": "^16.0.0",
     "react-native": "^0.55.4",
     "react-native-calendar-events": "1.6.3"
   },
   "dependencies": {
     "@frogpond/analytics": "^1.0.0",
-    "@frogpond/event-type": "^1.0.0",
-    "delay": "4.1.0"
+    "@frogpond/event-type": "^1.0.0"
   }
 }

--- a/modules/add-to-device-calendar/package.json
+++ b/modules/add-to-device-calendar/package.json
@@ -16,6 +16,6 @@
   "dependencies": {
     "@frogpond/analytics": "^1.0.0",
     "@frogpond/event-type": "^1.0.0",
-    "delay": "4.0.1"
+    "delay": "4.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2716,11 +2716,6 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
-delay@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/delay/-/delay-4.0.1.tgz#052120e49bc3617a92e9a6cd9556be2cf23397a0"
-  integrity sha512-wOsrzqdl8Lphi0v3g4FPz7zf0sT4o/u+z+LB+s1q0qzB9xw6QzZbdY9D6IoCojRHIxbaHvpUkLt6//1KB6VNug==
-
 delay@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/delay/-/delay-4.1.0.tgz#474cd28809da41d1a048a70a1d835f47ac377cd2"


### PR DESCRIPTION
This allows us to dedupe a version of delay out of getting downloaded.

Not sure why this one isn't a peer dependency, but oh well.