### PR TITLE
package: Remove now-unnecessary path to yarn.lock from d command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "compress-data": "gzip --keep docs/*.json",
     "danger": "danger ci",
     "data": "node scripts/bundle-data.js data/ docs/",
-    "d": "yarn-deduplicate yarn.lock && yarn",
+    "d": "yarn-deduplicate && yarn",
     "flow": "flow",
     "ios": "react-native run-ios",
     "ios:release": "react-native run-ios --configuration Release",


### PR DESCRIPTION
This was enabled by v1.1.0 of yarn-deduplicate being released.

(See release notes from #3336.)