### PR TITLE
Automatically skip native builds if not needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,6 +261,13 @@ jobs:
       FASTLANE_DISABLE_ANIMATION: '1'
     steps:
       - checkout
+      - run:
+          name: "Reconcile Git histories"
+          command: |
+            git checkout master
+            git reset --hard origin/master
+            git checkout $CIRCLE_BRANCH
+            git reset --hard origin/$CIRCLE_BRANCH
       - run: node --version
       - run: yarn --version
       - run: *set-ruby-version
@@ -322,6 +329,13 @@ jobs:
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout
+      - run:
+          name: "Reconcile Git histories"
+          command: |
+            git checkout master
+            git reset --hard origin/master
+            git checkout $CIRCLE_BRANCH
+            git reset --hard origin/$CIRCLE_BRANCH
       - run: yarn --version
       - run: *set-ruby-version
       - restore_cache: *restore-cache-yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,6 +274,7 @@ jobs:
           environment: {TERM: xterm-256color}
       - save_cache: *save-cache-gradle
       - run: mkdir -p logs/
+      - run: touch logs/build-status
       - run: *embed-env-vars
       - run:
           name: Run Fastlane
@@ -332,6 +333,7 @@ jobs:
       - run: brew tap wix/brew
       - run: brew install applesimutils
       - run: mkdir -p logs/
+      - run: touch logs/build-status
       - run: *embed-env-vars
       - run:
           name: Run Fastlane

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,8 +266,8 @@ jobs:
           command: |
             git checkout master
             git reset --hard origin/master
-            git checkout $CIRCLE_BRANCH
-            git reset --hard origin/$CIRCLE_BRANCH
+            git checkout "$CIRCLE_BRANCH"
+            git reset --hard "origin/$CIRCLE_BRANCH"
       - run: node --version
       - run: yarn --version
       - run: *set-ruby-version
@@ -334,8 +334,8 @@ jobs:
           command: |
             git checkout master
             git reset --hard origin/master
-            git checkout $CIRCLE_BRANCH
-            git reset --hard origin/$CIRCLE_BRANCH
+            git checkout "$CIRCLE_BRANCH"
+            git reset --hard "origin/$CIRCLE_BRANCH"
       - run: yarn --version
       - run: *set-ruby-version
       - restore_cache: *restore-cache-yarn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added a new "yarn d" command to deduplicate dependencies
 - Added Renovate as our new automated dependency management tool, with a nice configuration (#3193)
+- Added some logic to skip native builds if nothing that might affect them has changed (#3209)
 
 ### Changed
 - Adjusted and deduplicated logic in API scaffolding

--- a/fastlane/lib/commands.rb
+++ b/fastlane/lib/commands.rb
@@ -7,6 +7,10 @@ def auto_beta
     UI.message 'building beta'
     beta
   elsif api_keys_available?
+    unless should_build?
+      UI.message 'skipping build; no code changes to test'
+      return
+    end
     UI.message 'signing and building, but not deploying'
     build
   else

--- a/fastlane/lib/commands.rb
+++ b/fastlane/lib/commands.rb
@@ -3,24 +3,26 @@ def auto_beta
   if should_nightly?
     UI.message 'building nightly'
     nightly
+    return
   elsif should_beta?
     UI.message 'building beta'
     beta
-  elsif api_keys_available?
-    unless should_build?
-      UI.message 'skipping build; no code changes to test'
-      return
-    end
+    return
+  end
+
+  unless should_build?
+    UI.message 'skipping build; no code changes to test'
+    return
+  end
+
+  if api_keys_available?
     UI.message 'signing and building, but not deploying'
     build
-  else
-    unless should_build?
-      UI.message 'skipping build; no code changes to test'
-      return
-    end
-    UI.message 'just building (not signing)'
-    check_build
+    return
   end
+
+  UI.message 'just building (not signing)'
+  check_build
 end
 
 # Adds the github token for stodevx-bot to the CI machine

--- a/fastlane/lib/commands.rb
+++ b/fastlane/lib/commands.rb
@@ -10,6 +10,10 @@ def auto_beta
     UI.message 'signing and building, but not deploying'
     build
   else
+    unless should_build?
+      UI.message 'skipping build; no code changes to test'
+      return
+    end
     UI.message 'just building (not signing)'
     check_build
   end

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -110,7 +110,7 @@ def should_build?
   end
 
   # 1. need to get files changed in the current build since master
-  changed_files = sh("git diff --name-only '#{source_branch}' '#{current_branch}'").lines
+  changed_files = sh("git log --name-only --format='' '#{source_branch}'..'#{current_branch}'").lines.sort.uniq
 
   # 2. check for "packages we care about"
   if changed_files.include? 'package.json' and npm_native_package_changed?

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -51,6 +51,7 @@ def deps_diff(old_hash, new_hash, path)
   (new_hash.dig(*path).to_a - old_hash.dig(*path).to_a).to_h
 end
 
+NPM_DEP_NAME_REGEXP = /react|jsc/.freeze
 def npm_native_package_changed?
   old_package = JSON.parse(sh "git show '#{source_branch}:package.json'")
   new_package = JSON.parse(sh "git show '#{current_branch}:package.json'")
@@ -58,8 +59,7 @@ def npm_native_package_changed?
   changed_dependencies = deps_diff(old_package, new_package, ['dependencies']).keys
   changed_devdependencies = deps_diff(old_package, new_package, ['devDependencies']).keys
 
-  dep_name_regex = /react|jsc/
-  (changed_dependencies + changed_devdependencies).any? { |dep| dep =~ dep_name_regex }
+  (changed_dependencies + changed_devdependencies).any? { |dep| dep =~ NPM_DEP_NAME_REGEXP }
 end
 
 def native_build_globs
@@ -114,7 +114,7 @@ def should_build?
 
   # 2. check for "packages we care about"
   if changed_files.include? 'package.json' and npm_native_package_changed?
-    UI.message('should_build? some react|jsc dep changed, so yes')
+    UI.message("should_build? some dependency matching #{NPM_DEP_NAME_REGEXP.inspect} changed, so yes")
     return true
   end
 

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -88,23 +88,23 @@ def should_build?
   end
 
   source_globs = [
-    ".circleci/**",
-    "e2e/**",
-    "fastlane/**",
-    "scripts/**",
-    "Gemfile.lock",
+    '.circleci/**',
+    'e2e/**',
+    'fastlane/**',
+    'scripts/**',
+    'Gemfile.lock',
   ]
 
   case lane_context[:PLATFORM_NAME]
   when :android
     platform_globs = [
-      "android/**",
-      "{modules,source}/**/*.java",
+      'android/**',
+      '{modules,source}/**/*.java',
     ]
   when :ios
     platform_globs = [
-      "ios/**",
-      "{modules,source}/**/*.{h,m,mm}",
+      'ios/**',
+      '{modules,source}/**/*.{h,m,mm}',
     ]
   end
 

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -106,6 +106,8 @@ def should_build?
       'ios/**',
       '{modules,source}/**/*.{h,m,mm}',
     ]
+  else
+    platform_globs = []
   end
 
   native_file_changed = (source_globs + platform_globs).any? do |glob|

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -108,9 +108,9 @@ def should_build?
     ]
   end
 
-  native_file_changed = (source_globs + platform_globs).any? {
-    |glob| changed_files.any? { |path| File.fnmatch?(glob, path) }
-  }
+  native_file_changed = (source_globs + platform_globs).any? do |glob|
+    changed_files.any? { |path| File.fnmatch?(glob, path) }
+  end
 
   if native_file_changed
     UI.message('should_build? some native file changed, so yes')

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -121,7 +121,7 @@ def should_build?
   # 3. compare list of files to our sets of "files we care about"
   if native_file_changed?(changed_files)
     UI.message('should_build? some native file changed, so yes')
-    true
+    return true
   end
 
   # 4) if none matched, return false


### PR DESCRIPTION
Closes #2582 

```
[22:00:03]: -------------------------------------------------
[22:00:03]: --- Step: git diff --name-only 'master' 'foo' ---
[22:00:03]: -------------------------------------------------
[22:00:03]: $ git diff --name-only 'master' 'foo'
[22:00:03]: ▸ .circleci/config.yml
[22:00:03]: should_build? some native file changed, so yes
```

(this PR should trigger a native build; submitting early to test.)

---

With this PR, `fastlane` will automatically skip native iOS/Android builds when only JS code has changed, as it can't really affect the native results.

So we check if any of these files have changed:

```ruby
  source_globs = [
    '.circleci/**',
    'e2e/**',
    'fastlane/**',
    'scripts/**',
    'Gemfile.lock',
  ]

  case lane_context[:PLATFORM_NAME]
  when :android
    platform_globs = [
      'android/**',
      '{modules,source}/**/*.java',
    ]
  when :ios
    platform_globs = [
      'ios/**',
      '{modules,source}/**/*.{h,m,mm}',
    ]
  end
```

_or_, if any package.json dependencies/devDependencies that include the word "react" or "jsc" have changed.