### PR TITLE
Switch to sentry.io

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -56,7 +56,7 @@ jobs:
           FASTLANE_DISABLE_ANIMATION: '1'
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_SENTRY_AUTH_TOKEN }}
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
 
   ios:
@@ -83,7 +83,7 @@ jobs:
           FASTLANE_DISABLE_ANIMATION: '1'
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_SENTRY_AUTH_TOKEN }}
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
       - run: yarn detox build e2e --configuration ios.sim.release | xcpretty
       - run: yarn detox test e2e --configuration ios.sim.release --cleanup

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -55,7 +55,6 @@ jobs:
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'
           SENTRY_ORG: frog-pond-labs
-          SENTRY_URL: https://sentry.frogpond.tech/
           SENTRY_PROJECT: all-about-olaf
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
@@ -83,7 +82,6 @@ jobs:
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'
           SENTRY_ORG: frog-pond-labs
-          SENTRY_URL: https://sentry.frogpond.tech/
           SENTRY_PROJECT: all-about-olaf
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}

--- a/source/init/constants.ts
+++ b/source/init/constants.ts
@@ -1,7 +1,7 @@
 import {setVersionInfo, setAppName, setTimezone} from '@frogpond/constants'
 
 export const SENTRY_DSN =
-	'https://6f70285364b7417181e17db8bcf4de11@sentry.frogpond.tech/2'
+	'https://7f68e814c5c24c32a582f2ddc3d42b4c@o524787.ingest.sentry.io/5637838'
 
 import {version, name} from '../../package.json'
 


### PR DESCRIPTION
We have been encountering occasional issues like 502 errors when uploading source maps on nightlies.  Part of this is due to the fact that the requirements for a stable, self-hosted Sentry instance have grown significantly since we initially started.  In order to keep up with the new features added in new Sentry releases, we kept upgrading, but because of the CPU load induced by running our Sentry instance (and the RAM usage, which can sometimes cause long spikes in latency as different things get swapped in to handle requests) we began to see issues when we'd upload source maps at night.

Sentry also appears to offer an open-source discount which matches up with our goals.  We have a very low volume of errors, so the only real reason we'd need to apply for such a discount is to have additional team members on the Sentry organization.  For the time being, I'm perfectly happy with taking on any maintenance-related tasks or letting someone else drive my screen in that case.

This PR:
- Removes the `SENTRY_URL` CI environment variable, instead letting `sentry-cli` use the default (which I would expect to be `sentry.io`).
- Changes over the `SENTRY_AUTH_TOKEN` from the Integrations token generated on the old Sentry instance to one I generated this morning on the new instance with read permissions and write/admin where I thought might be helpful to have.  (We can change these permissions at will.)
- Changes the `SENTRY_DSN` to the DSN of our project in sentry.io.

I think it's safe to assume that green CI is pretty much the only testing that needs to happen for this PR.