### PR TITLE
🆗 Show alert after dev sentry button is pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Migrated our error handling to Sentry.
 - Enabled inline requires in the metro bundler
 - Updated references to ASC to be CAAS in dictionary and hours
+- Show alert after dev sentry send message or exception 
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)

--- a/source/views/settings/screens/overview/developer.js
+++ b/source/views/settings/screens/overview/developer.js
@@ -1,6 +1,7 @@
 // @flow
 import {Sentry, SentrySeverity} from 'react-native-sentry'
 import * as React from 'react'
+import {Alert} from 'react-native'
 import {Section, PushButtonCell} from '@frogpond/tableview'
 import {type NavigationScreenProp} from 'react-navigation'
 
@@ -14,9 +15,11 @@ export class DeveloperSection extends React.Component<Props> {
 		Sentry.captureMessage('A Sentry Message', {
 			level: SentrySeverity.Info,
 		})
+		Alert.alert('Sentry message sent.')
 	}
 	sendSentryException = () => {
 		Sentry.captureException(new Error('Debug Exception'))
+		Alert.alert('Sentry exception sent.')
 	}
 
 	render() {

--- a/source/views/settings/screens/overview/developer.js
+++ b/source/views/settings/screens/overview/developer.js
@@ -19,7 +19,7 @@ export class DeveloperSection extends React.Component<Props> {
 	}
 	sendSentryException = () => {
 		Sentry.captureException(new Error('Debug Exception'))
-		Alert.alert('Sentry exception sent.')
+		Alert.alert('Sentry exception sent')
 	}
 
 	render() {

--- a/source/views/settings/screens/overview/developer.js
+++ b/source/views/settings/screens/overview/developer.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import {Alert} from 'react-native'
 import {Section, PushButtonCell} from '@frogpond/tableview'
 import {type NavigationScreenProp} from 'react-navigation'
+import {isDevMode} from '@frogpond/constants'
 
 type Props = {navigation: NavigationScreenProp<*>}
 
@@ -15,11 +16,23 @@ export class DeveloperSection extends React.Component<Props> {
 		Sentry.captureMessage('A Sentry Message', {
 			level: SentrySeverity.Info,
 		})
-		Alert.alert('Sentry message sent')
+		this.showSentryAlert()
 	}
 	sendSentryException = () => {
 		Sentry.captureException(new Error('Debug Exception'))
-		Alert.alert('Sentry exception sent')
+		this.showSentryAlert()
+	}
+	showSentryAlert = () => {
+		if (isDevMode()) {
+			Alert.alert(
+				'Sentry button pressed',
+				'Nothing will appear in the dashboard during development.',
+			)
+		} else {
+			Sentry.setEventSentSuccessfully(event => {
+				Alert.alert(`Sent an event to Sentry: ${event.event_id}`)
+			})
+		}
 	}
 
 	render() {

--- a/source/views/settings/screens/overview/developer.js
+++ b/source/views/settings/screens/overview/developer.js
@@ -15,7 +15,7 @@ export class DeveloperSection extends React.Component<Props> {
 		Sentry.captureMessage('A Sentry Message', {
 			level: SentrySeverity.Info,
 		})
-		Alert.alert('Sentry message sent.')
+		Alert.alert('Sentry message sent')
 	}
 	sendSentryException = () => {
 		Sentry.captureException(new Error('Debug Exception'))


### PR DESCRIPTION
A confirmation because feedback is nice.