### PR TITLE
hours: Update Pause Kitchen Hours

### DIFF
--- a/data/building-hours/1-2-pause-kitchen.yaml
+++ b/data/building-hours/1-2-pause-kitchen.yaml
@@ -6,12 +6,12 @@ schedule:
   - title: Daylight
     notes: The late night menu starts at 9 p.m.
     hours:
-      - {days: [Mo], from: '10:30am', to: '12:00am'}
+      - {days: [Mo], from: '1:00pm', to: '12:00am'}
       - {days: [Tu], from: '11:30am', to: '12:00am'}
       - {days: [We], from: '1:00pm', to: '12:00am'}
       - {days: [Th], from: '11:30am', to: '12:00am'}
-      - {days: [Fr], from: '10:30am', to: '9:00pm'}
-      - {days: [Sa], from: '11:30am', to: '9:00pm'}
+      - {days: [Fr], from: '11:00am', to: '9:00pm'}
+      - {days: [Sa], from: '11:00am', to: '9:00pm'}
       - {days: [Su], from: '11:30am', to: '12:00am'}
 
   - title: Late Night


### PR DESCRIPTION
Updated hours taken from https://oleville.com/pause/.

Closes #4075.