### PR TITLE
dictionary: Rename dcc.yaml -> disc.yaml and update text

### DIFF
--- a/data/dictionary/dcc.yaml
+++ b/data/dictionary/dcc.yaml
@@ -1,3 +1,0 @@
-word: DCC
-definition: |
-  The Diversity Celebrations Committee is a branch of the Student Government Association (SGA) that provides entertaining and educational experiences that support St. Olaf College’s commitment to integrate diverse perspectives. The purpose of these events is to provide students with exposure to diverse cultures, communities, and ethnicities and celebrate these cultures.

--- a/data/dictionary/disc.yaml
+++ b/data/dictionary/disc.yaml
@@ -1,0 +1,3 @@
+word: DISC
+definition: |
+  The Diversity Initiatives Support Committee is a branch of the Student Government Association (SGA). The purpose of this branch is to provide organizations of historically marginalized groups with the support and funding necessary for them to accomplish their mission at St. Olaf.


### PR DESCRIPTION
Closes #5050.

Some digging confirms that DISC has supplanted DCC.  The first sentence here ("[...] is a branch [...]") is roughly the same, and the second sentence is found under "Who are we?" on Oleville.

See also: https://oleville.com/disc/.

