### PR TITLE
Prompt user when they open the safety home button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - All network requests are now cached according to the server's caching headers, even offline (#3310, #3320)
 - Added "Safety Concerns" tile that links to St. Olaf's official form for documenting safety concerns (#3345)
 - Added a prepare statement to apply an upstream fix to the VirtualizedList sticky header calculation (#3357)
+- Added a prompt before the user leaves the app from open-browser-url (#3361)
 
 ### Changed
 - Adjusted and deduplicated logic in API scaffolding

--- a/modules/open-url/open-url.js
+++ b/modules/open-url/open-url.js
@@ -82,7 +82,7 @@ export function openUrlInBrowser({url, id}: {url: string, id?: string}) {
 function promptConfirm(url: string) {
 	const app = appName()
 	const title = `Leaving ${app}`
-	const detail = `A web page will be opened in a browser outside of ${app}. Are you sure you want to open it?`
+	const detail = `A web page will be opened in a browser outside of ${app}.`
 	Alert.alert(title, detail, [
 		{text: 'Cancel', onPress: () => {}},
 		{text: 'Open', onPress: () => genericOpen(url)},

--- a/modules/open-url/open-url.js
+++ b/modules/open-url/open-url.js
@@ -1,8 +1,9 @@
 // @flow
 
-import {Platform, Linking} from 'react-native'
+import {Platform, Linking, Alert} from 'react-native'
 
 import {trackUrl, trackException} from '@frogpond/analytics'
+import {appName} from '@frogpond/constants'
 import SafariView from 'react-native-safari-view'
 import {CustomTabs} from 'react-native-custom-tabs'
 
@@ -75,5 +76,15 @@ export function canOpenUrl(url: string) {
 
 export function openUrlInBrowser({url, id}: {url: string, id?: string}) {
 	trackUrl(id || url)
-	return genericOpen(url)
+	return promptConfirm(url)
+}
+
+function promptConfirm(url: string) {
+	const app = appName()
+	const title = `Leaving ${app}`
+	const detail = `A web page will be opened in a browser outside of ${app}. Are you sure you want to open it?`
+	Alert.alert(title, detail, [
+		{text: 'Cancel', onPress: () => {}},
+		{text: 'Open', onPress: () => genericOpen(url)},
+	])
 }


### PR DESCRIPTION
It's a little jarring to leave the app without being warned. This provides an alert to inform the user.

This is behavior that happens currently with `openUrlInBrowser` which we're calling when we open the top-level "Safety Concern" home tile.

> **Leaving All About Olaf**
> A web page will be opened in a browser outside of All About Olaf. Are you sure you want to open it?
> [Cancel]  [Open]

iOS | Android
--|--
<img width="395" alt="ios-open-url" src="https://user-images.githubusercontent.com/5240843/50466262-c72f0e80-0959-11e9-9d2e-53f708504f81.png"> | <img width="487" alt="android-open-url" src="https://user-images.githubusercontent.com/5240843/50466264-c72f0e80-0959-11e9-9856-125722dcb46a.png">