### PR TITLE
Use the US/Central timezone, and centralize logic for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Changed
 - Switched time zone definitions from America/Winnipeg to US/Central
+- Pulled out time zone constants from all over the place into a central constant
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Switched time zone definitions from America/Winnipeg to US/Central
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/modules/ccc-calendar/index.js
+++ b/modules/ccc-calendar/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react'
+import {timezone} from '@frogpond/constants'
 import {reportNetworkProblem} from '@frogpond/analytics'
 import type {NavigationScreenProp} from 'react-navigation'
 import {EventList, type PoweredBy} from '@frogpond/event-list'
@@ -9,8 +10,6 @@ import moment from 'moment-timezone'
 import delay from 'delay'
 import {LoadingView} from '@frogpond/notice'
 import {API} from '@frogpond/api'
-
-const TIMEZONE = 'US/Central'
 
 type Props = {
 	calendar:
@@ -38,7 +37,7 @@ export class CccCalendarView extends React.Component<Props, State> {
 		loading: true,
 		refreshing: false,
 		error: null,
-		now: moment.tz(TIMEZONE),
+		now: moment.tz(timezone()),
 	}
 
 	componentDidMount() {
@@ -66,7 +65,7 @@ export class CccCalendarView extends React.Component<Props, State> {
 		return events
 	}
 
-	getEvents = async (now: moment = moment.tz(TIMEZONE)) => {
+	getEvents = async (now: moment = moment.tz(timezone())) => {
 		let url
 		if (typeof this.props.calendar === 'string') {
 			url = API(`/calendar/named/${this.props.calendar}`)

--- a/modules/ccc-calendar/index.js
+++ b/modules/ccc-calendar/index.js
@@ -9,7 +9,8 @@ import moment from 'moment-timezone'
 import delay from 'delay'
 import {LoadingView} from '@frogpond/notice'
 import {API} from '@frogpond/api'
-const TIMEZONE = 'America/Winnipeg'
+
+const TIMEZONE = 'US/Central'
 
 type Props = {
 	calendar:

--- a/modules/constants/index.js
+++ b/modules/constants/index.js
@@ -2,6 +2,10 @@
 
 import {Platform} from 'react-native'
 
+let TZ: string
+export const setTimezone = (zone: string) => (TZ = zone)
+export const timezone = () => TZ
+
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 
 let APP_VERSION: string

--- a/modules/constants/index.js
+++ b/modules/constants/index.js
@@ -4,7 +4,7 @@ import {Platform} from 'react-native'
 
 let TZ: string
 export const setTimezone = (zone: string) => (TZ = zone)
-export const timezone = () => TZ
+export const timezone = () => TZ || 'US/Central'
 
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 

--- a/modules/food-menu/lib/find-menu.js
+++ b/modules/food-menu/lib/find-menu.js
@@ -2,13 +2,12 @@
 import type momentT from 'moment'
 import moment from 'moment-timezone'
 import findIndex from 'lodash/findIndex'
+import {timezone} from '@frogpond/constants'
 import type {
 	DayPartMenuType,
 	DayPartsCollectionType,
 	ProcessedMealType,
 } from '../types'
-
-const CENTRAL_TZ = 'US/Central'
 
 export function findMenu(
 	dayparts: DayPartsCollectionType,
@@ -63,10 +62,10 @@ function findMenuIndex(dayparts: DayPartMenuType[], now: momentT): number {
 	// `now`, so that we don't have our days wandering all over the place.
 	const times = dayparts.map(({starttime, endtime}) => ({
 		start: moment
-			.tz(starttime, 'H:mm', true, CENTRAL_TZ)
+			.tz(starttime, 'H:mm', true, timezone())
 			.dayOfYear(now.dayOfYear()),
 		end: moment
-			.tz(endtime, 'H:mm', true, CENTRAL_TZ)
+			.tz(endtime, 'H:mm', true, timezone())
 			.dayOfYear(now.dayOfYear()),
 	}))
 

--- a/modules/food-menu/lib/find-menu.js
+++ b/modules/food-menu/lib/find-menu.js
@@ -7,7 +7,8 @@ import type {
 	DayPartsCollectionType,
 	ProcessedMealType,
 } from '../types'
-const CENTRAL_TZ = 'America/Winnipeg'
+
+const CENTRAL_TZ = 'US/Central'
 
 export function findMenu(
 	dayparts: DayPartsCollectionType,

--- a/source/init/constants.js
+++ b/source/init/constants.js
@@ -6,4 +6,4 @@ const {version, name} = require('../../package.json')
 
 setVersionInfo(version)
 setAppName(name)
-setTimezone("US/Central")
+setTimezone('US/Central')

--- a/source/init/constants.js
+++ b/source/init/constants.js
@@ -6,3 +6,4 @@ const {version, name} = require('../../package.json')
 
 setVersionInfo(version)
 setAppName(name)
+setTimezone("US/Central")

--- a/source/init/constants.js
+++ b/source/init/constants.js
@@ -1,6 +1,6 @@
 // @flow
 
-import {setVersionInfo, setAppName} from '@frogpond/constants'
+import {setVersionInfo, setAppName, setTimezone} from '@frogpond/constants'
 
 const {version, name} = require('../../package.json')
 

--- a/source/views/building-hours/detail/index.js
+++ b/source/views/building-hours/detail/index.js
@@ -4,7 +4,7 @@ import * as React from 'react'
 import type {BuildingType} from '../types'
 import {Timer} from '@frogpond/timer'
 import {BuildingDetail} from './building'
-import {CENTRAL_TZ} from '../lib'
+import {timezone} from '@frogpond/constants'
 import type {TopLevelViewPropsType} from '../../types'
 import {ConnectedBuildingFavoriteButton as FavoriteButton} from './toolbar-button'
 
@@ -41,7 +41,7 @@ export class BuildingHoursDetailView extends React.Component<Props> {
 						onProblemReport={this.reportProblem}
 					/>
 				)}
-				timezone={CENTRAL_TZ}
+				timezone={timezone()}
 			/>
 		)
 	}

--- a/source/views/building-hours/lib/__tests__/moment.helper.js
+++ b/source/views/building-hours/lib/__tests__/moment.helper.js
@@ -3,8 +3,8 @@ import moment from 'moment-timezone'
 export {moment}
 
 export const dayMoment = (time: string, format: ?string = 'ddd h:mma') =>
-	moment.tz(time, format, false, 'America/Winnipeg')
+	moment.tz(time, format, false, 'US/Central')
 export const hourMoment = (time: string) =>
-	moment.tz(time, 'h:mma', false, 'America/Winnipeg')
+	moment.tz(time, 'h:mma', false, 'US/Central')
 export const plainMoment = (time: string, format: string) =>
-	moment.tz(time, format, false, 'America/Winnipeg')
+	moment.tz(time, format, false, 'US/Central')

--- a/source/views/building-hours/lib/__tests__/moment.helper.js
+++ b/source/views/building-hours/lib/__tests__/moment.helper.js
@@ -2,9 +2,11 @@
 import moment from 'moment-timezone'
 export {moment}
 
+const CENTRAL_TZ = 'US/Central'
+
 export const dayMoment = (time: string, format: ?string = 'ddd h:mma') =>
-	moment.tz(time, format, false, 'US/Central')
+	moment.tz(time, format, false, CENTRAL_TZ)
 export const hourMoment = (time: string) =>
-	moment.tz(time, 'h:mma', false, 'US/Central')
+	moment.tz(time, 'h:mma', false, CENTRAL_TZ)
 export const plainMoment = (time: string, format: string) =>
-	moment.tz(time, format, false, 'US/Central')
+	moment.tz(time, format, false, CENTRAL_TZ)

--- a/source/views/building-hours/lib/constants.js
+++ b/source/views/building-hours/lib/constants.js
@@ -1,7 +1,7 @@
 // @flow
 import type {DayOfWeekEnumType} from '../types'
 
-export const CENTRAL_TZ = 'America/Winnipeg'
+export const CENTRAL_TZ = 'US/Central'
 export const TIME_FORMAT = 'h:mma'
 export const RESULT_FORMAT = 'LT'
 

--- a/source/views/building-hours/lib/constants.js
+++ b/source/views/building-hours/lib/constants.js
@@ -1,7 +1,6 @@
 // @flow
 import type {DayOfWeekEnumType} from '../types'
 
-export const CENTRAL_TZ = 'US/Central'
 export const TIME_FORMAT = 'h:mma'
 export const RESULT_FORMAT = 'LT'
 

--- a/source/views/building-hours/lib/index.js
+++ b/source/views/building-hours/lib/index.js
@@ -1,6 +1,5 @@
 // @flow
 
-export {CENTRAL_TZ} from './constants'
 export {getDetailedBuildingStatus} from './get-detailed-status'
 export {getShortBuildingStatus} from './get-short-status'
 export {formatBuildingTimes} from './format-times'

--- a/source/views/building-hours/lib/parse-hours.js
+++ b/source/views/building-hours/lib/parse-hours.js
@@ -1,8 +1,9 @@
 // @flow
 import moment from 'moment-timezone'
 import type {SingleBuildingScheduleType} from '../types'
+import {timezone} from '@frogpond/constants'
 
-import {TIME_FORMAT, CENTRAL_TZ} from './constants'
+import {TIME_FORMAT} from './constants'
 
 type HourPairType = {open: moment, close: moment}
 
@@ -17,10 +18,10 @@ export function parseHours(
 		dayOfYear -= 1
 	}
 
-	let open = moment.tz(fromTime, TIME_FORMAT, true, CENTRAL_TZ)
+	let open = moment.tz(fromTime, TIME_FORMAT, true, timezone())
 	open.dayOfYear(dayOfYear)
 
-	let close = moment.tz(toTime, TIME_FORMAT, true, CENTRAL_TZ)
+	let close = moment.tz(toTime, TIME_FORMAT, true, timezone())
 	close.dayOfYear(dayOfYear)
 
 	if (close.isBefore(open)) {

--- a/source/views/building-hours/stateful-list.js
+++ b/source/views/building-hours/stateful-list.js
@@ -12,7 +12,7 @@ import {reportNetworkProblem} from '@frogpond/analytics'
 import toPairs from 'lodash/toPairs'
 import groupBy from 'lodash/groupBy'
 import delay from 'delay'
-import {CENTRAL_TZ} from './lib'
+import {timezone} from '@frogpond/constants'
 import {API} from '@frogpond/api'
 import {Timer} from '@frogpond/timer'
 
@@ -123,7 +123,7 @@ export class BuildingHoursView extends React.PureComponent<Props, State> {
 						onRefresh={this.refresh}
 					/>
 				)}
-				timezone={CENTRAL_TZ}
+				timezone={timezone()}
 			/>
 		)
 	}

--- a/source/views/menus/lib/__tests__/find-menu.test.js
+++ b/source/views/menus/lib/__tests__/find-menu.test.js
@@ -2,9 +2,10 @@
 // @flow
 import {findMenu} from '../../../../../modules/food-menu/lib/find-menu'
 import moment from 'moment-timezone'
-const CENTRAL_TZ = 'America/Winnipeg'
 import type {DayPartsCollectionType} from '../../types'
 import uniqueId from 'lodash/uniqueId'
+
+const CENTRAL_TZ = 'US/Central'
 
 const generateDayparts: (
 	...{start: string, end: string}[]

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import {timezone} from '@frogpond/constants'
 import {NoticeView, LoadingView} from '@frogpond/notice'
 import type {TopLevelViewPropsType} from '../types'
 import {FoodMenu} from '@frogpond/food-menu'
@@ -26,7 +27,6 @@ import delay from 'delay'
 import retry from 'p-retry'
 import {API} from '@frogpond/api'
 
-const CENTRAL_TZ = 'US/Central'
 const BONAPP_HTML_ERROR_CODE = 'bonapp-html'
 
 const DEFAULT_MENU = [
@@ -62,7 +62,7 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
 		errormsg: null,
 		loading: true,
 		refreshing: false,
-		now: moment.tz(CENTRAL_TZ),
+		now: moment.tz(timezone()),
 		cafeMenu: null,
 		cafeInfo: null,
 	}
@@ -122,7 +122,7 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
 			}
 		}
 
-		this.setState(() => ({cafeMenu, cafeInfo, now: moment.tz(CENTRAL_TZ)}))
+		this.setState(() => ({cafeMenu, cafeInfo, now: moment.tz(timezone())}))
 	}
 
 	refresh = async (): any => {

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -26,7 +26,7 @@ import delay from 'delay'
 import retry from 'p-retry'
 import {API} from '@frogpond/api'
 
-const CENTRAL_TZ = 'America/Winnipeg'
+const CENTRAL_TZ = 'US/Central'
 const BONAPP_HTML_ERROR_CODE = 'bonapp-html'
 
 const DEFAULT_MENU = [

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -20,7 +20,7 @@ import {data as fallbackMenu} from '../../../docs/pause-menu.json'
 import {reportNetworkProblem} from '@frogpond/analytics'
 import {API} from '@frogpond/api'
 
-const CENTRAL_TZ = 'America/Winnipeg'
+const CENTRAL_TZ = 'US/Central'
 
 type Props = TopLevelViewPropsType & {
 	name: string,

--- a/source/views/menus/menu-github.js
+++ b/source/views/menus/menu-github.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import {timezone} from '@frogpond/constants'
 import {NoticeView, LoadingView} from '@frogpond/notice'
 import {FoodMenu} from '@frogpond/food-menu'
 import type {TopLevelViewPropsType} from '../types'
@@ -20,8 +21,6 @@ import {data as fallbackMenu} from '../../../docs/pause-menu.json'
 import {reportNetworkProblem} from '@frogpond/analytics'
 import {API} from '@frogpond/api'
 
-const CENTRAL_TZ = 'US/Central'
-
 type Props = TopLevelViewPropsType & {
 	name: string,
 	loadingMessage: string[],
@@ -40,7 +39,7 @@ export class GitHubHostedMenu extends React.PureComponent<Props, State> {
 	state = {
 		error: null,
 		loading: true,
-		now: moment.tz(CENTRAL_TZ),
+		now: moment.tz(timezone()),
 		foodItems: {},
 		corIcons: {},
 		meals: [],
@@ -98,7 +97,7 @@ export class GitHubHostedMenu extends React.PureComponent<Props, State> {
 					endtime: '23:59',
 				},
 			],
-			now: moment.tz(CENTRAL_TZ),
+			now: moment.tz(timezone()),
 		})
 	}
 

--- a/source/views/sis/course-search/detail/index.js
+++ b/source/views/sis/course-search/detail/index.js
@@ -22,7 +22,7 @@ import groupBy from 'lodash/groupBy'
 import map from 'lodash/map'
 import zip from 'lodash/zip'
 
-const CENTRAL_TZ = 'America/Winnipeg'
+const CENTRAL_TZ = 'US/Central'
 
 const Container = glamorous.scrollView({
 	paddingVertical: 6,

--- a/source/views/sis/course-search/detail/index.js
+++ b/source/views/sis/course-search/detail/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import * as React from 'react'
+import {timezone} from '@frogpond/constants'
 import {StyleSheet, Text, Platform} from 'react-native'
 import type {CourseType} from '../../../../lib/course-search'
 import glamorous from 'glamorous-native'
@@ -21,8 +22,6 @@ import {deptNum} from '../lib/format-dept-num'
 import groupBy from 'lodash/groupBy'
 import map from 'lodash/map'
 import zip from 'lodash/zip'
-
-const CENTRAL_TZ = 'US/Central'
 
 const Container = glamorous.scrollView({
 	paddingVertical: 6,
@@ -105,9 +104,9 @@ function Schedule({course}: {course: CourseType}) {
 	const schedule = map(groupedByDay, (offerings, day) => {
 		const timesFormatted = offerings.map(offering => {
 			const start = moment
-				.tz(offering.start, 'H:mm', CENTRAL_TZ)
+				.tz(offering.start, 'H:mm', timezone())
 				.format('h:mm A')
-			const end = moment.tz(offering.end, 'H:mm', CENTRAL_TZ).format('h:mm A')
+			const end = moment.tz(offering.end, 'H:mm', timezone()).format('h:mm A')
 			return `${start} – ${end}`
 		})
 		const locations = offerings.map(offering => offering.location)

--- a/source/views/stoprint/lib.js
+++ b/source/views/stoprint/lib.js
@@ -1,12 +1,12 @@
 // @flow
 
 const TIME_FORMAT = 'h:mm:ss A'
-const TIMEZONE = 'US/Central'
+import {timezone} from '@frogpond/constants'
 import moment from 'moment-timezone'
 
 const parseTime = (now: moment, time: string): null | moment => {
 	// interpret in Central time
-	let m = moment.tz(time, TIME_FORMAT, true, TIMEZONE)
+	let m = moment.tz(time, TIME_FORMAT, true, timezone())
 
 	// and set the date to today
 	m.dayOfYear(now.dayOfYear())

--- a/source/views/stoprint/lib.js
+++ b/source/views/stoprint/lib.js
@@ -1,7 +1,7 @@
 // @flow
 
 const TIME_FORMAT = 'h:mm:ss A'
-const TIMEZONE = 'America/Winnipeg'
+const TIMEZONE = 'US/Central'
 import moment from 'moment-timezone'
 
 const parseTime = (now: moment, time: string): null | moment => {

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -24,7 +24,7 @@ import sortBy from 'lodash/sortBy'
 import {getTimeRemaining} from './lib'
 import {Timer} from '@frogpond/timer'
 
-const TIMEZONE = 'America/Winnipeg'
+const TIMEZONE = 'US/Central'
 
 type ReactProps = TopLevelViewPropsType
 

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React from 'react'
+import {timezone} from '@frogpond/constants'
 import {Platform, SectionList} from 'react-native'
 import {connect} from 'react-redux'
 import {type ReduxState} from '../../redux'
@@ -23,8 +24,6 @@ import toPairs from 'lodash/toPairs'
 import sortBy from 'lodash/sortBy'
 import {getTimeRemaining} from './lib'
 import {Timer} from '@frogpond/timer'
-
-const TIMEZONE = 'US/Central'
 
 type ReactProps = TopLevelViewPropsType
 
@@ -111,7 +110,7 @@ class PrintJobsView extends React.PureComponent<Props, State> {
 					</Detail>
 				</ListRow>
 			)}
-			timezone={TIMEZONE}
+			timezone={timezone()}
 		/>
 	)
 

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -16,7 +16,7 @@ import type {StreamType} from './types'
 import delay from 'delay'
 import {API} from '@frogpond/api'
 
-const CENTRAL_TZ = 'America/Winnipeg'
+const CENTRAL_TZ = 'US/Central'
 
 const styles = StyleSheet.create({
 	listContainer: {

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react'
 import {StyleSheet, SectionList} from 'react-native'
-
+import {timezone} from '@frogpond/constants'
 import * as c from '@frogpond/colors'
 import {ListSeparator, ListSectionHeader} from '@frogpond/lists'
 import {NoticeView, LoadingView} from '@frogpond/notice'
@@ -15,8 +15,6 @@ import {toLaxTitleCase as titleCase} from 'titlecase'
 import type {StreamType} from './types'
 import delay from 'delay'
 import {API} from '@frogpond/api'
-
-const CENTRAL_TZ = 'US/Central'
 
 const styles = StyleSheet.create({
 	listContainer: {
@@ -67,7 +65,7 @@ export class StreamListView extends React.PureComponent<Props, State> {
 		this.setState(() => ({refreshing: false}))
 	}
 
-	getStreams = async (date: moment = moment.tz(CENTRAL_TZ)) => {
+	getStreams = async (date: moment = moment.tz(timezone())) => {
 		try {
 			const dateFrom = date.format('YYYY-MM-DD')
 			const dateTo = date

--- a/source/views/transportation/bus/lib/__tests__/moment.helper.js
+++ b/source/views/transportation/bus/lib/__tests__/moment.helper.js
@@ -1,8 +1,9 @@
 // @flow
 import moment from 'moment-timezone'
 
-export const time = (time: string) =>
-	moment.tz(time, 'h:mma', true, 'US/Central')
+const CENTRAL_TZ = 'US/Central'
+
+export const time = (time: string) => moment.tz(time, 'h:mma', true, CENTRAL_TZ)
 
 export const dayAndTime = (time: string) =>
-	moment.tz(time, 'dd h:mma', true, 'US/Central')
+	moment.tz(time, 'dd h:mma', true, CENTRAL_TZ)

--- a/source/views/transportation/bus/lib/parse-time.js
+++ b/source/views/transportation/bus/lib/parse-time.js
@@ -1,7 +1,7 @@
 // @flow
 
 const TIME_FORMAT = 'h:mma'
-const TIMEZONE = 'US/Central'
+import {timezone} from '@frogpond/constants'
 import moment from 'moment-timezone'
 
 export const parseTime = (now: moment) => (
@@ -13,7 +13,7 @@ export const parseTime = (now: moment) => (
 	}
 
 	// interpret in Central time
-	let m = moment.tz(time, TIME_FORMAT, true, TIMEZONE)
+	let m = moment.tz(time, TIME_FORMAT, true, timezone())
 
 	// and set the date to today
 	m.dayOfYear(now.dayOfYear())

--- a/source/views/transportation/bus/lib/parse-time.js
+++ b/source/views/transportation/bus/lib/parse-time.js
@@ -1,7 +1,7 @@
 // @flow
 
 const TIME_FORMAT = 'h:mma'
-const TIMEZONE = 'America/Winnipeg'
+const TIMEZONE = 'US/Central'
 import moment from 'moment-timezone'
 
 export const parseTime = (now: moment) => (

--- a/source/views/transportation/bus/map.js
+++ b/source/views/transportation/bus/map.js
@@ -11,7 +11,7 @@ import uniqBy from 'lodash/uniqBy'
 import isEqual from 'lodash/isEqual'
 import {Timer} from '@frogpond/timer'
 
-const TIMEZONE = 'America/Winnipeg'
+const TIMEZONE = 'US/Central'
 
 const styles = StyleSheet.create({
 	map: {...StyleSheet.absoluteFillObject},

--- a/source/views/transportation/bus/map.js
+++ b/source/views/transportation/bus/map.js
@@ -10,8 +10,7 @@ import {getScheduleForNow, processBusLine} from './lib'
 import uniqBy from 'lodash/uniqBy'
 import isEqual from 'lodash/isEqual'
 import {Timer} from '@frogpond/timer'
-
-const TIMEZONE = 'US/Central'
+import {timezone} from '@frogpond/constants'
 
 const styles = StyleSheet.create({
 	map: {...StyleSheet.absoluteFillObject},
@@ -35,7 +34,7 @@ export function BusMap(props: WrapperProps) {
 			interval={60000}
 			moment={true}
 			render={({now}) => <Map line={lineToDisplay} now={now} />}
-			timezone={TIMEZONE}
+			timezone={timezone()}
 		/>
 	)
 }

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -10,7 +10,7 @@ import {reportNetworkProblem} from '@frogpond/analytics'
 import * as defaultData from '../../../../docs/bus-times.json'
 import {API} from '@frogpond/api'
 
-const TIMEZONE = 'America/Winnipeg'
+const TIMEZONE = 'US/Central'
 
 const busTimesUrl = API('/transit/bus')
 

--- a/source/views/transportation/bus/wrapper.js
+++ b/source/views/transportation/bus/wrapper.js
@@ -9,8 +9,7 @@ import type {TopLevelViewPropsType} from '../../types'
 import {reportNetworkProblem} from '@frogpond/analytics'
 import * as defaultData from '../../../../docs/bus-times.json'
 import {API} from '@frogpond/api'
-
-const TIMEZONE = 'US/Central'
+import {timezone} from '@frogpond/constants'
 
 const busTimesUrl = API('/transit/bus')
 
@@ -78,7 +77,7 @@ export class BusView extends React.PureComponent<Props, State> {
 				render={({now}) => (
 					<BusLine line={activeBusLine} now={now} openMap={this.openMap} />
 				)}
-				timezone={TIMEZONE}
+				timezone={timezone()}
 			/>
 		)
 	}


### PR DESCRIPTION
This could have been two PR's, but it's not.

First, I changed every time zone to US/Central. Then I made a module and moved everything into that module.

Jest broke because init is not called beforehand.  So I needed to include a fallback, which I did.