### PR TITLE
Check if disclaimer is agreed to before fetching balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed rendering of markdown hardbreaks (#3379)
 - Fixed the dictionary editor and made it handle user input again (#3383, #3387)
 - Fixed DatePicker by removing an unnecessary call to getDerivedStateFromProps (#3382)
+- Fixed the balances view from refreshing if the user has not agreed to the alert (#3509)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -69,11 +69,11 @@ class BalancesView extends React.PureComponent<Props, State> {
 	}
 
 	componentDidMount() {
-		// calling "refresh" here, to make clear to the user
-		// that the data is being updated
-		this.refresh()
-
-		if (!this.props.alertSeen) {
+		if (this.props.alertSeen) {
+			// calling "refresh" here, to make clear to the user
+			// that the data is being updated
+			this.refresh()
+		} else {
 			Alert.alert('', LONG_DISCLAIMER, [
 				{text: 'I Disagree', onPress: this.goBack, style: 'cancel'},
 				{text: 'Okay', onPress: this.props.hasSeenAcknowledgement},
@@ -85,9 +85,7 @@ class BalancesView extends React.PureComponent<Props, State> {
 		let start = Date.now()
 		this.setState(() => ({loading: true}))
 
-		if (this.props.alertSeen) {
-			await this.fetchData()
-		}
+		await this.fetchData()
 
 		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
 		let elapsed = Date.now() - start

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -85,7 +85,9 @@ class BalancesView extends React.PureComponent<Props, State> {
 		let start = Date.now()
 		this.setState(() => ({loading: true}))
 
-		await this.fetchData()
+		if (this.props.alertSeen) {
+			await this.fetchData()
+		}
 
 		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
 		let elapsed = Date.now() - start


### PR DESCRIPTION
Resolves #3506

It was possible to not agree to the disclaimer about BonApp and have a successful data fetch, subverting the check. This actually checks if the disclaimer has been agreed to before running `fetchData` which calls `getBalances`.

I'm testing this locally with invalid credentials (as I do not have a login) –– so let me know if I've missed something!