### PR TITLE
Paper over Privacy Policy crash by removing nested lists

### DIFF
--- a/data/privacy.md
+++ b/data/privacy.md
@@ -32,12 +32,12 @@ reach servers that we control. Whenever your app makes such a request, the
 following information is logged:
 
 1. _Your public IP address_. We do not use this to identify you or for tracking
-purposes, and this is logged only for diagnostic purposes.
+  purposes, and this is logged only for diagnostic purposes.
 2. _The version of All About Olaf you are using and information about your
-phone_, which is sent as part of your device's request. This data is
-intentionally vague so that we can also not use this to identify you.
+  phone_, which is sent as part of your device's request. This data is
+  intentionally vague so that we can also not use this to identify you.
 3. _What you requested and how long it took_, which is widely considered to be
-fully anonymous.
+  fully anonymous.
 
 We also use a few tools to track our most used features and push notification
 receipts, as well as collect crash reports. These tools are:

--- a/data/privacy.md
+++ b/data/privacy.md
@@ -35,10 +35,10 @@ following information is logged:
 purposes, and this is logged only for diagnostic purposes.
 2. _The version of All About Olaf you are using and information about your
 phone_, which is sent as part of your device's request. This data is
-intentionally vague so that we can also not use this to identify you. 
+intentionally vague so that we can also not use this to identify you.
 3. _What you requested and how long it took_, which is widely considered to be
 fully anonymous.
- 
+
 We also use a few tools to track our most used features and push notification
 receipts, as well as collect crash reports. These tools are:
 

--- a/data/privacy.md
+++ b/data/privacy.md
@@ -2,83 +2,81 @@
 
 We respect your right to privacy when using our app, All About Olaf.
 
-Our policy towards privacy is simple: we aim to collect no data other
-than what we need to keep the app functional and ensure a smooth
-experience for all users.
+Our policy towards privacy is simple: we aim to collect no data other than
+what we need to keep the app functional and ensure a smooth experience for all
+users.
 
 ## Who runs this app?
 
-This app is developed and maintained by a mixed team of current
-students at St. Olaf College and alumni of St. Olaf College.  Anyone
-is welcome to make contributions to the app, and the source code for
-the app is publicly available [on GitHub][repo].  All contributions go
-through code review by maintainers.
+This app is developed and maintained by a mixed team of current students at
+St. Olaf College and alumni of St. Olaf College. Anyone is welcome to make
+contributions to the app, and the source code for the app is publicly
+available [on GitHub][repo]. All contributions go through code review by
+maintainers.
 
-This app is entirely self-funded, and we do not include advertisements
-on our app.  As such, our privacy policy is quite simple.
+This app is entirely self-funded, and we do not include advertisements on our
+app. As such, our privacy policy is quite simple.
 
 [repo]: https://github.com/StoDevX/AAO-React-Native
 
 ## What data do you collect?
 
-- When you "Sign in with St. Olaf" in the settings, your St. Olaf
-  username and password are stored locally, on your device, in the
-  encrypted keychain storage mechanism available on your device.  _We
-  do not transmit these credentials to or through any servers that we
-  control, and we do not have the ability to remotely access these
-  credentials_.  These credentials become inaccessible when you delete
-  the app.  We only transmit these credentials to on-campus servers,
-  and the security of those servers is not controlled by us.
+When you "Sign in with St. Olaf" in the settings, your St. Olaf username and
+password are stored locally, on your device, in the encrypted keychain storage
+mechanism available on your device. _We do not transmit these credentials to
+or through any servers that we control, and we do not have the ability to
+remotely access these credentials_. These credentials become inaccessible when
+you delete the app. We only transmit these credentials to on-campus servers,
+and the security of those servers is not controlled by us.
 
-- When you fetch any data besides your personal information, your
-  requests may reach servers that we control.  Whenever your app makes
-  such a request, the following information is logged:
-  - _Your public IP address_.  We do not use this to identify you or
-    for tracking purposes, and this is logged only for diagnostic
-    purposes.
-  - _The version of All About Olaf you are using and information about
-    your phone_, which is sent as part of your device's request.  This
-    data is intentionally vague so that we can also not use this to
-    identify you.
-  - _What you requested and how long it took_, which is widely
-    considered to be fully anonymous.
+When you fetch any data besides your personal information, your requests may
+reach servers that we control. Whenever your app makes such a request, the
+following information is logged:
 
-- We also use a few tools to track our most used features and push
-  notification receipts, as well as collect crash reports.  These
-  tools are:
-  - _Google Analytics_, which can be disabled via the "Share
-    Analytics" toggle in the Settings view.  Google Analytics records
-    slightly more in-depth information about your device, which we use
-    for ensuring that our app looks good on all screen sizes.
-  - _OneSignal_, which manages the delivery of our notifications,
-    collects device information to place you into categories.
-  - _BugSnag_, which collects crash reports and cannot be disabled
-    currently.  BugSnag collects in-depth information about the
-    device and circumstances leading up to a given crash.
+1. _Your public IP address_. We do not use this to identify you or for
+tracking purposes, and this is logged only for diagnostic purposes. 
+2. _The version of All About Olaf you are using and information about your
+phone_, which is sent as part of your device's request. This data is
+intentionally vague so that we can also not use this to identify you. 
+3. _What you requested and how long it took_, which is widely considered to be
+fully anonymous.
+ 
+We also use a few tools to track our most used features and push notification
+receipts, as well as collect crash reports. These tools are:
 
-- If you send us suggestions for updates to building hours, we will
-  anonymously add them to the app if we determine that they are
-  correct.  We do not currently give credit for these contributions,
-  primarily because we don't have an easy way of attributing these.
-  In its current form, the "suggest an update" feature requires you to
-  send an email, and this email is sent to our developer mailing list.
+- _Google Analytics_, which can be disabled via the "Share Analytics" toggle
+  in the Settings view. Google Analytics records slightly more in-depth
+  information about your device, which we use for ensuring that our app looks
+  good on all screen sizes.
 
-- If you choose to use the "Submit a Wi-Fi problem" feature or other
-  features and tools that use college systems such as StoPrint, your
-  data is transmitted to those systems exclusively, and we do not have
-  the ability to see it.
+- _OneSignal_, which manages the delivery of our notifications, collects
+  device information to place you into categories.
 
-Most importantly: **the developers and maintainers of All About Olaf
-_will not_, under any circumstances, grant access to any personally
-identifiable information that we may have collected to a third party,
-unless as required by law**.  We treat your data as confidential and
-have the utmost respect for your privacy, and we think that sharing
-data with other companies for marketing purposes or compensation is a
-blatant violation of trust; we will never share this data.
+- _BugSnag_, which collects crash reports and cannot be disabled currently.
+  BugSnag collects in-depth information about the device and circumstances
+  leading up to a given crash.
+
+If you send us suggestions for updates to building hours, we will anonymously
+add them to the app if we determine that they are correct. We do not currently
+give credit for these contributions, primarily because we don't have an easy
+way of attributing these. In its current form, the "suggest an update" feature
+requires you to send an email, and this email is sent to our developer mailing
+list.
+
+If you choose to use the "Submit a Wi-Fi problem" feature or other features
+and tools that use college systems such as StoPrint, your data is transmitted
+to those systems exclusively, and we do not have the ability to see it.
+
+Most importantly: **the developers and maintainers of All About Olaf _will
+not_, under any circumstances, grant access to any personally identifiable
+information that we may have collected to a third party, unless as required by
+law**. We treat your data as confidential and have the utmost respect for your
+privacy, and we think that sharing data with other companies for marketing
+purposes or compensation is a blatant violation of trust; we will never share
+this data.
 
 ### Contact Us
 
-If you have any questions, comments, or concerns about this privacy
-policy, please reach out to us via email at
-<allaboutolaf+privacy@stolaf.edu>.  This mailing list contains all
-active maintainers and developers.
+If you have any questions, comments, or concerns about this privacy policy,
+please reach out to us via email at <allaboutolaf+privacy@stolaf.edu>. This
+mailing list contains all active maintainers and developers.

--- a/data/privacy.md
+++ b/data/privacy.md
@@ -2,17 +2,15 @@
 
 We respect your right to privacy when using our app, All About Olaf.
 
-Our policy towards privacy is simple: we aim to collect no data other than
-what we need to keep the app functional and ensure a smooth experience for all
-users.
+Our policy towards privacy is simple: we aim to collect no data other than what
+we need to keep the app functional and ensure a smooth experience for all users.
 
 ## Who runs this app?
 
 This app is developed and maintained by a mixed team of current students at
 St. Olaf College and alumni of St. Olaf College. Anyone is welcome to make
-contributions to the app, and the source code for the app is publicly
-available [on GitHub][repo]. All contributions go through code review by
-maintainers.
+contributions to the app, and the source code for the app is publicly available
+[on GitHub][repo]. All contributions go through code review by maintainers.
 
 This app is entirely self-funded, and we do not include advertisements on our
 app. As such, our privacy policy is quite simple.
@@ -23,18 +21,18 @@ app. As such, our privacy policy is quite simple.
 
 When you "Sign in with St. Olaf" in the settings, your St. Olaf username and
 password are stored locally, on your device, in the encrypted keychain storage
-mechanism available on your device. _We do not transmit these credentials to
-or through any servers that we control, and we do not have the ability to
-remotely access these credentials_. These credentials become inaccessible when
-you delete the app. We only transmit these credentials to on-campus servers,
-and the security of those servers is not controlled by us.
+mechanism available on your device. _We do not transmit these credentials to or
+through any servers that we control, and we do not have the ability to remotely
+access these credentials_. These credentials become inaccessible when you delete
+the app. We only transmit these credentials to on-campus servers, and the
+security of those servers is not controlled by us.
 
 When you fetch any data besides your personal information, your requests may
 reach servers that we control. Whenever your app makes such a request, the
 following information is logged:
 
-1. _Your public IP address_. We do not use this to identify you or for
-tracking purposes, and this is logged only for diagnostic purposes. 
+1. _Your public IP address_. We do not use this to identify you or for tracking
+purposes, and this is logged only for diagnostic purposes.
 2. _The version of All About Olaf you are using and information about your
 phone_, which is sent as part of your device's request. This data is
 intentionally vague so that we can also not use this to identify you. 
@@ -44,13 +42,13 @@ fully anonymous.
 We also use a few tools to track our most used features and push notification
 receipts, as well as collect crash reports. These tools are:
 
-- _Google Analytics_, which can be disabled via the "Share Analytics" toggle
-  in the Settings view. Google Analytics records slightly more in-depth
-  information about your device, which we use for ensuring that our app looks
-  good on all screen sizes.
+- _Google Analytics_, which can be disabled via the "Share Analytics" toggle in
+  the Settings view. Google Analytics records slightly more in-depth information
+  about your device, which we use for ensuring that our app looks good on all
+  screen sizes.
 
-- _OneSignal_, which manages the delivery of our notifications, collects
-  device information to place you into categories.
+- _OneSignal_, which manages the delivery of our notifications, collects device
+  information to place you into categories.
 
 - _BugSnag_, which collects crash reports and cannot be disabled currently.
   BugSnag collects in-depth information about the device and circumstances
@@ -58,22 +56,21 @@ receipts, as well as collect crash reports. These tools are:
 
 If you send us suggestions for updates to building hours, we will anonymously
 add them to the app if we determine that they are correct. We do not currently
-give credit for these contributions, primarily because we don't have an easy
-way of attributing these. In its current form, the "suggest an update" feature
+give credit for these contributions, primarily because we don't have an easy way
+of attributing these. In its current form, the "suggest an update" feature
 requires you to send an email, and this email is sent to our developer mailing
 list.
 
-If you choose to use the "Submit a Wi-Fi problem" feature or other features
-and tools that use college systems such as StoPrint, your data is transmitted
-to those systems exclusively, and we do not have the ability to see it.
+If you choose to use the "Submit a Wi-Fi problem" feature or other features and
+tools that use college systems such as StoPrint, your data is transmitted to
+those systems exclusively, and we do not have the ability to see it.
 
-Most importantly: **the developers and maintainers of All About Olaf _will
-not_, under any circumstances, grant access to any personally identifiable
-information that we may have collected to a third party, unless as required by
-law**. We treat your data as confidential and have the utmost respect for your
-privacy, and we think that sharing data with other companies for marketing
-purposes or compensation is a blatant violation of trust; we will never share
-this data.
+Most importantly: **the developers and maintainers of All About Olaf _will not_,
+under any circumstances, grant access to any personally identifiable information
+that we may have collected to a third party, unless as required by law**. We
+treat your data as confidential and have the utmost respect for your privacy,
+and we think that sharing data with other companies for marketing purposes or
+compensation is a blatant violation of trust; we will never share this data.
 
 ### Contact Us
 

--- a/data/privacy.md
+++ b/data/privacy.md
@@ -7,13 +7,13 @@ we need to keep the app functional and ensure a smooth experience for all users.
 
 ## Who runs this app?
 
-This app is developed and maintained by a mixed team of current students at
-St. Olaf College and alumni of St. Olaf College. Anyone is welcome to make
+This app is developed and maintained by a mixed team of current students at St.
+Olaf College and alumni of St. Olaf College.  Anyone is welcome to make
 contributions to the app, and the source code for the app is publicly available
-[on GitHub][repo]. All contributions go through code review by maintainers.
+[on GitHub][repo].  All contributions go through code review by maintainers.
 
 This app is entirely self-funded, and we do not include advertisements on our
-app. As such, our privacy policy is quite simple.
+app.  As such, our privacy policy is quite simple.
 
 [repo]: https://github.com/StoDevX/AAO-React-Native
 
@@ -21,29 +21,29 @@ app. As such, our privacy policy is quite simple.
 
 When you "Sign in with St. Olaf" in the settings, your St. Olaf username and
 password are stored locally, on your device, in the encrypted keychain storage
-mechanism available on your device. _We do not transmit these credentials to or
+mechanism available on your device.  _We do not transmit these credentials to or
 through any servers that we control, and we do not have the ability to remotely
-access these credentials_. These credentials become inaccessible when you delete
-the app. We only transmit these credentials to on-campus servers, and the
+access these credentials_.  These credentials become inaccessible when you delete
+the app.  We only transmit these credentials to on-campus servers, and the
 security of those servers is not controlled by us.
 
 When you fetch any data besides your personal information, your requests may
-reach servers that we control. Whenever your app makes such a request, the
+reach servers that we control.  Whenever your app makes such a request, the
 following information is logged:
 
-1. _Your public IP address_. We do not use this to identify you or for tracking
+1. _Your public IP address_.  We do not use this to identify you or for tracking
   purposes, and this is logged only for diagnostic purposes.
 2. _The version of All About Olaf you are using and information about your
-  phone_, which is sent as part of your device's request. This data is
+  phone_, which is sent as part of your device's request.  This data is
   intentionally vague so that we can also not use this to identify you.
 3. _What you requested and how long it took_, which is widely considered to be
   fully anonymous.
 
 We also use a few tools to track our most used features and push notification
-receipts, as well as collect crash reports. These tools are:
+receipts, as well as collect crash reports.  These tools are:
 
 - _Google Analytics_, which can be disabled via the "Share Analytics" toggle in
-  the Settings view. Google Analytics records slightly more in-depth information
+  the Settings view.  Google Analytics records slightly more in-depth information
   about your device, which we use for ensuring that our app looks good on all
   screen sizes.
 
@@ -54,12 +54,11 @@ receipts, as well as collect crash reports. These tools are:
   BugSnag collects in-depth information about the device and circumstances
   leading up to a given crash.
 
-If you send us suggestions for updates to building hours, we will anonymously
-add them to the app if we determine that they are correct. We do not currently
-give credit for these contributions, primarily because we don't have an easy way
-of attributing these. In its current form, the "suggest an update" feature
-requires you to send an email, and this email is sent to our developer mailing
-list.
+If you send us suggestions for updates to building hours, we will anonymously add
+them to the app if we determine that they are correct.  We do not currently give
+credit for these contributions, primarily because we don't have an easy way of
+attributing these.  In its current form, the "suggest an update" feature requires
+you to send an email, and this email is sent to our developer mailing list.
 
 If you choose to use the "Submit a Wi-Fi problem" feature or other features and
 tools that use college systems such as StoPrint, your data is transmitted to
@@ -67,13 +66,13 @@ those systems exclusively, and we do not have the ability to see it.
 
 Most importantly: **the developers and maintainers of All About Olaf _will not_,
 under any circumstances, grant access to any personally identifiable information
-that we may have collected to a third party, unless as required by law**. We
-treat your data as confidential and have the utmost respect for your privacy,
-and we think that sharing data with other companies for marketing purposes or
+that we may have collected to a third party, unless as required by law**.  We
+treat your data as confidential and have the utmost respect for your privacy, and
+we think that sharing data with other companies for marketing purposes or
 compensation is a blatant violation of trust; we will never share this data.
 
 ### Contact Us
 
 If you have any questions, comments, or concerns about this privacy policy,
-please reach out to us via email at <allaboutolaf+privacy@stolaf.edu>. This
+please reach out to us via email at <allaboutolaf+privacy@stolaf.edu>.  This
 mailing list contains all active maintainers and developers.


### PR DESCRIPTION
Part of https://github.com/StoDevX/AAO-React-Native/issues/3260, which I will re-title to <q>Nested Lists in Markdown components crash the app</q> once this is merged.

I removed the list items under the "What data do you collect?" heading, to allow the nested lists to remain listed.

I also re-wrapped all lines to 80col, which I thought was what we were targeting?