### PR TITLE
Explicitly build nightlies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)
+- Made sure that nightly builds will get built (#3261)
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -76,9 +76,15 @@ def git_log_between(source, target)
   sh("git log --name-only --format='' '#{source}'..'#{target}'")
 end
 
+def anything_changed_yesterday?
+	yesterdays_changes = git_log_between('HEAD@{26 hours ago}', 'HEAD').unique_lines
+
+  yesterdays_changes.count > 0
+end
+
 # checks if the native build needs to be run
 def should_build?
-  return true if ENV['IS_NIGHTLY']
+  return anything_changed_yesterday? if ENV['IS_NIGHTLY']
 
   # Find the oldest common revision between HEAD's parent and our
   # default branch.

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -82,9 +82,13 @@ def anything_changed_yesterday?
   yesterdays_changes.count > 0
 end
 
+def should_build_nightly?
+	anything_changed_yesterday?
+end
+
 # checks if the native build needs to be run
 def should_build?
-  return anything_changed_yesterday? if ENV['IS_NIGHTLY']
+  return should_build_nightly? if ENV['IS_NIGHTLY']
 
   # Find the oldest common revision between HEAD's parent and our
   # default branch.

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -66,6 +66,12 @@ end
 
 DEFAULT_BRANCH = 'master'.freeze
 
+class String
+	def unique_lines
+		lines.uniq
+	end
+end
+
 def git_log_between(source, target)
   sh("git log --name-only --format='' '#{source}'..'#{target}'")
 end
@@ -90,7 +96,7 @@ def should_build?
   oldest_shared_revision = sh("git merge-base '#{DEFAULT_BRANCH}' 'HEAD^1'")
 
   # Get all files that changed between the fork point and HEAD
-  changed_files = git_log_between(oldest_shared_revision, 'HEAD').lines.sort.uniq
+  changed_files = git_log_between(oldest_shared_revision, 'HEAD').unique_lines
 
   # 1. Check if any packages we care about changed
   if changed_files.include?('package.json') &&

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -67,9 +67,10 @@ end
 DEFAULT_BRANCH = 'master'.freeze
 
 class String
-	def unique_lines
-		lines.uniq
-	end
+  def unique_lines
+    lines.uniq
+  end
+end
 end
 
 def git_log_between(source, target)
@@ -77,13 +78,13 @@ def git_log_between(source, target)
 end
 
 def anything_changed_yesterday?
-	yesterdays_changes = git_log_between('HEAD@{26 hours ago}', 'HEAD').unique_lines
+  yesterdays_changes = git_log_between('HEAD@{26 hours ago}', 'HEAD').unique_lines
 
   yesterdays_changes.count > 0
 end
 
 def should_build_nightly?
-	anything_changed_yesterday?
+  anything_changed_yesterday?
 end
 
 # checks if the native build needs to be run

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -72,6 +72,8 @@ end
 
 # checks if the native build needs to be run
 def should_build?
+	return true if ENV['IS_NIGHTLY']
+
   # Find the oldest common revision between HEAD's parent and our
   # default branch.
   #

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -72,7 +72,7 @@ end
 
 # checks if the native build needs to be run
 def should_build?
-	return true if ENV['IS_NIGHTLY']
+  return true if ENV['IS_NIGHTLY']
 
   # Find the oldest common revision between HEAD's parent and our
   # default branch.


### PR DESCRIPTION
Since `ios-nightly` and `android-nightly` are built off of the `ios` and `android` builds, I don't think we actually have any safeguards to ensure that we do actually build nightlies besides setting environment variables.

We should explicitly state that we want nightlies to be built.

This commit does that; if `ENV['IS_NIGHTLY']` is anything besides `nil` or false-y values likke that, it will report that the build should continue as planned.