### PR TITLE
ios: Unshallow Git history after checking out

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -63,6 +63,7 @@ jobs:
         with: {node-version: ^12.0}
       - run: sudo xcode-select -s /Applications/Xcode_11.1.app
       - uses: actions/checkout@master
+      - run: git fetch --prune --unshallow
       - run: gem install bundler:1.17.2 && bundle check || bundle install --frozen --path vendor/bundle
       - run: yarn install --frozen-lockfile
       - run: brew tap wix/brew


### PR DESCRIPTION
We want to have the full history back to the most recent tag.

This commit causes us to unshallow and prune up the Git history before moving on in the build.

Should clear up the spurious nightly failure we've had since actions/checkout v2 came out.