### PR TITLE
android: Switch out to the api-28-node image for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ jobs:
     # cmd: key is passed to solve a weird issue (see GitHub PR's 2170 and 2173).
     # this overrides the thing and forces the container to run /bin/bash as the "command"
     # so it doesn't get confused and OOM/exhaust the build resources (don't ask me)
-    docker: [{image: 'circleci/android:api-28-node8-alpha', cmd: '/bin/bash'}]
+    docker: [{image: 'circleci/android:api-28-node', cmd: '/bin/bash'}]
     environment: &android-env
       task: ANDROID
       FASTLANE_SKIP_UPDATE_CHECK: '1'


### PR DESCRIPTION
Worth some thought.

I'm mostly curious if the app even builds on this image.