### PR TITLE
ci: Use GitHub Actions for Data Deployment

### DIFF
--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -1,0 +1,38 @@
+name: Validate/Deploy Data
+
+on:
+  push: { branches: [master] }
+
+jobs:
+  validate-then-deploy:
+    name: Validate, then deploy data
+    runs-on: ubuntu-latest
+    env: task=GH_PAGES
+    steps:
+      - uses: actions/set-up-node@master
+        with: {node-version: ^12.0}
+      - name: Check out the code
+        uses: actions/checkout@master
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Validate the data
+        run: |
+          npm run validate-bus-data
+          npm run validate-data
+      # Having validated the data, we now prepare a bundle.  This script creates
+      # files in a docs/ directory.
+      - name: Bundle the data
+        run: npm run bundle-data
+      # Notes: actions/checkout@v2 no longer fetches entire history nor enters
+      # detached HEAD state.  We really just need to check out an (orphaned)
+      # branch and then add, commit, and push the appropriate directory.
+      - name: Commit the data
+        run: |
+          git checkout --orphan "gh-pages-$GITHUB_SHA"
+          git --work-tree=docs add .
+          git commit -m "Automated data deployment at $(date -Is)"
+          git show --stat HEAD
+      # If the previous commit successfully happened
+      - name: Deploy the data
+        run:
+          git push --force-with-lease "gh-pages-$GITHUB_SHA:gh-pages"

--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           git checkout --orphan "gh-pages-$GITHUB_SHA"
           git --work-tree=docs add .
-          git commit -m "Automated data deployment at $(date -Is)"
+          git commit --author="Data Deployment Bot <>" -m "Automated data deployment at $(date -Is)"
           git show --stat HEAD
       # If the previous commit successfully happened
       - name: Deploy the data

--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -35,4 +35,4 @@ jobs:
       # If the previous commit successfully happened
       - name: Deploy the data
         run:
-          git push --force-with-lease "gh-pages-$GITHUB_SHA:gh-pages"
+          git push --force-with-lease origin "gh-pages-$GITHUB_SHA:gh-pages"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ jobs:
         - npm run validate-bus-data
         - npm run validate-data
         - npm run bundle-data
-      deploy:
-        provider: pages
-        skip_cleanup: true
-        github_token: $GITHUB_PAGES_TOKEN
-        local_dir: docs/
+      #deploy:
+      #  provider: pages
+      #  skip_cleanup: true
+      #  github_token: $GITHUB_PAGES_TOKEN
+      #  local_dir: docs/
 
 cache:
   yarn: true


### PR DESCRIPTION
Besides the added last step that uses a `git push` refspec that maps `gh-pages-(SHA)` onto the remote `gh-pages`, the validation and bundling steps are the same, and now the deployment step looks like:


```console
$ git rev-parse --abbrev-ref HEAD
gh-pages-91d6e1dda48e2457f7a4a4d3342cec190ba078cb
$ git commit -m "Automated data deployment at $(date -Is)"
[gh-pages-91d6e1dda48e2457f7a4a4d3342cec190ba078cb (root-commit) f9f051d5] Automated data deployment at 2020-05-13T18:37:45-05:00
 17 files changed, 53 insertions(+)
 create mode 100644 breaks.json
 create mode 100644 building-hours.json
 create mode 100644 bus-times.json
 create mode 100644 chapel.json
 create mode 100644 color-printers.json
 create mode 100644 contact-info.json
 create mode 100644 credits.json
 create mode 100644 dictionary.json
 create mode 100644 faqs.json
 create mode 100644 help.json
 create mode 100644 legal.json
 create mode 100644 news-styles.css
 create mode 100644 news-styles.json
 create mode 100644 pause-menu.json
 create mode 100644 privacy.json
 create mode 100644 transportation.json
 create mode 100644 webcams.json
$ git show --stat HEAD
commit f9f051d518f180bdf41058cefcb9d144a884d4d8 (HEAD -> gh-pages-91d6e1dda48e2457f7a4a4d3342cec190ba078cb)
Author: AAO Data Deployment Bot <>
Date:   Wed May 13 18:37:45 2020 -0500

    Automated data deployment at 2020-05-13T18:37:45-05:00

 breaks.json         |  1 +
 building-hours.json |  1 +
 bus-times.json      |  1 +
 chapel.json         |  1 +
 color-printers.json |  1 +
 contact-info.json   |  1 +
 credits.json        |  1 +
 dictionary.json     |  1 +
 faqs.json           |  1 +
 help.json           |  1 +
 legal.json          |  1 +
 news-styles.css     | 37 +++++++++++++++++++++++++++++++++++++
 news-styles.json    |  1 +
 pause-menu.json     |  1 +
 privacy.json        |  1 +
 transportation.json |  1 +
 webcams.json        |  1 +
 17 files changed, 53 insertions(+)
```

I also temporarily disabled Travis deployments to prevent overwriting of commits made here.