### PR TITLE
Add loginViaCredentials to Stoprint view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed the balances view from refreshing if the user has not agreed to the alert (#3509)
 - Fixed course search crash (#3564)
 - Building signed Android APKs was broken after RN 0.59; now it is fixed (#3569)
+- Fixed an issue where StoPrint jobs failed to release properly (#3730)
+- Fixed StoPrint login issue (#3732)
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -96,7 +96,7 @@ class PrintJobsView extends React.PureComponent<Props, State> {
 
 	fetchData = async () => {
 		await this.logIn()
-		this.props.updatePrintJobs()
+		await this.props.updatePrintJobs()
 	}
 
 	keyExtractor = (item: PrintJob) => item.id.toString()

--- a/source/views/stoprint/print-jobs.js
+++ b/source/views/stoprint/print-jobs.js
@@ -6,7 +6,8 @@ import {Platform, SectionList} from 'react-native'
 import {connect} from 'react-redux'
 import {type ReduxState} from '../../redux'
 import {updatePrintJobs} from '../../redux/parts/stoprint'
-import {type LoginStateEnum} from '../../redux/parts/login'
+import {type LoginStateEnum, logInViaCredentials} from '../../redux/parts/login'
+import {loadLoginCredentials} from '../../lib/login'
 import {type PrintJob, STOPRINT_HELP_PAGE} from '../../lib/stoprint'
 import {
 	ListRow,
@@ -35,6 +36,7 @@ type ReduxStateProps = {
 }
 
 type ReduxDispatchProps = {
+	logInViaCredentials: (string, string) => Promise<any>,
 	updatePrintJobs: () => Promise<any>,
 }
 
@@ -80,7 +82,22 @@ class PrintJobsView extends React.PureComponent<Props, State> {
 		this.setState(() => ({loading: false}))
 	}
 
-	fetchData = () => this.props.updatePrintJobs()
+	logIn = async () => {
+		let {status} = this.props
+		if (status === 'logged-in' || status === 'checking') {
+			return
+		}
+
+		let {username = '', password = ''} = await loadLoginCredentials()
+		if (username && password) {
+			await this.props.logInViaCredentials(username, password)
+		}
+	}
+
+	fetchData = async () => {
+		await this.logIn()
+		this.props.updatePrintJobs()
+	}
 
 	keyExtractor = (item: PrintJob) => item.id.toString()
 
@@ -201,6 +218,8 @@ function mapStateToProps(state: ReduxState): ReduxStateProps {
 
 function mapDispatchToProps(dispatch): ReduxDispatchProps {
 	return {
+		logInViaCredentials: (username, password) =>
+			dispatch(logInViaCredentials(username, password)),
 		updatePrintJobs: () => dispatch(updatePrintJobs()),
 	}
 }


### PR DESCRIPTION
Resolves #3731.

This way, the credentials will be validated by the Olecard API before loading the Stoprint jobs, which is a good thing. Furthermore, the "Not Logged In" message will no longer appear, because the credentials will be validated and the loginState in Redux will be updated! 