### PR TITLE
Clean up Dangerfile

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -53,7 +53,7 @@ async function main() {
 // task=ANDROID
 //
 
-async function runAndroid() {
+function runAndroid() {
 	const logFile = readLogFile('./logs/build').split('\n')
 	const buildStatus = readLogFile('./logs/build-status')
 
@@ -70,7 +70,7 @@ async function runAndroid() {
 // task=IOS
 //
 
-async function runiOS() {
+function runiOS() {
 	const logFile = readLogFile('./logs/build').split('\n')
 	const buildStatus = readLogFile('./logs/build-status')
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -158,14 +158,22 @@ async function runJSのGeneral() {
 
 // New js files should have `@flow` at the top
 function flowAnnotated() {
-	danger.git.created_files
+	let noFlow = danger.git.created_files
 		.filter(path => path.endsWith('.js'))
 		// except for those in /flow-typed
 		.filter(filepath => !filepath.includes('flow-typed'))
 		.filter(filepath => !readFile(filepath).includes('@flow'))
-		.forEach(file =>
-			warn(`<code>${file}</code> has no <code>@flow</code> annotation!`),
-		)
+
+	if (!noFlow.length) {
+		return
+	}
+
+	markdown(
+		h.details(
+			h.summary('There is no <code>@flow</code> annotation in these file(s)'),
+			h.ul(...noFlow.map(file => h.li(h.code(file)))),
+		),
+	)
 }
 
 // Warn if tests have been enabled to the exclusion of all others

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -88,7 +88,7 @@ function runiOS() {
 	}
 
 	markdown(
-		h.h2('iOS Reportzzz'),
+		h.h2('iOS Report'),
 		h.details(
 			h.summary('Analysis of slow build times (>20s)'),
 			m.code({}, analysisFile),

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -88,7 +88,7 @@ function runiOS() {
 	}
 
 	markdown(
-		h.h2('iOS Report'),
+		h.h2('iOS Reportzzz'),
 		h.details(
 			h.summary('Analysis of slow build times (>20s)'),
 			m.code({}, analysisFile),

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -178,18 +178,26 @@ function flowAnnotated() {
 
 // Warn if tests have been enabled to the exclusion of all others
 function exclusionaryTests() {
-	danger.git.created_files
+	let exclusionary = danger.git.created_files
 		.filter(filepath => filepath.endsWith('.test.js'))
 		.map(filepath => ({filepath, content: readFile(filepath)}))
 		.filter(
 			({content}) =>
 				content.includes('it.only') || content.includes('describe.only'),
 		)
-		.forEach(({filepath}) =>
-			warn(
-				`An <code>only</code> was left in ${filepath} – no other tests can run.`,
+
+	if (!exclusionary.length) {
+		return
+	}
+
+	markdown(
+		h.details(
+			h.summary(
+				'An <code>only</code> was left these file(s) – no other tests can run.',
 			),
-		)
+			h.ul(...exclusionaryTests.map(file => h.li(h.code(file)))),
+		),
+	)
 }
 
 // Warn when PR size is large (mainly for hawken)

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -91,12 +91,15 @@ async function runiOS() {
 		return
 	}
 
-	markdown('## iOS Report')
-
 	// tee the "fastlane" output to a log, and run the analysis script
 	// to report back the longest compilation units
 	const analysisFile = readFile('./logs/analysis')
+	if (!analysisFile.trim().length) {
+		return
+	}
+
 	markdown(
+		h.h2('iOS Report'),
 		h.details(
 			h.summary('Analysis of slow build times (>20s)'),
 			m.code({}, analysisFile),

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -204,18 +204,18 @@ function exclusionaryTests() {
 function bigPr() {
 	const bigPRThreshold = 400 // lines
 	const thisPRSize = danger.github.pr.additions + danger.github.pr.deletions
-	if (thisPRSize > bigPRThreshold) {
-		warn(
-			h.details(
-				h.summary(
-					`Big PR! We like to try and keep PRs under ${bigPRThreshold} lines, and this one was ${thisPRSize} lines.`,
-				),
-				h.p(
-					'If the PR contains multiple logical changes, splitting each change into a separate PR will allow a faster, easier, and more thorough review.',
-				),
-			),
-		)
+	if (thisPRSize <= bigPRThreshold) {
+		return
 	}
+
+	markdown(
+		h.p(
+			`Big PR! We like to try and keep PRs under ${bigPRThreshold} lines, and this one was ${thisPRSize} lines.`,
+		),
+		h.p(
+			'If the PR contains multiple logical changes, splitting each change into a separate PR will allow a faster, easier, and more thorough review.',
+		),
+	)
 }
 
 // Remind us to check the xcodeproj, if it's changed

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -209,7 +209,7 @@ function bigPr() {
 }
 
 // Remind us to check the xcodeproj, if it's changed
-async function xcodeproj() {
+function xcodeproj() {
 	const pbxprojChanged = danger.git.modified_files.find(filepath =>
 		filepath.endsWith('project.pbxproj'),
 	)
@@ -218,7 +218,9 @@ async function xcodeproj() {
 		return
 	}
 
-	warn('The Xcode project file changed. Maintainers, double-check the changes!')
+	markdown(
+		'The Xcode project file changed. Maintainers, double-check the changes!',
+	)
 }
 
 function changelogSync() {
@@ -331,7 +333,7 @@ function runJSのLint() {
 		return
 	}
 
-	fileLog('Eslint had a thing to say!', eslintLog)
+	fileLog('ESLint had a thing to say!', eslintLog)
 }
 
 //
@@ -376,7 +378,7 @@ function fastlaneBuildLogTail(log /*: Array<string>*/, message /*: string*/) {
 		.map(stripAnsi)
 		.join('\n')
 
-	fail(
+	markdown(
 		h.details(
 			h.summary(message),
 			h.p(`Last ${n} lines`),

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -64,11 +64,6 @@ async function runAndroid() {
 		return
 	}
 
-	if (!(await didNativeDependencyChange())) {
-		// nothing changed to make this worth analyzing
-		return
-	}
-
 	// we do not currently do any android analysis
 }
 
@@ -83,11 +78,6 @@ async function runiOS() {
 	if (buildStatus !== '0') {
 		// returning early here because if the build fails, there's nothing to analyze
 		fastlaneBuildLogTail(logFile, 'iOS Build Failed')
-		return
-	}
-
-	if (!(await didNativeDependencyChange())) {
-		// nothing changed to make this worth analyzing
 		return
 	}
 
@@ -554,17 +544,6 @@ function listDirectoryTree(dirpath /*: string*/) /*: any*/ {
 		)
 		return {}
 	}
-}
-
-async function didNativeDependencyChange() /*: Promise<boolean>*/ {
-	const diff = await danger.git.JSONDiffForFile('package.json')
-
-	if (!diff.dependencies && !diff.devDependencies) {
-		return false
-	}
-
-	// If we need to, we can add more heuristics here in the future
-	return true
 }
 
 //

--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
     "bugsnag-sourcemaps": "1.0.4",
     "danger": "6.1.8",
     "danger-plugin-yarn": "1.3.1",
-    "directory-tree": "2.1.1",
     "eslint": "5.9.0",
     "eslint-config-prettier": "3.3.0",
     "eslint-plugin-babel": "5.3.0",
@@ -175,7 +174,6 @@
     "react-test-renderer": "16.6.1",
     "string-natural-compare": "2.0.3",
     "strip-ansi": "5.0.0",
-    "xcode": "1.0.0",
     "yarn-deduplicate": "1.0.3"
   },
   "optionalDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,11 +2653,6 @@ diff@^3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
   integrity sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==
 
-directory-tree@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/directory-tree/-/directory-tree-2.1.1.tgz#db42ab3bda37b0e7de51654ce9709b49cea2ba55"
-  integrity sha512-9uaftXCRHRntOsmeSxTMLNp52N0tb5eSXkLTIdbDnuC85lleB6/Xub6CG4swSrkS5XXHA56OpTiRj5ntRlsjCg==
-
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -8445,7 +8440,7 @@ ws@^3.3.1:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-xcode@1.0.0, xcode@^1.0.0:
+xcode@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/xcode/-/xcode-1.0.0.tgz#e1f5b1443245ded38c180796df1a10fdeda084ec"
   integrity sha1-4fWxRDJF3tOMGAeW3xoQ/e2ghOw=


### PR DESCRIPTION
closes #3244 

- hide the 'ios report' if it's empty
- update all blocks to report as "markdown" instead of "warn/fail" – other things will update the build status, so it's OK; plus, this way they'll comment inline instead of in Checks
- remove .pbxproj warnings – they were disabled anyway because they didn't work right
- clean up unused functions and dependencies