### PR TITLE
Update iOS build environment

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/setup-node@master
         with: {node-version: ^12.0}
-      - run: sudo xcode-select -s /Applications/Xcode_11.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_11.7.app
       - uses: actions/checkout@master
       - run: git fetch --prune --unshallow
       - run: gem install bundler:1.17.2

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -63,7 +63,7 @@ jobs:
 
   ios:
     name: Build for iOS
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - uses: actions/setup-node@master
         with: {node-version: ^12.0}

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -1226,7 +1226,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Hawken Rives (TMK6S7TPX2)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution: Hawken Rives (TMK6S7TPX2)";
 				CODE_SIGN_STYLE = Manual;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = TMK6S7TPX2;
@@ -1242,7 +1242,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = NFMTHAZVS9.com.drewvolz.stolaf;
 				PRODUCT_NAME = AllAboutOlaf;
 				PROVISIONING_PROFILE = "1519411d-0c35-4ef5-b2f9-d7524a9f28f3";
-				PROVISIONING_PROFILE_SPECIFIER = "match AdHoc NFMTHAZVS9.com.drewvolz.stolaf";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore NFMTHAZVS9.com.drewvolz.stolaf";
 				SWIFT_OBJC_BRIDGING_HEADER = "AllAboutOlafUITests/AllAboutOlaf-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
@@ -1257,7 +1257,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Hawken Rives (TMK6S7TPX2)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution: Hawken Rives (TMK6S7TPX2)";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = TMK6S7TPX2;
 				HEADER_SEARCH_PATHS = "$(inherited)";

--- a/package.json
+++ b/package.json
@@ -55,13 +55,13 @@
     "configurations": {
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/AllAboutOlaf.app",
-        "build": "xcodebuild -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.1' -derivedDataPath ios/build build",
+        "build": "xcodebuild -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.7' -derivedDataPath ios/build build",
         "type": "ios.simulator",
         "name": "iPhone 8"
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app",
-        "build": "xcodebuild -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -configuration Release -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.1' -derivedDataPath ios/build build",
+        "build": "xcodebuild -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -configuration Release -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.7' -derivedDataPath ios/build build",
         "type": "ios.simulator",
         "name": "iPhone 8"
       }


### PR DESCRIPTION
Xcode 11.1 was deprecated on 2020-11-05, which caused builds to start failing.

This PR pins us to the `macos-10.15` build environment, like we pin the Android builders to `ubuntu-18.04`, and changes the version we `xcode-select --install` to `11.7`, the latest `11.x` version available on the macOS build environment.

**This PR may still fail to build due to certificate issues, but it should no longer fail to even start building the iOS code.**

Also in this PR:
- Update code signing identity and provisioning profile
- Update detox simulator to iOS 13.7