### PR TITLE
Update Rølvaag hours per user suggestion

### DIFF
--- a/data/building-hours/4-3-rølvaag-library.yaml
+++ b/data/building-hours/4-3-rølvaag-library.yaml
@@ -6,8 +6,8 @@ schedule:
   - title: Hours
     hours:
       - {days: [Mo, Tu, We, Th], from: '7:45am', to: '2:00am'}
-      - {days: [Fr], from: '7:45am', to: '6:00pm'}
-      - {days: [Sa], from: '9:00am', to: '6:00pm'}
+      - {days: [Fr], from: '7:45am', to: '9:00pm'}
+      - {days: [Sa], from: '9:00am', to: '9:00pm'}
       - {days: [Su], from: '12:00pm', to: '2:00am'}
 
 breakSchedule:


### PR DESCRIPTION
Rølvaag closes at 9pm on Friday and Saturday.  I verified this against the posted hours on [the website](https://www.stolaf.edu/library/libinfo/hours.cfm) and the user suggestion, as well as the sign which is standing in the lobby today.