### PR TITLE
Print the danger changelog message inline

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -251,10 +251,8 @@ function changelogSync() {
 				h.summary(
 					'This PR modified important files but does not have any changes to the CHANGELOG.',
 				),
-				h.ul(
-					...changedSourceFiles.map(file => h.li(h.code(file))),
-				),
-			)
+				h.ul(...changedSourceFiles.map(file => h.li(h.code(file)))),
+			),
 		)
 	}
 }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -246,7 +246,7 @@ function changelogSync() {
 	const changedChangelog = danger.git.modified_files.includes('CHANGELOG.md')
 
 	if (!changedChangelog) {
-		message(
+		markdown(
 			h.details(
 				h.summary(
 					'This PR modified important files but does not have any changes to the CHANGELOG.',

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -235,19 +235,26 @@ function changelogSync() {
 		'index.js',
 	])
 
-	const changedSourceFiles = danger.git.modified_files.some(
+	const changedSourceFiles = danger.git.modified_files.filter(
 		file => noteworthyFolder.test(file) || noteworthyFiles.has(file),
 	)
 
-	if (!changedSourceFiles) {
+	if (!changedSourceFiles.length) {
 		return
 	}
 
 	const changedChangelog = danger.git.modified_files.includes('CHANGELOG.md')
 
 	if (!changedChangelog) {
-		warn(
-			'This PR modifies files in source/ but does not have any changes to the CHANGELOG.',
+		message(
+			h.details(
+				h.summary(
+					'This PR modified important files but does not have any changes to the CHANGELOG.',
+				),
+				h.ul(
+					...changedSourceFiles.map(file => h.li(h.code(file))),
+				),
+			)
 		)
 	}
 }


### PR DESCRIPTION
and also list the changed files in a `<details>` list.

The basic implementation here was taken from the "iOS long build steps" message.