### PR TITLE
fastlane/README: Remove dangling ref to ios:refresh_dsyms

### DIFF
--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -90,11 +90,6 @@ Submit a new nightly Beta Build to Testflight
 fastlane ios sourcemap
 ```
 Bundle an iOS sourcemap
-### ios refresh_dsyms
-```
-fastlane ios refresh_dsyms
-```
-Upload dYSM symbols to Bugsnag from Apple
 ### ios ci-run
 ```
 fastlane ios ci-run


### PR DESCRIPTION
We might bring it back under a different or similar name, but it's now out of date. (Subsequent fastlane invocations will keep removing these lines.