### PR TITLE
apply two small circle config tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
       - run: *run-danger
 
   android: &android
-    # cmd: key is passed to solve a weird issue (see GitHub PR's 2170 and 2173).
+    # we pass the `command:` key to solve a weird issue (see GitHub PRs 2170 and 2173).
     # this overrides the thing and forces the container to run /bin/bash as the "command"
     # so it doesn't get confused and OOM/exhaust the build resources (don't ask me)
     docker: [{image: 'circleci/android:api-28-node', command: '/bin/bash'}]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ jobs:
     # cmd: key is passed to solve a weird issue (see GitHub PR's 2170 and 2173).
     # this overrides the thing and forces the container to run /bin/bash as the "command"
     # so it doesn't get confused and OOM/exhaust the build resources (don't ask me)
-    docker: [{image: 'circleci/android:api-28-node', cmd: '/bin/bash'}]
+    docker: [{image: 'circleci/android:api-28-node', command: '/bin/bash'}]
     environment: &android-env
       task: ANDROID
       FASTLANE_SKIP_UPDATE_CHECK: '1'
@@ -336,7 +336,7 @@ jobs:
       task: IOS
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_ANIMATION: '1'
-      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_AUTO_UPDATE: '1'
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
     shell: /bin/bash --login -o pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Only set `scrollEnabled` if `multiline` is true (#3337)
 - Select, rather than deselect, first selected filter option of OR filters (#3347)
 - Updated our Ruby version for builds to 2.6.0 (#3367)
+- Continued cleanups in the Circle config (#3436)
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)


### PR DESCRIPTION
I can't find a reference to `cmd` in the docs, but they do talk about `command`. If the build fails, we'll know not to do the change.

The other is just clarification; numbers will get stringified anyway during env insertion, so let's be consistent.