### PR TITLE
android: Remove ndkVersion setting

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -129,10 +129,6 @@ String keystorePath = System.getenv("KEYSTORE_FILE")
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
-    // when we upgrade to tools.build:gradle:4.1.0, remove this, as gradle will download the
-    // appropriate version automatically (see https://stackoverflow.com/a/62320616/2347774)
-    ndkVersion '21.3.6528147'
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
We have recently been getting the [error](https://github.com/StoDevX/AAO-React-Native/runs/1892791145?check_suite_focus=true#step:11:762):

>```[08:42:11]: ▸ FAILURE: Build failed with an exception.
>[08:42:11]: ▸ * What went wrong:
>[08:42:11]: ▸ Execution failed for task ':app:stripReleaseDebugSymbols'.
>[08:42:11]: ▸ > No version of NDK matched the requested version 21.3.6528147. Versions available locally: 21.4.7075529, 21.4.7075529, 21.4.7075529
>```

When I went to bump `ndkVersion` to the latest of the 21.x series (21.4.7075529), I found this comment:

```gradle
    // when we upgrade to tools.build:gradle:4.1.0, remove this, as gradle will download the	
    // appropriate version automatically (see https://stackoverflow.com/a/62320616/2347774)	
    ndkVersion '21.3.6528147'
```

As our build tools now download Gradle 6, I think we can safely remove this line. A green Android build would indicate that this is the case.