### PR TITLE
ci: Validate data during JavaScript checks, too

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: yarn run bundle-data
+      - run: yarn run validate-data
       - run: yarn run pretty --no-write --list-different
       - run: yarn run flow check
       - run: yarn run lint

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -14,8 +14,8 @@ jobs:
         with: {node-version: ^12.0}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
-      - run: yarn run bundle-data
       - run: yarn run validate-data
+      - run: yarn run bundle-data
       - run: yarn run pretty --no-write --list-different
       - run: yarn run flow check
       - run: yarn run lint


### PR DESCRIPTION
What the title says.

Basically, before bundling the data, first make sure that it is valid.

Closes #4844.