### PR TITLE
String#unique_lines: Chomp after uniquing

### DIFF
--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -68,7 +68,7 @@ DEFAULT_BRANCH = 'master'.freeze
 
 class String
   def unique_lines
-    lines.uniq
+    lines.uniq.map(&:chomp)
   end
 end
 


### PR DESCRIPTION
This is done to make it possible to actually do sane filename inclusion checks.

Previously, `String#unique_lines` was returning filenames with `\n` appended… making it impossible to do a simple set inclusion check.

This should also make all of our PRs that aren't building because they're "not significant" more happy to build.