### PR TITLE
Update Buntrock Commons hours per user suggestion

### DIFF
--- a/data/building-hours/8-bc.yaml
+++ b/data/building-hours/8-bc.yaml
@@ -5,8 +5,8 @@ category: Academia
 schedule:
   - title: Hours
     hours:
-      - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '12:00am'}
-      - {days: [Sa, Su], from: '7:00am', to: '2:00am'}
+      - {days: [Su, Mo, Tu, We, Th], from: '7:00am', to: '12:00am'}
+      - {days: [Fr, Sa], from: '7:00am', to: '2:00am'}
 
 breakSchedule:
   fall: []

--- a/data/building-hours/8-bc.yaml
+++ b/data/building-hours/8-bc.yaml
@@ -5,8 +5,8 @@ category: Academia
 schedule:
   - title: Hours
     hours:
-      - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '10:00pm'}
-      - {days: [Sa, Su], from: '7:00am', to: '12:00am'}
+      - {days: [Mo, Tu, We, Th, Fr], from: '7:00am', to: '12:00am'}
+      - {days: [Sa, Su], from: '7:00am', to: '2:00am'}
 
 breakSchedule:
   fall: []


### PR DESCRIPTION
Taken from https://wp.stolaf.edu/buntrock/:

>- Sunday – Thursday: 7 am – midnight
>- Friday and Saturday: 7 am – 2 am