### PR TITLE
Revert "Update dependency react-native-onesignal to v3.2.8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-native-keychain": "3.0.0",
     "react-native-linear-gradient": "2.5.2",
     "react-native-network-info": "4.0.0",
-    "react-native-onesignal": "3.2.8",
+    "react-native-onesignal": "3.2.7",
     "react-native-paper": "2.1.3",
     "react-native-popover-view": "1.0.9",
     "react-native-restart": "0.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6609,10 +6609,10 @@ react-native-network-info@4.0.0:
   resolved "https://registry.yarnpkg.com/react-native-network-info/-/react-native-network-info-4.0.0.tgz#aade28ddcf38f5d2c4d8055078dd7f0d97c51cff"
   integrity sha512-ONyOUMJEhBSP5sDHCgBFk037ePL3auLB//W4H8+m+GDIMkRHNksJ2lTYvjEQf1gaYQp+fYl+xcDIo1d/odZwpA==
 
-react-native-onesignal@3.2.8:
-  version "3.2.8"
-  resolved "https://registry.yarnpkg.com/react-native-onesignal/-/react-native-onesignal-3.2.8.tgz#594a293f1f30262958bb0af9b6e98ca04d2038e8"
-  integrity sha512-Br9cIsMTi6tQqIZmB2vh2vCNom78qglbWn+ywsjEhjN1HLlZ7C4D/2x8i8MT23xEA9iiznJl2XSo7wU7Tom+7Q==
+react-native-onesignal@3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/react-native-onesignal/-/react-native-onesignal-3.2.7.tgz#8e3245b720af68af7d01ff572c56cbb3521b88f5"
+  integrity sha512-OLoTfE5iC21r4UsE+ebzr0HSpRIC0HSsQ5yfbWV5hxtiRRZy+ASgbd8VMK5Xbl7B0KqxmP13X9b/cCi+DWZAdg==
   dependencies:
     invariant "^2.2.2"
 


### PR DESCRIPTION
Reverts StoDevX/AAO-React-Native#3233

This caused some build failures? I think?

```
[19:52:33]: ▸ Linking OneSignalNotificationServiceExtension
[19:52:33]: ▸ ❌  ld: could not reparse object file in bitcode bundle: 'Invalid bitcode version (Producer: '1000.11.45.5_0' Reader: '902.0.39.2_0')', using libLTO version 'LLVM version 9.1.0, (clang-902.0.39.2)' for architecture armv7
[19:52:33]: ▸ Linking OneSignalNotificationServiceExtension
[19:52:33]: ▸ ❌  ld: could not reparse object file in bitcode bundle: 'Invalid bitcode version (Producer: '1000.11.45.5_0' Reader: '902.0.39.2_0')', using libLTO version 'LLVM version 9.1.0, (clang-902.0.39.2)' for architecture arm64
[19:52:33]: ▸ ❌  clang: error: linker command failed with exit code 1 (use -v to see invocation)
[19:52:33]: ▸  ARCHIVE FAILED 
[19:52:33]: ▸ The following build commands failed:
[19:52:33]: ▸ Ld /Users/distiller/Library/Developer/Xcode/DerivedData/AllAboutOlaf-gsgmmkgctncqaieyozhooclokioi/Build/Intermediates.noindex/ArchiveIntermediates/AllAboutOlaf/IntermediateBuildFilesPath/AllAboutOlaf.build/Release-iphoneos/OneSignalNotificationServiceExtension.build/Objects-normal/arm64/OneSignalNotificationServiceExtension normal arm64
```

from https://circleci.com/workflow-run/f0036f2a-a264-49ee-8265-6ab6a42eb0de and https://circleci.com/workflow-run/19cc3b9c-5be3-48ce-9018-30ef87578953