### PR TITLE
fastlane: Add support from beta-ing from GitHub Actions

### DIFF
--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -27,7 +27,7 @@ end
 def tagged?
 	travis = ENV['TRAVIS_TAG'] && !ENV['TRAVIS_TAG'].empty?
 	circle = ENV['CIRCLE_TAG'] && !ENV['CIRCLE_TAG'].empty?
-	github = ENV['GITHUB_REF'] && ENV['GITHUB_REF'] =~ /^refs\/tags\/(.+)$/
+	github = ENV['GITHUB_REF'] && ENV['GITHUB_REF'] =~ /^refs\/tags\//
 	github || travis || circle
 end
 

--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -27,13 +27,19 @@ end
 def tagged?
 	travis = ENV['TRAVIS_TAG'] && !ENV['TRAVIS_TAG'].empty?
 	circle = ENV['CIRCLE_TAG'] && !ENV['CIRCLE_TAG'].empty?
-	travis || circle
+	github = ENV['GITHUB_REF'] && ENV['GITHUB_REF'] =~ /^refs\/tags\/(.+)$/
+	github || travis || circle
 end
 
 # does the commit message tell us to make a new beta?
 def commit_says_deploy?
-	commit = ENV['TRAVIS_COMMIT_MESSAGE'] || ENV['GIT_COMMIT_DESC']
+	commit = ENV['TRAVIS_COMMIT_MESSAGE'] || ENV['GIT_COMMIT_DESC'] || `git show --pretty=format:%B HEAD`
 	commit =~ /\[ci run beta\]/
+end
+
+# are we running on github actions?
+def github_actions?
+	!!ENV['GITHUB_SHA']
 end
 
 # are we running on travis?


### PR DESCRIPTION
In two parts:

- Add code for testing the `GITHUB_REF` environment variable, which is present on GitHub Actions builds and will be set to `refs/tags/<tag>` on tag builds.

- Add a fallback that shells out to `git show` to retrieve commit messages in case we want to use that instead.

The workflow should be otherwise identical… so no changes to the GitHub Actions config are required. (Yay!)