### PR TITLE
Return stale-but-cached data if offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added Renovate as our new automated dependency management tool, with a nice configuration (#3193)
 - Add "open webpage" row to student work detail
 - Added some logic to skip native builds if nothing that might affect them has changed (#3209)
-- All network requests are now cached according to the server's caching headers (#3310)
+- All network requests are now cached according to the server's caching headers, even offline (#3310, #3320)
 
 ### Changed
 - Adjusted and deduplicated logic in API scaffolding

--- a/modules/fetch/cached.js
+++ b/modules/fetch/cached.js
@@ -59,7 +59,12 @@ export async function insertForUrl(url: string, data: mixed) {
 }
 
 // Does the magic: stores a Request into AsyncStorage
-type CacheItemArgs = {key: string, response: Response, policy: CachePolicy, bundled?: boolean}
+type CacheItemArgs = {
+	key: string,
+	response: Response,
+	policy: CachePolicy,
+	bundled?: boolean,
+}
 async function cacheItem({key, response, policy, bundled}: CacheItemArgs) {
 	response = await serializeResponse(response)
 
@@ -107,7 +112,10 @@ export async function cachedFetch(request: Request): Promise<Response> {
 	if (process.env.NODE_ENV === 'development') {
 		let bundledResponse = await AsyncStorage.getItem(`${ROOT}:${key}:bundled`)
 		if (bundledResponse) {
-			debug && console.log(`fetch(${request.url}): in dev mode; returning bundled data`)
+			debug &&
+				console.log(
+					`fetch(${request.url}): in dev mode; returning bundled data`,
+				)
 			let {body, ...init} = JSON.parse(bundledResponse)
 			return new Response(body, init)
 		}

--- a/source/app.js
+++ b/source/app.js
@@ -6,6 +6,7 @@ import './init/moment'
 import './init/analytics'
 import './init/api'
 import './init/theme'
+import './init/data'
 // import './init/navigation'
 import {ONESIGNAL_APP_ID} from './init/notifications'
 


### PR DESCRIPTION
> A followup to #3310 

Turns out that I had never included explicit "hey, if you're offline, just return the cached data, even if it's stale" instructions to the `cachedFetch` function.

If we had any data that was ever marked as fresh, #3310 would have let you use that offline, I believe, but I don't have any of that so 🤷‍♀️.

I recommend looking through this PR one commit at a time; the final commit reorganizes the file somewhat to reduce the `cachedFetch` function to 24loc.

I also tweaked it to always return bundled data when in development.