### PR TITLE
Use the scrollEnabled prop and nix the prepare call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Told Circle to use Xcode 10.1 to build and test the iOS app
 - Updated Fastlane support url to point to the project's issues tracker (#3314)
 - Ignore specific proptype warning for react markdown (#3329)
+- Only set `scrollEnabled` if `multiline` is true (#3337)
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)
@@ -38,6 +39,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Resolved some circular `require` statements in our code (#3280)
 - Resolved issue with OleCard login just never working (#3308)
 - Made build tooling always build tagged commits (#3323)
+
+### Removed
+- Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/modules/tableview/cells/selectable.js
+++ b/modules/tableview/cells/selectable.js
@@ -18,8 +18,7 @@ export const SelectableCell = ({text}: {text: string}) => (
 		dataDetectorTypes="all"
 		editable={false}
 		multiline={true}
-		// TODO(react-native@0.58): enable this once React Native no longer dies when opening Settings
-		//scrollEnabled={false}
+		scrollEnabled={false}
 		style={styles.text}
 		value={text}
 	/>

--- a/modules/tableview/cells/textfield.js
+++ b/modules/tableview/cells/textfield.js
@@ -69,6 +69,11 @@ export class CellTextField extends React.Component<Props> {
 	}
 
 	render() {
+		let moreProps = {}
+		if (this.props.multiline) {
+			moreProps.scrollEnabled = false
+		}
+
 		const labelWidthStyle =
 			this.props.labelWidth !== null && this.props.labelWidth !== undefined
 				? {width: this.props.labelWidth}
@@ -95,11 +100,10 @@ export class CellTextField extends React.Component<Props> {
 				placeholder={this.props.placeholder}
 				placeholderTextColor={c.iosPlaceholderText}
 				returnKeyType={this.props.returnKeyType}
-				// TODO(react-native@0.58): enable this once React Native no longer dies when opening Settings
-				//scrollEnabled={false}
 				secureTextEntry={this.props.secureTextEntry}
 				style={[styles.customTextInput]}
 				value={this.props.value}
+				{...moreProps}
 			/>
 		)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "ios:release": "react-native run-ios --configuration Release",
     "ios-simulator": "xcrun instruments -s devices | peco --select-1 --query 'Simulator iPhone' --on-cancel error | sed  's~.*\\[\\(.*\\)\\].*~\\1~' | xargs open -n -a Simulator --args -CurrentDeviceUDID",
     "lint": "eslint --report-unused-disable-directives --max-warnings=0 --cache source/ modules/ scripts/ *.js",
-    "prepare": "sed -i.bak 's/\\(_backedTextInputView.scrollEnabled = \\)YES;/\\1NO;/' node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.m",
     "pretty": "prettier --write '{source,modules,scripts,e2e}/**/*.{js,json}' 'data/**/*.css' '*.js'",
     "p": "pretty-quick",
     "start": "react-native start",


### PR DESCRIPTION
Closes #2538

We no longer need to run a `sed` to tweak React Native's `RCTMultilineTextInputView`  value for `scrollEnabled`. 

I've tested this by:

1. Removing `node_modules`
2. Removing the `prepare` script
3. Reinstalling packages with `yarn`
4. Rebuilding the project
5. Uncommenting the `scrollEnabled` prop
6. Reloading
7. Going to different views that use our `<TextInput />`
8. Verifying that scrolling is enabled/disabled per the setting