### PR TITLE
Resign first responder on searchbar blur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixed an issue where StoPrint jobs failed to release properly (#3730)
 - Fixed StoPrint login issue (#3732)
 - Fixed a crash that prevented all Android tab views from loading
+- Fixed the iOS keyboard not dismissing when returning from a detail view of a searchbar
 
 ### Removed
 - Removed the `prepare` script patching `ScrollEnabled` inside `RCTMultilineTextInputView` (#3337)

--- a/modules/searchbar/searchbar-ios.js
+++ b/modules/searchbar/searchbar-ios.js
@@ -34,6 +34,10 @@ export class SearchBar extends React.Component<Props> {
 		this._ref = ref
 	}
 
+	onHandleBlur = () => {
+		this._ref && this._ref.unFocus()
+	}
+
 	render() {
 		return (
 			<NativeSearchBar
@@ -41,6 +45,7 @@ export class SearchBar extends React.Component<Props> {
 				autoCorrect={false}
 				hideBackground={true}
 				onCancelButtonPress={this.props.onCancel}
+				onBlur={this.onHandleBlur}
 				onChangeText={this.props.onChange}
 				onFocus={this.props.onFocus}
 				onSearchButtonPress={this.handleSearchButtonPress}

--- a/modules/searchbar/searchbar-ios.js
+++ b/modules/searchbar/searchbar-ios.js
@@ -44,8 +44,8 @@ export class SearchBar extends React.Component<Props> {
 				ref={this.handleRef}
 				autoCorrect={false}
 				hideBackground={true}
-				onCancelButtonPress={this.props.onCancel}
 				onBlur={this.onHandleBlur}
+				onCancelButtonPress={this.props.onCancel}
 				onChangeText={this.props.onChange}
 				onFocus={this.props.onFocus}
 				onSearchButtonPress={this.handleSearchButtonPress}


### PR DESCRIPTION
Resolves #1141 

This handles preventing the keyboard from reappearing on the detail view as well as fully closes the keyboard when returning to the view that instantiated it.

The keyboard was never fully resigning first responder. We observed the keyboard disappear when navigating to the Student Orgs detail view, but it would reappear when navigating to a view beyond such as a webview.

This aims to use the searchbar's `onBlur` event to resign the searchbar's textinput as first responder since we're not inputting text after navigating away from the searchbar.