### PR TITLE
Rework the Balances acknowledgement behavior

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,6 +9,9 @@
 ; remove this after rn-linear-gradient fixes their @flow/no type arguments issue
 .*/node_modules/react-native-linear-gradient/.*
 
+; remove after github.com/react-native-community/react-native-safe-area-view/pull/57 is merged
+.*/node_modules/react-native-safe-area-view/.*
+
 [include]
 
 [libs]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated `react-native-vector-icons` to v6 and made some compatibility fixes (#3162)
 - Addressed color banding in SIS/Balances on Android (#3462)
 - [wip] Fix OleCard login stuff (#3503)
+- Adjusted how we present the BonApp ultimatum on first visiting the Balances tab (#3515)
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)

--- a/flow-typed/npm/react-native-safe-area-view_vx.x.x.js
+++ b/flow-typed/npm/react-native-safe-area-view_vx.x.x.js
@@ -1,0 +1,29 @@
+// flow-typed signature: cb2c9a90ff7a6666ce4f91fe6560603b
+// flow-typed version: <<STUB>>/react-native-safe-area-view_v0.13.0/flow_v0.78.0
+
+declare module 'react-native-safe-area-view' {
+	// $FlowFixMe: Flow library definitions currently don't support type dependencies between libraries. See https://github.com/flowtype/flow-typed/issues/16.
+	import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
+
+	declare export type SafeAreaViewForceInsetValue = 'always' | 'never';
+
+	declare export type ForceInset = {|
+	  top?: SafeAreaViewForceInsetValue,
+	  bottom?: SafeAreaViewForceInsetValue,
+	  left?: SafeAreaViewForceInsetValue,
+	  right?: SafeAreaViewForceInsetValue,
+	  horizontal?: SafeAreaViewForceInsetValue,
+	  vertical?: SafeAreaViewForceInsetValue
+	|};
+
+	declare export type SafeAreaViewProps = $ReadOnly<{|
+	  ...ViewProps,
+	  forceInset?: ?ForceInset
+	|}>;
+
+	declare export default class SafeAreaView extends React$Component<SafeAreaViewProps> {}
+
+	declare export function withSafeArea(
+	  forceInset?: ?ForceInset
+	): <T: React$ComponentType<*>>(WrappedComponent: T) => T;
+}

--- a/modules/button/index.js
+++ b/modules/button/index.js
@@ -31,12 +31,22 @@ const styles = StyleSheet.create({
 	},
 })
 
+const inverted = StyleSheet.create({
+	text: {
+		...Platform.select({
+			ios: iOSUIKit.calloutBlackObject,
+			android: material.buttonBlackObject,
+		}),
+	},
+})
+
 type Props = {
 	title?: string,
 	onPress?: () => any,
 	disabled?: boolean,
 	buttonStyle?: any,
 	textStyle?: any,
+	mode?: 'default' | 'inverted',
 	theme: AppTheme,
 }
 
@@ -46,13 +56,21 @@ function Button({
 	disabled = false,
 	buttonStyle = null,
 	textStyle = null,
+	mode = 'default',
 	theme,
 }: Props) {
-	let background = {backgroundColor: theme.buttonBackground}
-	let foreground = {color: theme.buttonForeground}
+	let background =
+		mode === 'default'
+			? {backgroundColor: theme.buttonBackground}
+			: {backgroundColor: theme.buttonForeground}
+	let foreground =
+		mode === 'default'
+			? {color: theme.buttonForeground}
+			: {color: theme.buttonBackground}
 
+	let textStyleThing = mode === 'default' ? styles.text : inverted.text
 	let containerStyle = [styles.button, background, buttonStyle]
-	let style = [styles.text, foreground, textStyle]
+	let style = [textStyleThing, foreground, textStyle]
 
 	return (
 		<BasicButton

--- a/source/views/sis/balances-acknowledgement.js
+++ b/source/views/sis/balances-acknowledgement.js
@@ -80,12 +80,12 @@ export default connect(
 	{hasSeenAcknowledgement},
 )(BalancesOrAcknowledgementView)
 
-type AcknowledgementProps = {
+type AcknowledgementProps = {|
 	title: string,
 	subtitle: string,
 	children: React.Node,
 	onPositive: () => any,
-}
+|}
 
 function AndroidAck(props: AcknowledgementProps) {
 	let {title, subtitle, children, onPositive} = props

--- a/source/views/sis/balances-acknowledgement.js
+++ b/source/views/sis/balances-acknowledgement.js
@@ -106,7 +106,7 @@ function AndroidAck(props: AcknowledgementProps) {
 			/>
 			<Card.Content>{children}</Card.Content>
 			<Card.Actions>
-				<Button onPress={onPositive}>I Agree</Button>
+				<Button mode="contained" onPress={onPositive}>I Agree</Button>
 			</Card.Actions>
 		</Card>
 	)

--- a/source/views/sis/balances-acknowledgement.js
+++ b/source/views/sis/balances-acknowledgement.js
@@ -106,7 +106,9 @@ function AndroidAck(props: AcknowledgementProps) {
 			/>
 			<Card.Content>{children}</Card.Content>
 			<Card.Actions>
-				<Button mode="contained" onPress={onPositive}>I Agree</Button>
+				<Button mode="contained" onPress={onPositive}>
+					I Agree
+				</Button>
 			</Card.Actions>
 		</Card>
 	)

--- a/source/views/sis/balances-acknowledgement.js
+++ b/source/views/sis/balances-acknowledgement.js
@@ -1,0 +1,52 @@
+// @flow
+
+import * as React from 'react'
+import {StyleSheet, ScrollView, View, Text} from 'react-native'
+import {TabBarIcon} from '@frogpond/navigation-tabs'
+import {connect} from 'react-redux'
+import {hasSeenAcknowledgement} from '../../redux/parts/settings'
+import {type ReduxState} from '../../redux'
+import type {TopLevelViewPropsType} from '../types'
+import BalancesView from './balances'
+
+type ReactProps = TopLevelViewPropsType
+
+type ReduxStateProps = {
+	alertSeen: boolean,
+}
+
+type ReduxDispatchProps = {
+	hasSeenAcknowledgement: () => any,
+}
+
+type Props = ReactProps & ReduxStateProps & ReduxDispatchProps
+
+BalancesOrAcknowledgementView.navigationOptions = {
+	tabBarLabel: 'Balances',
+	tabBarIcon: TabBarIcon('card'),
+}
+
+function BalancesOrAcknowledgementView(props: Props) {
+	if (props.alertSeen) {
+		return <BalancesView navigation={props.navigation} />
+	}
+
+	return (
+		<ScrollView>
+			<Text>This data may be inaccurate.</Text>
+			<Text>Bon Appétit is always right.</Text>
+			<Text>This app is unofficial.</Text>
+		</ScrollView>
+	)
+}
+
+function mapState(state: ReduxState): ReduxStateProps {
+	return {
+		alertSeen: state.settings ? state.settings.unofficiallyAcknowledged : false,
+	}
+}
+
+export default connect(
+	mapState,
+	{hasSeenAcknowledgement},
+)(BalancesView)

--- a/source/views/sis/balances-acknowledgement.js
+++ b/source/views/sis/balances-acknowledgement.js
@@ -1,7 +1,7 @@
 // @flow
 
 import * as React from 'react'
-import {StyleSheet, ScrollView, Platform, Alert, View} from 'react-native'
+import {StyleSheet, ScrollView, Platform, View} from 'react-native'
 import {TabBarIcon} from '@frogpond/navigation-tabs'
 import {connect} from 'react-redux'
 import {hasSeenAcknowledgement} from '../../redux/parts/settings'
@@ -35,7 +35,6 @@ function BalancesOrAcknowledgementView(props: Props) {
 	return (
 		<ScrollView contentContainerStyle={styles.container}>
 			<Acknowledgement
-				onNegative={() => Alert.alert('You said "No"')}
 				onPositive={props.hasSeenAcknowledgement}
 				subtitle="Bon Appétit is always right"
 				title="Before you continue…"
@@ -85,11 +84,10 @@ type AcknowledgementProps = {
 	subtitle: string,
 	children: React.Node,
 	onPositive: () => any,
-	onNegative: () => any,
 }
 
 function AndroidAck(props: AcknowledgementProps) {
-	let {title, subtitle, children, onPositive, onNegative} = props
+	let {title, subtitle, children, onPositive} = props
 
 	return (
 		<Card style={styles.androidCard}>
@@ -100,23 +98,23 @@ function AndroidAck(props: AcknowledgementProps) {
 			/>
 			<Card.Content>{children}</Card.Content>
 			<Card.Actions>
-				<Button onPress={onNegative}>I Disagree</Button>
-				<Button onPress={onPositive}>Agreed</Button>
+				<Button onPress={onPositive}>
+					I Agree
+				</Button>
 			</Card.Actions>
 		</Card>
 	)
 }
 
 function IosAck(props: AcknowledgementProps) {
-	let {title, subtitle, children, onPositive, onNegative} = props
+	let {title, children, onPositive} = props
 
 	return (
-		<IosCard footer={subtitle} header={title}>
+		<IosCard header={title}>
 			{children}
 
 			<View style={styles.iosButtonRow}>
-				<IosButton mode="inverted" onPress={onNegative} title="I Disagree" />
-				<IosButton onPress={onPositive} title="Agreed" />
+				<IosButton onPress={onPositive} title="I Agree" />
 			</View>
 		</IosCard>
 	)

--- a/source/views/sis/balances-acknowledgement.js
+++ b/source/views/sis/balances-acknowledgement.js
@@ -106,9 +106,7 @@ function AndroidAck(props: AcknowledgementProps) {
 			/>
 			<Card.Content>{children}</Card.Content>
 			<Card.Actions>
-				<Button onPress={onPositive}>
-					I Agree
-				</Button>
+				<Button onPress={onPositive}>I Agree</Button>
 			</Card.Actions>
 		</Card>
 	)

--- a/source/views/sis/balances-acknowledgement.js
+++ b/source/views/sis/balances-acknowledgement.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import {StyleSheet, ScrollView, Platform, View} from 'react-native'
+import Icon from 'react-native-vector-icons/Ionicons'
 import {TabBarIcon} from '@frogpond/navigation-tabs'
 import {connect} from 'react-redux'
 import {hasSeenAcknowledgement} from '../../redux/parts/settings'
@@ -92,7 +93,14 @@ function AndroidAck(props: AcknowledgementProps) {
 	return (
 		<Card style={styles.androidCard}>
 			<Card.Title
-				left={props => <Avatar.Icon {...props} icon="warning" />}
+				left={props => (
+					<Avatar.Icon
+						{...props}
+						icon={({size, color}) => (
+							<Icon name="md-warning" size={size} style={{color}} />
+						)}
+					/>
+				)}
 				subtitle={subtitle}
 				title={title}
 			/>

--- a/source/views/sis/balances-acknowledgement.js
+++ b/source/views/sis/balances-acknowledgement.js
@@ -1,30 +1,31 @@
 // @flow
 
 import * as React from 'react'
-import {StyleSheet, ScrollView, View, Text} from 'react-native'
+import {StyleSheet, ScrollView, Platform, Alert, View} from 'react-native'
 import {TabBarIcon} from '@frogpond/navigation-tabs'
 import {connect} from 'react-redux'
 import {hasSeenAcknowledgement} from '../../redux/parts/settings'
 import {type ReduxState} from '../../redux'
 import type {TopLevelViewPropsType} from '../types'
+import {Avatar, Button, Card, Paragraph as AndroidP} from 'react-native-paper'
+import {Paragraph as IosP} from '@frogpond/markdown'
+import {Card as IosCard} from '@frogpond/silly-card'
+import {Button as IosButton} from '@frogpond/button'
 import BalancesView from './balances'
-
-type ReactProps = TopLevelViewPropsType
 
 type ReduxStateProps = {
 	alertSeen: boolean,
 }
 
-type ReduxDispatchProps = {
+type Props = {
+	...TopLevelViewPropsType,
+	...ReduxStateProps,
+	// from redux mapDispatch
 	hasSeenAcknowledgement: () => any,
 }
 
-type Props = ReactProps & ReduxStateProps & ReduxDispatchProps
-
-BalancesOrAcknowledgementView.navigationOptions = {
-	tabBarLabel: 'Balances',
-	tabBarIcon: TabBarIcon('card'),
-}
+let Acknowledgement = Platform.OS === 'android' ? AndroidAck : IosAck
+let Paragraph = Platform.OS === 'android' ? AndroidP : IosP
 
 function BalancesOrAcknowledgementView(props: Props) {
 	if (props.alertSeen) {
@@ -32,12 +33,40 @@ function BalancesOrAcknowledgementView(props: Props) {
 	}
 
 	return (
-		<ScrollView>
-			<Text>This data may be inaccurate.</Text>
-			<Text>Bon Appétit is always right.</Text>
-			<Text>This app is unofficial.</Text>
+		<ScrollView contentContainerStyle={styles.container}>
+			<Acknowledgement
+				onNegative={() => Alert.alert('You said "No"')}
+				onPositive={props.hasSeenAcknowledgement}
+				subtitle="Bon Appétit is always right"
+				title="Before you continue…"
+			>
+				<Paragraph>
+					While we strive to keep this app and the data therein up-to-date,
+					there will always be issues, especially seeing as we are not part of
+					the college. (Students and alumni of, yes, but officially sponsored
+					by, no.)
+				</Paragraph>
+				<Paragraph>
+					As such, we require that you agree to the following statement before
+					you can see your balances within the app:
+				</Paragraph>
+				<Paragraph style={styles.bonappNotice}>
+					This data may be inaccurate.{'\n'}
+					Bon Appétit is always right.{'\n'}
+					This app is unofficial.
+				</Paragraph>
+				<Paragraph>
+					If you disagree, you will simply not be able to access this Balances
+					view. The rest of the app will remain available for perusal.
+				</Paragraph>
+			</Acknowledgement>
 		</ScrollView>
 	)
+}
+
+BalancesOrAcknowledgementView.navigationOptions = {
+	tabBarLabel: 'Balances',
+	tabBarIcon: TabBarIcon('card'),
 }
 
 function mapState(state: ReduxState): ReduxStateProps {
@@ -49,4 +78,66 @@ function mapState(state: ReduxState): ReduxStateProps {
 export default connect(
 	mapState,
 	{hasSeenAcknowledgement},
-)(BalancesView)
+)(BalancesOrAcknowledgementView)
+
+type AcknowledgementProps = {
+	title: string,
+	subtitle: string,
+	children: React.Node,
+	onPositive: () => any,
+	onNegative: () => any,
+}
+
+function AndroidAck(props: AcknowledgementProps) {
+	let {title, subtitle, children, onPositive, onNegative} = props
+
+	return (
+		<Card style={styles.androidCard}>
+			<Card.Title
+				left={props => <Avatar.Icon {...props} icon="warning" />}
+				subtitle={subtitle}
+				title={title}
+			/>
+			<Card.Content>{children}</Card.Content>
+			<Card.Actions>
+				<Button onPress={onNegative}>I Disagree</Button>
+				<Button onPress={onPositive}>Agreed</Button>
+			</Card.Actions>
+		</Card>
+	)
+}
+
+function IosAck(props: AcknowledgementProps) {
+	let {title, subtitle, children, onPositive, onNegative} = props
+
+	return (
+		<IosCard footer={subtitle} header={title}>
+			{children}
+
+			<View style={styles.iosButtonRow}>
+				<IosButton mode="inverted" onPress={onNegative} title="I Disagree" />
+				<IosButton onPress={onPositive} title="Agreed" />
+			</View>
+		</IosCard>
+	)
+}
+
+let styles = StyleSheet.create({
+	container: {
+		marginVertical: 10,
+	},
+	androidCard: {
+		marginHorizontal: 10,
+	},
+	bonappNotice: {
+		fontWeight: Platform.select({
+			ios: '600',
+			android: '700',
+		}),
+		textAlign: 'center',
+	},
+	iosButtonRow: {
+		flexDirection: 'row',
+		justifyContent: 'space-around',
+	},
+})

--- a/source/views/sis/balances-acknowledgement.js
+++ b/source/views/sis/balances-acknowledgement.js
@@ -134,6 +134,7 @@ let styles = StyleSheet.create({
 	},
 	androidCard: {
 		marginHorizontal: 10,
+		marginBottom: 10,
 	},
 	bonappNotice: {
 		fontWeight: Platform.select({

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -206,15 +206,10 @@ export default connect(
 	{logInViaCredentials},
 )(BalancesView)
 
-let cellMargin = 10
-let cellSidePadding = 10
-let cellEdgePadding = 10
-
 let styles = StyleSheet.create({
 	stage: {
 		backgroundColor: c.sectionBgColor,
-		paddingTop: 20,
-		paddingBottom: 20,
+		paddingVertical: 20,
 	},
 
 	common: {
@@ -240,11 +235,9 @@ let styles = StyleSheet.create({
 		height: 88,
 		flex: 1,
 		alignItems: 'center',
-		paddingTop: cellSidePadding,
-		paddingBottom: cellSidePadding,
-		paddingRight: cellEdgePadding,
-		paddingLeft: cellEdgePadding,
-		marginBottom: cellMargin,
+		paddingVertical: 10,
+		paddingHorizontal: 10,
+		marginBottom: 10,
 	},
 
 	// Text styling

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -1,18 +1,9 @@
 // @flow
 
 import * as React from 'react'
-import {
-	StyleSheet,
-	ScrollView,
-	View,
-	Text,
-	RefreshControl,
-	Alert,
-} from 'react-native'
-import {TabBarIcon} from '@frogpond/navigation-tabs'
+import {StyleSheet, ScrollView, View, Text, RefreshControl} from 'react-native'
 import {connect} from 'react-redux'
 import {Cell, TableView, Section} from '@frogpond/tableview'
-import {hasSeenAcknowledgement} from '../../redux/parts/settings'
 import {logInViaCredentials} from '../../redux/parts/login'
 import {type LoginStateEnum} from '../../redux/parts/login'
 import {getBalances} from '../../lib/financials'
@@ -23,19 +14,15 @@ import * as c from '@frogpond/colors'
 import type {TopLevelViewPropsType} from '../types'
 
 const DISCLAIMER = 'This data may be outdated or otherwise inaccurate.'
-const LONG_DISCLAIMER =
-	'This data may be inaccurate.\nBon Appétit is always right.\nThis app is unofficial.'
 
 type ReactProps = TopLevelViewPropsType
 
 type ReduxStateProps = {
 	status: LoginStateEnum,
-	alertSeen: boolean,
 }
 
 type ReduxDispatchProps = {
 	logInViaCredentials: (string, string) => Promise<any>,
-	hasSeenAcknowledgement: () => any,
 }
 
 type Props = ReactProps & ReduxStateProps & ReduxDispatchProps
@@ -52,11 +39,6 @@ type State = {
 }
 
 class BalancesView extends React.PureComponent<Props, State> {
-	static navigationOptions = {
-		tabBarLabel: 'Balances',
-		tabBarIcon: TabBarIcon('card'),
-	}
-
 	state = {
 		loading: false,
 		flex: null,
@@ -72,13 +54,6 @@ class BalancesView extends React.PureComponent<Props, State> {
 		// calling "refresh" here, to make clear to the user
 		// that the data is being updated
 		this.refresh()
-
-		if (!this.props.alertSeen) {
-			Alert.alert('', LONG_DISCLAIMER, [
-				{text: 'I Disagree', onPress: this.goBack, style: 'cancel'},
-				{text: 'Okay', onPress: this.props.hasSeenAcknowledgement},
-			])
-		}
 	}
 
 	refresh = async () => {
@@ -132,8 +107,6 @@ class BalancesView extends React.PureComponent<Props, State> {
 	}
 
 	openSettings = () => this.props.navigation.navigate('SettingsView')
-
-	goBack = () => this.props.navigation.goBack(null)
 
 	render() {
 		let {
@@ -224,14 +197,13 @@ class BalancesView extends React.PureComponent<Props, State> {
 
 function mapState(state: ReduxState): ReduxStateProps {
 	return {
-		alertSeen: state.settings ? state.settings.unofficiallyAcknowledged : false,
 		status: state.login ? state.login.status : 'initializing',
 	}
 }
 
 export default connect(
 	mapState,
-	{logInViaCredentials, hasSeenAcknowledgement},
+	{logInViaCredentials},
 )(BalancesView)
 
 let cellMargin = 10

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -162,21 +162,18 @@ class BalancesView extends React.PureComponent<Props, State> {
 					<Section footer={DISCLAIMER} header="BALANCES">
 						<View style={styles.balancesRow}>
 							<FormattedValueCell
-								formatter={getValueOrNa}
 								indeterminate={loading}
 								label="Flex"
 								value={flex}
 							/>
 
 							<FormattedValueCell
-								formatter={getValueOrNa}
 								indeterminate={loading}
 								label="Ole"
 								value={ole}
 							/>
 
 							<FormattedValueCell
-								formatter={getValueOrNa}
 								indeterminate={loading}
 								label="Copy/Print"
 								style={styles.finalCell}
@@ -188,14 +185,12 @@ class BalancesView extends React.PureComponent<Props, State> {
 					<Section footer={DISCLAIMER} header="MEAL PLAN">
 						<View style={styles.balancesRow}>
 							<FormattedValueCell
-								formatter={getValueOrNa}
 								indeterminate={loading}
 								label="Daily Meals Left"
 								value={dailyMeals}
 							/>
 
 							<FormattedValueCell
-								formatter={getValueOrNa}
 								indeterminate={loading}
 								label="Weekly Meals Left"
 								style={styles.finalCell}
@@ -308,9 +303,9 @@ function FormattedValueCell(props: {
 	label: string,
 	value: ?string,
 	style?: any,
-	formatter: (?string) => string,
+	formatter?: (?string) => string,
 }) {
-	let {indeterminate, label, value, style, formatter} = props
+	let {indeterminate, label, value, style, formatter = getValueOrNa} = props
 
 	return (
 		<View style={[styles.rectangle, styles.common, styles.balances, style]}>

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -38,7 +38,7 @@ type State = {
 	message: ?string,
 }
 
-class BalancesView extends React.PureComponent<Props, State> {
+class BalancesView extends React.Component<Props, State> {
 	state = {
 		loading: false,
 		flex: null,

--- a/source/views/sis/index.js
+++ b/source/views/sis/index.js
@@ -2,7 +2,7 @@
 
 import {TabNavigator} from '../../../modules/navigation-tabs/tabbed-view'
 
-import BalancesView from './balances'
+import BalancesOrAcknowledgementView from './balances-acknowledgement'
 import StudentWorkView from './student-work'
 import {CourseSearchView} from './course-search'
 import TESView from './tes'
@@ -11,7 +11,7 @@ export {JobDetailView} from './student-work/detail'
 export {CourseSearchResultsView, CourseDetailView} from './course-search'
 
 const SisView = TabNavigator({
-	BalancesView: {screen: BalancesView},
+	BalancesView: {screen: BalancesOrAcknowledgementView},
 	CourseSearchView: {screen: CourseSearchView},
 	TESView: {screen: TESView},
 	StudentWorkView: {screen: StudentWorkView},


### PR DESCRIPTION
Also closes #3506 

---

My basic premise here is multi-fold:

1. I don't like that we block off the rest of the SIS tab (stuwork, courses, TES) with a _modal_ from Balances
2. I want to prevent any possible way to see stuff happening in the background, before you've acknowledged BonApp's superiority

And so, I thought to myself – why not an interstitial?

iOS | Android
--- | ---
<img width="487" src="https://user-images.githubusercontent.com/464441/53384689-6a43da80-3941-11e9-8712-1f91c888e245.png"> | <img width="487" src="https://user-images.githubusercontent.com/464441/53384855-f6560200-3941-11e9-805a-995d18378a6f.png">

If you <kbd>I Agree</kbd>, then this view hides and renders Balances, instead – I also tested to make sure there wasn't a noticeable flash of this while Redux was loading state, and I could never make out any sort of disruption. (If this turns out to be an issue on nightly, I'll take another look. My fallback plan was to do something with rendering `null` if redux hadn't loaded the value yet, but I'd rather not do that unless it's needed.)

If you don't agree, well… you just don't agree!

---

I also have other variations on the Android screen, about which style of button we want to use. I don't know which one is most applicable here; I know Cards typically have used "text" buttons, but I'm not sure how that's changing with MD 2.0.

Anyway.

text | outlined | contained
--- | --- | ---
![screenshot_1551149926](https://user-images.githubusercontent.com/464441/53384857-f6560200-3941-11e9-8524-9e4a328bafc6.png) | ![screenshot_1551149917](https://user-images.githubusercontent.com/464441/53384856-f6560200-3941-11e9-9c0a-e987e4632b50.png) | ![screenshot_1551149907](https://user-images.githubusercontent.com/464441/53384855-f6560200-3941-11e9-805a-995d18378a6f.png)