### PR TITLE
circle: Move nightly back two hours

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: 17 10 * * *
+          cron: 17 8 * * *
           filters: {branches: {only: [master]}}
     jobs:
       - cache-yarn-linux


### PR DESCRIPTION
When DST ends on November 4th, this will mean that we are three hours back, as we will then have an offset of UTC-06:00.

I wonder if Apple's servers are broken at 3am/2am as opposed to 5am. That's what this is intended to fix.