### PR TITLE
Turn on Sentry integration

### DIFF
--- a/source/init/sentry.js
+++ b/source/init/sentry.js
@@ -10,7 +10,9 @@ export function bootSentry() {
 		handlePromiseRejection: true,
 	})
 
-	if (!IS_PRODUCTION) {
+	if (IS_PRODUCTION) {
 		config.install()
 	}
 }
+
+bootSentry()

--- a/source/views/settings/screens/overview/developer.js
+++ b/source/views/settings/screens/overview/developer.js
@@ -1,4 +1,5 @@
 // @flow
+import {Sentry, SentrySeverity} from 'react-native-sentry'
 import * as React from 'react'
 import {Section, PushButtonCell} from '@frogpond/tableview'
 import {type NavigationScreenProp} from 'react-navigation'
@@ -9,6 +10,14 @@ export class DeveloperSection extends React.Component<Props> {
 	onAPIButton = () => this.props.navigation.navigate('APITestView')
 	onBonAppButton = () => this.props.navigation.navigate('BonAppPickerView')
 	onDebugButton = () => this.props.navigation.navigate('DebugView')
+	sendSentryMessage = () => {
+		Sentry.captureMessage('A Sentry Message', {
+			level: SentrySeverity.Info,
+		})
+	}
+	sendSentryException = () => {
+		Sentry.captureException(new Error('Debug Exception'))
+	}
 
 	render() {
 		return (
@@ -19,6 +28,14 @@ export class DeveloperSection extends React.Component<Props> {
 					title="Bon Appetit Picker"
 				/>
 				<PushButtonCell onPress={this.onDebugButton} title="Debug" />
+				<PushButtonCell
+					onPress={this.sendSentryMessage}
+					title="Send a Sentry Message"
+				/>
+				<PushButtonCell
+					onPress={this.sendSentryException}
+					title="Send a Sentry Exception"
+				/>
 			</Section>
 		)
 	}


### PR DESCRIPTION
Fun catch today: Sentry wasn't even getting turned on in `IS_PRODUCTION` builds.

Now Sentry _is_ getting turned on.

Also, add a couple of buttons to the debug menu so you can annoy everyone by spamming errors. 💯 