### PR TITLE
(Try to) Fix Sentry sourcemap association

### DIFF
--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -54,7 +54,7 @@ def upload_sourcemap_to_sentry
 	       'files',
 	       current_bundle_version,
 	       'upload-sourcemaps',
-	       "--dist #{current_bundle_version}",
+	       "--dist #{current_bundle_code}",
 	       "--strip-prefix #{File.expand_path(File.join(__FILE__, '..', '..', '..'))}",
 	       '--rewrite',
 	       args[:sourcemap_output]

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -1,19 +1,3 @@
-# Gets the version, be it from Travis, Testflight, or Google Play
-def current_build_number(**args)
-	return build_number if build_number
-
-	begin
-		case lane_context[:PLATFORM_NAME]
-		when :android
-			(google_play_track_version_codes(track: args[:track]) + 1).to_s
-		when :ios
-			(latest_testflight_build_number + 1).to_s
-		end
-	rescue StandardError
-		'1'
-	end
-end
-
 # get the current build number from the environment
 def build_number
 	travis = ENV['TRAVIS_BUILD_NUMBER']
@@ -36,11 +20,11 @@ def current_bundle_version
 end
 
 # Copy the package.json version into the other version locations
-def propagate_version(**args)
+def propagate_version
 	return unless ENV.key? 'CI'
 
 	version = get_package_key(key: :version)
-	build = current_build_number(track: args[:track] || nil)
+	build = build_number
 
 	UI.message "Propagating version: #{version}"
 	UI.message 'into the Info.plist and build.gradle files'

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -37,7 +37,7 @@ def generate_build_numbers
 end
 
 # Copy the package.json version into the other version locations
-def propagate_version
+def propagate_version(**args)
 	return unless ENV.key? 'CI'
 
 	version = get_package_key(key: :version)

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -1,11 +1,3 @@
-# get the current build number from the environment
-def build_number
-	travis = ENV['TRAVIS_BUILD_NUMBER']
-	# bring circle's build numbers up to pass Travis'?
-	circle = (ENV['CIRCLE_BUILD_NUM'].to_i + 3250).to_s
-	travis || circle
-end
-
 # Get the current "app bundle" version
 def current_bundle_version
 	case lane_context[:PLATFORM_NAME]
@@ -19,23 +11,42 @@ def current_bundle_version
 	end
 end
 
-# Copy the package.json version into the other version locations
-def propagate_version
-	return unless ENV.key? 'CI'
+# Get the current "app bundle" version code (mostly for Sentry)
+def current_bundle_code
+	case lane_context[:PLATFORM_NAME]
+	when :android
+		get_gradle_version_code(gradle_path: lane_context[:GRADLE_FILE])
+	when :ios
+		get_info_plist_value(path: 'ios/AllAboutOlaf/Info.plist',
+		                     key: 'CFBundleVersion')
+	else
+		raise 'wtf'
+	end
+end
 
-	version = get_package_key(key: :version)
-	build = build_number
-
-	UI.message "Propagating version: #{version}"
-	UI.message 'into the Info.plist and build.gradle files'
-
-	UI.message "Setting build number to #{build}"
+# Generate build number
+def generate_build_numbers
+	build = (ENV['CIRCLE_BUILD_NUM'].to_i + 3250).to_s
 
 	# android's build number goes way up because we need to exceed the old build
 	# numbers generated for the x86 build.
 	ci_build_num = build
 	build = ((2 * 1_048_576) + build.to_i).to_s if lane_context[:PLATFORM_NAME] == :android
-	UI.message "Actually setting build number to #{build} because we're on android"
+
+	{ci: ci_build_num, build: build}
+end
+
+# Copy the package.json version into the other version locations
+def propagate_version
+	return unless ENV.key? 'CI'
+
+	version = get_package_key(key: :version)
+
+	UI.message "Propagating version: #{version}"
+	UI.message 'into the Info.plist and build.gradle files'
+
+	build_numbers = generate_build_numbers
+	UI.message "Version codes are {CI: #{build_numbers[:ci]}, distribution: #{build_numbers[:build]}}"
 
 	version = "#{version.split('-')[0]}-pre" if should_nightly?
 	UI.message "Actually putting #{version} into the binaries (because we're doing a nightly)"
@@ -44,16 +55,16 @@ def propagate_version
 	# never set the "+" into the binaries
 	unless version.include? '+'
 		# we always want the CI build number in js-land
-		set_package_data(data: { version: "#{version}+#{ci_build_num}" })
+		set_package_data(data: { version: "#{version}+#{build_numbers[:ci]}" })
 	end
 
 	case lane_context[:PLATFORM_NAME]
 	when :android
 		set_gradle_version_name(version_name: version, gradle_path: lane_context[:GRADLE_FILE])
-		set_gradle_version_code(version_code: build, gradle_path: lane_context[:GRADLE_FILE])
+		set_gradle_version_code(version_code: build_numbers[:build], gradle_path: lane_context[:GRADLE_FILE])
 	when :ios
 		# we're splitting here because iTC can't handle versions with dashes in them
 		increment_version_number(version_number: version.split('-')[0], xcodeproj: ENV['GYM_PROJECT'])
-		increment_build_number(build_number: build, xcodeproj: ENV['GYM_PROJECT'])
+		increment_build_number(build_number: build_numbers[:build], xcodeproj: ENV['GYM_PROJECT'])
 	end
 end


### PR DESCRIPTION
First commit:

>Previously we were just calling `current_build_number` which immediately passed with the results from `build_number`.  Instead, just call `build_number`, which doesn't need `args[:track]`.

Second commit:

>We were previously just sending the value of current_bundle_version as both the `RELEASE_NAME` and `DISTRIBUTION_NAME` parameters for the Sentry CLI, however, this was incorrect.  It seems that Sentry instead associates with the provided `DISTRIBUTION_NAME`, (i.e. iOS'
`CFBundleVersion` or Android's `versionCode`)
>
>So we were uploading with `2.8.0-pre` in both `RELEASE_NAME` and
`DISTRIBUTION_NAME` instead of `2.8.0-pre` for `RELEASE_NAME` and the
distribution version code for `DISTRIBUTION_NAME`
>
>Now, we have a helper that can query against the gradle stuff and get the appropriate values out, and we use that in the sourcemap upload step.

(The commit messages summarize the PR but are included here for reference.)