### PR TITLE
Temporarily disable the Android nightly builds

### DIFF
--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -1,6 +1,13 @@
 # should we build and release to the nightly channel?
 def should_nightly?
-	github_scheduled? || travis_cron? || circle_nightly?
+	# FIXME(rye): Android builds are taking forever to get through review,
+	# and every deploy after an unreviewed build causes the review process
+	# to restart.  This is less than ideal.
+	#
+	# (TODO(rye): Uncomment this once we can get our builds thru review
+	# more safely.)
+	# github_scheduled? || travis_cron? || circle_nightly?
+	(github_scheduled? || travis_cron? || circle_nightly?) && ENV['FASTLANE_PLATFORM_NAME'] != 'android'
 end
 
 # was this build triggered by a schedule event on GH?

--- a/fastlane/platforms/android.rb
+++ b/fastlane/platforms/android.rb
@@ -43,7 +43,7 @@ platform :android do
 				apk.end_with? '-release.aab'
 			end
 
-		supply(track: track, check_superseded_tracks: true)
+		supply(track: track)
 
 		generate_sourcemap
 		upload_sourcemap_to_sentry


### PR DESCRIPTION
To (hopefully) help our backlog get cleared up, we need to stop uploading nightlies.

This PR adds another check to the `should_nightly?` helper to check and see if the current Fastlane platform name is not `android` before allowing the nightly.