### PR TITLE
ci: Pin build executors to their current versions

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   js:
     name: JavaScript Checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/setup-node@master
         with: {node-version: ^12.0}
@@ -27,7 +27,7 @@ jobs:
 
   android:
     name: Build for Android
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/setup-node@master
         with: {node-version: ^12.0}
@@ -57,7 +57,7 @@ jobs:
 
   ios:
     name: Build for iOS
-    runs-on: macOS-latest
+    runs-on: macOS-10.14
     steps:
       - uses: actions/setup-node@master
         with: {node-version: ^12.0}


### PR DESCRIPTION
In case something changes, we'd rather not be surprised, I suppose.

I think I'm fine with it as long as it's not specifically for macOS, and as long as we keep updating things quickly, which hasn't been an issue.