### PR TITLE
Fix popover crash on interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Made sure that nightly builds will get built if something changed (#3261)
 - Fixed a syntax error in build skipping script (#3262)
 - Forced build skipping script to actually query Git history for nightly skip check (#3275)
+- Fixed the touchable ref from not passing from the filter toolbar button to the popover (#3279)
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/modules/filter/filter-popover.js
+++ b/modules/filter/filter-popover.js
@@ -33,6 +33,10 @@ export class FilterPopover extends React.PureComponent<Props, State> {
 		const {filter} = this.state
 		const {anchor, onClosePopover, visible} = this.props
 
+		if (typeof anchor !== 'object') {
+			throw new Error('FilterPopover only supports createRef refs')
+		}
+
 		return (
 			<Popover
 				arrowStyle={arrowStyle}

--- a/modules/filter/filter-popover.js
+++ b/modules/filter/filter-popover.js
@@ -6,7 +6,7 @@ import type {FilterType} from './types'
 import * as c from '@frogpond/colors'
 
 type Props = {
-	anchor: ?React.Ref<*>,
+	anchor: React.Ref<*>,
 	filter: FilterType,
 	onClosePopover: (filter: FilterType) => any,
 	visible: boolean,
@@ -36,7 +36,7 @@ export class FilterPopover extends React.PureComponent<Props, State> {
 		return (
 			<Popover
 				arrowStyle={arrowStyle}
-				fromView={anchor}
+				fromView={anchor.current}
 				isVisible={visible}
 				onClose={() => onClosePopover(filter)}
 				placement="bottom"


### PR DESCRIPTION
Part of #3164. Fixes the touchable ref from not passing from `filter toolbar button` to the `popover`.

**Known issue:** the toggles, switches, checkboxes, scrolling menus, etc do not apply. This purely attempts to fix the crashing app. Getting them to work again is the next step.

Much thanks to @hawkrives for the clarity on why this was broken.

> createRef and ref={cb} both work similarly
> They start null, and then get populated after stuff is mounted
> ~stuff
> ref={cb} needs to be on the _view_ that we want to use as the anchor
> And then we pass anchor={this.refName} to the popover
> 
> Similarly with createRef
> pass ref={this.refName} to the actual anchor, and then anchor={this.refName} as well
> Without actually _attaching_ the ref anywhere, it's always going to be null