### PR TITLE
Enable rn-screens and use enableScreens

### DIFF
--- a/source/app.js
+++ b/source/app.js
@@ -11,7 +11,7 @@ import './init/sentry'
 import './init/api'
 import './init/theme'
 import './init/data'
-// import './init/navigation'
+import './init/navigation'
 
 import * as React from 'react'
 import {Provider as ReduxProvider} from 'react-redux'

--- a/source/init/navigation.js
+++ b/source/init/navigation.js
@@ -2,8 +2,4 @@
 
 import {enableScreens} from 'react-native-screens'
 
-// eslint-plugin-react-hooks occasionally has a false-positive;
-// this method, while named use*, is not a hook.
-
-// eslint-disable-next-line react-hooks/rules-of-hooks
 enableScreens()

--- a/source/init/navigation.js
+++ b/source/init/navigation.js
@@ -1,9 +1,9 @@
 // @flow
 
-import {useScreens} from 'react-native-screens'
+import {enableScreens} from 'react-native-screens'
 
 // eslint-plugin-react-hooks occasionally has a false-positive;
 // this method, while named use*, is not a hook.
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
-useScreens()
+enableScreens()


### PR DESCRIPTION
Followup to #4927 

- Replace instance of `useScreens` with `enableScreens`
- Removes commented-out import of the navigation init