### PR TITLE
Disable sticky headers for menus and courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Ignore specific proptype warning for react markdown (#3329)
 - Only set `scrollEnabled` if `multiline` is true (#3337)
 - Select, rather than deselect, first selected filter option of OR filters (#3347)
+- Menus and Course Search will have non-sticky headers until a RN bug is fixed (#3353)
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)

--- a/modules/food-menu/fancy-menu.js
+++ b/modules/food-menu/fancy-menu.js
@@ -207,6 +207,8 @@ export class FancyMenu extends React.Component<Props, State> {
 				renderItem={this.renderItem}
 				renderSectionHeader={this.renderSectionHeader}
 				sections={(groupedMenuData: any)}
+				// remove this after react native fixes the sticky header positioning
+				stickySectionHeadersEnabled={false}
 				style={styles.inner}
 				windowSize={5}
 			/>

--- a/source/views/sis/course-search/list.js
+++ b/source/views/sis/course-search/list.js
@@ -121,6 +121,8 @@ export class CourseResultsList extends React.PureComponent<Props> {
 				renderItem={this.renderItem}
 				renderSectionHeader={this.renderSectionHeader}
 				sections={(results: any)}
+				// remove this after react native fixes the sticky header positioning
+				stickySectionHeadersEnabled={false}
 				style={style}
 				windowSize={10}
 			/>


### PR DESCRIPTION
Closes #3348

If we can compromise on the headers not being sticky for `FancyMenu` and `CourseSearch`, this appears to hide the react native issue with headers not remembering their positions when a list is scrolling.

I do not think we need to apply this to any of the other `SectionList` components.

Thoughts?