### PR TITLE
Fix(?) [and clean up] Android CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
     description: 'Save the Bundler cache'
     steps:
       - save_cache:
-          key: &bundler-key >-
+          key: &bundler-cache-key >-
             v2-ruby-dependencies
             {{ arch }}
             {{ checksum "Gemfile.lock" }}
@@ -23,7 +23,7 @@ commands:
     description: 'Restore the Bundler cache'
     steps:
       - restore_cache:
-          key: *bundler-key
+          key: *bundler-cache-key
 
   danger:
     description: 'Run Danger'
@@ -38,7 +38,7 @@ commands:
     description: 'Save the Gradle cache'
     steps:
       - save_cache:
-          key: &gradle-key >-
+          key: &gradle-cache-key >-
             v1-gradle-dependencies
             {{ arch }}
             {{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}
@@ -52,7 +52,7 @@ commands:
     description: 'Restore the Gradle cache'
     steps:
       - restore_cache:
-          key: *gradle-key
+          key: *gradle-cache-key
 
   set-ruby-version:
     description: 'Set the Ruby Version'
@@ -76,7 +76,7 @@ commands:
     description: 'Save the Yarn cache'
     steps:
       - save_cache:
-          key: &yarn-key >-
+          key: &yarn-cache-key >-
             v3-yarn-dependencies
             {{ arch }}
             {{ checksum "yarn.lock" }}
@@ -86,7 +86,7 @@ commands:
     description: 'Restore the Yarn cache'
     steps:
       - restore_cache:
-          key: *yarn-key
+          key: *yarn-cache-key
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ commands:
           key: &gradle-key >-
             v1-gradle-dependencies
             {{ arch }}
+            {{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}
             {{ checksum "android/build.gradle" }}
             {{ checksum "android/app/build.gradle" }}
             {{ checksum "node_modules/react-native/package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,15 @@ commands:
     description: 'Save the Bundler cache'
     steps:
       - save_cache:
-          key: 'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+          key: &bundler-key
+            'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
           paths: [./vendor/bundle]
 
   bundler-restore:
     description: 'Restore the Bundler cache'
     steps:
       - restore_cache:
-          key: 'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+          key: *bundler-key
 
   danger:
     description: 'Run Danger'
@@ -35,14 +36,15 @@ commands:
     description: 'Save the Gradle cache'
     steps:
       - save_cache:
-          key: 'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+          key: &gradle-key
+            'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
           paths: [~/.gradle]
 
   gradle-restore:
     description: 'Restore the Gradle cache'
     steps:
       - restore_cache:
-          key: 'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+          key: *gradle-key
 
   set-ruby-version:
     description: 'Set the Ruby Version'
@@ -66,14 +68,15 @@ commands:
     description: 'Save the Yarn cache'
     steps:
       - save_cache:
-          key: 'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
+          key: &yarn-key
+            'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
           paths: [~/.cache/yarn, ~/Library/Caches/Yarn]
 
   yarn-restore:
     description: 'Restore the Yarn cache'
     steps:
       - restore_cache:
-          key: 'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
+          key: *yarn-key
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ commands:
             {{ arch }}
             {{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}
             {{ checksum "android/build.gradle" }}
+            {{ checksum "android/settings.gradle" }}
             {{ checksum "android/app/build.gradle" }}
             {{ checksum "node_modules/react-native/package.json" }}
           paths: [~/.gradle]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,10 @@ commands:
     description: 'Save the Bundler cache'
     steps:
       - save_cache:
-          key: &bundler-key
-            'v2-ruby-dependencies-{{ arch }}-{{ checksum "Gemfile.lock" }}'
+          key: &bundler-key >-
+            v2-ruby-dependencies
+            {{ arch }}
+            {{ checksum "Gemfile.lock" }}
           paths: [./vendor/bundle]
 
   bundler-restore:
@@ -36,8 +38,12 @@ commands:
     description: 'Save the Gradle cache'
     steps:
       - save_cache:
-          key: &gradle-key
-            'v1-gradle-dependencies-{{ arch }}-{{ checksum "android/build.gradle" }}-{{ checksum "android/app/build.gradle" }}-{{ checksum "node_modules/react-native/package.json" }}'
+          key: &gradle-key >-
+            v1-gradle-dependencies
+            {{ arch }}
+            {{ checksum "android/build.gradle" }}
+            {{ checksum "android/app/build.gradle" }}
+            {{ checksum "node_modules/react-native/package.json" }}
           paths: [~/.gradle]
 
   gradle-restore:
@@ -68,8 +74,10 @@ commands:
     description: 'Save the Yarn cache'
     steps:
       - save_cache:
-          key: &yarn-key
-            'v3-yarn-dependencies-{{ arch }}-{{ checksum "yarn.lock" }}'
+          key: &yarn-key >-
+            v3-yarn-dependencies
+            {{ arch }}
+            {{ checksum "yarn.lock" }}
           paths: [~/.cache/yarn, ~/Library/Caches/Yarn]
 
   yarn-restore:


### PR DESCRIPTION
Last night's Android nightly didn't complete successfully; https://circleci.com/gh/StoDevX/AAO-React-Native/49056.

```
Exit status of command '/home/circleci/project/android/gradlew assembleRelease -p ./android' was 1 instead of 0.

FAILURE: Build failed with an exception.

* Where:
Build file '/home/circleci/project/android/app/build.gradle' line: 195

* What went wrong:
A problem occurred evaluating project ':app'.
> Could not set unknown property 'hasFile' for project ':app' of type org.gradle.api.Project.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s
```

In #3557, I did the following, because _my_ gradle wouldn't build the debug version because it couldn't find `bundleReleaseJsAndAssets`.

```diff
gradle.projectsEvaluated {
    // hook bundleData into the android build process
+    if (project.hasProperty('bundleDebugJsAndAssets')) {
        bundleDebugJsAndAssets.dependsOn bundleData
+    }
+    if (project.hasProperty('bundleReleaseJsAndAssets')) {
        bundleReleaseJsAndAssets.dependsOn bundleData
+    }
}
```

My hypothesis here is that we're somehow running an old version of Gradle on Circle, since we don't track the `android/gradle/wrapper/gradle-wrapper.properties` file (which controls the version) in our cache key.

So!

I did ~~two~~ three things here:

1. I adjusted the `load-*` cache instructions to use the same key as the `save-*` cache instructions, to prevent accidental typos between the two
2. I split the cache keys with spaces instead of hyphens, and I split them across multiple lines in the source, to make it easier to read and to add new items (see the relevant bit of YAML syntax: [playground](https://nodeca.github.io/js-yaml/#yaml=LSAmZm9vID4tCiAgdjEKICBncmFkbGUKICBkZXBlbmRlbmNpZXMKICB7eyBhcmNoIH19CiAge3sgY2hlY2tzdW0gImFuZHJvaWQvYnVpbGQuZ3JhZGxlIiB9fQogIHt7IGNoZWNrc3VtICJhbmRyb2lkL3NldHRpbmdzLmdyYWRsZSIgfX0KICB7eyBjaGVja3N1bSAiYW5kcm9pZC9hcHAvYnVpbGQuZ3JhZGxlIiB9fQogIHt7IGNoZWNrc3VtICJub2RlX21vZHVsZXMvcmVhY3QtbmF0aXZlL3BhY2thZ2UuanNvbiIgfX0K), [SO answer](https://stackoverflow.com/a/21699210))
3. I added `{{ checksum "android/gradle/wrapper/gradle-wrapper.properties" }}` and `{{ checksum "android/settings.gradle" }}` to the cache key. 
    1. `gradle-wrapper.properties` tracks the version of Gradle that we want to use
    2. `android/settings.gradle` is YAADF (yet another android dependencies file), so I just added it for completeness