### PR TITLE
Update Safety Committee url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add "open webpage" row to student work detail
 - Added some logic to skip native builds if nothing that might affect them has changed (#3209)
 - All network requests are now cached according to the server's caching headers, even offline (#3310, #3320)
-- Added "Safety Concerns" tile that links to St. Olaf's official form for documenting safety concerns (#3345)
+- Added "Safety Concerns" tile that links to St. Olaf's official form for documenting safety concerns (#3345, #3394)
 - Added a prepare statement to apply an upstream fix to the VirtualizedList sticky header calculation (#3357)
 - Added a prompt before the user leaves the app from open-browser-url (#3361)
 - Added more descriptive messages provided by Bon Appetit for closed cafeterias (#3374)

--- a/source/views/views.js
+++ b/source/views/views.js
@@ -174,7 +174,7 @@ export const allViews: Array<ViewType> = [
 	},
 	{
 		type: 'browser-url',
-		url: 'https://wp.stolaf.edu/safety-committee/report-a-safety-concern-2/',
+		url: 'https://wp.stolaf.edu/safety-committee/report/',
 		view: 'SafetyView',
 		title: 'Safety Concerns',
 		icon: 'warning',


### PR DESCRIPTION
I moved the website page from `https://wp.stolaf.edu/safety-committee/report-a-safety-concern-2/` to `https://wp.stolaf.edu/safety-committee/report/`.

```diff
-https://wp.stolaf.edu/safety-committee/report-a-safety-concern-2/
+https://wp.stolaf.edu/safety-committee/report/
```

I've already cherry-picked this commit into `v2.7`.