### PR TITLE
circle: Add --jit flag to Fastlane runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,7 @@ jobs:
           command: bundle exec fastlane android ci-run | tee ./logs/build
           environment:
             GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $CIRCLE_SHA1)
+            RUBYOPT: --jit
       - store_artifacts:
           path: ./android/app/build/outputs/apk/release/
       - run: *run-danger
@@ -374,6 +375,7 @@ jobs:
           command: bundle exec fastlane ios ci-run | tee ./logs/build
           environment:
             GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $CIRCLE_SHA1)
+            RUBYOPT: --jit
       - run: yarn detox build --configuration ios.sim.release | xcpretty
       - run: yarn detox test --configuration ios.sim.release --cleanup
       - store_artifacts: {path: ./ios/build/AllAboutOlaf.app.dSYM.zip}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,8 +360,8 @@ jobs:
           name: Skip build if possible
           command: ./scripts/should-skip-build && circleci step halt || echo "Build continuing."
       - run: yarn --version
-      - run: chruby
       - run: *set-ruby-version
+      - run: chruby
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile
       - save_cache: *save-cache-yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ x-config:
   x-commands: # command shorthands
     - &set-ruby-version
       name: Set Ruby Version
-      command: echo "ruby-2.5.3" > ~/.ruby-version
+      command: echo "ruby-2.6.0" > ~/.ruby-version
     - &run-danger
       command: |
         if ! [[ $CIRCLE_PR_NUMBER ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,7 @@ jobs:
           name: Skip build if possible
           command: ./scripts/should-skip-build && circleci step halt || echo "Build continuing."
       - run: yarn --version
+      - run: chruby
       - run: *set-ruby-version
       - restore_cache: *restore-cache-yarn
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
Just for fun, and to see if this affects performance at all.  I doubt it will, since most of Fastlane's work involves waiting around for everything else to run.  But still.

I wonder about adding it to the `scripts/should-skip-build` thing… I've experienced a bit of slowdown though because it's so short.