### PR TITLE
Fix Failed Login Bug

### DIFF
--- a/source/lib/financials/balances.js
+++ b/source/lib/financials/balances.js
@@ -1,7 +1,5 @@
 // @flow
-import {loadLoginCredentials} from '../login'
-import buildFormData from '../formdata'
-import {OLECARD_AUTH_URL, OLECARD_DATA_ENDPOINT} from './urls'
+import {OLECARD_DATA_ENDPOINT} from './urls'
 import type {BalancesShapeType, OleCardBalancesType} from './types'
 
 type BalancesOrErrorType =

--- a/source/lib/financials/balances.js
+++ b/source/lib/financials/balances.js
@@ -9,24 +9,7 @@ type BalancesOrErrorType =
 	| {error: false, value: BalancesShapeType}
 
 export async function getBalances(): Promise<BalancesOrErrorType> {
-	const {username, password} = await loadLoginCredentials()
-
-	if (!username || !password) {
-		return {error: true, value: new Error('Not logged in')}
-	}
-
-	const form = buildFormData({username, password})
-
 	try {
-		let loginResponse = await fetch(OLECARD_AUTH_URL, {
-			method: 'POST',
-			body: form,
-		})
-
-		if (loginResponse.url.includes('message=')) {
-			return {error: true, value: new Error('Login failed')}
-		}
-
 		const resp: OleCardBalancesType = await fetchJson(OLECARD_DATA_ENDPOINT)
 
 		if (resp.error != null) {

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -33,7 +33,7 @@ export type LoginResultEnum =
 
 type Args = {attempts?: number}
 
-export async function performLogin({attempts = 0}: Args = {}): Promise<
+export async function performLogin({attempts = 1}: Args = {}): Promise<
 	LoginResultEnum,
 > {
 	let {username, password} = await loadLoginCredentials()

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -33,7 +33,7 @@ export type LoginResultEnum =
 
 type Args = {attempts?: number}
 
-export async function performLogin({attempts = 1}: Args = {}): Promise<
+export async function performLogin({attempts = 0}: Args = {}): Promise<
 	LoginResultEnum,
 > {
 	let {username, password} = await loadLoginCredentials()

--- a/source/redux/parts/settings.js
+++ b/source/redux/parts/settings.js
@@ -99,7 +99,7 @@ export function logInViaCredentials(
 
 		await saveLoginCredentials({username, password})
 
-		let result = await performLogin()
+		let result = await performLogin({attempts: 1})
 		if (result === 'success') {
 			dispatch({type: CREDENTIALS_LOGIN_SUCCESS})
 			trackLogIn()
@@ -107,6 +107,7 @@ export function logInViaCredentials(
 			dispatch({type: CREDENTIALS_LOGIN_FAILURE})
 			trackLoginFailure('Bad credentials')
 			showInvalidLoginMessage()
+			clearLoginCredentials()
 		} else if (result === 'no-credentials') {
 			dispatch({type: CREDENTIALS_LOGIN_FAILURE})
 			trackLoginFailure('No credentials')

--- a/source/views/settings/screens/overview/login-credentials.js
+++ b/source/views/settings/screens/overview/login-credentials.js
@@ -49,7 +49,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 		let {username = '', password = ''} = await loadLoginCredentials()
 		this.setState(() => ({username, password}))
 
-		if (username && password) {
+		if (username && password && this.props.loginState !== 'logged-in') {
 			this.props.logIn(username, password)
 		}
 	}

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -83,21 +83,18 @@ class BalancesView extends React.PureComponent<Props, State> {
 		}
 	}
 
-	login = async () => {
-		if (this.state.loginState !== 'logged-in') {
+	refresh = async () => {
+		if (this.props.loginState !== 'logged-in') {
 			const {username, password} = await loadLoginCredentials()
 			if (username && password) {
 				await this.props.logIn(username, password)
 			}
 		}
-	}
-
-	refresh = async () => {
-		await this.login()
 		let start = Date.now()
 		this.setState(() => ({loading: true}))
-
-		await this.fetchData()
+		if (this.props.loginState === 'logged-in') {
+			await this.fetchData()
+		}
 
 		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
 		let elapsed = Date.now() - start
@@ -205,7 +202,7 @@ class BalancesView extends React.PureComponent<Props, State> {
 					</Section>
 				</TableView>
 
-				{(loginState !== 'logged-in' || message) && (
+				{((loginState !== 'logged-in' && !loading) || message) && (
 					<Section footer="You'll need to log in in order to see this data.">
 						{loginState !== 'logged-in' ? (
 							<Cell

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -21,6 +21,8 @@ import {type ReduxState} from '../../redux'
 import delay from 'delay'
 import * as c from '@frogpond/colors'
 import type {TopLevelViewPropsType} from '../types'
+import {logInViaCredentials} from '../../redux/parts/settings'
+import {loadLoginCredentials} from '../../lib/login'
 
 const DISCLAIMER = 'This data may be outdated or otherwise inaccurate.'
 const LONG_DISCLAIMER =
@@ -35,6 +37,7 @@ type ReduxStateProps = {
 
 type ReduxDispatchProps = {
 	hasSeenAcknowledgement: () => any,
+	logIn: (string, string) => any,
 }
 
 type Props = ReactProps & ReduxStateProps & ReduxDispatchProps
@@ -80,7 +83,17 @@ class BalancesView extends React.PureComponent<Props, State> {
 		}
 	}
 
+	login = async () => {
+		if (this.state.loginState !== 'logged-in') {
+			const {username, password} = await loadLoginCredentials()
+			if (username && password) {
+				await this.props.logIn(username, password)
+			}
+		}
+	}
+
 	refresh = async () => {
+		await this.login()
 		let start = Date.now()
 		this.setState(() => ({loading: true}))
 
@@ -221,6 +234,7 @@ function mapState(state: ReduxState): ReduxStateProps {
 function mapDispatch(dispatch): ReduxDispatchProps {
 	return {
 		hasSeenAcknowledgement: () => dispatch(hasSeenAcknowledgement()),
+		logIn: (user, pass) => dispatch(logInViaCredentials(user, pass)),
 	}
 }
 


### PR DESCRIPTION
All this PR does is set the default number of login attempts to 2. I have tested this and it works, since the login request only fails on the first request made after booting the app up. This is definitely a hot fix, and may not be needed in the future if the login logic changes. Resolves #2847.