### PR TITLE
fastlane: Use yarn instead of npx

### DIFF
--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -31,7 +31,7 @@ def generate_sourcemap
 	args = sourcemap_args
 
 	cmd = [
-	       'npx react-native bundle',
+	       'yarn react-native bundle',
 	       '--dev false',
 	       "--platform '#{args[:platform]}'",
 	       "--entry-file '#{args[:entry_file]}'",
@@ -59,7 +59,7 @@ def upload_sourcemap_to_sentry
 	args = sourcemap_args
 
 	cmd = [
-	       'npx @sentry/cli',
+	       'yarn sentry-cli',
 	       'releases',
 	       'files',
 	       "#{bundle_identifier}-#{current_bundle_version}",


### PR DESCRIPTION
`npx` _might_ happily move us up into versions of react-native we have not explicitly upgraded to, which can break stuff pre-emptively. This PR removes the last uses of `npx` in the codebase.