### PR TITLE
Fix stoprint release

### DIFF
--- a/source/views/stoprint/print-release.js
+++ b/source/views/stoprint/print-release.js
@@ -159,7 +159,7 @@ export class PrintJobReleaseView extends React.PureComponent<Props, State> {
 		const {printer, job} = this.props.navigation.state.params
 		const {username} = await loadLoginCredentials()
 		const {heldJob} = this.state
-		if (!heldJob) {
+		if (!heldJob || !username) {
 			showGeneralError(this.returnToJobsView)
 			return
 		}

--- a/source/views/stoprint/print-release.js
+++ b/source/views/stoprint/print-release.js
@@ -70,7 +70,7 @@ function PrinterInformation({printer}: {printer: Printer}) {
 
 type Props = TopLevelViewPropsType & {
 	navigation: {
-		state: {params: {job: PrintJob, printer: ?Printer, username: ?string}},
+		state: {params: {job: PrintJob, printer: ?Printer}},
 	},
 }
 
@@ -156,7 +156,8 @@ export class PrintJobReleaseView extends React.PureComponent<Props, State> {
 
 	releaseJob = async () => {
 		this.setState(() => ({status: 'printing'}))
-		const {printer, username, job} = this.props.navigation.state.params
+		const {printer, job} = this.props.navigation.state.params
+		const {username} = await loadLoginCredentials()
 		const {heldJob} = this.state
 		if (!heldJob) {
 			showGeneralError(this.returnToJobsView)


### PR DESCRIPTION
Resolves #3485.

Turns out that we were trying to extract the username from the navigation params, rather than loading them using `loadLoginCredentials`. I guess this never got updated when we moved away from storing login credentials in redux itself. I tested this though and it resolves the issue!