### PR TITLE
deploy-data: Unshallow right before deploying the data

### DIFF
--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -14,6 +14,8 @@ jobs:
         with: {node-version: ^12.0}
       - name: Check out the code
         uses: actions/checkout@master
+      - name: Unshallow the history
+        run: git fetch --prune --unshallow
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Validate the data

--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -14,8 +14,6 @@ jobs:
         with: {node-version: ^12.0}
       - name: Check out the code
         uses: actions/checkout@master
-      - name: Unshallow the history
-        run: git fetch --prune --unshallow
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Validate the data
@@ -35,7 +33,9 @@ jobs:
           git --work-tree=docs add .
           git commit --author="Data Deployment Bot <>" -m "Automated data deployment at $(date -Is)"
           git show --stat HEAD
-      # If the previous commit successfully happened
+      # If the previous commit successfully happened, download the latest state
+      # of the remote branch gh-pages.
       - name: Deploy the data
-        run:
+        run: |
+          git fetch --prune --unshallow origin gh-pages
           git push --force-with-lease origin "gh-pages-$GITHUB_SHA:gh-pages"


### PR DESCRIPTION
Pretty self-explanatory.  This is needed because `actions/checkout` does not unshallow so that Git understands the `gh-pages` ref, so we need to have some notion of what it is on the remote before we can overwrite it.