### PR TITLE
s|US/Central|America/Chicago|g

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Adjusted and deduplicated logic in API scaffolding
-- Switched time zone definitions from America/Winnipeg to US/Central
+- Switched time zone definitions from America/Winnipeg to US/Central, and then to America/Chicago
 - Pulled out time zone constants from all over the place into a central constant
 - Removed list footer credit for student activities dictionary (we're the source now)
 - Updated the privacy policy to more closely match what we do

--- a/modules/constants/index.js
+++ b/modules/constants/index.js
@@ -4,7 +4,13 @@ import {Platform} from 'react-native'
 
 let TZ: string
 export const setTimezone = (zone: string) => (TZ = zone)
-export const timezone = () => TZ || 'US/Central'
+export const timezone = () => {
+	if (!TZ) {
+		throw new Error('timezone is not set')
+	}
+
+	return TZ
+}
 
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
       "source/**/*.js",
       "!**/node_modules/**"
     ],
+    "setupFiles": [
+      "./scripts/jest-setup.js"
+    ],
     "transformIgnorePatterns": [
       "node_modules/(?!(jest-)?react-native|glamorous-native|react-navigation)"
     ],

--- a/scripts/jest-setup.js
+++ b/scripts/jest-setup.js
@@ -1,0 +1,3 @@
+import {setTimezone} from '@frogpond/constants'
+
+setTimezone('America/Chicago')

--- a/scripts/jest-setup.js
+++ b/scripts/jest-setup.js
@@ -1,3 +1,5 @@
+// @flow
+
 import {setTimezone} from '@frogpond/constants'
 
 setTimezone('America/Chicago')

--- a/source/init/constants.js
+++ b/source/init/constants.js
@@ -6,4 +6,4 @@ const {version, name} = require('../../package.json')
 
 setVersionInfo(version)
 setAppName(name)
-setTimezone('US/Central')
+setTimezone('America/Chicago')

--- a/source/views/building-hours/lib/__tests__/moment.helper.js
+++ b/source/views/building-hours/lib/__tests__/moment.helper.js
@@ -2,7 +2,7 @@
 import moment from 'moment-timezone'
 export {moment}
 
-const CENTRAL_TZ = 'US/Central'
+const CENTRAL_TZ = 'America/Chicago'
 
 export const dayMoment = (time: string, format: ?string = 'ddd h:mma') =>
 	moment.tz(time, format, false, CENTRAL_TZ)

--- a/source/views/menus/lib/__tests__/find-menu.test.js
+++ b/source/views/menus/lib/__tests__/find-menu.test.js
@@ -5,7 +5,7 @@ import moment from 'moment-timezone'
 import type {DayPartsCollectionType} from '../../types'
 import uniqueId from 'lodash/uniqueId'
 
-const CENTRAL_TZ = 'US/Central'
+const CENTRAL_TZ = 'America/Chicago'
 
 const generateDayparts: (
 	...{start: string, end: string}[]

--- a/source/views/transportation/bus/lib/__tests__/moment.helper.js
+++ b/source/views/transportation/bus/lib/__tests__/moment.helper.js
@@ -1,7 +1,7 @@
 // @flow
 import moment from 'moment-timezone'
 
-const CENTRAL_TZ = 'US/Central'
+const CENTRAL_TZ = 'America/Chicago'
 
 export const time = (time: string) => moment.tz(time, 'h:mma', true, CENTRAL_TZ)
 


### PR DESCRIPTION
Closes #3198.

There should be no functional difference here, as documented in #3198.

I also tweaked Jest to automatically set the timezone when doing tests, which I figure is OK since it's kinda equivalent with the app; the app sets this as a global thing during init, so the tests can too.