### PR TITLE
dependabot: Use an empty commit message prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,14 @@ updates:
     interval: weekly
     time: '11:00'
   open-pull-requests-limit: 10
+  commit-message: { prefix: "" }
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
     time: '11:00'
   open-pull-requests-limit: 10
+  commit-message: { prefix: "" }
   ignore:
   - dependency-name: react-markdown
     versions:


### PR DESCRIPTION
I have successfully used this on another project, and it seems to successfully prevent dependabot from using prefixes like "build(deps)" which I find annoying.  They're useful if you're using tools like semantic commits to generate changelogs or whatnot, but we aren't doing that, so I think it's best to leave those prefixes off.

Now, instead of creating PRs and commits with titles like `build(deps): Bump blah to blah` we'll just get titles like `Bump blah to blah`

Currently-open PRs will not have the new changes, but could be recreated to adopt the new style.