### PR TITLE
Fix signed Gradle builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,6 +327,7 @@ jobs:
           command: ./scripts/should-skip-build && circleci step halt || echo "Build continuing."
       - run: node --version
       - run: yarn --version
+      - run: cd android && ./gradlew --version
       - set-ruby-version
       - workspace-attach-node_modules
       - bundler-restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed DatePicker by removing an unnecessary call to getDerivedStateFromProps (#3382)
 - Fixed the balances view from refreshing if the user has not agreed to the alert (#3509)
 - Fixed course search crash (#3564)
+- Building signed Android APKs was broken after RN 0.59; now it is fixed (#3569)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -122,6 +122,7 @@ android {
     }
 
     signingConfigs {
+        // originally derived from https://gist.github.com/gabrielemariotti/6856974
         String filePath = System.getenv("KEYSTORE_FILE")
 
         if (filePath == null) {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -97,6 +97,11 @@ def enableSeparateBuildPerCPUArchitecture = false
  */
 def enableProguardInReleaseBuilds = false
 
+/**
+ * Fetch the keystore file's path from the environment
+ */
+String keystorePath = System.getenv("KEYSTORE_FILE")
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
@@ -123,19 +128,17 @@ android {
 
     signingConfigs {
         // originally derived from https://gist.github.com/gabrielemariotti/6856974
-        String filePath = System.getenv("KEYSTORE_FILE")
-
-        if (filePath == null) {
+        if (keystorePath == null) {
             logger.warn "env['KEYSTORE_FILE'] not set"
             release
             return
         } else {
-            logger.warn "env['KEYSTORE_FILE'] = ${filePath}"
+            logger.warn "env['KEYSTORE_FILE'] = ${keystorePath}"
         }
 
-        def propFile = new File(filePath)
+        def propFile = new File(keystorePath)
         if (!propFile.canRead()) {
-            logger.warn "${filePath} is not readable"
+            logger.warn "${keystorePath} is not readable"
             release
             return
         }
@@ -170,7 +173,9 @@ android {
 
             minifyEnabled enableProguardInReleaseBuilds
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
-            signingConfig signingConfigs.release
+            if (keystorePath != null) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -122,8 +122,32 @@ android {
     }
 
     signingConfigs {
-        // the signingConfig is configured below
-        release
+        String filePath = System.getenv("KEYSTORE_FILE")
+
+        if (filePath == null) {
+            logger.warn "env['KEYSTORE_FILE'] not set"
+            release
+            return
+        } else {
+            logger.warn "env['KEYSTORE_FILE'] = ${filePath}"
+        }
+
+        def propFile = new File(filePath)
+        if (!propFile.canRead()) {
+            logger.warn "${filePath} is not readable"
+            release
+            return
+        }
+
+        def props = new Properties()
+        props.load(new FileInputStream(propFile))
+
+        release {
+            storeFile file(props['STORE_FILE'])
+            storePassword props['STORE_PASSWORD']
+            keyAlias props['KEY_ALIAS']
+            keyPassword props['KEY_PASSWORD']
+        }
     }
 
     splits {
@@ -184,41 +208,6 @@ android {
 
         resolutionStrategy.force 'org.webkit:android-jsc:r236355'
     }
-}
-
-// borrowed from https://gist.github.com/gabrielemariotti/6856974
-def propFile = new File('android/app/signing.properties')
-if (propFile.canRead()) {
-    Properties props = new Properties()
-    props.load(new FileInputStream(propFile))
-
-    bool hasFile = props != null && props.containsKey('STORE_FILE');
-    bool hasPassword = props != null && props.containsKey('STORE_PASSWORD');
-    bool hasAlias = props != null && props.containsKey('KEY_ALIAS');
-    bool hasKeyPass = props != null && props.containsKey('KEY_PASSWORD');
-
-    if (hasFile && hasPassword && hasAlias && hasKeyPass) {
-        logger.info 'android/app/signing.properties is fully functional.'
-        android.signingConfigs.release.storeFile = file(props['STORE_FILE'])
-        android.signingConfigs.release.storePassword = props['STORE_PASSWORD']
-        android.signingConfigs.release.keyAlias = props['KEY_ALIAS']
-        android.signingConfigs.release.keyPassword = props['KEY_PASSWORD']
-    } else {
-        println 'android/app/signing.properties found, but some entries are missing.'
-        if (props == null) {
-            logger.warn '`props` was null'
-        } else {
-            logger.warn "has STORE_FILE [y/n]: ${props.containsKey('STORE_FILE')}"
-            logger.warn "has STORE_PASSWORD [y/n]: ${props.containsKey('STORE_PASSWORD')}"
-            logger.warn "has KEY_ALIAS [y/n]: ${props.containsKey('KEY_ALIAS')}"
-            logger.warn "has KEY_PASSWORD [y/n]: ${props.containsKey('KEY_PASSWORD')}"
-        }
-        android.buildTypes.release.signingConfig = null
-    }
-} else {
-    logger.warn 'android/app/signing.properties not found.'
-    logger.warn "cwd: ${new File(".").absolutePath}"
-    android.buildTypes.release.signingConfig = null
 }
 
 dependencies {


### PR DESCRIPTION
Somehow, configuring Gradle's signing options separately from the main `android{}` block results in an error about "can not find .hasProperty on project"

and like

wtf gradle

anyway

this avoids that by doing the configuration inside the `android{}` block

---

I've tested this locally; it works for both debug and release builds, and on both signed and unsigned builds.