### PR TITLE
Fix olecard login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Forced build skipping script to actually query Git history for nightly skip check (#3275)
 - Fixed the touchable ref from not passing from the filter toolbar button to the popover (#3279)
 - Resolved some circular `require` statements in our code (#3280)
+- Resolved issue with OleCard login just never working (#3308)
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -47,6 +47,7 @@ export async function performLogin({
 		loginResult = await fetch(OLECARD_AUTH_URL, {
 			method: 'POST',
 			body: form,
+			credentials: 'include',
 		})
 	} catch (err) {
 		let wasNetworkFailure = err.message === 'Network request failed'

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -30,6 +30,8 @@ export type LoginResultEnum =
 	| 'network'
 	| 'bad-credentials'
 	| 'no-credentials'
+	| 'server-error'
+	| 'other'
 
 type Args = {attempts?: number}
 
@@ -41,14 +43,28 @@ export async function performLogin({
 		return 'no-credentials'
 	}
 
-	const form = buildFormData({username, password})
-	let loginResult = null
+	let form = buildFormData({username, password})
+
 	try {
-		loginResult = await fetch(OLECARD_AUTH_URL, {
+		let {status: statusCode} = await rawFetch(OLECARD_AUTH_URL, {
 			method: 'POST',
 			body: form,
 			credentials: 'include',
 		})
+
+		if (statusCode >= 400 && statusCode < 500) {
+			return 'bad-credentials'
+		}
+
+		if (statusCode >= 500 && statusCode < 600) {
+			return 'server-error'
+		}
+
+		if (statusCode < 200 || statusCode >= 300) {
+			return 'other'
+		}
+
+		return 'success'
 	} catch (err) {
 		let wasNetworkFailure = err.message === 'Network request failed'
 		if (wasNetworkFailure && attempts > 0) {
@@ -57,12 +73,4 @@ export async function performLogin({
 		}
 		return 'network'
 	}
-
-	const page = await loginResult.text()
-
-	if (page.includes('Password')) {
-		return 'bad-credentials'
-	}
-
-	return 'success'
 }

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -67,10 +67,13 @@ export async function performLogin({
 		return 'success'
 	} catch (err) {
 		let wasNetworkFailure = err.message === 'Network request failed'
-		if (wasNetworkFailure && attempts > 0) {
-			// console.log(`login failed; trying ${attempts - 1} more time(s)`)
-			return performLogin({attempts: attempts - 1})
+		if (wasNetworkFailure) {
+			if (attempts > 0) {
+				// console.log(`login failed; trying ${attempts - 1} more time(s)`)
+				return performLogin({attempts: attempts - 1})
+			}
+			return 'network'
 		}
-		return 'network'
+		return 'other'
 	}
 }

--- a/source/redux/parts/login.js
+++ b/source/redux/parts/login.js
@@ -42,7 +42,7 @@ const showNetworkFailureMessage = () =>
 const showServerErrorMessage = () =>
 	Alert.alert(
 		'Server Failure',
-		'The OleCard Server is having issues right now. Please try again later.',
+		"We're having issues talking to the OleCard server. Please try again later.",
 		[{text: 'OK'}],
 	)
 

--- a/source/redux/parts/login.js
+++ b/source/redux/parts/login.js
@@ -39,6 +39,13 @@ const showNetworkFailureMessage = () =>
 		[{text: 'OK'}],
 	)
 
+const showServerErrorMessage = () =>
+	Alert.alert(
+		'Server Failure',
+		'The OleCard Server is having issues right now. Please try again later.',
+		[{text: 'OK'}],
+	)
+
 const showInvalidLoginMessage = () =>
 	Alert.alert(
 		'Invalid Login',
@@ -85,6 +92,14 @@ export function logInViaCredentials(
 			dispatch({type: LOGIN_FAILURE})
 			trackLoginFailure('No network')
 			showNetworkFailureMessage()
+		} else if (result === 'server-error') {
+			dispatch({type: LOGIN_FAILURE})
+			trackLoginFailure('Server error')
+			showServerErrorMessage()
+		} else if (result === 'other') {
+			dispatch({type: LOGIN_FAILURE})
+			trackLoginFailure('Unknown problem')
+			showUnknownFailureMessage()
 		} else {
 			showUnknownFailureMessage()
 			;(result: empty)


### PR DESCRIPTION
Closes #3181

---

`fetch()` doesn't send cookies by default (good).

`fetch()` in RN@<0.57 apparently sent cookies along with a redirect (hmm).

`olecard/login.cfm` redirects you to `olecard/index.cfm`, which checks to make sure you're logged in… except that because the cookies weren't sent, it can't find your session, and it kicks you back to the login page.

so we'll just pass along the credentials.

---

and that one-line change is all it took.

I went ahead and refactored some of the other bits after fixing the core issue; now we just check the status code to detect failed login, instead of string matching on the page looking for the phrase "Password". (We couldn't do this before because the server didn't send a 403. Now it does.)

I'm using `rawFetch` here because our stock fetch() wrapper auto-rejects the request if it returns a non-2xx statuscode.