### PR TITLE
ci: Attribute data deployment commits to github-actions[bot]

### DIFF
--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -29,8 +29,8 @@ jobs:
       # branch and then add, commit, and push the appropriate directory.
       - name: Commit the data
         run: |
-          git config --global user.name "Data Deployment Bot"
-          git config --global user.email ""
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout --orphan "gh-pages-$GITHUB_SHA"
           git --work-tree=docs add .
           git commit -m "Automated data deployment at $(date -Is)"

--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -33,7 +33,7 @@ jobs:
           git config --global user.email ""
           git checkout --orphan "gh-pages-$GITHUB_SHA"
           git --work-tree=docs add .
-          git commit --author="Data Deployment Bot <>" -m "Automated data deployment at $(date -Is)"
+          git commit -m "Automated data deployment at $(date -Is)"
           git show --stat HEAD
       # If the previous commit successfully happened, download the latest state
       # of the remote branch gh-pages.


### PR DESCRIPTION
- Remove the per-commit `--author=` setting since Git _requires_ a committer to be specified via at least `user.email`, and will default to the values of those fields for authorship information.

- Use [the API response](https://api.github.com/users/github-actions%5Bbot%5D) to identify the `login` and `id` fields of the `github-actions[bot]` user (which I believe has the permissions allocated to the token included on the runner), and use that user as the author and committer.

I did this mostly to get the avatar to something we control, but also to eliminate the non-existant account we were using previously.  I feel like this is more elegant.