### PR TITLE
Fix android tabbar crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Building signed Android APKs was broken after RN 0.59; now it is fixed (#3569)
 - Fixed an issue where StoPrint jobs failed to release properly (#3730)
 - Fixed StoPrint login issue (#3732)
+- Fixed a crash that prevented all Android tab views from loading
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/modules/colors/util.js
+++ b/modules/colors/util.js
@@ -15,7 +15,7 @@ export function firstReadable(
 	possibilities = possibilities.map(c => tinycolor(c))
 	let readable = possibilities.find(c => tinycolor.isReadable(c, background))
 	if (readable) {
-		return readable
+		return readable.firstReadable
 	}
 	return tinycolor.mostReadable(background, [black, white])
 }

--- a/modules/colors/util.js
+++ b/modules/colors/util.js
@@ -8,10 +8,7 @@ import {black, white} from './colors'
  * foreground color that is readable (at WCAG AA-Small), or black/white if
  * none of the options were readable.
  */
-export function firstReadable(
-	background: string,
-	possibilities: Array<string>,
-) {
+export function firstReadable(background: string, possibilities: Array<any>) {
 	possibilities = possibilities.map(c => tinycolor(c))
 	let readable = possibilities.find(c => tinycolor.isReadable(c, background))
 	if (readable) {

--- a/modules/colors/util.js
+++ b/modules/colors/util.js
@@ -15,7 +15,7 @@ export function firstReadable(
 	possibilities = possibilities.map(c => tinycolor(c))
 	let readable = possibilities.find(c => tinycolor.isReadable(c, background))
 	if (readable) {
-		return readable.firstReadable
+		return readable.toString()
 	}
-	return tinycolor.mostReadable(background, [black, white])
+	return tinycolor.mostReadable(background, [black, white]).toString()
 }

--- a/modules/colors/util.js
+++ b/modules/colors/util.js
@@ -15,7 +15,7 @@ export function firstReadable(
 	possibilities = possibilities.map(c => tinycolor(c))
 	let readable = possibilities.find(c => tinycolor.isReadable(c, background))
 	if (readable) {
-		return readable.toString()
+		return readable.toRgbString()
 	}
-	return tinycolor.mostReadable(background, [black, white]).toString()
+	return tinycolor.mostReadable(background, [black, white]).toRgbString()
 }

--- a/source/lib/theme.js
+++ b/source/lib/theme.js
@@ -74,7 +74,7 @@ export const iosTabBarActiveColor = sto.purple
 
 export const androidStatusBarColor = tinycolor(navigationBackground)
 	.darken(20)
-	.toString()
+	.toRgbString()
 
 export const statusBarStyle = Platform.select({
 	ios: tinycolor.isReadable('#000', navigationBackground)

--- a/source/views/streaming/radio/station-krlx.js
+++ b/source/views/streaming/radio/station-krlx.js
@@ -15,7 +15,7 @@ const colors: PlayerTheme = {
 	tintColor,
 	buttonTextColor: tinycolor
 		.mostReadable(tintColor, [c.white, c.black])
-		.toString(),
+		.toRgbString(),
 	textColor: tintColor,
 	imageBorderColor: tintColor,
 	imageBackgroundColor: 'transparent',

--- a/source/views/streaming/radio/station-krlx.js
+++ b/source/views/streaming/radio/station-krlx.js
@@ -13,7 +13,9 @@ import {type PlayerTheme} from './types'
 let tintColor = '#33348e'
 const colors: PlayerTheme = {
 	tintColor,
-	buttonTextColor: tinycolor.mostReadable(tintColor, [c.white, c.black]),
+	buttonTextColor: tinycolor
+		.mostReadable(tintColor, [c.white, c.black])
+		.toString(),
 	textColor: tintColor,
 	imageBorderColor: tintColor,
 	imageBackgroundColor: 'transparent',

--- a/source/views/streaming/radio/station-ksto.js
+++ b/source/views/streaming/radio/station-ksto.js
@@ -13,7 +13,9 @@ import {type PlayerTheme} from './types'
 let tintColor = '#37a287'
 const colors: PlayerTheme = {
 	tintColor,
-	buttonTextColor: tinycolor.mostReadable(tintColor, [sto.white, sto.black]),
+	buttonTextColor: tinycolor
+		.mostReadable(tintColor, [sto.white, sto.black])
+		.toString(),
 	textColor: tintColor,
 	imageBorderColor: 'transparent',
 	imageBackgroundColor: tinycolor(tintColor)

--- a/source/views/streaming/radio/station-ksto.js
+++ b/source/views/streaming/radio/station-ksto.js
@@ -15,13 +15,13 @@ const colors: PlayerTheme = {
 	tintColor,
 	buttonTextColor: tinycolor
 		.mostReadable(tintColor, [sto.white, sto.black])
-		.toString(),
+		.toRgbString(),
 	textColor: tintColor,
 	imageBorderColor: 'transparent',
 	imageBackgroundColor: tinycolor(tintColor)
 		.complement()
 		.setAlpha(0.2)
-		.toString(),
+		.toRgbString(),
 }
 
 export class KstoStationView extends React.Component<TopLevelViewPropsType> {


### PR DESCRIPTION
Fixes a crash on all Android tabbed views. They were expecting to receive a hex color string. This uses first readable color (string) instead of that returned instance.