### PR TITLE
Fix OleCard login (maybe, probably… at least on the simulator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Changed custom BonApp cafe viewer icon to a cog instead of the ionicons logo (#3458)
 - Updated `react-native-vector-icons` to v6 and made some compatibility fixes (#3162)
 - Addressed color banding in SIS/Balances on Android (#3462)
+- [wip] Fix OleCard login stuff (#3503)
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)

--- a/source/views/settings/screens/overview/login-credentials.js
+++ b/source/views/settings/screens/overview/login-credentials.js
@@ -137,11 +137,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 }
 
 function mapStateToProps(state: ReduxState): ReduxStateProps {
-	if (!state.login) {
-		return {status: 'initializing'}
-	}
-
-	return {status: state.login.status}
+	return {status: state.login ? state.login.status : 'initializing'}
 }
 
 export const ConnectedCredentialsLoginSection = connect(

--- a/source/views/settings/screens/overview/login-credentials.js
+++ b/source/views/settings/screens/overview/login-credentials.js
@@ -18,7 +18,7 @@ type ReduxStateProps = {
 }
 
 type ReduxDispatchProps = {
-	logInViaCredentials: (string, string) => any,
+	logInViaCredentials: (string, string) => Promise<any>,
 	logOutViaCredentials: () => any,
 }
 
@@ -27,12 +27,16 @@ type Props = ReduxStateProps & ReduxDispatchProps
 type State = {
 	username: string,
 	password: string,
+	loadingCredentials: boolean,
+	initialCheckComplete: boolean,
 }
 
 class CredentialsLoginSection extends React.Component<Props, State> {
 	state = {
 		username: '',
 		password: '',
+		loadingCredentials: true,
+		initialCheckComplete: false,
 	}
 
 	componentDidMount() {
@@ -47,11 +51,13 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 
 	loadCredentialsFromKeychain = async () => {
 		let {username = '', password = ''} = await loadLoginCredentials()
-		this.setState(() => ({username, password}))
+		this.setState(() => ({username, password, loadingCredentials: false}))
 
 		if (username && password) {
-			this.props.logInViaCredentials(username, password)
+			await this.props.logInViaCredentials(username, password)
 		}
+
+		this.setState(() => ({initialCheckComplete: true}))
 	}
 
 	logIn = () => {
@@ -65,24 +71,36 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 
 	render() {
 		const {status} = this.props
-		const {username, password} = this.state
+		const {
+			username,
+			password,
+			loadingCredentials,
+			initialCheckComplete,
+		} = this.state
 
 		const loggedIn = status === 'logged-in'
-		const loading = status === 'checking'
+		const checkingCredentials = status === 'checking'
+		const hasBothCredentials = username && password
+
+		// this becomes TRUE when (a) creds are loaded from AsyncStorage and
+		// (b) the initial check from those credentials has completed
+		const checkingState = loadingCredentials || !initialCheckComplete
 
 		return (
 			<Section
 				footer='St. Olaf login enables the "meals remaining" feature.'
 				header="ST. OLAF LOGIN"
 			>
-				{loggedIn ? (
+				{checkingState ? (
+					<Cell title="Loading…" />
+				) : loggedIn ? (
 					<Cell title={`Logged in as ${username}.`} />
 				) : (
 					[
 						<CellTextField
 							key={0}
 							_ref={this._usernameInput}
-							disabled={loading}
+							disabled={checkingCredentials}
 							label="Username"
 							onChangeText={text => this.setState(() => ({username: text}))}
 							onSubmitEditing={this.focusPassword}
@@ -94,7 +112,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 						<CellTextField
 							key={1}
 							_ref={this._passwordInput}
-							disabled={loading}
+							disabled={checkingCredentials}
 							label="Password"
 							onChangeText={text => this.setState(() => ({password: text}))}
 							onSubmitEditing={loggedIn ? noop : this.logIn}
@@ -107,9 +125,9 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 				)}
 
 				<LoginButton
-					disabled={loading || (!username || !password)}
+					disabled={!hasBothCredentials || checkingCredentials || checkingState}
 					label="St. Olaf"
-					loading={loading}
+					loading={checkingCredentials || checkingState}
 					loggedIn={loggedIn}
 					onPress={loggedIn ? this.logOut : this.logIn}
 				/>

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -230,7 +230,7 @@ class BalancesView extends React.PureComponent<Props, State> {
 function mapState(state: ReduxState): ReduxStateProps {
 	return {
 		alertSeen: state.settings ? state.settings.unofficiallyAcknowledged : false,
-		status: state.login ? state.login.status : 'initializing'
+		status: state.login ? state.login.status : 'initializing',
 	}
 }
 

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -13,8 +13,10 @@ import {TabBarIcon} from '@frogpond/navigation-tabs'
 import {connect} from 'react-redux'
 import {Cell, TableView, Section} from '@frogpond/tableview'
 import {hasSeenAcknowledgement} from '../../redux/parts/settings'
+import {logInViaCredentials} from '../../redux/parts/login'
 import {type LoginStateEnum} from '../../redux/parts/login'
 import {getBalances} from '../../lib/financials'
+import {loadLoginCredentials} from '../../lib/login'
 import {type ReduxState} from '../../redux'
 import delay from 'delay'
 import * as c from '@frogpond/colors'
@@ -32,6 +34,7 @@ type ReduxStateProps = {
 }
 
 type ReduxDispatchProps = {
+	logInViaCredentials: (string, string) => Promise<any>,
 	hasSeenAcknowledgement: () => any,
 }
 
@@ -91,7 +94,22 @@ class BalancesView extends React.PureComponent<Props, State> {
 		this.setState(() => ({loading: false}))
 	}
 
+	logIn = async () => {
+		let {status} = this.props
+		if (status === 'logged-in' || status === 'checking') {
+			return
+		}
+
+		let {username = '', password = ''} = await loadLoginCredentials()
+		if (username && password) {
+			await this.props.logInViaCredentials(username, password)
+		}
+	}
+
 	fetchData = async () => {
+		// trigger the login so that the banner at the bottom hides itself
+		await this.logIn()
+
 		let balances = await getBalances()
 
 		if (balances.error === true) {
@@ -212,19 +230,13 @@ class BalancesView extends React.PureComponent<Props, State> {
 function mapState(state: ReduxState): ReduxStateProps {
 	return {
 		alertSeen: state.settings ? state.settings.unofficiallyAcknowledged : false,
-		status: state.login ? state.login.status : 'logged-out',
-	}
-}
-
-function mapDispatch(dispatch): ReduxDispatchProps {
-	return {
-		hasSeenAcknowledgement: () => dispatch(hasSeenAcknowledgement()),
+		status: state.login ? state.login.status : 'initializing'
 	}
 }
 
 export default connect(
 	mapState,
-	mapDispatch,
+	{logInViaCredentials, hasSeenAcknowledgement},
 )(BalancesView)
 
 let cellMargin = 10


### PR DESCRIPTION
Part of #3318 

I attacked this from two angles:

---

I needed to address the way that LoginCredentials (fails at) rendering with async credential loading, and I also wanted to fix up a bit of the jitter that it has when it's busy running the initial can-you-log-in check with saved credentials. 

I did this with a few extra state variables, to track the progress through the loading sequence. Fairly straightforward.

---

Next, I needed to address (at the very least) the way in which the Balances screen always says "not logged in".

I did this by triggering the login mechanism if you aren't marked as logged in. Also fairly straightforward.

---

I'd like to merge this and test it in the nightly; I kinda doubt that this will fix all of our OleCard issues, but it should hopefully make it a little better. I'm just having a hard time replicating the issues on the simulator.