### PR TITLE
Add flex: 1 to CellTextField's content areas

### DIFF
--- a/modules/tableview/cells/textfield.js
+++ b/modules/tableview/cells/textfield.js
@@ -22,11 +22,13 @@ const styles = StyleSheet.create({
 		alignItems: 'stretch',
 		paddingTop: 0,
 		paddingBottom: 0,
+		flex: 1,
 	},
 	multilineCell: {
 		alignItems: 'stretch',
 		paddingTop: 10,
 		paddingBottom: 10,
+		flex: 1,
 	},
 })
 


### PR DESCRIPTION
It appears that rn-tableview-simple no longer sets this, which caused our TextInput to be flex:1 of a 0-width-ish view.

Closes #3496 

After:

| * | * |
--- | ---
![telegram-cloud-file-1-806622940-73477--7368985597436812628](https://user-images.githubusercontent.com/464441/53218624-79194d00-3622-11e9-9d16-fee5662b8995.jpg) | ![telegram-cloud-file-1-806623547-74652-5784207060069074416](https://user-images.githubusercontent.com/464441/53218621-74ed2f80-3622-11e9-8a13-8a40bcbc698a.jpg)
