### PR TITLE
Fastlane: Use Netrc gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem "fastlane"
+gem "netrc"
 gem 'json'
 gem 'xcodeproj'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     multipart-post (2.0.0)
     nanaimo (0.2.6)
     naturally (2.2.0)
+    netrc (0.11.0)
     os (1.0.0)
     parallel (1.17.0)
     parser (2.6.2.1)
@@ -171,6 +172,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   json
+  netrc
   rubocop (~> 0.60)
   xcodeproj
 

--- a/fastlane/lib/commands.rb
+++ b/fastlane/lib/commands.rb
@@ -26,6 +26,7 @@ end
 def authorize_ci_for_keys
 	token = ENV['GITHUB_KEYS_REPOSITORY_TOKEN']
 
+	# Ensure an entry for github.com exists in ~/.netrc
 	netrc = Netrc.read
 	unless netrc["github.com"]
 		UI.message "An entry for github.com was not found in ~/.netrc; setting..."

--- a/fastlane/lib/commands.rb
+++ b/fastlane/lib/commands.rb
@@ -1,3 +1,5 @@
+require 'netrc'
+
 # Pick what to do - build + deploy, build + sign, or just plain build.
 def auto_beta
 	if should_nightly?
@@ -24,10 +26,11 @@ end
 def authorize_ci_for_keys
 	token = ENV['GITHUB_KEYS_REPOSITORY_TOKEN']
 
-	# see macoscope.com/blog/simplify-your-life-with-fastlane-match
-	# we're allowing the CI access to the keys repo
-	File.open("#{ENV['HOME']}/.netrc", 'a+') do |file|
-		file << "machine github.com\n  login #{token}"
+	netrc = Netrc.read
+	unless netrc["github.com"]
+		UI.message "An entry for github.com was not found in ~/.netrc; setting..."
+		netrc["github.com"] = token
+		netrc.save
 	end
 end
 


### PR DESCRIPTION
Rather than (naïvely and indiscriminately appending to `~/.netrc`, this commit introduces the `netrc` gem, which we can use for reading from and writing to `netrc` files just the same.

Resolves #3662.