### PR TITLE
[circle2.1] add "executors" to centralize executor configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,33 @@
 ---
-version: 2
+version: 2.1
+
+executors:
+  node:
+    docker:
+      - image: 'circleci/node:10'
+
+  ruby:
+    docker:
+      - image: 'circleci/ruby:2.5.3'
+
+  android:
+    docker:
+      # command: key is passed to solve a weird issue (see GitHub PR's 2170 and 2173).
+      # this overrides the thing and forces the container to run /bin/bash as the "command"
+      # so it doesn't get confused and OOM/exhaust the build resources (don't ask me)
+      - image: 'circleci/android:api-28-node8-alpha'
+        command: '/bin/bash'
+
+  ios:
+    macos:
+      xcode: '9.4.1'
+    shell: /bin/bash --login -o pipefail
+    environment:
+      LC_ALL: en_US.UTF-8
+      LANG: en_US.UTF-8
 
 x-config:
-  x-images:
-    - &docker-node
-      - image: 'circleci/node:10'
-    - &docker-ruby
-      - image: 'circleci/ruby:2.5.3'
-  x-caching:  # caching instructions
+  x-caching: # caching instructions
     - &save-cache-yarn
       key: 'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
       paths: [~/.cache/yarn, ~/Library/Caches/Yarn]
@@ -47,7 +67,6 @@ x-config:
         touch .env.js
 
 workflows:
-  version: 2
   analyze-and-build:
     # The way this works is, Circle runs analyze-and-build on every commit
     # to every branch.
@@ -114,7 +133,7 @@ workflows:
 
 jobs:
   cache-yarn-linux:
-    docker: *docker-node
+    executor: node
     steps:
       - checkout
       - restore_cache: *restore-cache-yarn
@@ -124,7 +143,7 @@ jobs:
       - persist_to_workspace: *persist-workspace-node_modules
 
   cache-bundler-linux:
-    docker: *docker-ruby
+    executor: ruby
     steps:
       - checkout
       - run: *set-ruby-version
@@ -136,7 +155,7 @@ jobs:
       - save_cache: *save-cache-bundler
 
   danger:
-    docker: *docker-node
+    executor: node
     environment:
       task: JS-general
     steps:
@@ -145,7 +164,7 @@ jobs:
       - run: *run-danger
 
   flow:
-    docker: *docker-node
+    executor: node
     environment:
       task: JS-flow
     steps:
@@ -157,7 +176,7 @@ jobs:
       - run: *run-danger
 
   jest:
-    docker: *docker-node
+    executor: node
     environment:
       task: JS-jest
       JEST_JUNIT_OUTPUT: ./test-results/jest/junit.xml
@@ -182,7 +201,7 @@ jobs:
             fi
 
   prettier:
-    docker: *docker-node
+    executor: node
     environment:
       task: JS-prettier
     steps:
@@ -201,7 +220,7 @@ jobs:
       - run: *run-danger
 
   yarn-dedupe:
-    docker: *docker-node
+    executor: node
     environment:
       task: JS-yarn-dedupe
     steps:
@@ -220,7 +239,7 @@ jobs:
       - run: *run-danger
 
   eslint:
-    docker: *docker-node
+    executor: node
     environment:
       task: JS-lint
     steps:
@@ -235,7 +254,7 @@ jobs:
           path: ./test-results
 
   data:
-    docker: *docker-node
+    executor: node
     environment:
       task: JS-data
     steps:
@@ -251,10 +270,7 @@ jobs:
       - run: *run-danger
 
   android: &android
-    # cmd: key is passed to solve a weird issue (see GitHub PR's 2170 and 2173).
-    # this overrides the thing and forces the container to run /bin/bash as the "command"
-    # so it doesn't get confused and OOM/exhaust the build resources (don't ask me)
-    docker: [{image: 'circleci/android:api-28-node8-alpha', cmd: '/bin/bash'}]
+    executor: android
     environment: &android-env
       task: ANDROID
       FASTLANE_SKIP_UPDATE_CHECK: '1'
@@ -302,7 +318,7 @@ jobs:
       IS_NIGHTLY: '1'
 
   android-bundle:
-    docker: *docker-node
+    executor: node
     environment:
       task: JS-bundle-android
     steps:
@@ -321,15 +337,12 @@ jobs:
       - run: *run-danger
 
   ios: &ios
-    macos: {xcode: '9.4.1'}
+    executor: ios
     environment: &ios-env
       task: IOS
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_ANIMATION: '1'
-      HOMEBREW_NO_AUTO_UPDATE: 1
-      LC_ALL: en_US.UTF-8
-      LANG: en_US.UTF-8
-    shell: /bin/bash --login -o pipefail
+      HOMEBREW_NO_AUTO_UPDATE: '1'
     steps:
       - checkout
       - run:
@@ -376,7 +389,7 @@ jobs:
       IS_NIGHTLY: '1'
 
   ios-bundle:
-    docker: *docker-node
+    executor: node
     environment:
       task: JS-bundle-ios
     steps:


### PR DESCRIPTION
Instead of using YAML references, which get a bit messy after a while, and can't really handle multiple top-level keys, we can use CircleCI 2.1's new `executors` top-level structure to define custom "executors" for ourselves.

A simple one:

```yaml
executors:
  node:
    docker:
      - image: 'circleci/node:10'
```

A more complex one:

```yaml
executors:
  ios:
    macos:
      xcode: '9.4.1'
    shell: /bin/bash --login -o pipefail
    environment:
      LC_ALL: en_US.UTF-8
      LANG: en_US.UTF-8
```

---

This is really a question of "will Circle do anything with this config". I'm just idly poking at this while I wait for local native android builds.