### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@drewvolz @hawkrives kristofer.rye@gmail.com


### PR DESCRIPTION
This file will allow for GitHub to automagically figure out who gets requested for review based on what a PR concerns.

For now, it will request everyone's review.

Feedback welcome.