### PR TITLE
danger: Fix double negative in changelogSync exclusion

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -238,7 +238,7 @@ function changelogSync() {
 
 	const changedSourceFiles = danger.git.modified_files.filter(file => {
 		let noteworthy = noteworthyFolder.test(file) || noteworthyFiles.has(file)
-		let excluded = !definitelyNotNoteworthy.test(file)
+		let excluded = definitelyNotNoteworthy.test(file)
 
 		return noteworthy && !excluded
 	})


### PR DESCRIPTION
I'm choosing to leave the negation in the return because I want files that are "noteworthy 'and' 'not' excluded"; also, files are "excluded" if they are "definitelyNotNoteworthy."

So this makes a lot more sense than what I was doing before.

Closes #3248.