### PR TITLE
actions: Raise the ulimit to accommodate an ENOSPC error

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle
+      - run: echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_watches && echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_queued_events && echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_instances && sudo sysctl -p
       - run: cd android && ./gradlew androidDependencies --console=plain
       - run: echo 'org.gradle.workers.max=2' >> ./android/gradle.properties
       - run: bundle exec fastlane android ci-run

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -33,7 +33,8 @@ jobs:
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: gem install bundler && bundle check || bundle install --frozen --path vendor/bundle
-      - run: echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_watches && echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_queued_events && echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_instances && sudo sysctl -p
+      - name: Raise the fs.inotify ulimits to 524288 watches/queued events/user instances
+        run: echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_watches && echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_queued_events && echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_instances && sudo sysctl -p
       - run: cd android && ./gradlew androidDependencies --console=plain
       - run: echo 'org.gradle.workers.max=2' >> ./android/gradle.properties
       - run: bundle exec fastlane android ci-run


### PR DESCRIPTION
GitHub Actions workers apparently have a default `fs.inotify.{max_user_watches,max_queued_events,max_user_instances}` limit of `8192`, which can sometimes cause watchman to completely break with an `ENOSPC` error, as on the [v2.8.0-beta.7 Android build](https://github.com/StoDevX/AAO-React-Native/pull/4070/checks?check_run_id=242488528).

It is worth noting that—at least, locally—I have over 38000 files installed. It makes sense, then, that we would reach the limit, if watchman was naïvely trying to open more watcher instances than the number of files.

This PR aims to resolve this issue by introducing a step on the Android build to raise this limit to `524288`, which is `2^19`, a clearly nice number to work with.