### PR TITLE
Remove regex matching from "redux" package group

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -26,7 +26,7 @@
       "groupName": "react-navigation packages"
     },
     {
-      "packagePatterns": ["^redux$", "^react-redux$"],
+      "packageNames": ["redux", "react-redux"],
       "groupName": "redux packages"
     }
   ]


### PR DESCRIPTION
I didn't realize this was an option when I set up the config.