### PR TITLE
DictionaryEditorView: Remove getDerivedStateFromProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed some strange behavior with hours and bus schedules around the new year (#3376, #3378)
 - Fixed rendering of markdown softbreaks (#3377)
 - Fixed rendering of markdown hardbreaks (#3379)
+- Fixed the dictionary editor and made it handle user input again (#3383)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/source/views/dictionary/report/editor.js
+++ b/source/views/dictionary/report/editor.js
@@ -33,14 +33,6 @@ export class DictionaryEditorView extends React.PureComponent<Props, State> {
 		definition: this.props.navigation.state.params.word.definition,
 	}
 
-	static getDerivedStateFromProps(nextProps: Props) {
-		let entry = nextProps.navigation.state.params.word
-		return {
-			term: entry.word,
-			definition: entry.definition,
-		}
-	}
-
 	submit = () => {
 		submitReport(this.props.navigation.state.params.word, {
 			word: this.state.term,


### PR DESCRIPTION
Yeah. It works better now, but it may not handle outside-in prop changes.

Fixes #2577.