### PR TITLE
Fix should-skip-build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)
-- Made sure that nightly builds will get built (#3261)
-- Fixed build skipping script
+- Made sure that nightly builds will get built if something changed (#3261)
+- Fixed a syntax error in build skipping script (#3262)
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)
 - Made sure that nightly builds will get built (#3261)
+- Fixed build skipping script
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -71,7 +71,6 @@ class String
     lines.uniq
   end
 end
-end
 
 def git_log_between(source, target)
   sh("git log --name-only --format='' '#{source}'..'#{target}'")


### PR DESCRIPTION
It had an extra `end` in it which was causing builds to always get run.