### PR TITLE
TabBarIcon: Add platformPrefixIcon helper and use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added a prepare statement to apply an upstream fix to the VirtualizedList sticky header calculation (#3357)
 - Added a prompt before the user leaves the app from open-browser-url (#3361)
 - Added more descriptive messages provided by Bon Appetit for closed cafeterias (#3374)
+- Added `@frogpond/icon` module with a helper for platform-prefixing modules (#3459)
 
 ### Changed
 - Adjusted and deduplicated logic in API scaffolding

--- a/modules/icon/index.js
+++ b/modules/icon/index.js
@@ -1,0 +1,5 @@
+// @flow
+
+export {Icon} from 'react-native-vector-icons/Ionicons'
+
+export {platformPrefixIconName} from './platform-prefix-icon-name'

--- a/modules/icon/index.js
+++ b/modules/icon/index.js
@@ -1,5 +1,5 @@
 // @flow
 
-export {Icon} from 'react-native-vector-icons/Ionicons'
+export {default as Icon} from 'react-native-vector-icons/Ionicons'
 
 export {platformPrefixIconName} from './platform-prefix-icon-name'

--- a/modules/icon/package.json
+++ b/modules/icon/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@frogpond/icon",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC",
+  "scripts": {
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "react-native": "^0.57.0",
+    "react-native-vector-icons": "^6.0.0"
+  }
+}

--- a/modules/icon/platform-prefix-icon-name.js
+++ b/modules/icon/platform-prefix-icon-name.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {Platform} from 'react-native'
-import {Icon} from '.'
+import {Icon} from '@frogpond/icon'
 
 export function platformPrefixIconName(name: string) {
 	let isAvailable = Icon.hasIcon(name)

--- a/modules/icon/platform-prefix-icon-name.js
+++ b/modules/icon/platform-prefix-icon-name.js
@@ -1,0 +1,16 @@
+// @flow
+
+import {Platform} from 'react-native'
+import {Icon} from '.'
+
+export function platformPrefixIconName(name: string) {
+	let isAvailable = Icon.hasIcon(name)
+	let isAvailableOnBothPlatforms =
+		Icon.hasIcon(`ios-${name}`) && Icon.hasIcon(`md-${name}`)
+
+	if (isAvailable && !isAvailableOnBothPlatforms) {
+		return name
+	}
+
+	return Platform.OS === 'ios' ? `ios-${name}` : `md-${name}`
+}

--- a/modules/navigation-tabs/tabbar-icon.js
+++ b/modules/navigation-tabs/tabbar-icon.js
@@ -2,6 +2,7 @@
 import * as React from 'react'
 import {StyleSheet, Platform} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
+import {platformPrefixIconName} from '@frogpond/icon'
 
 const styles = StyleSheet.create({
 	icon: {
@@ -17,21 +18,9 @@ type Props = {
 	focused: boolean,
 }
 
-export const platformPrefixIcon = (name: string) => {
-	let isAvailable = Icon.hasIcon(name)
-	let isAvailableOnBothPlatforms =
-		Icon.hasIcon(`ios-${name}`) && Icon.hasIcon(`md-${name}`)
-
-	if (isAvailable && !isAvailableOnBothPlatforms) {
-		return name
-	}
-
-	return Platform.OS === 'ios' ? `ios-${name}` : `md-${name}`
-}
-
 export const TabBarIcon = (icon: string) => ({tintColor}: Props) => (
 	<Icon
-		name={platformPrefixIcon(icon)}
+		name={platformPrefixIconName(icon)}
 		style={[styles.icon, {color: tintColor}]}
 	/>
 )

--- a/modules/navigation-tabs/tabbar-icon.js
+++ b/modules/navigation-tabs/tabbar-icon.js
@@ -18,6 +18,14 @@ type Props = {
 }
 
 export const platformPrefixIcon = (name: string) => {
+	let isAvailable = Icon.hasIcon(name)
+	let isAvailableOnBothPlatforms =
+		Icon.hasIcon(`ios-${name}`) && Icon.hasIcon(`md-${name}`)
+
+	if (isAvailable && !isAvailableOnBothPlatforms) {
+		return name
+	}
+
 	return Platform.OS === 'ios' ? `ios-${name}` : `md-${name}`
 }
 

--- a/modules/navigation-tabs/tabbar-icon.js
+++ b/modules/navigation-tabs/tabbar-icon.js
@@ -17,6 +17,10 @@ type Props = {
 	focused: boolean,
 }
 
+export const platformPrefixIcon = (name: string) => {
+	return Platform.OS === 'ios' ? `ios-${name}` : `md-${name}`
+}
+
 export const TabBarIcon = (icon: string) => ({tintColor}: Props) => (
 	<Icon name={`ios-${icon}`} style={[styles.icon, {color: tintColor}]} />
 )

--- a/modules/navigation-tabs/tabbar-icon.js
+++ b/modules/navigation-tabs/tabbar-icon.js
@@ -30,5 +30,8 @@ export const platformPrefixIcon = (name: string) => {
 }
 
 export const TabBarIcon = (icon: string) => ({tintColor}: Props) => (
-	<Icon name={`ios-${icon}`} style={[styles.icon, {color: tintColor}]} />
+	<Icon
+		name={platformPrefixIcon(icon)}
+		style={[styles.icon, {color: tintColor}]}
+	/>
 )


### PR DESCRIPTION
Instead of prefixing all input with `ios-`, (which necessitated #3458 to fix some breakage) use some reusable logic on both platforms.

The `platformPrefixIcon` helper has the following behavior:

| `${name}` is available¹ | `ios-${name}` is available¹ | `md-${name}` is available¹ | Result of `platformPrefixIcon(name)` |
|---|---|---|---|
| 🚫| any | any | `name` |
| ✅ | 🚫 | 🚫 | `name` |
| ✅ | ✅ | 🚫 | `name` |
| ✅ | 🚫 | ✅ | `name` |
| ✅ | ✅ | ✅ | `ios-${name}` or `md-${name}` depending on the value of `Platform.OS` |

* * *

Here are some screenshots of the newly-available `md-`-prefixed tab bar icons. I have no complaints as an Android user, and I think this nets us an improvement.

| ![screenshot_1549239084](https://user-images.githubusercontent.com/1566689/52184922-2694ff80-27df-11e9-832e-ede386b606a5.png) | ![screenshot_1549238146](https://user-images.githubusercontent.com/1566689/52184848-77f0bf00-27de-11e9-88c5-acb93fab5746.png) |
|---|---|
| ![screenshot_1549238160](https://user-images.githubusercontent.com/1566689/52184850-77f0bf00-27de-11e9-9796-ad6fec90809c.png) | ![screenshot_1549238169](https://user-images.githubusercontent.com/1566689/52184851-77f0bf00-27de-11e9-97e3-ddc4d6f75588.png) |

***
¹: Availability of a given icon is computed by `Icon.hasIcon`, which was introduced in `react-native-vector-icons` version `4.6.0` and works by querying the available glyphTable.
