### PR TITLE
Apply upstream patch from #2205

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added some logic to skip native builds if nothing that might affect them has changed (#3209)
 - All network requests are now cached according to the server's caching headers, even offline (#3310, #3320)
 - Added "Safety Concerns" tile that links to St. Olaf's official form for documenting safety concerns (#3345)
+- Added a prepare statement to apply an upstream fix to the VirtualizedList sticky header calculation (#3357)
 
 ### Changed
 - Adjusted and deduplicated logic in API scaffolding

--- a/contrib/0000-rn-22025-fix-jumpy-lists.patch
+++ b/contrib/0000-rn-22025-fix-jumpy-lists.patch
@@ -6,8 +6,8 @@
                const stickyBlock = this._getFrameMetricsApprox(ii);
 -              const leadSpace = stickyBlock.offset - initBlock.offset;
 +              const leadSpace =
-+                stickyBlockOffset -
-+                initBlockOffset -
++                stickyBlock.offset -
++                initBlock.offset -
 +                (this.props.initialScrollIndex ? 0 : initBlock.length);
                cells.push(
                  <View key="$sticky_lead" style={{[spacerKey]: leadSpace}} />,

--- a/contrib/0000-rn-22025-fix-jumpy-lists.patch
+++ b/contrib/0000-rn-22025-fix-jumpy-lists.patch
@@ -1,0 +1,14 @@
+--- ./node_modules/react-native/Libraries/Lists/VirtualizedList.js
++++ ./node_modules/react-native/Libraries/Lists/VirtualizedList.js
+@@ -805,7 +805,10 @@ class VirtualizedList extends React.Pure
+             if (stickyIndicesFromProps.has(ii + stickyOffset)) {
+               const initBlock = this._getFrameMetricsApprox(lastInitialIndex);
+               const stickyBlock = this._getFrameMetricsApprox(ii);
+-              const leadSpace = stickyBlock.offset - initBlock.offset;
++              const leadSpace =
++                stickyBlockOffset -
++                initBlockOffset -
++                (this.props.initialScrollIndex ? 0 : initBlock.length);
+               cells.push(
+                 <View key="$sticky_lead" style={{[spacerKey]: leadSpace}} />,
+               );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ios:release": "react-native run-ios --configuration Release",
     "ios-simulator": "xcrun instruments -s devices | peco --select-1 --query 'Simulator iPhone' --on-cancel error | sed  's~.*\\[\\(.*\\)\\].*~\\1~' | xargs open -n -a Simulator --args -CurrentDeviceUDID",
     "lint": "eslint --report-unused-disable-directives --max-warnings=0 --cache source/ modules/ scripts/ *.js",
-    "prepare": "sed -i.bak 's/\\(const leadSpace = stickyBlock.offset - initBlock.offset\\);/\\1 - (this.props.initialScrollIndex ? 0 : initBlock.length);/' node_modules/react-native/Libraries/Lists/VirtualizedList.js",
+    "prepare": "patch -p0 -Nfsi contrib/*.patch || true",
     "pretty": "prettier --write '{source,modules,scripts,e2e}/**/*.{js,json}' 'data/**/*.css' '*.js'",
     "p": "pretty-quick",
     "start": "react-native start",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "ios:release": "react-native run-ios --configuration Release",
     "ios-simulator": "xcrun instruments -s devices | peco --select-1 --query 'Simulator iPhone' --on-cancel error | sed  's~.*\\[\\(.*\\)\\].*~\\1~' | xargs open -n -a Simulator --args -CurrentDeviceUDID",
     "lint": "eslint --report-unused-disable-directives --max-warnings=0 --cache source/ modules/ scripts/ *.js",
+    "prepare": "sed -i.bak 's/\\(const leadSpace = stickyBlock.offset - initBlock.offset\\);/\\1 - (this.props.initialScrollIndex ? 0 : initBlock.length);/' node_modules/react-native/Libraries/Lists/VirtualizedList.js",
     "pretty": "prettier --write '{source,modules,scripts,e2e}/**/*.{js,json}' 'data/**/*.css' '*.js'",
     "p": "pretty-quick",
     "start": "react-native start",


### PR DESCRIPTION
> Fix regression of VirtualizedList jumpy header

I'm in favor of applying this to the repo instead of #3353, so this would close #3353.

This takes the unverified fix from upstream to patch the VirtualizedList's leadSpace calculation. It appears to work. I like this better than disabling sticky headers altogether in menus and course search.