### PR TITLE
Disable navigation persistence

### DIFF
--- a/source/navigation/constants.js
+++ b/source/navigation/constants.js
@@ -2,4 +2,6 @@
 
 import {IS_PRODUCTION} from '@frogpond/constants'
 
-export const persistenceKey = IS_PRODUCTION ? 'NavState' : null
+// disabling navigation persistence until we finish an audit of the app
+// export const persistenceKey = IS_PRODUCTION ? 'NavState' : null
+export const persistenceKey = null

--- a/source/navigation/constants.js
+++ b/source/navigation/constants.js
@@ -1,7 +1,7 @@
 // @flow
 
-import {IS_PRODUCTION} from '@frogpond/constants'
+export const persistenceKey = null
 
 // disabling navigation persistence until we finish an audit of the app
+// import {IS_PRODUCTION} from '@frogpond/constants'
 // export const persistenceKey = IS_PRODUCTION ? 'NavState' : null
-export const persistenceKey = null


### PR DESCRIPTION
We have at least one screen where, if you unload the app and re-open it, the app will crash when you resume it. (EventDetail, because deserializing the app state doesn't re-hydrate the moments, and we just get strings back out.)

(I never filed an issue for that bug, oops.)