### PR TITLE
Fix up sentry-cli invocation

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -49,7 +49,10 @@ jobs:
           GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'
-          SENTRY_PROPERTIES: '../android/sentry.properties'
+          SENTRY_ORG: frog-pond-labs
+          SENTRY_URL: https://sentry.frogpond.tech/
+          SENTRY_PROJECT: all-about-olaf
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
 
   ios:
@@ -72,7 +75,10 @@ jobs:
           GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'
-          SENTRY_PROPERTIES: '../ios/sentry.properties'
+          SENTRY_ORG: frog-pond-labs
+          SENTRY_URL: https://sentry.frogpond.tech/
+          SENTRY_PROJECT: all-about-olaf
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
       - run: yarn detox build e2e --configuration ios.sim.release | xcpretty
       - run: yarn detox test e2e --configuration ios.sim.release --cleanup

--- a/android/sentry.properties
+++ b/android/sentry.properties
@@ -1,4 +1,0 @@
-defaults.url=https://sentry.frogpond.tech/
-defaults.org=frog-pond-labs
-defaults.project=all-about-olaf
-#auth.token=SENTRY_AUTH_TOKEN

--- a/ios/sentry.properties
+++ b/ios/sentry.properties
@@ -1,4 +1,0 @@
-defaults.url=https://sentry.frogpond.tech/
-defaults.org=frog-pond-labs
-defaults.project=all-about-olaf
-#auth.token=SENTRY_AUTH_TOKEN


### PR DESCRIPTION
Instead of relying upon relative paths to directories and trying to figure out why sourcemaps are still failing to upload, this commit instead reconfigures CI to expose a few environment variables to the fastlane process.

Closes #4063. (for now)

Mostly I'm just curious if this will fix anything on the nightly.