### PR TITLE
Use fetch api's delay in some of the refresh functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated references to ASC to be CAAS in dictionary and hours
 - Show alert after dev sentry send message or exception 
 - Update finals hours notice to be a summer notice
+- Opt to use fetch api's delay in some of the refresh functions
 
 ### Fixed
 - Fixed an issue where Fastlane was reporting build failures despite having skipped the build (#3215)

--- a/source/views/menus/menu-bonapp.js
+++ b/source/views/menus/menu-bonapp.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import delay from 'delay'
 import {timezone} from '@frogpond/constants'
 import {NoticeView, LoadingView} from '@frogpond/notice'
 import type {TopLevelViewPropsType} from '../types'
@@ -106,11 +105,11 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
 
 		try {
 			let cafeMenuPromise: Promise<MenuInfoType> = fetch(menuUrl, {
-				forReload: reload ? 500 : 0,
+				delay: reload ? 500 : 0,
 			}).json()
 
 			let cafeInfoPromise: Promise<CafeInfoType> = fetch(cafeUrl, {
-				forReload: reload ? 500 : 0,
+				delay: reload ? 500 : 0,
 			}).json()
 
 			let [cafeMenu, cafeInfo] = await Promise.all([
@@ -133,17 +132,8 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
 	}
 
 	refresh = async (): any => {
-		let start = Date.now()
 		this.setState(() => ({refreshing: true}))
-
 		await this.fetchData(this.props, true)
-
-		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
-		let elapsed = Date.now() - start
-		if (elapsed < 500) {
-			await delay(500 - elapsed)
-		}
-
 		this.setState(() => ({refreshing: false}))
 	}
 

--- a/source/views/news/news-container.js
+++ b/source/views/news/news-container.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import delay from 'delay'
 import type {StoryType} from './types'
 import {LoadingView} from '@frogpond/notice'
 import type {TopLevelViewPropsType} from '../types'
@@ -46,24 +45,15 @@ export default class NewsContainer extends React.PureComponent<Props, State> {
 		}
 
 		let entries: Array<StoryType> = await fetch(url, {
-			forReload: reload ? 500 : 0,
+			delay: reload ? 500 : 0,
 		}).json()
 
 		this.setState(() => ({entries}))
 	}
 
 	refresh = async (): any => {
-		let start = Date.now()
 		this.setState(() => ({refreshing: true}))
-
 		await this.fetchData(true)
-
-		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
-		let elapsed = Date.now() - start
-		if (elapsed < 500) {
-			await delay(500 - elapsed)
-		}
-
 		this.setState(() => ({refreshing: false}))
 	}
 

--- a/source/views/sis/student-work/index.js
+++ b/source/views/sis/student-work/index.js
@@ -7,7 +7,6 @@ import type {TopLevelViewPropsType} from '../../types'
 import * as c from '@frogpond/colors'
 import {ListSeparator, ListSectionHeader} from '@frogpond/lists'
 import {NoticeView, LoadingView} from '@frogpond/notice'
-import delay from 'delay'
 import toPairs from 'lodash/toPairs'
 import orderBy from 'lodash/orderBy'
 import groupBy from 'lodash/groupBy'
@@ -55,8 +54,10 @@ export default class StudentWorkView extends React.PureComponent<Props, State> {
 		})
 	}
 
-	fetchData = async () => {
-		let data: Array<JobType> = await fetch(API('/jobs')).json()
+	fetchData = async (reload?: boolean) => {
+		let data: Array<JobType> = await fetch(API('/jobs'), {
+			delay: reload ? 500 : 0,
+		}).json()
 
 		// force title-case on the job types, to prevent not-actually-duplicate headings
 		let processed: Array<JobType> = data.map(job => ({
@@ -85,16 +86,8 @@ export default class StudentWorkView extends React.PureComponent<Props, State> {
 	}
 
 	refresh = async (): any => {
-		let start = Date.now()
 		this.setState(() => ({refreshing: true}))
-
-		await this.fetchData()
-
-		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
-		let elapsed = Date.now() - start
-		if (elapsed < 500) {
-			await delay(500 - elapsed)
-		}
+		await this.fetchData(true)
 		this.setState(() => ({refreshing: false}))
 	}
 

--- a/source/views/transportation/other-modes/list.js
+++ b/source/views/transportation/other-modes/list.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react'
-import delay from 'delay'
 import {OtherModesRow} from './row'
 import {TabBarIcon} from '@frogpond/navigation-tabs'
 import * as defaultData from '../../../../docs/transportation.json'
@@ -57,23 +56,17 @@ export class OtherModesView extends React.PureComponent<Props, State> {
 	}
 
 	refresh = async (): any => {
-		let start = Date.now()
 		this.setState(() => ({refreshing: true}))
-
-		await this.fetchData()
-
-		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
-		let elapsed = Date.now() - start
-		if (elapsed < 500) {
-			await delay(500 - elapsed)
-		}
-
+		await this.fetchData(true)
 		this.setState(() => ({refreshing: false}))
 	}
 
-	fetchData = async () => {
+	fetchData = async (reload?: boolean) => {
 		let {data: modes}: {data: Array<OtherModeType>} = await fetch(
 			transportationUrl,
+			{
+				delay: reload ? 500 : 0,
+			},
 		).json()
 		this.setState(() => ({modes}))
 	}

--- a/source/views/transportation/other-modes/list.js
+++ b/source/views/transportation/other-modes/list.js
@@ -64,9 +64,7 @@ export class OtherModesView extends React.PureComponent<Props, State> {
 	fetchData = async (reload?: boolean) => {
 		let {data: modes}: {data: Array<OtherModeType>} = await fetch(
 			transportationUrl,
-			{
-				delay: reload ? 500 : 0,
-			},
+			{delay: reload ? 500 : 0},
 		).json()
 		this.setState(() => ({modes}))
 	}


### PR DESCRIPTION
In some cases, the fetch API param `delay` was named `forReload`. This PR renames that prop to swizzle where the delay logic happens. 

Renamed delay prop and removed from refresh altogether 
* Bonapp Menu
* News

Added fetch delay logic but removed from refresh altogether
* Student work
* Transportation (other modes)