### PR TITLE
Fix color banding in balances (and clean up other spots too)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated Ruby to version 2.6.1 (#3452)
 - Changed custom BonApp cafe viewer icon to a cog instead of the ionicons logo (#3458)
 - Updated `react-native-vector-icons` to v6 and made some compatibility fixes (#3162)
+- Addressed color banding in SIS/Balances on Android (#3462)
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)

--- a/modules/button/index.js
+++ b/modules/button/index.js
@@ -18,7 +18,7 @@ const styles = StyleSheet.create({
 		overflow: 'hidden',
 	},
 	disabled: {
-		backgroundColor: c.iosLightBackground,
+		backgroundColor: c.sectionBgColor,
 	},
 	text: {
 		...Platform.select({

--- a/modules/filter/filter-popover.js
+++ b/modules/filter/filter-popover.js
@@ -54,5 +54,5 @@ const popoverContainer = {
 }
 
 const arrowStyle = {
-	backgroundColor: c.iosLightBackground,
+	backgroundColor: c.sectionBgColor,
 }

--- a/modules/filter/filter-popover.js
+++ b/modules/filter/filter-popover.js
@@ -35,7 +35,6 @@ export class FilterPopover extends React.PureComponent<Props, State> {
 
 		return (
 			<Popover
-				arrowStyle={arrowStyle}
 				fromView={anchor.current}
 				isVisible={visible}
 				onClose={() => onClosePopover(filter)}
@@ -51,8 +50,5 @@ export class FilterPopover extends React.PureComponent<Props, State> {
 const popoverContainer = {
 	minWidth: 200,
 	maxWidth: 300,
-}
-
-const arrowStyle = {
 	backgroundColor: c.sectionBgColor,
 }

--- a/source/navigation/navigator.js
+++ b/source/navigation/navigator.js
@@ -13,10 +13,7 @@ const styles = StyleSheet.create({
 		backgroundColor: theme.navigationBackground,
 	},
 	card: {
-		backgroundColor: Platform.select({
-			ios: c.iosLightBackground,
-			android: c.androidLightBackground,
-		}),
+		backgroundColor: c.sectionBgColor,
 	},
 })
 

--- a/source/views/building-hours/detail/building.js
+++ b/source/views/building-hours/detail/building.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {ScrollView, StyleSheet, Platform, Image} from 'react-native'
+import {ScrollView, StyleSheet, Image} from 'react-native'
 import {images as buildingImages} from '../../../../images/spaces'
 import type {BuildingType} from '../types'
 import moment from 'moment-timezone'

--- a/source/views/building-hours/detail/building.js
+++ b/source/views/building-hours/detail/building.js
@@ -16,14 +16,7 @@ import {ListFooter} from '@frogpond/lists'
 const styles = StyleSheet.create({
 	container: {
 		alignItems: 'stretch',
-		...Platform.select({
-			android: {
-				backgroundColor: c.androidLightBackground,
-			},
-			ios: {
-				backgroundColor: c.iosLightBackground,
-			},
-		}),
+		backgroundColor: c.sectionBgColor,
 	},
 	image: {
 		width: null,

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -233,7 +233,7 @@ let cellEdgePadding = 10
 
 let styles = StyleSheet.create({
 	stage: {
-		backgroundColor: c.iosLightBackground,
+		backgroundColor: c.sectionBgColor,
 		paddingTop: 20,
 		paddingBottom: 20,
 	},


### PR DESCRIPTION
This PR gets rid of that annoying gray banding on the Android balances screen.

I also went through the app and removed all other hard-coded references to `iosBackgroundColor`, except the ones in `.ios.js` files.

before | after
--- | ---
<img src=https://user-images.githubusercontent.com/464441/52188758-2d7d3b80-27fa-11e9-8543-8c36aa12d16c.jpg width=320> | <img src=https://user-images.githubusercontent.com/464441/52188735-12aac700-27fa-11e9-9ffa-5c2a4ec32b13.png width=320>

