### PR TITLE
macos 10.15

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -57,7 +57,7 @@ jobs:
 
   ios:
     name: Build for iOS
-    runs-on: macOS-10.14
+    runs-on: macos-latest
     steps:
       - uses: actions/setup-node@master
         with: {node-version: ^12.0}


### PR DESCRIPTION
Hi GitHub. 

GitHub is requiring at we switch to “macos-latest” as they don’t want to support multiple MacOS environments. 

![BD0FB7E6-E6F7-40B3-84CD-D2016F4DEA3E](https://user-images.githubusercontent.com/464441/68350044-c4965d00-00c4-11ea-8fee-fd7aa6321122.png)
