### PR TITLE
renovate: Raise prConcurrentLimit to 10

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -8,7 +8,7 @@
       "after 5pm on every weekday"
     ]
   },
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 10,
   "timezone": "America/Chicago",
   "ignoreDeps": [
     "flow-bin",


### PR DESCRIPTION
My primary motivation for doing this is when we have two or so "stalled" PR's that need further work.  I'd like to be able to have the other PR's get through and merged in the meantime.

I haven't actually seen many instances where PR's by Renovate would actually trigger a rebase when another is merged.  I think this is because the yarn.lock format is nice enough that dependencies are more or less kept separate from each other.  In package.json, only neighboring dependency changes seem to be the things that trigger rebases.