### PR TITLE
Don't trim dictionary words and definitions while editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed some strange behavior with hours and bus schedules around the new year (#3376, #3378)
 - Fixed rendering of markdown softbreaks (#3377)
 - Fixed rendering of markdown hardbreaks (#3379)
-- Fixed the dictionary editor and made it handle user input again (#3383)
+- Fixed the dictionary editor and made it handle user input again (#3383, #3387)
 - Fixed DatePicker by removing an unnecessary call to getDerivedStateFromProps (#3382)
 
 ### Removed

--- a/source/views/dictionary/report/editor.js
+++ b/source/views/dictionary/report/editor.js
@@ -35,8 +35,8 @@ export class DictionaryEditorView extends React.PureComponent<Props, State> {
 
 	submit = () => {
 		submitReport(this.props.navigation.state.params.word, {
-			word: this.state.term,
-			definition: this.state.definition,
+			word: this.state.term.trim(),
+			definition: this.state.definition.trim(),
 		})
 	}
 
@@ -49,8 +49,7 @@ export class DictionaryEditorView extends React.PureComponent<Props, State> {
 	}
 
 	render() {
-		let term = this.state.term ? this.state.term.trim() : ''
-		let definition = this.state.definition ? this.state.definition.trim() : ''
+		let {term, definition} = this.state
 
 		return (
 			<ScrollView


### PR DESCRIPTION
Closes #3386

This avoids trimming dictionary words and definitions while editing. This should fix the UX where spaces were impossible to enter at the end of the input for both fields as we were stripping them on edit.