### PR TITLE
Remove coveralls from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,16 +216,6 @@ jobs:
       - danger
       - store_test_results:
           path: ./test-results
-      - run: yarn global add coveralls
-      - run:
-          name: coveralls
-          command: |
-            export PATH=$PATH:$(yarn global bin)
-            export COVERALLS_SERVICE_NAME=CircleCI
-            export COVERALLS_SERVICE_JOB_ID=$CIRCLE_BUILD_NUM
-            if ! [[ $CIRCLE_PR_NUMBER ]]; then
-              coveralls < ./coverage/lcov.info
-            fi
 
   prettier:
     executor: node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed Google Analytics tracking (#3517)
 - Removed the `data` prop on other-transport modes and important contacts (#3528)
 - Removed the remaining references to BugSnag
+- Removed coveralls coverage reporting
 
 ## [2.6.3] - 2018-09-17
 ### Fixed


### PR DESCRIPTION
> at least it's not a 503 today

We're hitting a 405 on our PRs, so let's say goodbye for now.