### PR TITLE
[RN Upgrade] iOS: Remove ReactCommon from HEADER_SEARCH_PATHS in buildSettings

### DIFF
--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -1868,7 +1868,6 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
-					"$(SRCROOT)/../node_modules/react-native/ReactCommon/**",
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -1819,7 +1819,6 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
-					"$(SRCROOT)/../node_modules/react-native/ReactCommon/**",
 					"$(SRCROOT)/../node_modules/react-native-keychain/RNKeychainManager",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-device-info/RNDeviceInfo",


### PR DESCRIPTION
This was done at the suggestion of a couple of random Internet people.

It seems to properly build… but the question is whether or not this is the only such required change.  And if this is indeed a good idea.