### PR TITLE
Sectionlist tweaks on menu, contacts, and transportation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Addressed color banding in SIS/Balances on Android (#3462)
 - [wip] Fix OleCard login stuff (#3503)
 - Adjusted how we present the BonApp ultimatum on first visiting the Balances tab (#3515)
+- Changed the `data` prop on fancy-menu to be `extraData` (#3528)
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)
@@ -67,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)
 - Removed Google Analytics tracking (#3517)
+- Removed the `data` prop on other-transport modes and important contacts (#3528)
 
 ## [2.6.3] - 2018-09-17
 ### Fixed

--- a/modules/food-menu/fancy-menu.js
+++ b/modules/food-menu/fancy-menu.js
@@ -204,7 +204,7 @@ export class FancyMenu extends React.Component<Props, State> {
 				ItemSeparatorComponent={Separator}
 				ListEmptyComponent={messageView}
 				ListHeaderComponent={header}
-				data={filters}
+				extraData={filters}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.props.onRefresh}
 				refreshing={this.props.refreshing}

--- a/source/views/contacts/list.js
+++ b/source/views/contacts/list.js
@@ -85,7 +85,6 @@ export class ContactsListView extends React.PureComponent<Props, State> {
 			<SectionList
 				ItemSeparatorComponent={ListSeparator}
 				ListEmptyComponent={<ListEmpty mode="bug" />}
-				data={groupedData}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.refresh}
 				refreshing={this.state.loading}

--- a/source/views/transportation/other-modes/list.js
+++ b/source/views/transportation/other-modes/list.js
@@ -97,7 +97,6 @@ export class OtherModesView extends React.PureComponent<Props, State> {
 			<SectionList
 				ItemSeparatorComponent={ListSeparator}
 				ListEmptyComponent={<ListEmpty mode="bug" />}
-				data={groupedData}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.refresh}
 				refreshing={this.state.refreshing}


### PR DESCRIPTION
Two things are happening in this PR:

First, the "Important Contacts" and "Transportation Other Modes" section lists do not have filters or search, so I ask that we remove<code><sup>1</sup></code> the `data` prop from them –– which I think should be `extraData`.

We can handle this in two ways:
* a) `data` could be passed-in as [`extraData`](https://facebook.github.io/react-native/docs/sectionlist#extradata)... or
* b) it could be removed because we're not searching or filtering on either of these views

Next, the "Fancy Menu" component is a filterable list, so we should rename<code><sup>1</sup></code> `data` to `extraData` because the data is passed-in within the `sections` prop, and we need to tell it to re-render because it is a pure component.  

<hr>

<code><sup>1</sup></code> `section.data` is a thing, but `data` is not a top-level prop of `SectionList` as per [the docs](https://facebook.github.io/react-native/docs/sectionlist.html#props).
