### PR TITLE
fastlane: Fix `check_build` lane

### DIFF
--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -32,6 +32,8 @@ platform :ios do
 		products_dir = products_dir.map { |entry| entry.gsub(/.*BUILT_PRODUCTS_DIR = /, '') }
 		products = products_dir.map { |entry| entry + "/#{ENV['GYM_OUTPUT_NAME']}.app/" }
 
+		propagate_version
+
 		# save it to a log file for later use
 		FileUtils.mkdir_p('../logs')
 		File.open('../logs/products', 'w') { |file| file.write(products.to_json) }
@@ -39,14 +41,12 @@ platform :ios do
 		# build the .app
 		build_status = 0
 		begin
-			propagate_version
-			xcodebuild(
-			           build: true,
-			           scheme: ENV['GYM_SCHEME'],
-			           workspace: ENV['GYM_WORKSPACE'],
-			           destination: 'generic/platform=iOS',
-			           xcargs: %(CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""),
-			           )
+			gym(include_bitcode: true,
+			    include_symbols: true,
+			    skip_codesigning: true,
+			    skip_package_ipa: true,
+			    skip_package_pkg: true,
+			    skip_archive: true)
 		rescue IOError => e
 			build_status = 1
 			raise e


### PR DESCRIPTION
We don't typically get fork PRs, so there was a disparity between how we built for normal PRs and fork/restricted PRs.

This PR changes `check_build` for iOS to now use `gym` (like the "normal" `build` lane), which should make maintaining these two sides much simpler. We explicitly _don't_ have certificates available in the restricted case, so we disable signing and archive building and the like to effectively just test the compile.