### PR TITLE
danger: Add manual exclusion for CHANGELOG requirement

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -234,10 +234,14 @@ function changelogSync() {
 		'Gemfile',
 		'index.js',
 	])
+	const definitelyNotNoteworthy = /package\.json|yarn\.lock/
 
-	const changedSourceFiles = danger.git.modified_files.some(
-		file => noteworthyFolder.test(file) || noteworthyFiles.has(file),
-	)
+	const changedSourceFiles = danger.git.modified_files.some(file => {
+		let noteworthy = noteworthyFolder.test(file) || noteworthyFiles.has(file)
+		let excluded = !definitelyNotNoteworthy.test(file)
+
+		return noteworthy && !excluded
+	})
 
 	if (!changedSourceFiles) {
 		return

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -234,7 +234,7 @@ function changelogSync() {
 		'Gemfile',
 		'index.js',
 	])
-	const definitelyNotNoteworthy = /package\.json|yarn\.lock/
+	const definitelyNotNoteworthy = /package\.json|yarn\.lock/gu
 
 	const changedSourceFiles = danger.git.modified_files.some(file => {
 		let noteworthy = noteworthyFolder.test(file) || noteworthyFiles.has(file)


### PR DESCRIPTION
This prevents things like `package.json` file changes in `modules/` from triggering a CHANGELOG warning, as in #3220.