### PR TITLE
Update interior dependencies

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5328,9 +5328,9 @@ merge-stream@^1.0.1:
     readable-stream "^2.0.1"
 
 merge@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
-  integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
+  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
 
 metro-babel-register@^0.48.1:
   version "0.48.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2619,7 +2619,7 @@ denodeify@^1.2.1:
   resolved "https://registry.yarnpkg.com/denodeify/-/denodeify-1.2.1.tgz#3a36287f5034e699e7577901052c2e6c94251631"
   integrity sha1-OjYof1A05pnnV3kBBSwubJQlFjE=
 
-depd@~1.1.1, depd@~1.1.2:
+depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
@@ -5659,13 +5659,13 @@ moment@2.22.2, "moment@>= 2.9.0", moment@^2.10.6:
   integrity sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=
 
 morgan@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
-  integrity sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
+  integrity sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==
   dependencies:
     basic-auth "~2.0.0"
     debug "2.6.9"
-    depd "~1.1.1"
+    depd "~1.1.2"
     on-finished "~2.3.0"
     on-headers "~1.0.1"
 


### PR DESCRIPTION
<details><summary><code>$ yarn audit</code></summary>

```
yarn audit v1.12.3
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > metro-cache > metro-core >            │
│               │ jest-haste-map > sane > exec-sh > merge                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro-core > jest-haste-map > sane > exec-sh  │
│               │ > merge                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro-core > jest-haste-map > sane > watch >  │
│               │ exec-sh > merge                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Code Injection                                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ morgan                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.9.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > morgan                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/736                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @hawkrives/react-native-alphabetlistview                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @hawkrives/react-native-alphabetlistview > merge             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @frogpond/listview                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @frogpond/listview >                                         │
│               │ @hawkrives/react-native-alphabetlistview > merge             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > jest-haste-map > sane > exec-sh > merge    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > jest-haste-map > sane > watch > exec-sh >  │
│               │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > jest-runner > jest-haste-map > sane >      │
│               │ exec-sh > merge                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > jest-runner > jest-haste-map > sane >      │
│               │ watch > exec-sh > merge                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > jest-runner > jest-runtime >               │
│               │ jest-haste-map > sane > exec-sh > merge                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > jest-runner > jest-runtime >               │
│               │ jest-haste-map > sane > watch > exec-sh > merge              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > jest-runtime > jest-haste-map > sane >     │
│               │ exec-sh > merge                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest > jest-cli > jest-runtime > jest-haste-map > sane >     │
│               │ watch > exec-sh > merge                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > metro-config > metro-cache >          │
│               │ metro-core > jest-haste-map > sane > watch > exec-sh > merge │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > jest-haste-map > sane > watch >       │
│               │ exec-sh > merge                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > metro-config > metro-core >           │
│               │ jest-haste-map > sane > exec-sh > merge                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > metro-cache > metro-core >            │
│               │ jest-haste-map > sane > watch > exec-sh > merge              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > metro-config > metro-core >           │
│               │ jest-haste-map > sane > watch > exec-sh > merge              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > jest-haste-map > sane > exec-sh >     │
│               │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > metro-core > jest-haste-map > sane >  │
│               │ exec-sh > merge                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > metro-config > metro-cache >          │
│               │ metro-core > jest-haste-map > sane > exec-sh > merge         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ merge                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ react-native                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ react-native > metro > metro-core > jest-haste-map > sane >  │
│               │ watch > exec-sh > merge                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/722                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
23 vulnerabilities found - Packages audited: 75070
Severity: 22 Low | 1 Moderate
```

</details>

Fixed up updating `merge` and `morgan` to solve two vulnerabilities as reported by `yarn audit`.