### PR TITLE
Fix Sentry Sourcemap Uploading

### DIFF
--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -8,13 +8,11 @@ def sourcemap_args
 		entry_file = 'index.js'
 		bundle_output = 'index.android.bundle'
 		sourcemap_output = 'index.android.bundle.map'
-		bundle_url = 'index.android.bundle'
 	when :ios
 		platform = 'ios'
 		entry_file = 'index.js'
 		bundle_output = 'main.jsbundle'
 		sourcemap_output = 'main.jsbundle.map'
-		bundle_url = 'main.jsbundle'
 	end
 
 	{
@@ -22,7 +20,6 @@ def sourcemap_args
 		entry_file: entry_file,
 		bundle_output: bundle_output,
 		sourcemap_output: sourcemap_output,
-		bundle_url: bundle_url,
 	}
 end
 

--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -63,6 +63,7 @@ def upload_sourcemap_to_sentry
 	       "--dist #{current_bundle_code}",
 	       "--strip-prefix #{File.expand_path(File.join(__FILE__, '..', '..', '..'))}",
 	       '--rewrite',
+	       args[:bundle_output]
 	       args[:sourcemap_output]
 	].join ' '
 

--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -6,14 +6,14 @@ def sourcemap_args
 	when :android
 		platform = 'android'
 		entry_file = 'index.js'
-		bundle_output = '../android-release.bundle'
-		sourcemap_output = '../android-release.bundle.map'
+		bundle_output = 'index.android.bundle'
+		sourcemap_output = 'index.android.bundle.map'
 		bundle_url = 'index.android.bundle'
 	when :ios
 		platform = 'ios'
 		entry_file = 'index.js'
-		bundle_output = '../ios-release.bundle'
-		sourcemap_output = '../ios-release.bundle.map'
+		bundle_output = 'main.jsbundle'
+		sourcemap_output = 'main.jsbundle.map'
 		bundle_url = 'main.jsbundle'
 	end
 

--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -63,7 +63,7 @@ def upload_sourcemap_to_sentry
 	       "--dist #{current_bundle_code}",
 	       "--strip-prefix #{File.expand_path(File.join(__FILE__, '..', '..', '..'))}",
 	       '--rewrite',
-	       args[:bundle_output]
+	       args[:bundle_output],
 	       args[:sourcemap_output]
 	].join ' '
 


### PR DESCRIPTION
So we've been properly uploading _some_ of the sourcemap files, but there have been a couple of problems.

- We haven't been uploading files that match the [naming rules](https://docs.sentry.io/platforms/react-native/manual-setup/sourcemaps/#naming-rules). For example, last night [we uploaded](https://github.com/StoDevX/AAO-React-Native/runs/2311877624?check_suite_focus=true#step:11:857) `android-release.bundle.map`, which is not `index.android.bundle`.
- We haven't actually been uploading the _bundle_ — just the sourcemap. (See the "we uploaded" link above; it only included the sourcemap filename, not the actual bundle filename too).

This PR updates the sourcemaps code to follow [the guidelines](https://docs.sentry.io/platforms/react-native/manual-setup/sourcemaps/) and removes the old `bundle_url` arg. I'm still not sure about which directory these commands will execute in, so there might need to be follow-ups to fix that, but this should at least get us closer to having working sourcemaps.

I'm not sure how this will affect native code bundling, but we'll at least get the JavaScript sourcemaps now.

I think I will try beta-ing after this PR is merged to both check that our beta pipeline still works well and also to test this new sourcemap uploading.