### PR TITLE
add dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,9 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    update_schedule: "daily"
+    directory: "/"
+
+  - package_manager: "ruby:bundler"
+    update_schedule: "weekly"
+    directory: "/"


### PR DESCRIPTION
By default, Dependabot will update Ruby and JS dependencies "live".

That is, as soon as the update is published to the package repository. However, we have been innundated with updates to certain packages, `*cough*`aws-* via fastlane`*cough*`, which we don't even directly depend on.

So, this commit sets Ruby updates to update weekly, and JS updates to update daily.