### PR TITLE
codecov: No longer produce commit statuses

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,8 +8,8 @@ coverage:
   range: '70...100'
 
   status:
-    project: yes
-    patch: yes
+    project: no
+    patch: no
     changes: no
 
 parsers:


### PR DESCRIPTION
We have found that code coverage is not generated for Detox testing, which is (unsurprisingly) a _very_ big hole in our potential covered codebase.

Core business logic should certainly be tested, but we have no real way of measuring the coverage of our other areas of logic; this commit suspends the red-herring alerts that cause _entire PRs_ to be visibly "failing," despite being perfectly valid and well-tested.