### PR TITLE
[WIP] Add safearea to the homescreen buttons

### DIFF
--- a/source/views/home/button.js
+++ b/source/views/home/button.js
@@ -9,6 +9,7 @@ import {Touchable} from '@frogpond/touchable'
 import {transparent} from '@frogpond/colors'
 import {homescreenForegroundDark, homescreenForegroundLight} from './colors'
 import {iPhoneX} from '@frogpond/device'
+import {SafeAreaView} from 'react-navigation'
 
 type Props = {
 	view: ViewType,
@@ -20,17 +21,19 @@ export function HomeScreenButton({view, onPress}: Props) {
 		view.foreground === 'light' ? styles.lightForeground : styles.darkForeground
 
 	return (
-		<TouchableButton
-			gradient={view.gradient}
-			label={view.title}
-			onPress={onPress}
-			tint={view.tint}
-		>
-			<View style={styles.contents}>
-				<Icon name={view.icon} size={32} style={[foreground, styles.icon]} />
-				<Text style={[foreground, styles.text]}>{view.title}</Text>
-			</View>
-		</TouchableButton>
+		<SafeAreaView>
+			<TouchableButton
+				gradient={view.gradient}
+				label={view.title}
+				onPress={onPress}
+				tint={view.tint}
+			>
+				<View style={styles.contents}>
+					<Icon name={view.icon} size={32} style={[foreground, styles.icon]} />
+					<Text style={[foreground, styles.text]}>{view.title}</Text>
+				</View>
+			</TouchableButton>
+		</SafeAreaView>
 	)
 }
 


### PR DESCRIPTION
This idea comes from @hawkrives. Adding safearea view to the buttons _does_ get us home screen buttons that respect the safe area, but they do have weird calculation side effects.

![photo_2019-02-03 14 50 02](https://user-images.githubusercontent.com/5240843/52184143-58e53380-27c4-11e9-918f-83229d6bdbfc.jpeg)

![photo_2019-02-03 14 49 57](https://user-images.githubusercontent.com/5240843/52184144-5aaef700-27c4-11e9-9c99-779f84977687.jpeg)
