### PR TITLE
Fix Jest around the New Year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug where filters were not applying correctly in menu and course search views (#3344, #3350)
 - Fixed the text color of the safety concerns button (#3349)
 - Fixed bug where applied filters would be cleared on a pull-to-refresh of the BonApp menus (#3352)
+- Fixed some strange behavior with hours and bus schedules around the new year (#3376)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/source/views/building-hours/lib/__tests__/parse-hours.test.js
+++ b/source/views/building-hours/lib/__tests__/parse-hours.test.js
@@ -35,7 +35,7 @@ it('will add a day to the close time with nextDay:true', () => {
 	expect(close.isAfter(now)).toBe(true)
 })
 
-describe('handles wierd times', () => {
+describe('handles weird times', () => {
 	it('handles Friday at 4:30pm', () => {
 		const now = dayMoment('Fri 4:30pm')
 		const input = {days: [], from: '10:00am', to: '2:00am'}

--- a/source/views/building-hours/lib/parse-hours.js
+++ b/source/views/building-hours/lib/parse-hours.js
@@ -7,6 +7,8 @@ import {TIME_FORMAT} from './constants'
 
 type HourPairType = {open: moment, close: moment}
 
+// TODO: Do "dayOfYear" handling better so that we don't need to handle wrapping at
+// the 6 month mark. (See #3375 for why this function changed.)
 export function parseHours(
 	{from: fromTime, to: toTime}: SingleBuildingScheduleType,
 	m: moment,
@@ -21,8 +23,18 @@ export function parseHours(
 	let open = moment.tz(fromTime, TIME_FORMAT, true, timezone())
 	open.dayOfYear(dayOfYear)
 
+	let sixMonthsAgo = moment(m).subtract(6, 'months')
+
+	if (open.isBefore(sixMonthsAgo)) {
+		open.add(1, 'year')
+	}
+
 	let close = moment.tz(toTime, TIME_FORMAT, true, timezone())
 	close.dayOfYear(dayOfYear)
+
+	if (close.isBefore(sixMonthsAgo)) {
+		close.add(1, 'year')
+	}
 
 	if (close.isBefore(open)) {
 		close.add(1, 'day')

--- a/source/views/transportation/bus/lib/parse-time.js
+++ b/source/views/transportation/bus/lib/parse-time.js
@@ -4,6 +4,8 @@ const TIME_FORMAT = 'h:mma'
 import {timezone} from '@frogpond/constants'
 import moment from 'moment-timezone'
 
+// TODO: Do "dayOfYear" handling better so that we don't need to handle wrapping at
+// the 6 month mark. (See #3375 for why this function changed.)
 export const parseTime = (now: moment) => (
 	time: string | false,
 ): null | moment => {

--- a/source/views/transportation/bus/lib/parse-time.js
+++ b/source/views/transportation/bus/lib/parse-time.js
@@ -18,5 +18,11 @@ export const parseTime = (now: moment) => (
 	// and set the date to today
 	m.dayOfYear(now.dayOfYear())
 
+	let sixMonthsAgo = moment(now).subtract(6, 'months')
+
+	if (m.isBefore(sixMonthsAgo)) {
+		m.add(1, 'year')
+	}
+
 	return m
 }


### PR DESCRIPTION
Closes #3375.

My notes on `parseHours`:

>Previously, `m`'s dayOfYear was applied to both `open` and `close`, but if `m` was in the next year, then its `dayOfYear` would be low, and `open` and `close` would be freely wrapped around to the beginning of the year.
>
>Now, `parseHours` checks if `open` or `close` are six months prior to `m`, and if so, adds `1` year.  `m` is used only to provide context to "10am" and such kinds of strings, so I think this is a safe bet, and could probably be done less aggressively.

CC @hawkrives for another set of eyes.  I think a similar fix will be needed for bus schedules.