### PR TITLE
Require exact props for CellTextField

### DIFF
--- a/modules/tableview/cells/textfield.js
+++ b/modules/tableview/cells/textfield.js
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
 	},
 })
 
-type Props = {
+type Props = {|
 	label?: string,
 	_ref: any => any,
 	disabled: boolean,
@@ -45,7 +45,7 @@ type Props = {
 	autoCapitalize: 'characters' | 'words' | 'sentences' | 'none',
 	value: string,
 	labelWidth?: number,
-}
+|}
 
 export class CellTextField extends React.Component<Props> {
 	_input: any

--- a/source/views/building-hours/report/overview.js
+++ b/source/views/building-hours/report/overview.js
@@ -306,7 +306,6 @@ type TextFieldProps = {text: string, onChange: string => any}
 const TitleCell = ({text, onChange = () => {}}: TextFieldProps) => (
 	<CellTextField
 		autoCapitalize="words"
-		hideLabel={true}
 		onChangeText={onChange}
 		onSubmitEditing={onChange}
 		placeholder="Title"
@@ -319,7 +318,6 @@ const TitleCell = ({text, onChange = () => {}}: TextFieldProps) => (
 const NotesCell = ({text, onChange}: TextFieldProps) => (
 	<CellTextField
 		autoCapitalize="sentences"
-		hideLabel={true}
 		onChangeText={onChange}
 		onSubmitEditing={onChange}
 		placeholder="Notes"

--- a/source/views/dictionary/report/editor.js
+++ b/source/views/dictionary/report/editor.js
@@ -87,7 +87,6 @@ type TextFieldProps = {text: string, onChange: string => any}
 const TitleCell = ({text, onChange = () => {}}: TextFieldProps) => (
 	<CellTextField
 		autoCapitalize="words"
-		hideLabel={true}
 		onChangeText={onChange}
 		onSubmitEditing={onChange}
 		placeholder="Title"
@@ -99,7 +98,6 @@ const TitleCell = ({text, onChange = () => {}}: TextFieldProps) => (
 const DefinitionCell = ({text, onChange = () => {}}: TextFieldProps) => (
 	<CellTextField
 		autoCapitalize="sentences"
-		hideLabel={true}
 		multiline={true}
 		onChangeText={onChange}
 		onSubmitEditing={onChange}


### PR DESCRIPTION
By default, until Flow 0.92, which we don't use yet, Flow treats objects defined with `{ blah }` as somewhat-malleable objects – for instance, when we use a `{}` as the Props to a component, we can pass along any prop keys we want, and Flow won't complain.

The "exact object" syntax, `{| blah |}`, which is the _default_ in 0.92, I think, restricts the allowable keys down to just the ones listed.

By restricting the CellTextField props, I found that we were passing an unknown prop `hideLabel` to CellTextField, and removed it.