### PR TITLE
fastlane: Also check `ENV['GITHUB_KEYS_REPOSITORY_TOKEN']` and emptiness also when determining whether to sign

### DIFF
--- a/fastlane/lib/util.rb
+++ b/fastlane/lib/util.rb
@@ -25,7 +25,9 @@ end
 
 # does the build have the api keys needed for signing?
 def api_keys_available?
-	ENV['MATCH_PASSWORD'] && ENV['FASTLANE_PASSWORD']
+	ENV['MATCH_PASSWORD'] && !ENV['MATCH_PASSWORD'].empty? &&
+		ENV['FASTLANE_PASSWORD'] && !ENV['FASTLANE_PASSWORD'].empty? &&
+		ENV['GITHUB_KEYS_REPOSITORY_TOKEN'] && !ENV['GITHUB_KEYS_REPOSITORY_TOKEN'].empty?
 end
 
 # is this a build of a tagged commit?


### PR DESCRIPTION
Yep, the title pretty much says it all.

GitHub [recently changed](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/) the behavior of dependabot PRs to reduce the security exposure imposed by running unconstrained install scripts.

Our `analyze-and-build` workflow passes in a variety of secrets which are read by `fastlane` via `ENV`. However, because this `ENV` mapping seems to always be applied regardless of whether or not the underlying secret is accessible, it seems like GitHub Actions might be _setting_ the various environment variables to empty strings rather than simply _not setting_ them. (If these variables were _not set_, then `ENV['VAR']` would be `nil` in Ruby, rather than `""`.  Since `""` is truthy but `nil` is not, this leads to the disparity.)

Once this PR is merged, we can try `dependabot rebase`-ing a PR to see if this resolves the problem. I nominate #5095 for that.