### PR TITLE
getBalances: Include credentials through CORS

### DIFF
--- a/source/lib/financials/balances.js
+++ b/source/lib/financials/balances.js
@@ -21,6 +21,7 @@ export async function getBalances(): Promise<BalancesOrErrorType> {
 		let loginResponse = await fetch(OLECARD_AUTH_URL, {
 			method: 'POST',
 			body: form,
+			credentials: 'include',
 		})
 
 		if (loginResponse.url.includes('message=')) {


### PR DESCRIPTION
We "trust" this endpoint to redirect to the right place, so we need this because CORS policy is not correct, it seems.

Maybe a fix for #3318?