### PR TITLE
Revert "enable inline requires in metro bundler"

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -10,7 +10,7 @@ module.exports = {
 		getTransformOptions: () => ({
 			transform: {
 				experimentalImportSupport: false,
-				inlineRequires: true,
+				inlineRequires: false,
 			},
 		}),
 	},


### PR DESCRIPTION
This reverts commit 62183cf21a045d3aa43814462fb267f0a9c67498.

Closes #3646.