### PR TITLE
Enable Android "app bundles"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,8 +345,6 @@ jobs:
           command: bundle exec fastlane android ci-run | tee ./logs/build
           environment:
             GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $CIRCLE_SHA1)
-      - store_artifacts:
-          path: ./android/app/build/outputs/apk/release/
       - danger
 
   android-nightly:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -199,6 +199,18 @@ android {
         }
     }
 
+    bundle {
+        language {
+            enableSplit = true
+        }
+        density {
+            enableSplit = true
+        }
+        abi {
+            enableSplit = true
+        }
+    }
+
     dexOptions {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
         preDexLibraries = preDexEnabled && !ciBuild

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -199,11 +199,9 @@ android {
         }
     }
 
-    android {
-        dexOptions {
-            // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
-            preDexLibraries = preDexEnabled && !ciBuild
-        }
+    dexOptions {
+        // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
+        preDexLibraries = preDexEnabled && !ciBuild
     }
 
     configurations.all {

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -83,12 +83,12 @@ platform :android do
 		dest = File.expand_path('..', '.')
 
 		# we export this variable so that Gradle knows where to find the .properties file
-		signing_props_dest = "#{dest}/android/app/signing.properties"
+		signing_props_dest = "#{dest}/android/app/upload-keystore.properties"
 		ENV['KEYSTORE_FILE'] = signing_props_dest
 
 		pairs = [
-			{:from => "#{src}/signing.properties", :to => signing_props_dest},
-			{:from => "#{src}/my-release-key.keystore", :to => "#{dest}/android/app/my-release-key.keystore"},
+			{:from => "#{src}/upload-keystore.properties", :to => signing_props_dest},
+			{:from => "#{src}/upload-keystore.keystore", :to => "#{dest}/android/app/upload-keystore.keystore"},
 			{:from => "#{src}/play-private-key.json", :to => "#{dest}/fastlane/play-private-key.json"},
 		]
 

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -8,7 +8,7 @@ platform :android do
 		build_status = 0
 		begin
 			propagate_version(track: options[:track])
-			gradle(task: 'assemble',
+			gradle(task: 'bundle',
 			       build_type: 'Release',
 			       print_command: true,
 			       print_command_output: true)
@@ -20,9 +20,9 @@ platform :android do
 		end
 
 		UI.message 'Generated files:'
-		UI.message lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS]
+		UI.message lane_context[SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS]
 
-		output = lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].to_json
+		output = lane_context[SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS].to_json
 		File.open('../logs/products', 'w') { |file| file.write(output) }
 	end
 
@@ -38,9 +38,9 @@ platform :android do
 		matchesque
 		build(track: track)
 
-		lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] =
-			lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].select do |apk|
-				apk.end_with? '-release.apk'
+		lane_context[SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS] =
+			lane_context[SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS].select do |apk|
+				apk.end_with? '-release.aab'
 			end
 
 		supply(track: track, check_superseded_tracks: true)

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -40,11 +40,10 @@ platform :android do
 
 		lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] =
 			lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS].select do |apk|
-			apk.end_with? '-release.apk'
-		end
+				apk.end_with? '-release.apk'
+			end
 
-		supply(track: track,
-		       check_superseded_tracks: true)
+		supply(track: track, check_superseded_tracks: true)
 
 		generate_sourcemap
 		upload_sourcemap_to_bugsnag


### PR DESCRIPTION
> ## Deliver apps and features on demand with the Android App Bundle
> By publishing your apps using the Android App Bundle, you can reduce the size of your app, simplify releases, and deliver features on demand. Because of its added benefits, the Android App Bundle is the recommended publishing format on Google Play.
>
> ### How app bundles work
>
> App bundles use a new serving model, known as Google Play’s Dynamic Delivery, to build and deliver APKs that are optimized for each device configuration. By removing unused code and resources for other devices, this delivery model results in a smaller, more efficient app for users to install.
>
> Note: To use app bundles, you must enroll in app signing by Google Play.

Google automatically generates split APKs for us!

## Before (16.89 MB)
ABI | Screen density | Download APK size
-- | -- | --
armeabi-v7a & x86 | all | 16.89 MB

## After (6.42 - 14.23 MB)
ABI | Screen density | Download APK size
-- | -- | --
arm64-v8a | xxxhdpi | 13.75 MB
arm64-v8a | xxhdpi | 13.73 MB
arm64-v8a | xhdpi | 12.80 MB
arm64-v8a | hdpi | 12.80 MB
arm64-v8a | mdpi | 12.79 MB
arm64-v8a | ldpi | 12.80 MB
armeabi-v7a | xxxhdpi | 12.93 MB
armeabi-v7a | xxhdpi | 12.92 MB
armeabi-v7a | xhdpi | 11.99 MB
armeabi-v7a | hdpi | 11.98 MB
armeabi-v7a | mdpi | 11.98 MB
armeabi-v7a | ldpi | 11.98 MB
armeabi | xxxhdpi | 7.38 MB
armeabi | xxhdpi | 7.37 MB
armeabi | xhdpi | 6.44 MB
armeabi | hdpi | 6.43 MB
armeabi | mdpi | 6.43 MB
armeabi | ldpi | 6.43 MB
x86_64 | xxxhdpi | 14.23 MB
x86_64 | xxhdpi | 14.21 MB
x86_64 | xhdpi | 13.29 MB
x86_64 | hdpi | 13.28 MB
x86_64 | mdpi | 13.27 MB
x86_64 | ldpi | 13.28 MB
x86 | xxxhdpi | 13.96 MB
x86 | xxhdpi | 13.95 MB
x86 | xhdpi | 13.02 MB
x86 | hdpi | 13.01 MB
x86 | mdpi | 13.01 MB
x86 | ldpi | 13.02 MB
