### PR TITLE
Remove unnecessary flow ignores

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,35 +2,12 @@
 ; We fork some components by platform
 .*/*[.]android.js
 
-; Ignore "BUCK" generated dirs
-<PROJECT_ROOT>/\.buckd/
-
-; Ignore unexpected extra "@providesModule"
-.*/node_modules/.*/node_modules/fbjs/.*
-
-; Ignore duplicate module providers: For RN Apps installed via npm, the
-; "Libraries" folder is inside "node_modules/react-native", but in the source
-; repo it is in the root.
-.*/Libraries/react-native/React.js
-
-; Ignore polyfills
-.*/Libraries/polyfills/.*
-
-; Ignore metro
-.*/node_modules/metro/.*
-
 ; Ignore the vendor/ folder, since CIs stick ruby deps in there
 <PROJECT_ROOT>/vendor/
 <PROJECT_ROOT>/.bundle/
 
-; Ignore other things
-.*/node_modules/.*/__tests?__/.*
-.*/node_modules/.*/examples/.*
-.*/node_modules/react-native-mock/.*
-.*/node_modules/react-native-restart/.*
 ; remove this after rn-linear-gradient fixes their @flow/no type arguments issue
 .*/node_modules/react-native-linear-gradient/.*
-.*/node_modules/yarn-deduplicate/.*
 
 [include]
 


### PR DESCRIPTION
We don't really need to ignore these things. `yarn run flow` is still successful with this CL applied.

I'm not seeing an appreciable speed difference with this, either. Just +4 seconds. `flow` takes long enough on `master` that this difference has no appreciable effect for me.

```console
> time yarn run flow
yarn run v1.12.3
$ flow
Launching Flow server for /Users/kristofer/Git/GitHub/StoDevX/AAO-React-Native
Spawned flow server (pid=67530)
Logs will go to /private/tmp/flow/zSUserszSkristoferzSGitzSGitHubzSStoDevXzSAAO-React-Native.log
Monitor logs will go to /private/tmp/flow/zSUserszSkristoferzSGitzSGitHubzSStoDevXzSAAO-React-Native.monitor_log
No errors!
✨  Done in 21.41s.
       21.77 real         0.47 user         0.22 sys
> git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
> time yarn run flow
yarn run v1.12.3
$ flow
Launching Flow server for /Users/kristofer/Git/GitHub/StoDevX/AAO-React-Native
Spawned flow server (pid=68812)
Logs will go to /private/tmp/flow/zSUserszSkristoferzSGitzSGitHubzSStoDevXzSAAO-React-Native.log
Monitor logs will go to /private/tmp/flow/zSUserszSkristoferzSGitzSGitHubzSStoDevXzSAAO-React-Native.monitor_log
No errors!
✨  Done in 16.97s.
       17.24 real         0.42 user         0.13 sys
```