### PR TITLE
Remove source for the student activities dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Switched time zone definitions from America/Winnipeg to US/Central
 - Pulled out time zone constants from all over the place into a central constant
+- Removed list footer credit for student activities dictionary (we're the source now)
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -63,7 +63,7 @@ export class DictionaryDetailView extends React.PureComponent<Props> {
 
 				<ListFooter
 					href={STO_SA_DICT_URL}
-					title={'Collected by the humans of All About Olaf'}
+					title="Collected by the humans of All About Olaf"
 				/>
 			</Container>
 		)

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -7,7 +7,6 @@ import {Button} from '@frogpond/button'
 import glamorous from 'glamorous-native'
 import type {WordType} from './types'
 import type {TopLevelViewPropsType} from '../types'
-import {GH_NEW_ISSUE_URL} from '../../lib/constants'
 
 const Term = glamorous.text({
 	fontSize: 36,

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -57,9 +57,7 @@ export class DictionaryDetailView extends React.PureComponent<Props> {
 
 				<Button onPress={this.handleEditButtonPress} title="Suggest an Edit" />
 
-				<ListFooter
-					title="Collected by the humans of All About Olaf"
-				/>
+				<ListFooter title="Collected by the humans of All About Olaf" />
 			</Container>
 		)
 	}

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -63,9 +63,7 @@ export class DictionaryDetailView extends React.PureComponent<Props> {
 
 				<ListFooter
 					href={STO_SA_DICT_URL}
-					title={
-						'Collected by the humans of All About Olaf,\nfrom the Student Activities dictionary'
-					}
+					title={'Collected by the humans of All About Olaf'}
 				/>
 			</Container>
 		)

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -9,10 +9,6 @@ import type {WordType} from './types'
 import type {TopLevelViewPropsType} from '../types'
 import {GH_NEW_ISSUE_URL} from '../../lib/constants'
 
-// TODO: This doesn't point at the SA dictionary because they don't have an
-// overview page.
-const STO_SA_DICT_URL = GH_NEW_ISSUE_URL
-
 const Term = glamorous.text({
 	fontSize: 36,
 	textAlign: 'center',

--- a/source/views/dictionary/detail.js
+++ b/source/views/dictionary/detail.js
@@ -62,7 +62,6 @@ export class DictionaryDetailView extends React.PureComponent<Props> {
 				<Button onPress={this.handleEditButtonPress} title="Suggest an Edit" />
 
 				<ListFooter
-					href={STO_SA_DICT_URL}
 					title="Collected by the humans of All About Olaf"
 				/>
 			</Container>


### PR DESCRIPTION
> Hawken: I got confirmation that the Student Activities dictionary is no more, and there's no official replacement.