### PR TITLE
Change the Directory view endpoint

### DIFF
--- a/source/views/views.js
+++ b/source/views/views.js
@@ -73,7 +73,7 @@ export const allViews: Array<ViewType> = [
 	},
 	{
 		type: 'url',
-		url: 'https://www.stolaf.edu/personal/index.cfm',
+		url: 'https://www.stolaf.edu/directory',
 		view: 'DirectoryView',
 		title: 'Directory',
 		icon: 'v-card',


### PR DESCRIPTION
I change it to `/directory` because that redirects within the same path; I could change it to `/directory/search`, but I don't want to pin to the `search` endpoint. This also keeps the redirect mostly open-ended server-side.