### PR TITLE
html-lib: Update usage of htmlparser2

### DIFF
--- a/modules/html-lib/index.js
+++ b/modules/html-lib/index.js
@@ -1,5 +1,5 @@
 // @flow
-import htmlparser from 'htmlparser2'
+import htmlparser2 from 'htmlparser2'
 import cssSelect from 'css-select'
 export {cssSelect}
 
@@ -8,7 +8,7 @@ import {AllHtmlEntities} from 'html-entities'
 export const entities = new AllHtmlEntities()
 
 export function parseHtml(string: string): Object {
-	return htmlparser.parseDOM(string, {
+	return htmlparser2.parseDOM(string, {
 		withDomLvl1: true,
 		normalizeWhitespace: false,
 		xmlMode: false,

--- a/modules/html-lib/index.js
+++ b/modules/html-lib/index.js
@@ -1,5 +1,5 @@
 // @flow
-import htmlparser2 from 'htmlparser2'
+import {parseDOM} from 'htmlparser2'
 import cssSelect from 'css-select'
 export {cssSelect}
 
@@ -8,7 +8,7 @@ import {AllHtmlEntities} from 'html-entities'
 export const entities = new AllHtmlEntities()
 
 export function parseHtml(string: string): Object {
-	return htmlparser2.parseDOM(string, {
+	return parseDOM(string, {
 		withDomLvl1: true,
 		normalizeWhitespace: false,
 		xmlMode: false,


### PR DESCRIPTION
Inspired by [this line][a] and [this line][b], I decided to try simply adding a 2.  Flow, Jest, and the rest of the tools seem to agree that this looks like a good change.

Have not verified that this actually fixes the broken views, but for now I will note that this seems to be the resolution for #3921.

[a]: https://github.com/fb55/htmlparser2/commit/759b1220c03e55a895f971deab9f1e94c30a7f61#diff-04c6e90faac2675aa89e2176d2eec7d8L19
[b]: https://github.com/fb55/htmlparser2/commit/759b1220c03e55a895f971deab9f1e94c30a7f61#diff-04c6e90faac2675aa89e2176d2eec7d8R21