### PR TITLE
ssb: Also consider optionalDependencies key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added a prompt before the user leaves the app from open-browser-url (#3361)
 - Added more descriptive messages provided by Bon Appetit for closed cafeterias (#3374)
 - Added `@frogpond/icon` module with a helper for platform-prefixing modules (#3459)
+- Added consideration of `optionalDependencies` to our build scripts (#3489)
 
 ### Changed
 - Adjusted and deduplicated logic in API scaffolding

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -24,8 +24,9 @@ def npm_native_package_changed?(source, target)
 
 	deps_diff = hash_diff(old_package, new_package, ['dependencies']).keys
 	devdeps_diff = hash_diff(old_package, new_package, ['devDependencies']).keys
+	optdeps_diff = hash_diff(old_package, new_package, ['optionalDependencies']).keys
 
-	(deps_diff + devdeps_diff).any? { |dep| dep =~ NPM_DEP_NAME_REGEXP }
+	(deps_diff + devdeps_diff + optdeps_diff).any? { |dep| dep =~ NPM_DEP_NAME_REGEXP }
 end
 
 BASE_GLOBS = [


### PR DESCRIPTION
Resolves #3488.

This simply extracts that key from the `hash_diff` and then includes it in the subject matter of the call to `Enumerable#any?`.  When we change an optionalDependency, this should cover it.

CC @hawkrives 