### PR TITLE
should-skip-build: Start abstracting away ambiguous nightly skipping wording, and potentially fix nightlies

### DIFF
--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -98,6 +98,10 @@ end
 class Commit
 	attr_reader :hash
 
+	def self.HEAD
+		self.new('HEAD')
+	end
+
 	def initialize(ref)
 		@hash = dereference(ref)
 	end

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -73,6 +73,20 @@ class String
   end
 end
 
+class Numeric
+	def hours
+		minutes * 60
+	end
+
+	def minutes
+		seconds * 60
+	end
+
+	def seconds
+		self
+	end
+end
+
 class Commit
 	attr_reader :hash
 

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -73,6 +73,11 @@ class String
 end
 
 class Commit
+	attr_reader :hash
+
+	def initialize(hash)
+		@hash = hash
+	end
 end
 
 def changes_after(time, ref = 'HEAD')

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -74,48 +74,48 @@ class String
 end
 
 class Numeric
-	def weeks
-		days * 7
-	end
+  def weeks
+    days * 7
+  end
 
-	def days
-		hours * 24
-	end
+  def days
+    hours * 24
+  end
 
-	def hours
-		minutes * 60
-	end
+  def hours
+    minutes * 60
+  end
 
-	def minutes
-		seconds * 60
-	end
+  def minutes
+    seconds * 60
+  end
 
-	def seconds
-		self
-	end
+  def seconds
+    self
+  end
 end
 
 class Commit
-	attr_reader :hash
+  attr_reader :hash
 
-	def self.HEAD
-		self.new('HEAD')
-	end
+  def self.HEAD
+    self.new('HEAD')
+  end
 
-	def initialize(ref)
-		@hash = dereference(ref)
-	end
+  def initialize(ref)
+    @hash = dereference(ref)
+  end
 
-	def time
-		git_author_time = `git show --format="%aI" --quiet #{@hash}`
-		Time.parse(git_author_time)
-	end
+  def time
+    git_author_time = `git show --format="%aI" --quiet #{@hash}`
+    Time.parse(git_author_time)
+  end
 
-	protected
+  protected
 
-	def dereference(ref)
-		`git rev-parse #{ref}`
-	end
+  def dereference(ref)
+    `git rev-parse #{ref}`
+  end
 end
 
 def changes_after(time, ref = 'HEAD')
@@ -127,8 +127,8 @@ def git_log_between(source, target)
 end
 
 def anything_changed_yesterday?
-	head_time = Commit.HEAD.time
-	readback_time = head_time - 26.hours
+  head_time = Commit.HEAD.time
+  readback_time = head_time - 26.hours
 
   yesterdays_changes = changes_after(readback_time.iso8601).unique_lines
 

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -79,6 +79,8 @@ class Commit
 		@hash = dereference(ref)
 	end
 
+	protected
+
 	def dereference(ref)
 		`git rev-parse #{ref}`
 	end

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -79,6 +79,10 @@ class Commit
 		@hash = dereference(ref)
 	end
 
+	def time
+		`git show --format="%aI" --quiet #{@hash}`
+	end
+
 	protected
 
 	def dereference(ref)

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -80,7 +80,7 @@ class Commit
 	end
 
 	def dereference(ref)
-		`git show-ref --hash #{ref}`
+		`git rev-parse #{ref}`
 	end
 end
 

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'json'
+require 'time'
 
 PLATFORM = (ENV['task'] || 'unknown').freeze
 
@@ -80,7 +81,8 @@ class Commit
 	end
 
 	def time
-		`git show --format="%aI" --quiet #{@hash}`
+		git_author_time = `git show --format="%aI" --quiet #{@hash}`
+		Time.parse(git_author_time)
 	end
 
 	protected

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -129,7 +129,8 @@ end
 def anything_changed_yesterday?
 	head_time = Commit.HEAD.time
 	readback_time = head_time - 26.hours
-  yesterdays_changes = changes_after('26 hours ago').unique_lines
+
+  yesterdays_changes = changes_after(readback_time.iso8601).unique_lines
 
   yesterdays_changes.count > 0
 end

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -75,8 +75,12 @@ end
 class Commit
 	attr_reader :hash
 
-	def initialize(hash)
-		@hash = hash
+	def initialize(ref)
+		@hash = dereference(ref)
+	end
+
+	def dereference(ref)
+		`git show-ref --hash #{ref}`
 	end
 end
 

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -74,6 +74,14 @@ class String
 end
 
 class Numeric
+	def weeks
+		days * 7
+	end
+
+	def days
+		hours * 24
+	end
+
 	def hours
 		minutes * 60
 	end

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -72,6 +72,9 @@ class String
   end
 end
 
+class Commit
+end
+
 def changes_after(time, ref = 'HEAD')
   sh("git log --name-only --format='' --after='#{time}' '#{ref}'")
 end

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -127,6 +127,8 @@ def git_log_between(source, target)
 end
 
 def anything_changed_yesterday?
+	head_time = Commit.HEAD.time
+	readback_time = head_time - 26.hours
   yesterdays_changes = changes_after('26 hours ago').unique_lines
 
   yesterdays_changes.count > 0


### PR DESCRIPTION
This way, we know exactly what time `git log` is going off of, which will make any other necessary troubleshooting much easier.

I began by adding a `Commit` class, which can be used as a holder for some business logic.  I implemented dereferencing of SHAs, so this class can accept anything (commit, ref, tag, etc.) that can go to `git rev-parse`.

Then I added a `#time` helper which is then used by `anything_changed_yesterday?`, in addition to some idiomatic `Numeric` helpers shamelessly borrowed from Rails.

`anything_changed_yesterday?` now queries the `HEAD` commit's commit date, subtracts 26 hours' worth of seconds, and converts back to ISO8601 which then gets fed to `git log --after=`, hopefully disambiguating the history.