### PR TITLE
Enable Renovate lockfile maintenance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,9 +112,9 @@ workflows:
       - jest:
           filters: *filters
           requires: [cache-yarn-linux]
-      - yarn-dedupe:
-          filters: *filters
-          requires: [cache-yarn-linux]
+      # - yarn-dedupe:
+      #     filters: *filters
+      #     requires: [cache-yarn-linux]
       - prettier:
           filters: *filters
           requires: [cache-yarn-linux]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,6 @@ workflows:
       - danger: {requires: [cache-yarn-linux]}
       - flow: {requires: [cache-yarn-linux]}
       - jest: {requires: [cache-yarn-linux]}
-      - yarn-dedupe: {requires: [cache-yarn-linux]}
       - prettier: {requires: [cache-yarn-linux]}
       - eslint: {requires: [cache-yarn-linux]}
       - data: {requires: [cache-yarn-linux]}

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -4,8 +4,9 @@
     ":semanticCommitsDisabled"
   ],
   "lockFileMaintenance": {
+    "enabled": true,
     "schedule": [
-      "after 5pm on every weekday"
+      "before 5am on saturday"
     ]
   },
   "prConcurrentLimit": 10,


### PR DESCRIPTION
I figured out how to turn on the Renovate lockfile deduplication (https://github.com/hawkrives/gobbldygook/commit/ad05d76c9abc85829dc5b1f4db40f45996c2c84d). 

It's now run thrice on GB; it appears to do a combination of "yarn-dedupe" and a "yarn update". 

> 1. https://github.com/hawkrives/gobbldygook/pull/2583
> 2. https://github.com/hawkrives/gobbldygook/pull/2587
> 3. https://github.com/hawkrives/gobbldygook/pull/2591

I think we should turn it on, set to run every evening or so, and turn off the yarn-dedupe Danger rule. 

---

Actually let me rephrase a little

I would like to experiment with replacing the manual Danger rule with the Renovate feature; we would just disable the Danger one temporarily while we enable the Renovate one. 

We could then run the experiment for a week or two, and see how we feel about it afterwards. (Or abort the experiment at any time during, if we want, by probably deleting one line and uncommenting another one.)