### PR TITLE
ssb: Add #changes_after helper and use it for "yesterday" logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)
 - Made sure that nightly builds will get built if something changed (#3261)
 - Fixed a syntax error in build skipping script (#3262)
+- Forced build skipping script to actually query Git history for nightly skip check (#3275)
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -72,12 +72,16 @@ class String
   end
 end
 
+def changes_after(time, ref = 'HEAD')
+  sh("git log --name-only --format='' --after='#{time}' '#{ref}'")
+end
+
 def git_log_between(source, target)
   sh("git log --name-only --format='' '#{source}'..'#{target}'")
 end
 
 def anything_changed_yesterday?
-  yesterdays_changes = git_log_between('HEAD@{26 hours ago}', 'HEAD').unique_lines
+  yesterdays_changes = changes_after('26 hours ago').unique_lines
 
   yesterdays_changes.count > 0
 end


### PR DESCRIPTION
Closes #3274.

This explicitly uses git-log with a chronological time, as opposed to our previous way of doing things which required the use of the reflog.

On fresh clones, the reflog will not be over 26 hours old, and hence Git complains and does not produce full results.