### PR TITLE
Add notice about finals hours

### DIFF
--- a/data/building-hours/0-1-finals.yaml
+++ b/data/building-hours/0-1-finals.yaml
@@ -1,0 +1,6 @@
+name: Finals
+category: Info
+isNotice: true
+noticeMessage: Finals are upon us! Hours may be wrong. Please let us know.
+
+schedule: []


### PR DESCRIPTION
This uses the keys provided in https://github.com/StoDevX/AAO-React-Native/pull/2041, from January 2018, to add a "notice" row to the hours section.