### PR TITLE
Fix Jest after the New Year too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed bug where filters were not applying correctly in menu and course search views (#3344, #3350)
 - Fixed the text color of the safety concerns button (#3349)
 - Fixed bug where applied filters would be cleared on a pull-to-refresh of the BonApp menus (#3352)
-- Fixed some strange behavior with hours and bus schedules around the new year (#3376)
+- Fixed some strange behavior with hours and bus schedules around the new year (#3376, #3378)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/source/views/building-hours/lib/parse-hours.js
+++ b/source/views/building-hours/lib/parse-hours.js
@@ -24,9 +24,12 @@ export function parseHours(
 	open.dayOfYear(dayOfYear)
 
 	let sixMonthsAgo = moment(m).subtract(6, 'months')
+	let sixMonthsFromNow = moment(m).add(6, 'months')
 
 	if (open.isBefore(sixMonthsAgo)) {
 		open.add(1, 'year')
+	} else if (open.isAfter(sixMonthsFromNow)) {
+		open.subtract(1, 'year')
 	}
 
 	let close = moment.tz(toTime, TIME_FORMAT, true, timezone())
@@ -34,6 +37,8 @@ export function parseHours(
 
 	if (close.isBefore(sixMonthsAgo)) {
 		close.add(1, 'year')
+	} else if (close.isAfter(sixMonthsFromNow)) {
+		close.subtract(1, 'year')
 	}
 
 	if (close.isBefore(open)) {

--- a/source/views/transportation/bus/lib/parse-time.js
+++ b/source/views/transportation/bus/lib/parse-time.js
@@ -21,9 +21,12 @@ export const parseTime = (now: moment) => (
 	m.dayOfYear(now.dayOfYear())
 
 	let sixMonthsAgo = moment(now).subtract(6, 'months')
+	let sixMonthsFromNow = moment(now).add(6, 'months')
 
 	if (m.isBefore(sixMonthsAgo)) {
 		m.add(1, 'year')
+	} else if (m.isAfter(sixMonthsFromNow)) {
+		m.subtract(1, 'year')
 	}
 
 	return m


### PR DESCRIPTION
Apparently the logic from #3376 cuts both ways.

No snapshot updates needed? That's fun.