### PR TITLE
Fastlane: Re-enable Android nightlies

### DIFF
--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -1,13 +1,6 @@
 # should we build and release to the nightly channel?
 def should_nightly?
-	# FIXME(rye): Android builds are taking forever to get through review,
-	# and every deploy after an unreviewed build causes the review process
-	# to restart.  This is less than ideal.
-	#
-	# (TODO(rye): Uncomment this once we can get our builds thru review
-	# more safely.)
-	# github_scheduled? || travis_cron? || circle_nightly?
-	(github_scheduled? || travis_cron? || circle_nightly?) && ENV['FASTLANE_PLATFORM_NAME'] != 'android'
+	github_scheduled? || travis_cron? || circle_nightly?
 end
 
 # was this build triggered by a schedule event on GH?


### PR DESCRIPTION
Per out-of-band discussion, we want to give this a try tonight and see if we can get a nightly out the door on Android in due time.

- If the published build still hasn't gone through review, we shouldn't publish. We should check at 23:00 UTC tomorrow (2020-11-17) to see if the nightly from tonight has been published, and if not, probably publish it.