### PR TITLE
Render markdown with line breaks appropriately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed the text color of the safety concerns button (#3349)
 - Fixed bug where applied filters would be cleared on a pull-to-refresh of the BonApp menus (#3352)
 - Fixed some strange behavior with hours and bus schedules around the new year (#3376, #3378)
+- Fixed rendering of markdown softbreaks (#3377)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/modules/markdown/markdown.js
+++ b/modules/markdown/markdown.js
@@ -15,7 +15,7 @@ import {Link} from './link'
 import {Image} from './image'
 import {List, ListItem} from './list'
 
-const Softbreak = () => <Text>{'\n'}</Text>
+const Softbreak = () => ' '
 const Hardbreak = () => <Text>&lt;br&gt;</Text>
 const HorizontalRule = glamorous.view({
 	width: '100%',


### PR DESCRIPTION
Closes #3369.

This PR converts softbreaks to a single space.

<details>
<summary>📸 Screenshots</summary>

~ | ~
--|--
Before | <img width="914" alt="image" src="https://user-images.githubusercontent.com/5240843/50571373-3abb8c00-0d5d-11e9-80ce-3e69493a4259.png">
After | <img width="914" alt="image" src="https://user-images.githubusercontent.com/5240843/50571389-c9c8a400-0d5d-11e9-96a5-f3f45bb6f474.png">

</details>