### PR TITLE
Fix broken filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Resolved some circular `require` statements in our code (#3280)
 - Resolved issue with OleCard login just never working (#3308)
 - Made build tooling always build tagged commits (#3323)
+- Fixed bug where filters were not applying correctly in menu and course search views (#3344)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/modules/filter/filter-popover.js
+++ b/modules/filter/filter-popover.js
@@ -21,10 +21,6 @@ export class FilterPopover extends React.PureComponent<Props, State> {
 		filter: this.props.filter,
 	}
 
-	static getDerivedStateFromProps(props: Props) {
-		return {filter: props.filter}
-	}
-
 	onFilterChanged = (filter: FilterType) => {
 		this.setState(() => ({filter: filter}))
 	}

--- a/modules/food-menu/fancy-menu.js
+++ b/modules/food-menu/fancy-menu.js
@@ -74,7 +74,7 @@ export class FancyMenu extends React.Component<Props, State> {
 		// us overriding our changes from FilterView.onDismiss
 		if (
 			!prevState.cachedFoodItems ||
-			props.foodItems === prevState.cachedFoodItems
+			props.foodItems !== prevState.cachedFoodItems
 		) {
 			let {foodItems, menuCorIcons, meals, now} = props
 			let filters = buildFilters(values(foodItems), menuCorIcons, meals, now)


### PR DESCRIPTION
Resolves #3281.

The `getDerivedStateFromProps` in both the popover component and the fancy menu were overwriting the changes made to the state of each component when the filters were supposed to update, which was causing the unexpected behavior. I tested this and it resolves the bug.