### PR TITLE
Disable cached fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added a new "yarn d" command to deduplicate dependencies
 - Added Renovate as our new automated dependency management tool, with a nice configuration (#3193)
 - Add "open webpage" row to student work detail
-- Added some logic to skip native builds if nothing that might affect them has changed (#3209)
+- Added [and then disabled] some logic to skip native builds if nothing that might affect them has changed (#3209)
 - All network requests are now cached according to the server's caching headers, even offline (#3310, #3320)
 - Added "Safety Concerns" tile that links to St. Olaf's official form for documenting safety concerns (#3345, #3394)
 - Added a prepare statement to apply an upstream fix to the VirtualizedList sticky header calculation (#3357)

--- a/modules/fetch/index.js
+++ b/modules/fetch/index.js
@@ -2,7 +2,7 @@
 
 /* globals Request */
 
-import {cachedFetch} from './cached'
+// import {cachedFetch} from './cached'
 import {userAgent} from '@frogpond/constants'
 import delay from 'delay'
 import queryString from 'query-string'
@@ -93,7 +93,7 @@ class Fetch {
 	}
 
 	async fetch() {
-		let response = await cachedFetch(this.request)
+		let response = await global.fetch(this.request)
 
 		if (this.options.throwHttpErrors && !response.ok) {
 			throw new HTTPError(response)
@@ -109,7 +109,9 @@ class Fetch {
 	}
 }
 
-export const fetch = (
+const doFetch = (
 	input: RequestInfo = '',
 	init?: RequestOptions & ExpandedFetchArgs = {},
 ): ResponsePromise => (new Fetch(input, init): any)
+
+export {doFetch as fetch}


### PR DESCRIPTION
They don't work right.

I'm leaving in the rest of the value-add, like `fetch().json()`, because those are nice additions, and they work.