### PR TITLE
🏗 Adopt GitHub Actions and switch to CodeCov for coverage!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,53 +90,6 @@ commands:
 
 workflows:
   version: 2
-  analyze-and-build:
-    # The way this works is, Circle runs analyze-and-build on every commit
-    # to every branch.
-    # Fastlane checks the environment to see if it should build or deploy,
-    # and if there's a tag then it deploys (otherwise it just builds.)
-    # These same jobs are run by the "nightly" workflow, which has a
-    # different CIRCLE_WORKFLOW_ID, which should allow us to only deploy
-    # nightlies from that branch.
-    jobs: &basic-jobs
-      - cache-yarn-linux:
-          filters: &filters {tags: {only: /.*/}}
-      - cache-bundler-linux:
-          filters: &filters {tags: {only: /.*/}}
-      - danger:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - flow:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - jest:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      # - yarn-dedupe:
-      #     filters: *filters
-      #     requires: [cache-yarn-linux]
-      - prettier:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - eslint:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - data:
-          filters: *filters
-          requires: [cache-yarn-linux]
-      - ios:
-          filters: *filters
-          requires: [danger, flow, jest, prettier, eslint, data]
-      - android:
-          filters: *filters
-          requires:
-            [danger, flow, jest, prettier, eslint, data, cache-bundler-linux]
-      - ios-bundle:
-          filters: *filters
-          requires: [danger, flow, jest, prettier, eslint, data]
-      - android-bundle:
-          filters: *filters
-          requires: [danger, flow, jest, prettier, eslint, data]
   nightly:
     triggers:
       - schedule:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach"
+  behavior: default
+  require_changes: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: '70...100'
 
   status:
     project: yes
@@ -21,6 +21,6 @@ parsers:
       macro: no
 
 comment:
-  layout: "reach"
+  layout: 'reach'
   behavior: default
   require_changes: no

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -10,4 +10,5 @@ jobs:
     - uses: actions/checkout@master
     - run: yarn install
     - run: yarn run bundle-data
+    - run: yarn run pretty
     - run: yarn run flow check

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -8,4 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - run: yarn install
     - run: yarn run flow

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -22,28 +22,6 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
 
-  bundle-android:
-    name: Test Android Bundle
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-node@master
-        with: {node-version: ^12.0}
-      - uses: actions/checkout@master
-      - run: yarn install --frozen-lockfile
-      - run: yarn run bundle-data
-      - run: yarn run --silent bundle:android
-
-  bundle-ios:
-    name: Test iOS Bundle
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-node@master
-        with: {node-version: ^12.0}
-      - uses: actions/checkout@master
-      - run: yarn install --frozen-lockfile
-      - run: yarn run bundle-data
-      - run: yarn run --silent bundle:ios
-
   android:
     name: Build for Android
     runs-on: ubuntu-latest

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -7,4 +7,5 @@ jobs:
     name: Flow
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@master
     - run: yarn run flow

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -45,6 +45,7 @@ jobs:
       - run: yarn run --silent bundle:ios
 
   android:
+    name: Build for Android
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@master
@@ -69,6 +70,7 @@ jobs:
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
 
   ios:
+    name: Build for iOS
     runs-on: macOS-latest
     steps:
       - uses: actions/setup-node@master

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -60,6 +60,8 @@ jobs:
         env:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MAPBOX_KEY: ${{ secrets.MAPBOX_KEY }}
+          ONESIGNAL_KEY: ${{ secrets.ONESIGNAL_KEY }}
           GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'
@@ -80,6 +82,8 @@ jobs:
         env:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MAPBOX_KEY: ${{ secrets.MAPBOX_KEY }}
+          ONESIGNAL_KEY: ${{ secrets.ONESIGNAL_KEY }}
           GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -78,7 +78,7 @@ jobs:
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle
       - run: brew tap wix/brew
       - run: brew install applesimutils
-      - run: bundle exec fastlane ios ci-run
+      - run: timeout 90m bundle exec fastlane ios ci-run
         env:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@master
-        with:
-          version: ^12.0
+        with: {version: ^12.0}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: yarn run bundle-data

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@master
-        with: {version: ^12.0}
+        with: {node-version: ^12.0}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: yarn run bundle-data
@@ -23,20 +23,22 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash)
 
   bundle-android:
+    name: Test Android Bundle
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@master
-        with: { version: ^12.0 }
+        with: {node-version: ^12.0}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: yarn run bundle-data
       - run: yarn run --silent bundle:android
 
   bundle-ios:
+    name: Test iOS Bundle
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@master
-        with: { version: ^12.0 }
+        with: {node-version: ^12.0}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: yarn run bundle-data
@@ -46,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@master
-        with: { version: ^12.0 }
+        with: {node-version: ^12.0}
       - uses: actions/setup-ruby@master
         with: {ruby-version: ^2.6}
       - uses: actions/checkout@master

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -58,4 +58,30 @@ jobs:
       - run: echo 'org.gradle.workers.max=2' >> ./android/gradle.properties
       - run: bundle exec fastlane android ci-run
         env:
+          GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_DISABLE_ANIMATION: '1'
+          SENTRY_PROPERTIES: '../android/sentry.properties'
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
+
+  ios:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/setup-node@master
+        with: {node-version: ^12.0}
+      - uses: actions/setup-ruby@master
+        with: {ruby-version: ^2.6}
+      - uses: actions/checkout@master
+      - run: yarn install --frozen-lockfile
+      - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle
+      - run: brew tap wix/brew
+      - run: brew install applesimutils
+      - run: bundle exec fastlane ios ci-run
+        env:
+          GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_DISABLE_ANIMATION: '1'
+          SENTRY_PROPERTIES: '../ios/sentry.properties'
+          GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
+      - run: yarn detox build e2e --configuration ios.sim.release | xcpretty
+      - run: yarn detox test e2e --configuration ios.sim.release --cleanup

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -7,18 +7,18 @@ jobs:
     name: js
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-node@master
-      with:
-        version: ^12.0
-    - uses: actions/checkout@master
-    - run: yarn install
-    - run: yarn run bundle-data
-    - run: yarn run pretty
-    - run: yarn run flow check
-    - run: yarn run lint
-    - name: Run tests
-      run: yarn run test --coverage
-    - name: Upload coverage
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: bash <(curl -s https://codecov.io/bash)
+      - uses: actions/setup-node@master
+        with:
+          version: ^12.0
+      - uses: actions/checkout@master
+      - run: yarn install
+      - run: yarn run bundle-data
+      - run: yarn run pretty
+      - run: yarn run flow check
+      - run: yarn run lint
+      - name: Run tests
+        run: yarn run test --coverage
+      - name: Upload coverage
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -78,7 +78,7 @@ jobs:
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle
       - run: brew tap wix/brew
       - run: brew install applesimutils
-      - run: timeout 90m bundle exec fastlane ios ci-run
+      - run: bundle exec fastlane ios ci-run
         env:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -42,3 +42,14 @@ jobs:
       - run: yarn run bundle-data
       - run: yarn run --silent bundle:ios
 
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@master
+        with: { version: ^12.0 }
+      - uses: actions/checkout@master
+      - run: yarn install --frozen-lockfile
+      - run: bundle check || bundle install --frozen --path vendor/bundle
+      - run: android/gradlew androidDependencies --console=plain
+      - run: echo 'org.gradle.workers.max=2' >> android/gradle.properties
+      - run: bundle exec fastlane android ci-run

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -7,6 +7,9 @@ jobs:
     name: js
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/setup-node@master
+      with:
+        version: ^12.0
     - uses: actions/checkout@master
     - run: yarn install
     - run: yarn run bundle-data

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -55,3 +55,5 @@ jobs:
       - run: cd android && ./gradlew androidDependencies --console=plain
       - run: echo 'org.gradle.workers.max=2' >> ./android/gradle.properties
       - run: bundle exec fastlane android ci-run
+        env:
+          GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -18,3 +18,7 @@ jobs:
     - run: yarn run lint
     - name: Run tests
       run: yarn run test --coverage
+    - name: Upload coverage
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -1,3 +1,10 @@
 name: Analyze and build the source
 
 on: push
+
+jobs:
+  flow:
+    name: Flow
+    runs-on: ubuntu-latest
+    steps:
+    - run: yarn run flow

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           version: ^12.0
       - uses: actions/checkout@master
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
       - run: yarn run bundle-data
       - run: yarn run pretty
       - run: yarn run flow check

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   js:
-    name: js
+    name: Run JavaScript Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@master

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -1,1 +1,3 @@
 name: Analyze and build the source
+
+on: push

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -1,4 +1,4 @@
-name: Analyze and build the source
+name: Analyze and Build
 
 on: push
 

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -22,3 +22,5 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
+      - run: yarn run --silent bundle:android
+      - run: yarn run --silent bundle:ios

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-node@master
         with: { version: ^12.0 }
       - uses: actions/setup-ruby@master
-        with: {ruby-version: '2.x'}
+        with: {ruby-version: ^2.6}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -1,0 +1,1 @@
+name: Analyze and build the source

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -58,6 +58,8 @@ jobs:
       - run: echo 'org.gradle.workers.max=2' >> ./android/gradle.properties
       - run: bundle exec fastlane android ci-run
         env:
+          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'
@@ -76,6 +78,8 @@ jobs:
       - run: brew install applesimutils
       - run: bundle exec fastlane ios ci-run
         env:
+          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -47,11 +47,9 @@ jobs:
     steps:
       - uses: actions/setup-node@master
         with: { version: ^12.0 }
-      - uses: actions/setup-ruby@master
-        with: {ruby-version: '>= 2.6.3'}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
-      - run: bundle check || bundle install --frozen --path vendor/bundle
+      - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle
       - run: android/gradlew androidDependencies --console=plain
       - run: echo 'org.gradle.workers.max=2' >> android/gradle.properties
       - run: bundle exec fastlane android ci-run

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - uses: actions/setup-node@master
         with: { version: ^12.0 }
+      - uses: actions/setup-ruby@master
+        with: { ruby-version: 2.6.3 }
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: bundle check || bundle install --frozen --path vendor/bundle

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -78,6 +78,7 @@ jobs:
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle
       - run: brew tap wix/brew
       - run: brew install applesimutils
+      - run: sudo xcode-select -switch /Applications/Xcode_10.3.app
       - run: bundle exec fastlane ios ci-run
         env:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -9,4 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: yarn install
-    - run: yarn run flow
+    - name: Bundle data, then run flow
+      run: |
+        yarn run bundle-data
+        yarn run flow check

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   js:
-    name: Run JavaScript Checks
+    name: JavaScript Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@master

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -12,3 +12,4 @@ jobs:
     - run: yarn run bundle-data
     - run: yarn run pretty
     - run: yarn run flow check
+    - run: yarn run lint

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - uses: actions/setup-node@master
         with: { version: ^12.0 }
+      - uses: actions/setup-ruby@master
+        with: {ruby-version: '2.x'}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-node@master
         with: { version: ^12.0 }
       - uses: actions/setup-ruby@master
-        with: { ruby-version: 2.6.3 }
+        with: {ruby-version: >= 2.6.3}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: bundle check || bundle install --frozen --path vendor/bundle

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -3,8 +3,8 @@ name: Analyze and build the source
 on: push
 
 jobs:
-  flow:
-    name: Flow
+  js:
+    name: js
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -78,7 +78,6 @@ jobs:
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle
       - run: brew tap wix/brew
       - run: brew install applesimutils
-      - run: sudo xcode-select -switch /Applications/Xcode_10.3.app
       - run: bundle exec fastlane ios ci-run
         env:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -21,5 +21,24 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash)
+
+  bundle-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@master
+        with: { version: ^12.0 }
+      - uses: actions/checkout@master
+      - run: yarn install --frozen-lockfile
+      - run: yarn run bundle-data
       - run: yarn run --silent bundle:android
+
+  bundle-ios:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@master
+        with: { version: ^12.0 }
+      - uses: actions/checkout@master
+      - run: yarn install --frozen-lockfile
+      - run: yarn run bundle-data
       - run: yarn run --silent bundle:ios
+

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -52,6 +52,6 @@ jobs:
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle
-      - run: android/gradlew androidDependencies --console=plain
-      - run: echo 'org.gradle.workers.max=2' >> android/gradle.properties
+      - run: cd android && ./gradlew androidDependencies --console=plain
+      - run: echo 'org.gradle.workers.max=2' >> ./android/gradle.properties
       - run: bundle exec fastlane android ci-run

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -9,7 +9,5 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: yarn install
-    - name: Bundle data, then run flow
-      run: |
-        yarn run bundle-data
-        yarn run flow check
+    - run: yarn run bundle-data
+    - run: yarn run flow check

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -13,3 +13,5 @@ jobs:
     - run: yarn run pretty
     - run: yarn run flow check
     - run: yarn run lint
+    - name: Run tests
+      run: yarn run test --coverage

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-node@master
         with: { version: ^12.0 }
       - uses: actions/setup-ruby@master
-        with: {ruby-version: >= 2.6.3}
+        with: {ruby-version: '>= 2.6.3'}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: bundle check || bundle install --frozen --path vendor/bundle

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -69,8 +69,6 @@ jobs:
     steps:
       - uses: actions/setup-node@master
         with: {node-version: ^12.0}
-      - uses: actions/setup-ruby@master
-        with: {ruby-version: ^2.6}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle

--- a/fastlane/lib/commands.rb
+++ b/fastlane/lib/commands.rb
@@ -28,13 +28,11 @@ def authorize_ci_for_keys
 
 	# Ensure an entry for github.com exists in ~/.netrc
 	netrc = Netrc.read
-	puts "Before: " + `cat ~/.netrc | wc -c`
 	unless netrc["github.com"]
 		UI.message "An entry for github.com was not found in ~/.netrc; setting..."
-		netrc["github.com"] = token
+		netrc["github.com"] = token, nil
 		netrc.save
 	end
-	puts " After: " + `cat ~/.netrc | wc -c`
 end
 
 # Clone the match repo (for Android)

--- a/fastlane/lib/commands.rb
+++ b/fastlane/lib/commands.rb
@@ -30,7 +30,7 @@ def authorize_ci_for_keys
 	netrc = Netrc.read
 	unless netrc["github.com"]
 		UI.message "An entry for github.com was not found in ~/.netrc; setting..."
-		netrc["github.com"] = token, nil
+		netrc["github.com"] = token, ''
 		netrc.save
 	end
 end

--- a/fastlane/lib/commands.rb
+++ b/fastlane/lib/commands.rb
@@ -28,11 +28,13 @@ def authorize_ci_for_keys
 
 	# Ensure an entry for github.com exists in ~/.netrc
 	netrc = Netrc.read
+	puts "Before: " + `cat ~/.netrc | wc -c`
 	unless netrc["github.com"]
 		UI.message "An entry for github.com was not found in ~/.netrc; setting..."
 		netrc["github.com"] = token
 		netrc.save
 	end
+	puts " After: " + `cat ~/.netrc | wc -c`
 end
 
 # Clone the match repo (for Android)

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -26,6 +26,7 @@ end
 
 # Generate build number
 def build_number
+	# Should last until ~2080 for Android.
 	DateTime.now.to_time.to_i - DateTime.parse("2014-01-01").to_time.to_i
 end
 

--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -25,15 +25,8 @@ def current_bundle_code
 end
 
 # Generate build number
-def generate_build_numbers
-	build = (ENV['CIRCLE_BUILD_NUM'].to_i + 3250).to_s
-
-	# android's build number goes way up because we need to exceed the old build
-	# numbers generated for the x86 build.
-	ci_build_num = build
-	build = ((2 * 1_048_576) + build.to_i).to_s if lane_context[:PLATFORM_NAME] == :android
-
-	{ci: ci_build_num, build: build}
+def build_number
+	DateTime.now.to_time.to_i - DateTime.parse("2014-01-01").to_time.to_i
 end
 
 # Copy the package.json version into the other version locations
@@ -45,8 +38,8 @@ def propagate_version(**args)
 	UI.message "Propagating version: #{version}"
 	UI.message 'into the Info.plist and build.gradle files'
 
-	build_numbers = generate_build_numbers
-	UI.message "Version codes are {CI: #{build_numbers[:ci]}, distribution: #{build_numbers[:build]}}"
+	number = build_number
+	UI.message "Version code is #{number}"
 
 	version = "#{version.split('-')[0]}-pre" if should_nightly?
 	UI.message "Actually putting #{version} into the binaries (because we're doing a nightly)"
@@ -55,16 +48,16 @@ def propagate_version(**args)
 	# never set the "+" into the binaries
 	unless version.include? '+'
 		# we always want the CI build number in js-land
-		set_package_data(data: { version: "#{version}+#{build_numbers[:ci]}" })
+		set_package_data(data: { version: "#{version}+#{number}" })
 	end
 
 	case lane_context[:PLATFORM_NAME]
 	when :android
 		set_gradle_version_name(version_name: version, gradle_path: lane_context[:GRADLE_FILE])
-		set_gradle_version_code(version_code: build_numbers[:build], gradle_path: lane_context[:GRADLE_FILE])
+		set_gradle_version_code(version_code: number, gradle_path: lane_context[:GRADLE_FILE])
 	when :ios
 		# we're splitting here because iTC can't handle versions with dashes in them
 		increment_version_number(version_number: version.split('-')[0], xcodeproj: ENV['GYM_PROJECT'])
-		increment_build_number(build_number: build_numbers[:build], xcodeproj: ENV['GYM_PROJECT'])
+		increment_build_number(build_number: number, xcodeproj: ENV['GYM_PROJECT'])
 	end
 end

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -2098,7 +2098,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = TMK6S7TPX2;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -2098,7 +2098,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEBUG_INFORMATION_FORMAT = "dwarf";
 				DEVELOPMENT_TEAM = TMK6S7TPX2;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = OneSignalNotificationServiceExtension/Info.plist;


### PR DESCRIPTION
# Background

This repository finally has access to the GitHub Actions-based CI/CD offering directly by GitHub, so we thought it was time to migrate! A lot of the commit history here is me "battling" GitHub Actions to get everything functional, but I did try to keep each commit relatively small and reviewable, so it might be easier to go through each commit and review individual items.

# Motivation

CI/CD with GitHub is free for OSS projects, of which we are one. This means it's a great idea for us to switch so that we get multiple parallel macOS executors. Plus, porting CI configurations is one of our specialties at this point, so another exercise was long due.

# Architecture

I have placed things into a total of five builds. Instead of inter-dependent (staged) builds, all will run at once. This is because our prior strategy was to test the stuff that was most likely to break first. However, with unlimited resources, it isn't necessary. We can always add `needs` configurations in the future if we need to have structure/prevent swamping GitHub.

# Subtasks

- [x] Remove `analyze-and-build` workflow from CircleCI configuration
- [x] Port `analyze-and-build` workflow from Circle into GitHub Actions
- [x] Disable Coveralls
- [x] Set up CodeCov

(We also had some stuff here for the new nightlies, but those aren't blockers on this PR)

# Questions to be answered

- [x] Should we get rid of Danger in favor of (hopefully) future support for the annotations API? Or does it need to be added back? @hawkrives, might I defer work on that to you?