### PR TITLE
👽 Android: Disable native heap pointer tagging, extract native libraries

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="${isDebug}"
         android:allowNativeHeapPointerTagging="false"
+        android:extractNativeLibs="true"
     >
       <activity
           android:launchMode="singleTop"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
         android:icon="@mipmap/ic_launcher"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="${isDebug}"
+        android:allowNativeHeapPointerTagging="false"
     >
       <activity
           android:launchMode="singleTop"


### PR DESCRIPTION
This PR adds configurations for the `android:allowNativeHeapPointerTagging` and `android:extractNativeLibs` attributes on our Android application manifest.

- `android:allowNativeHeapPointerTagging` controls whether or not our app has the Heap Pointer Tagging enabled. It is disabled at this point [at the recommendation of Sentry](https://docs.sentry.io/platforms/android/usage/advanced-usage/), so that Sentry can tag heap pointers instead of the native OS.

- `android:extractNativeLibs` controls whether the package installer will extract native libraries into the filesystem, or just load them from the apk. If set to false (which, for gradle plugin 3.6 and greater, is the default) it instead requires them to be stored page-aligned and uncompressed within the APK, resulting in larger APK sizes, but comparatively lower runtime overheads for loading native libraries. However, Sentry does not support this at the moment, and needs access to the extracted native libraries in order to properly track crashes. This option is enabled [at the recommendation of Sentry](https://docs.sentry.io/platforms/android/usage/advanced-usage/).