### PR TITLE
Align empty notice views

### DIFF
--- a/modules/event-list/event-list.js
+++ b/modules/event-list/event-list.js
@@ -75,6 +75,7 @@ export class EventList extends React.Component<Props> {
 			<SectionList
 				ItemSeparatorComponent={FullWidthSeparator}
 				ListEmptyComponent={<NoticeView text="No events." />}
+				contentContainerStyle={styles.contentContainer}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.props.onRefresh}
 				refreshing={this.props.refreshing}
@@ -92,5 +93,8 @@ const styles = StyleSheet.create({
 	container: {
 		flex: 1,
 		backgroundColor: c.white,
+	},
+	contentContainer: {
+		flexGrow: 1,
 	},
 })

--- a/modules/food-menu/fancy-menu.js
+++ b/modules/food-menu/fancy-menu.js
@@ -54,6 +54,9 @@ const styles = StyleSheet.create({
 	message: {
 		paddingVertical: 16,
 	},
+	contentContainer: {
+		flexGrow: 1,
+	},
 })
 
 const LEFT_MARGIN = 28
@@ -204,6 +207,7 @@ export class FancyMenu extends React.Component<Props, State> {
 				ItemSeparatorComponent={Separator}
 				ListEmptyComponent={messageView}
 				ListHeaderComponent={header}
+				contentContainerStyle={styles.contentContainer}
 				extraData={filters}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.props.onRefresh}

--- a/modules/lists/list-empty.js
+++ b/modules/lists/list-empty.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react'
-import {View, Text} from 'react-native'
+import {NoticeView} from '@frogpond/notice'
 
 type Props = {
 	mode: 'bug' | 'normal',
@@ -8,10 +8,6 @@ type Props = {
 
 export class ListEmpty extends React.PureComponent<Props> {
 	render() {
-		return (
-			<View>
-				<Text>List is empty</Text>
-			</View>
-		)
+		return <NoticeView text="List is empty" />
 	}
 }

--- a/source/views/building-hours/list.js
+++ b/source/views/building-hours/list.js
@@ -10,12 +10,14 @@ import type {BuildingType} from './types'
 
 import * as c from '@frogpond/colors'
 import {ListSeparator, ListSectionHeader} from '@frogpond/lists'
+import {NoticeView} from '@frogpond/notice'
 
 export {BuildingHoursDetailView} from './detail'
 
 const styles = StyleSheet.create({
 	container: {
 		backgroundColor: c.white,
+		flexGrow: 1,
 	},
 })
 
@@ -50,6 +52,7 @@ export class BuildingHoursList extends React.PureComponent<Props> {
 		return (
 			<SectionList
 				ItemSeparatorComponent={ListSeparator}
+				ListEmptyComponent={<NoticeView text="No hours." />}
 				contentContainerStyle={styles.container}
 				extraData={this.props}
 				keyExtractor={this.keyExtractor}

--- a/source/views/contacts/list.js
+++ b/source/views/contacts/list.js
@@ -28,6 +28,9 @@ const styles = StyleSheet.create({
 	listContainer: {
 		backgroundColor: c.white,
 	},
+	contentContainer: {
+		flexGrow: 1,
+	},
 })
 
 type Props = TopLevelViewPropsType
@@ -85,6 +88,7 @@ export class ContactsListView extends React.PureComponent<Props, State> {
 			<SectionList
 				ItemSeparatorComponent={ListSeparator}
 				ListEmptyComponent={<ListEmpty mode="bug" />}
+				contentContainerStyle={styles.contentContainer}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.refresh}
 				refreshing={this.state.loading}

--- a/source/views/dictionary/list.js
+++ b/source/views/dictionary/list.js
@@ -49,6 +49,9 @@ const styles = StyleSheet.create({
 	rowDetailText: {
 		fontSize: 14,
 	},
+	contentContainer: {
+		flexGrow: 1,
+	},
 })
 
 type Props = TopLevelViewPropsType
@@ -111,6 +114,7 @@ export function DictionaryView(props: Props) {
 				ListEmptyComponent={
 					<NoticeView text={`No results found for "${query}"`} />
 				}
+				contentContainerStyle={styles.contentContainer}
 				keyExtractor={(item: WordType, index) => item.word + index}
 				keyboardDismissMode="on-drag"
 				keyboardShouldPersistTaps="never"

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -13,6 +13,9 @@ const styles = StyleSheet.create({
 	listContainer: {
 		backgroundColor: c.white,
 	},
+	contentContainer: {
+		flexGrow: 1,
+	},
 })
 
 type Props = TopLevelViewPropsType & {
@@ -55,6 +58,7 @@ export class NewsList extends React.PureComponent<Props> {
 			<FlatList
 				ItemSeparatorComponent={this.renderSeparator}
 				ListEmptyComponent={<NoticeView text="No news." />}
+				contentContainerStyle={styles.contentContainer}
 				data={entries}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.props.onRefresh}

--- a/source/views/sis/course-search/results.js
+++ b/source/views/sis/course-search/results.js
@@ -164,6 +164,7 @@ class CourseSearchResultsView extends React.Component<Props, State> {
 				<CourseResultsList
 					key={searchQuery.toLowerCase()}
 					applyFilters={this.props.applyFilters}
+					contentContainerStyle={styles.contentContainer}
 					courses={this.props.allCourses}
 					filters={filters}
 					filtersLoaded={filtersLoaded}
@@ -205,6 +206,9 @@ let styles = StyleSheet.create({
 	},
 	common: {
 		backgroundColor: c.white,
+	},
+	contentContainer: {
+		flexGrow: 1,
 	},
 	darken: {},
 })

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -21,6 +21,9 @@ const styles = StyleSheet.create({
 	listContainer: {
 		backgroundColor: c.white,
 	},
+	contentContainer: {
+		flexGrow: 1,
+	},
 })
 
 type Props = TopLevelViewPropsType
@@ -124,6 +127,7 @@ export default class StudentWorkView extends React.PureComponent<Props, State> {
 				ListEmptyComponent={
 					<NoticeView text="There are no open job postings." />
 				}
+				contentContainerStyle={styles.contentContainer}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.refresh}
 				refreshing={this.state.refreshing}

--- a/source/views/streaming/streams/list.js
+++ b/source/views/streaming/streams/list.js
@@ -20,6 +20,9 @@ const styles = StyleSheet.create({
 	listContainer: {
 		backgroundColor: c.white,
 	},
+	contentContainer: {
+		flexGrow: 1,
+	},
 })
 
 type Props = {}
@@ -120,6 +123,7 @@ export class StreamListView extends React.PureComponent<Props, State> {
 			<SectionList
 				ItemSeparatorComponent={ListSeparator}
 				ListEmptyComponent={<NoticeView text="No Streams" />}
+				contentContainerStyle={styles.contentContainer}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.refresh}
 				refreshing={this.state.refreshing}

--- a/source/views/student-orgs/list.js
+++ b/source/views/student-orgs/list.js
@@ -49,6 +49,9 @@ const styles = StyleSheet.create({
 		flex: 1,
 		backgroundColor: white,
 	},
+	contentContainer: {
+		flexGrow: 1,
+	},
 })
 
 type Props = TopLevelViewPropsType
@@ -127,6 +130,7 @@ export function StudentOrgsView(props: Props) {
 				ListEmptyComponent={
 					<NoticeView text={`No results found for "${query}"`} />
 				}
+				contentContainerStyle={styles.contentContainer}
 				keyExtractor={(item, index) => item.name + index}
 				keyboardDismissMode="on-drag"
 				keyboardShouldPersistTaps="never"

--- a/source/views/transportation/other-modes/list.js
+++ b/source/views/transportation/other-modes/list.js
@@ -25,6 +25,9 @@ const styles = StyleSheet.create({
 	listContainer: {
 		backgroundColor: c.white,
 	},
+	contentContainer: {
+		flexGrow: 1,
+	},
 })
 
 type Props = TopLevelViewPropsType
@@ -97,6 +100,7 @@ export class OtherModesView extends React.PureComponent<Props, State> {
 			<SectionList
 				ItemSeparatorComponent={ListSeparator}
 				ListEmptyComponent={<ListEmpty mode="bug" />}
+				contentContainerStyle={styles.contentContainer}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.refresh}
 				refreshing={this.state.refreshing}


### PR DESCRIPTION
Closes #3997.

* This PR takes on the task of centering our empty notices on SectionLists and FlatLists.
* Adding `contentContainerStyle` to our lists with `flexGrow: 1` handles this nicely.
* Adds an empty list component to building hours
* Converts ListEmpty from a TextView/View to a NoticeView

<details>
<summary>📸 Screenshots</summary>

Before | After
--|--
<img width="486" alt="Screen Shot 2019-09-12 at 7 04 05 PM" src="https://user-images.githubusercontent.com/5240843/64835016-3e184000-d599-11e9-95fe-72355f33b1d6.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 05 27 PM" src="https://user-images.githubusercontent.com/5240843/64835017-3e184000-d599-11e9-98f1-5e75b227778e.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 11 55 PM" src="https://user-images.githubusercontent.com/5240843/64835018-3eb0d680-d599-11e9-9ab1-d7ed31b6f615.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 13 01 PM" src="https://user-images.githubusercontent.com/5240843/64835019-3eb0d680-d599-11e9-8c58-3341df1cb293.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 17 18 PM" src="https://user-images.githubusercontent.com/5240843/64835021-3eb0d680-d599-11e9-8c53-e441e940dbf2.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 16 52 PM" src="https://user-images.githubusercontent.com/5240843/64835020-3eb0d680-d599-11e9-8dbb-5b372ca5e695.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 18 30 PM" src="https://user-images.githubusercontent.com/5240843/64835022-3eb0d680-d599-11e9-9c15-e2dfd230d0dd.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 19 03 PM" src="https://user-images.githubusercontent.com/5240843/64835024-3eb0d680-d599-11e9-872c-54ec681dc2d0.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 23 57 PM" src="https://user-images.githubusercontent.com/5240843/64835026-3f496d00-d599-11e9-9e8e-c584293e6e91.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 20 07 PM" src="https://user-images.githubusercontent.com/5240843/64835025-3f496d00-d599-11e9-9754-f08795d2f1b6.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 26 50 PM" src="https://user-images.githubusercontent.com/5240843/64835028-3f496d00-d599-11e9-925b-c5255eb86211.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 26 00 PM" src="https://user-images.githubusercontent.com/5240843/64835027-3f496d00-d599-11e9-93ca-6fe9e9285964.png"> 
<img width="486" alt="Screen Shot 2019-09-12 at 7 30 22 PM" src="https://user-images.githubusercontent.com/5240843/64835029-3f496d00-d599-11e9-9d35-89dd89e913c1.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 30 39 PM" src="https://user-images.githubusercontent.com/5240843/64835030-3f496d00-d599-11e9-928f-ba41068d8d85.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 32 56 PM" src="https://user-images.githubusercontent.com/5240843/64835031-3fe20380-d599-11e9-9add-f9c65f6477a5.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 34 14 PM" src="https://user-images.githubusercontent.com/5240843/64835032-3fe20380-d599-11e9-9411-d9099816df0b.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 36 56 PM" src="https://user-images.githubusercontent.com/5240843/64835033-3fe20380-d599-11e9-9105-d30772964627.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 37 09 PM" src="https://user-images.githubusercontent.com/5240843/64835034-3fe20380-d599-11e9-989f-8190fd8c5f09.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 38 29 PM" src="https://user-images.githubusercontent.com/5240843/64835035-3fe20380-d599-11e9-955f-f95197ea1849.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 39 19 PM" src="https://user-images.githubusercontent.com/5240843/64835036-3fe20380-d599-11e9-9d15-8f7bc013bdc7.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 40 04 PM" src="https://user-images.githubusercontent.com/5240843/64835037-407a9a00-d599-11e9-882f-39fcf20fc154.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 40 37 PM" src="https://user-images.githubusercontent.com/5240843/64835038-407a9a00-d599-11e9-85e1-3bd45d229ae8.png">
<img width="486" alt="Screen Shot 2019-09-12 at 7 49 51 PM" src="https://user-images.githubusercontent.com/5240843/64835039-407a9a00-d599-11e9-8bb8-631b0c55548f.png"> | <img width="486" alt="Screen Shot 2019-09-12 at 7 50 31 PM" src="https://user-images.githubusercontent.com/5240843/64835040-407a9a00-d599-11e9-84bd-d501ac3782c0.png">

</details>