### PR TITLE
Fix Sentry nightly invocation

### DIFF
--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -49,8 +49,7 @@ def bundle_identifier
 	when :android
 		"com.allaboutolaf"
 	when :ios
-		get_info_plist_value(path: 'ios/AllAboutOlaf/Info.plist',
-		                     key: 'CFBundleIdentifier')
+		"NFMTHAZVS9.com.drewvolz.stolaf"
 	end
 end
 


### PR DESCRIPTION
by hard-coding PRODUCT_BUNDLE_IDENTIFIER in Fastlane's Sentry invocation, like we do for Android already.