### PR TITLE
fastlane: Better changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add a Danger rule to help enforce consistent use of the CHANGELOG
 - Refactored Fastlane files to resolve some code style issues
 - Updated Android JSC requirement to r236355
+- Changed Fastlane Testflight changelog format to be more concise
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/fastlane/lib/git.rb
+++ b/fastlane/lib/git.rb
@@ -9,7 +9,11 @@ def git_changelog
   to_ref = ENV['TRAVIS_COMMIT'] || ENV['CIRCLE_SHA1'] || 'HEAD'
   from_ref = newest_tag
 
+  describe = sh("git describe --tags #{to_ref}")
+
   pr_merges = sh("git log #{from_ref}..#{to_ref} --oneline --grep 'Merge pull request'")
+
+  "Merged Pull Requests as of #{describe}:\n\n#{pr_merges}"
 end
 
 # Makes a changelog from the timespan passed

--- a/fastlane/lib/git.rb
+++ b/fastlane/lib/git.rb
@@ -9,7 +9,7 @@ def git_changelog
   to_ref = ENV['TRAVIS_COMMIT'] || ENV['CIRCLE_SHA1'] || 'HEAD'
   from_ref = newest_tag
 
-  graph = sh("git log #{from_ref}..#{to_ref} --oneline --graph")
+  graph = sh("git log #{from_ref}..#{to_ref} --oneline --grep 'Merge pull request'")
 
   # make sure to trim off whitespace from the graph lines
   # to keep the character count down

--- a/fastlane/lib/git.rb
+++ b/fastlane/lib/git.rb
@@ -9,11 +9,9 @@ def git_changelog
   to_ref = ENV['TRAVIS_COMMIT'] || ENV['CIRCLE_SHA1'] || 'HEAD'
   from_ref = newest_tag
 
-  graph = sh("git log #{from_ref}..#{to_ref} --oneline --grep 'Merge pull request'")
+  merged_prs = sh("git log #{from_ref}..#{to_ref} --oneline --grep 'Merge pull request'")
 
-  # make sure to trim off whitespace from the graph lines
-  # to keep the character count down
-  graph
+  merged_prs
     .lines
     .map(&:chomp)
     .join "\n"

--- a/fastlane/lib/git.rb
+++ b/fastlane/lib/git.rb
@@ -14,6 +14,9 @@ def git_changelog
   pr_merges = sh("git log #{from_ref}..#{to_ref} --oneline --grep 'Merge pull request'")
 
   "Merged Pull Requests as of #{describe}:\n\n#{pr_merges}"
+    .gsub(/pull request |StoDevX\//,'')
+    .gsub(/Merge/, '—')
+    .gsub(' from', ': ')
 end
 
 # Makes a changelog from the timespan passed

--- a/fastlane/lib/git.rb
+++ b/fastlane/lib/git.rb
@@ -9,12 +9,7 @@ def git_changelog
   to_ref = ENV['TRAVIS_COMMIT'] || ENV['CIRCLE_SHA1'] || 'HEAD'
   from_ref = newest_tag
 
-  merged_prs = sh("git log #{from_ref}..#{to_ref} --oneline --grep 'Merge pull request'")
-
-  merged_prs
-    .lines
-    .map(&:chomp)
-    .join "\n"
+  pr_merges = sh("git log #{from_ref}..#{to_ref} --oneline --grep 'Merge pull request'")
 end
 
 # Makes a changelog from the timespan passed

--- a/fastlane/lib/git.rb
+++ b/fastlane/lib/git.rb
@@ -11,7 +11,7 @@ def git_changelog
 
   describe = sh("git describe --tags #{to_ref}")
 
-  pr_merges = sh("git log #{from_ref}..#{to_ref} --oneline --grep 'Merge pull request'")
+  pr_merges = sh("git log #{from_ref}..#{to_ref} --pretty='format:%s' --grep 'Merge pull request'")
 
   "Merged Pull Requests as of #{describe}:\n\n#{pr_merges}"
     .gsub(/pull request |StoDevX\//,'')

--- a/fastlane/lib/git.rb
+++ b/fastlane/lib/git.rb
@@ -15,7 +15,7 @@ def git_changelog
 
   "Merged Pull Requests as of #{describe}:\n\n#{pr_merges}"
     .gsub(/Merge pull request |StoDevX\//,'')
-    .gsub(' from', ': ')
+    .gsub(' from ', ': ')
 end
 
 # Makes a changelog from the timespan passed

--- a/fastlane/lib/git.rb
+++ b/fastlane/lib/git.rb
@@ -14,8 +14,7 @@ def git_changelog
   pr_merges = sh("git log #{from_ref}..#{to_ref} --pretty='format:%s' --grep 'Merge pull request'")
 
   "Merged Pull Requests as of #{describe}:\n\n#{pr_merges}"
-    .gsub(/pull request |StoDevX\//,'')
-    .gsub(/Merge/, '—')
+    .gsub(/Merge pull request |StoDevX\//,'')
     .gsub(' from', ': ')
 end
 


### PR DESCRIPTION
This PR resolves #2822 by improving the iOS changelog format.

We now go from something like this:
```
*   e399b3ec Merge pull request #3045 from StoDevX/greenkeeper/react-native-0.57.0
|\  
| * 64d82112 remove fix-rn script
| * 79e66da2 disable [scrollEnabled] prop since it crashes RN@0.57.5
| *   40441dab Merge pull request #3185 from StoDevX/rn-0.57.5--remove-hsps
| |\  
| | * 5e916782 ios: Add HEADER_SEARCH_PATHS back to OneSignal targets
| | * 04d1da4f ios: Add back react-native-onesignal to pbxproj
| | * f0a42fd5 iOS: Try completely removing HEADER_SEARCH_PATHS
| * | 216d40d7 restore the accidentally-removed onesignal typedef
| * | c0003614 bump detox to v9.1.2
| * |   55a8ec62 Merge pull request #3184 from StoDevX/rn-0.57.5-remove-rc-from-hsp
| |\ \  
| | |/  
| | * 218edfd0 ios: Also remove ReactCommon from Release HSPs
| | * 9778d0c0 iOS: Try removing ReactCommon from the header search paths
| * | f4486778 remove react-navigation flow exclusion
| * | 7117a35e remove react-theme-provider flow exclusion
| * | ace369b7 update rn-linear-gradient to 2.4.4
| * | d19aef5e update callstack/react-theme-provider to 1.0.7
| * | 5872e53c RN 0.57.2 added [scrollEnabled] to the flow types
| * |   2e109eeb Merge pull request #3183 from StoDevX/rn-0.57.5--master-sync
| |\ \  
| | |/  
| |/|   
| | * f49bfd2b modules/lists/list-row: Remove unused eslint-disable directive
| | *   aea005fd Merge branch 'master' into greenkeeper/react-native-0.57.0
| | |\  
| |/ /  
| * | cf350ed1 yarn: Deduplicate the lockfile
| * | db893aa7 start update to v0.57.5
| * | 48978d03 bump eslint targeted flow version to 0.78
| * | 750d4c7c bump eslint target react version to 16.6
| * | 34e7a419 yarn: Upgrade react-native to 0.57.4
| * |   b672ab3f Merge branch 'master' into greenkeeper/react-native-0.57.0
| |\ \  
[...]
```
to something much more manageable and understandable like this:
```
Merged Pull Requests as of v2.6.3-470-ge399b3ec:

e399b3ec Merge pull request #3045 from StoDevX/greenkeeper/react-native-0.57.0
161270ad Merge pull request #3189 from StoDevX/express-bus-update
40441dab Merge pull request #3185 from StoDevX/rn-0.57.5--remove-hsps
55a8ec62 Merge pull request #3184 from StoDevX/rn-0.57.5-remove-rc-from-hsp
2e109eeb Merge pull request #3183 from StoDevX/rn-0.57.5--master-sync
7dbfc225 Merge pull request #3180 from StoDevX/jsc-android--236355.0.0
b3db5d0e Merge pull request #3179 from StoDevX/fastlane-refactor
647381c7 Merge pull request #3178 from StoDevX/danger-check-changelog
4f502fb9 Merge pull request #3177 from StoDevX/sync-changelog
46dc636a Merge pull request #3156 from StoDevX/sarn-website
a1aeefd8 Merge pull request #3176 from StoDevX/hours/pause-kitchen
8a22ebe1 Merge pull request #3174 from StoDevX/travis-xenial
d03bfd3f Merge pull request #3166 from StoDevX/remove-credentials-from-redux
d62c38ad Merge pull request #3172 from StoDevX/bundle-update
ec89f24d Merge pull request #3171 from StoDevX/circle-node-10
04be818d Merge pull request #3167 from StoDevX/disable-nav-persistence
6cb26732 Merge pull request #3108 from StoDevX/update-privacy
[...]
```