### PR TITLE
A few small cleanups in CellTextField and LoginCredentials

### DIFF
--- a/modules/tableview/cells/textfield.js
+++ b/modules/tableview/cells/textfield.js
@@ -101,7 +101,7 @@ export class CellTextField extends React.Component<Props> {
 				placeholderTextColor={c.iosPlaceholderText}
 				returnKeyType={this.props.returnKeyType}
 				secureTextEntry={this.props.secureTextEntry}
-				style={[styles.customTextInput]}
+				style={styles.customTextInput}
 				value={this.props.value}
 				{...moreProps}
 			/>

--- a/modules/tableview/cells/textfield.js
+++ b/modules/tableview/cells/textfield.js
@@ -107,13 +107,15 @@ export class CellTextField extends React.Component<Props> {
 			/>
 		)
 
+		const style = this.props.multiline
+			? styles.multilineCell
+			: styles.singlelineCell
+
 		return (
 			<Cell
 				cellAccessoryView={input}
 				cellContentView={label}
-				contentContainerStyle={
-					this.props.multiline ? styles.multilineCell : styles.singlelineCell
-				}
+				contentContainerStyle={style}
 			/>
 		)
 	}

--- a/source/views/settings/screens/overview/login-credentials.js
+++ b/source/views/settings/screens/overview/login-credentials.js
@@ -54,8 +54,9 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 		}
 	}
 
-	logIn = () =>
+	logIn = () => {
 		this.props.logInViaCredentials(this.state.username, this.state.password)
+	}
 
 	logOut = () => {
 		this.setState(() => ({username: '', password: ''}))


### PR DESCRIPTION
1. remove an extra array from a `style` prop
2. remove an (IMO) overly-verbose prop (thanks prettier) and pulled it into a variable
3. added braces to the `logIn` function so it matches the `logOut` function