### PR TITLE
DatePicker: Remove getDerivedStateFromProps definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed some strange behavior with hours and bus schedules around the new year (#3376, #3378)
 - Fixed rendering of markdown softbreaks (#3377)
 - Fixed rendering of markdown hardbreaks (#3379)
-- Fixed DatePicker by removing an unnecessary call to getDerivedStateFromProps (#3382)
 - Fixed the dictionary editor and made it handle user input again (#3383)
+- Fixed DatePicker by removing an unnecessary call to getDerivedStateFromProps (#3382)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed some strange behavior with hours and bus schedules around the new year (#3376, #3378)
 - Fixed rendering of markdown softbreaks (#3377)
 - Fixed rendering of markdown hardbreaks (#3379)
+- Fixed DatePicker by removing an unnecessary call to getDerivedStateFromProps (#3382)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/modules/datepicker/index.js
+++ b/modules/datepicker/index.js
@@ -44,17 +44,6 @@ export class DatePicker extends React.Component<Props, State> {
 		timezone: this.props.initialDate.tz(),
 	}
 
-	static getDerivedStateFromProps(nextProps: Props, prevState: State) {
-		if (nextProps.initialDate === prevState.date) {
-			return null
-		}
-
-		return {
-			date: nextProps.initialDate,
-			timezone: nextProps.initialDate.tz(),
-		}
-	}
-
 	formatDate = (date: moment) => {
 		const {mode, format = FORMATS[mode]} = this.props
 		return moment(date).format(format)


### PR DESCRIPTION
See #3381. Actually, fixes #3381.

All of a sudden, state persists! Amazing.