### PR TITLE
Use React.createRef instead of callback refs in a few spots

### DIFF
--- a/modules/tableview/cells/textfield.js
+++ b/modules/tableview/cells/textfield.js
@@ -75,9 +75,7 @@ export class CellTextField extends React.Component<Props> {
 		}
 
 		const labelWidthStyle =
-			this.props.labelWidth !== null && this.props.labelWidth !== undefined
-				? {width: this.props.labelWidth}
-				: null
+			this.props.labelWidth != null ? {width: this.props.labelWidth} : null
 
 		const label = this.props.label ? (
 			<Text onPress={this.focusInput} style={[styles.label, labelWidthStyle]}>

--- a/modules/tableview/cells/textfield.js
+++ b/modules/tableview/cells/textfield.js
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
 
 type Props = {
 	label?: string,
-	_ref: any => any,
+	_ref?: {current: null | React.ElementRef<typeof TextInput>},
 	disabled: boolean,
 	multiline?: boolean,
 	onChangeText: string => any,
@@ -46,22 +46,18 @@ type Props = {
 }
 
 export class CellTextField extends React.Component<Props> {
-	_input: any
-
 	static defaultProps = {
 		disabled: false,
 		placeholder: '',
-		_ref: () => {},
 		returnKeyType: 'default',
 		secureTextEntry: false,
 		autoCapitalize: 'none',
 	}
 
-	focusInput = () => this._input.focus()
+	_ref = this.props._ref || React.createRef()
 
-	cacheRef = (ref: any) => {
-		this._input = ref
-		this.props._ref(ref)
+	focusInput = () => {
+		this._ref.current && this._ref.current.focus()
 	}
 
 	onSubmit = () => {
@@ -87,7 +83,7 @@ export class CellTextField extends React.Component<Props> {
 
 		const input = (
 			<TextInput
-				ref={this.cacheRef}
+				ref={this.props._ref}
 				autoCapitalize={this.props.autoCapitalize}
 				autoCorrect={false}
 				clearButtonMode="while-editing"

--- a/source/views/settings/screens/overview/login-credentials.js
+++ b/source/views/settings/screens/overview/login-credentials.js
@@ -30,9 +30,6 @@ type State = {
 }
 
 class CredentialsLoginSection extends React.Component<Props, State> {
-	_usernameInput: any
-	_passwordInput: any
-
 	state = {
 		username: '',
 		password: '',
@@ -42,7 +39,11 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 		this.loadCredentialsFromKeychain()
 	}
 
-	focusPassword = () => this._passwordInput.focus()
+	_usernameInput = React.createRef()
+	_passwordInput = React.createRef()
+
+	focusPassword = () =>
+		this._passwordInput.current && this._passwordInput.current.focus()
 
 	loadCredentialsFromKeychain = async () => {
 		let {username = '', password = ''} = await loadLoginCredentials()
@@ -60,9 +61,6 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 		this.setState(() => ({username: '', password: ''}))
 		this.props.logOutViaCredentials()
 	}
-
-	getUsernameRef = ref => (this._usernameInput = ref)
-	getPasswordRef = ref => (this._passwordInput = ref)
 
 	render() {
 		const {status} = this.props
@@ -82,7 +80,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 					[
 						<CellTextField
 							key={0}
-							_ref={this.getUsernameRef}
+							_ref={this._usernameInput}
 							disabled={loading}
 							label="Username"
 							onChangeText={text => this.setState(() => ({username: text}))}
@@ -94,7 +92,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 						/>,
 						<CellTextField
 							key={1}
-							_ref={this.getPasswordRef}
+							_ref={this._passwordInput}
 							disabled={loading}
 							label="Password"
 							onChangeText={text => this.setState(() => ({password: text}))}

--- a/source/views/settings/screens/overview/login-credentials.js
+++ b/source/views/settings/screens/overview/login-credentials.js
@@ -65,9 +65,6 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 	getUsernameRef = ref => (this._usernameInput = ref)
 	getPasswordRef = ref => (this._passwordInput = ref)
 
-	onChangeUsername = (text = '') => this.setState(() => ({username: text}))
-	onChangePassword = (text = '') => this.setState(() => ({password: text}))
-
 	render() {
 		const {status} = this.props
 		const {username, password} = this.state
@@ -89,7 +86,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 							_ref={this.getUsernameRef}
 							disabled={loading}
 							label="Username"
-							onChangeText={this.onChangeUsername}
+							onChangeText={text => this.setState(() => ({username: text}))}
 							onSubmitEditing={this.focusPassword}
 							placeholder="username"
 							returnKeyType="next"
@@ -101,7 +98,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 							_ref={this.getPasswordRef}
 							disabled={loading}
 							label="Password"
-							onChangeText={this.onChangePassword}
+							onChangeText={text => this.setState(() => ({password: text}))}
 							onSubmitEditing={loggedIn ? noop : this.logIn}
 							placeholder="password"
 							returnKeyType="done"

--- a/source/views/settings/screens/overview/login-credentials.js
+++ b/source/views/settings/screens/overview/login-credentials.js
@@ -91,7 +91,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 							label="Username"
 							onChangeText={this.onChangeUsername}
 							onSubmitEditing={this.focusPassword}
-							placeholder="ole"
+							placeholder="username"
 							returnKeyType="next"
 							secureTextEntry={false}
 							value={username}
@@ -103,7 +103,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 							label="Password"
 							onChangeText={this.onChangePassword}
 							onSubmitEditing={loggedIn ? noop : this.logIn}
-							placeholder="the$lion"
+							placeholder="password"
 							returnKeyType="done"
 							secureTextEntry={true}
 							value={password}

--- a/source/views/settings/screens/overview/login-credentials.js
+++ b/source/views/settings/screens/overview/login-credentials.js
@@ -42,7 +42,6 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 		this.loadCredentialsFromKeychain()
 	}
 
-	focusUsername = () => this._usernameInput.focus()
 	focusPassword = () => this._passwordInput.focus()
 
 	loadCredentialsFromKeychain = async () => {


### PR DESCRIPTION
1. returns username/password placeholders to "username" and "password"
2. replaces a few instance methods with inline functions
3. removes an unused `focusUsername` function

and the meat of this PR – replacing a use of "callback refs" with `React.createRef`.

`createRef`, as you might have guessed from the name, creates a ref. Instead of callback refs, which require you to pass a function to the `ref` prop, then wait for it to be called, and which we had to type as `any` because I couldn't for the life of me figure out how to type them, we can use the createRef API to make a box that holds the actual thing for us.

Flow automatically types them when you set them on the class, and the appropriate type for them in an arguments list is, AFAICT, `{current: null | React.ElementRef<typeof TextInput>}`.

Callback refs aren't deprecated, but createRefs allow you the same flexibility, but with a little less mental hoop-jumping IMO.