### PR TITLE
(Maybe) fix sentry sourcemaps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ jobs:
       task: ANDROID
       FASTLANE_SKIP_UPDATE_CHECK: '1'
       FASTLANE_DISABLE_ANIMATION: '1'
-      SENTRY_PROPERTIES: 'android/sentry.properties'
+      SENTRY_PROPERTIES: '../android/sentry.properties'
     steps:
       - checkout
       - run:
@@ -381,7 +381,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: '1'
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
-      SENTRY_PROPERTIES: 'ios/sentry.properties'
+      SENTRY_PROPERTIES: '../ios/sentry.properties'
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout


### PR DESCRIPTION
There's a comment in the fastlane configs about the commands being run
from within the fastlane dir. (as the cwd)

This commit prefixes the `SENTRY_PROPERTIES` environment variable with
`..` so that it... points to the right thing?

Just guessing.