### PR TITLE
Allow for setting of server url in development

### DIFF
--- a/modules/tableview/cells/textfield.tsx
+++ b/modules/tableview/cells/textfield.tsx
@@ -37,7 +37,7 @@ type Props = {
 	disabled: boolean
 	multiline?: boolean
 	onChangeText: (string) => any
-	onSubmitEditing: (string) => any
+	onSubmitEditing?: (string) => any
 	placeholder: string
 	returnKeyType: 'done' | 'next' | 'default'
 	secureTextEntry: boolean
@@ -62,7 +62,7 @@ export class CellTextField extends React.Component<Props> {
 	}
 
 	onSubmit = () => {
-		this.props.onSubmitEditing(this.props.value)
+		this.props.onSubmitEditing?.(this.props.value)
 	}
 
 	render() {

--- a/source/init/api.ts
+++ b/source/init/api.ts
@@ -1,3 +1,15 @@
 import {setApiRoot} from '@frogpond/api'
+import * as storage from '../lib/storage'
+import {PRODUCTION_SERVER_URL} from '../lib/constants'
 
-setApiRoot('https://stolaf.api.frogpond.tech/v1')
+const configureApiRoot = async () => {
+	let address = await storage.getServerAddress()
+
+	if (!address) {
+		address = PRODUCTION_SERVER_URL
+	}
+
+	setApiRoot(address)
+}
+
+configureApiRoot()

--- a/source/init/api.ts
+++ b/source/init/api.ts
@@ -1,12 +1,12 @@
 import {setApiRoot} from '@frogpond/api'
 import * as storage from '../lib/storage'
-import {PRODUCTION_SERVER_URL} from '../lib/constants'
+import {DEFAULT_URL} from '../lib/constants'
 
 const configureApiRoot = async () => {
 	let address = await storage.getServerAddress()
 
 	if (!address) {
-		address = PRODUCTION_SERVER_URL
+		address = DEFAULT_URL
 	}
 
 	setApiRoot(address)

--- a/source/lib/constants.ts
+++ b/source/lib/constants.ts
@@ -1,3 +1,3 @@
 export const GH_BASE_URL = 'https://github.com/StoDevX/AAO-React-Native'
 export const GH_NEW_ISSUE_URL = `${GH_BASE_URL}/issues/new`
-export const PRODUCTION_SERVER_URL = 'https://stolaf.api.frogpond.tech/v1'
+export const DEFAULT_URL = 'https://stolaf.api.frogpond.tech/v1'

--- a/source/lib/constants.ts
+++ b/source/lib/constants.ts
@@ -1,2 +1,3 @@
 export const GH_BASE_URL = 'https://github.com/StoDevX/AAO-React-Native'
 export const GH_NEW_ISSUE_URL = `${GH_BASE_URL}/issues/new`
+export const PRODUCTION_SERVER_URL = 'https://stolaf.api.frogpond.tech/v1'

--- a/source/lib/storage.ts
+++ b/source/lib/storage.ts
@@ -1,4 +1,5 @@
 import {
+	getItem,
 	setItem,
 	clearAsyncStorage,
 	getItemAsBoolean,
@@ -34,6 +35,14 @@ export function setAcknowledgementStatus(status: boolean): Promise<void> {
 }
 export function getAcknowledgementStatus(): Promise<boolean> {
 	return getItemAsBoolean(acknowledgementStatusKey)
+}
+
+const serverAddressKey = 'settings:server-address'
+export function setServerAddress(address: string): Promise<void> {
+	return setItem(serverAddressKey, address)
+}
+export function getServerAddress(): Promise<string> {
+	return getItem(serverAddressKey)
 }
 
 /// MARK: Favorite Buildings

--- a/source/views/settings/screens/overview/developer.tsx
+++ b/source/views/settings/screens/overview/developer.tsx
@@ -1,28 +1,16 @@
 import * as Sentry from '@sentry/react-native'
 import * as React from 'react'
-import {Alert, StyleSheet} from 'react-native'
-import {
-	Section,
-	PushButtonCell,
-	CellTextField,
-	ButtonCell,
-} from '@frogpond/tableview'
+import {Alert} from 'react-native'
+import { Section, PushButtonCell } from '@frogpond/tableview'
 import type {NavigationScreenProp} from 'react-navigation'
 import {isDevMode} from '@frogpond/constants'
-import restart from 'react-native-restart'
-import * as storage from '../../../../lib/storage'
-import {PRODUCTION_SERVER_URL} from '../../../../lib/constants'
+import { ServerUrlSection } from './server-url'
 
 type Props = {
 	navigation: NavigationScreenProp<any>
 }
 
 export const DeveloperSection = ({navigation}: Props): React.ReactElement => {
-	const [serverAddress, setServerAddress] = React.useState('')
-	const _serverAddress = React.useRef<CellTextField>(null)
-
-	const [errorMessage, setErrorMessage] = React.useState('')
-
 	const onAPIButton = () => navigation.navigate('APITestView')
 	const onBonAppButton = () => navigation.navigate('BonAppPickerView')
 	const onDebugButton = () => navigation.navigate('DebugView')
@@ -47,31 +35,6 @@ export const DeveloperSection = ({navigation}: Props): React.ReactElement => {
 		}
 	}
 
-	const checkForValidity = (text: string) => {
-		const pattern = /^(http|https):\/\/[^ "]+$/u
-		const isUrlValid = pattern.test(text)
-		const isValid = isUrlValid || text.length === 0
-
-		isValid ? setErrorMessage('') : setErrorMessage('Waiting for a valid url…')
-	}
-
-	const handleOnChange = (text: string) => {
-		setServerAddress(text)
-		checkForValidity(text)
-	}
-
-	const refreshApp = () => {
-		storage.setServerAddress(serverAddress)
-		restart.Restart()
-	}
-
-	React.useMemo(async () => {
-		if (!serverAddress && !_serverAddress.current) {
-			const address = await storage.getServerAddress()
-			setServerAddress(address)
-		}
-	}, [serverAddress])
-
 	return (
 		<>
 			<Section header="DEVELOPER">
@@ -88,32 +51,7 @@ export const DeveloperSection = ({navigation}: Props): React.ReactElement => {
 				/>
 			</Section>
 
-			<Section
-				footer={
-					serverAddress ? '' : 'Empty means we will use the production server.'
-				}
-				header="SERVER"
-			>
-				<CellTextField
-					key={0}
-					_ref={_serverAddress}
-					onChangeText={handleOnChange}
-					placeholder={`${PRODUCTION_SERVER_URL}`}
-					value={serverAddress}
-				/>
-				<ButtonCell
-					disabled={errorMessage.length > 0}
-					onPress={refreshApp}
-					textStyle={styles.buttonCell}
-					title={errorMessage ? errorMessage : 'Update Server URL'}
-				/>
-			</Section>
+			<ServerUrlSection />
 		</>
 	)
 }
-
-const styles = StyleSheet.create({
-	buttonCell: {
-		textAlign: 'center',
-	},
-})

--- a/source/views/settings/screens/overview/developer.tsx
+++ b/source/views/settings/screens/overview/developer.tsx
@@ -1,10 +1,10 @@
 import * as Sentry from '@sentry/react-native'
 import * as React from 'react'
 import {Alert} from 'react-native'
-import { Section, PushButtonCell } from '@frogpond/tableview'
+import {Section, PushButtonCell} from '@frogpond/tableview'
 import type {NavigationScreenProp} from 'react-navigation'
 import {isDevMode} from '@frogpond/constants'
-import { ServerUrlSection } from './server-url'
+import {ServerUrlSection} from './server-url'
 
 type Props = {
 	navigation: NavigationScreenProp<any>

--- a/source/views/settings/screens/overview/developer.tsx
+++ b/source/views/settings/screens/overview/developer.tsx
@@ -1,25 +1,40 @@
 import * as Sentry from '@sentry/react-native'
 import * as React from 'react'
-import {Alert} from 'react-native'
-import {Section, PushButtonCell} from '@frogpond/tableview'
+import {Alert, StyleSheet} from 'react-native'
+import {
+	Section,
+	PushButtonCell,
+	CellTextField,
+	ButtonCell,
+} from '@frogpond/tableview'
 import type {NavigationScreenProp} from 'react-navigation'
 import {isDevMode} from '@frogpond/constants'
+import restart from 'react-native-restart'
+import * as storage from '../../../../lib/storage'
+import {PRODUCTION_SERVER_URL} from '../../../../lib/constants'
 
-type Props = {navigation: NavigationScreenProp<any>}
+type Props = {
+	navigation: NavigationScreenProp<any>
+}
 
-export class DeveloperSection extends React.Component<Props> {
-	onAPIButton = () => this.props.navigation.navigate('APITestView')
-	onBonAppButton = () => this.props.navigation.navigate('BonAppPickerView')
-	onDebugButton = () => this.props.navigation.navigate('DebugView')
-	sendSentryMessage = () => {
+export const DeveloperSection = ({navigation}: Props): React.ReactElement => {
+	const [serverAddress, setServerAddress] = React.useState('')
+	const _serverAddress = React.useRef<CellTextField>(null)
+
+	const [errorMessage, setErrorMessage] = React.useState('')
+
+	const onAPIButton = () => navigation.navigate('APITestView')
+	const onBonAppButton = () => navigation.navigate('BonAppPickerView')
+	const onDebugButton = () => navigation.navigate('DebugView')
+	const sendSentryMessage = () => {
 		Sentry.captureMessage('A Sentry Message', {level: 'info'})
-		this.showSentryAlert()
+		showSentryAlert()
 	}
-	sendSentryException = () => {
+	const sendSentryException = () => {
 		Sentry.captureException(new Error('Debug Exception'))
-		this.showSentryAlert()
+		showSentryAlert()
 	}
-	showSentryAlert = () => {
+	const showSentryAlert = () => {
 		if (isDevMode()) {
 			Alert.alert(
 				'Sentry button pressed',
@@ -32,24 +47,73 @@ export class DeveloperSection extends React.Component<Props> {
 		}
 	}
 
-	render() {
-		return (
+	const checkForValidity = (text: string) => {
+		const pattern = /^(http|https):\/\/[^ "]+$/u
+		const isUrlValid = pattern.test(text)
+		const isValid = isUrlValid || text.length === 0
+
+		isValid ? setErrorMessage('') : setErrorMessage('Waiting for a valid url…')
+	}
+
+	const handleOnChange = (text: string) => {
+		setServerAddress(text)
+		checkForValidity(text)
+	}
+
+	const refreshApp = () => {
+		storage.setServerAddress(serverAddress)
+		restart.Restart()
+	}
+
+	React.useMemo(async () => {
+		if (!serverAddress && !_serverAddress.current) {
+			const address = await storage.getServerAddress()
+			setServerAddress(address)
+		}
+	}, [serverAddress])
+
+	return (
+		<>
 			<Section header="DEVELOPER">
-				<PushButtonCell onPress={this.onAPIButton} title="API Tester" />
+				<PushButtonCell onPress={onAPIButton} title="API Tester" />
+				<PushButtonCell onPress={onBonAppButton} title="Bon Appetit Picker" />
+				<PushButtonCell onPress={onDebugButton} title="Debug" />
 				<PushButtonCell
-					onPress={this.onBonAppButton}
-					title="Bon Appetit Picker"
-				/>
-				<PushButtonCell onPress={this.onDebugButton} title="Debug" />
-				<PushButtonCell
-					onPress={this.sendSentryMessage}
+					onPress={sendSentryMessage}
 					title="Send a Sentry Message"
 				/>
 				<PushButtonCell
-					onPress={this.sendSentryException}
+					onPress={sendSentryException}
 					title="Send a Sentry Exception"
 				/>
 			</Section>
-		)
-	}
+
+			<Section
+				footer={
+					serverAddress ? '' : 'Empty means we will use the production server.'
+				}
+				header="SERVER"
+			>
+				<CellTextField
+					key={0}
+					_ref={_serverAddress}
+					onChangeText={handleOnChange}
+					placeholder={`${PRODUCTION_SERVER_URL}`}
+					value={serverAddress}
+				/>
+				<ButtonCell
+					disabled={errorMessage.length > 0}
+					onPress={refreshApp}
+					textStyle={styles.buttonCell}
+					title={errorMessage ? errorMessage : 'Update Server URL'}
+				/>
+			</Section>
+		</>
+	)
 }
+
+const styles = StyleSheet.create({
+	buttonCell: {
+		textAlign: 'center',
+	},
+})

--- a/source/views/settings/screens/overview/server-url.tsx
+++ b/source/views/settings/screens/overview/server-url.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import {StyleSheet} from 'react-native'
+import { Section, CellTextField, ButtonCell } from '@frogpond/tableview'
+import restart from 'react-native-restart'
+import * as storage from '../../../../lib/storage'
+import {DEFAULT_URL} from '../../../../lib/constants'
+
+export const ServerUrlSection = (): React.ReactElement => {
+	const [serverAddress, setServerAddress] = React.useState('')
+	const serverAddressRef = React.useRef<CellTextField>(null)
+
+	const [errorMessage, setErrorMessage] = React.useState('')
+
+	const checkForValidity = (text: string) => {
+		const pattern = /^(http|https):\/\/[^ "]+$/u
+		const isUrlValid = pattern.test(text)
+		const isValid = isUrlValid || text.length === 0
+
+		isValid ? setErrorMessage('') : setErrorMessage('Waiting for a valid URL…')
+	}
+
+	const handleOnChange = (text: string) => {
+		setServerAddress(text)
+		checkForValidity(text)
+	}
+
+	const refreshApp = () => {
+		storage.setServerAddress(serverAddress)
+		restart.Restart()
+	}
+
+	React.useMemo(async () => {
+		if (!serverAddress && !serverAddressRef.current) {
+			const address = await storage.getServerAddress()
+			setServerAddress(address)
+		}
+	}, [serverAddress])
+
+	return (
+        <Section
+            footer={
+                serverAddress ? '' : 'Empty means we will use the default URL.'
+            }
+            header="SERVER URL"
+        >
+            <CellTextField
+                key={0}
+                _ref={serverAddressRef}
+                onChangeText={handleOnChange}
+                placeholder={DEFAULT_URL}
+                value={serverAddress}
+            />
+            <ButtonCell
+                disabled={errorMessage.length > 0}
+                onPress={refreshApp}
+                textStyle={styles.buttonCell}
+                title={errorMessage ? errorMessage : 'Save'}
+            />
+        </Section>
+	)
+}
+
+const styles = StyleSheet.create({
+	buttonCell: {
+		textAlign: 'center',
+	},
+})

--- a/source/views/settings/screens/overview/server-url.tsx
+++ b/source/views/settings/screens/overview/server-url.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {StyleSheet} from 'react-native'
-import { Section, CellTextField, ButtonCell } from '@frogpond/tableview'
+import {Section, CellTextField, ButtonCell} from '@frogpond/tableview'
 import restart from 'react-native-restart'
 import * as storage from '../../../../lib/storage'
 import {DEFAULT_URL} from '../../../../lib/constants'
@@ -37,26 +37,24 @@ export const ServerUrlSection = (): React.ReactElement => {
 	}, [serverAddress])
 
 	return (
-        <Section
-            footer={
-                serverAddress ? '' : 'Empty means we will use the default URL.'
-            }
-            header="SERVER URL"
-        >
-            <CellTextField
-                key={0}
-                _ref={serverAddressRef}
-                onChangeText={handleOnChange}
-                placeholder={DEFAULT_URL}
-                value={serverAddress}
-            />
-            <ButtonCell
-                disabled={errorMessage.length > 0}
-                onPress={refreshApp}
-                textStyle={styles.buttonCell}
-                title={errorMessage ? errorMessage : 'Save'}
-            />
-        </Section>
+		<Section
+			footer={serverAddress ? '' : 'Empty means we will use the default URL.'}
+			header="SERVER URL"
+		>
+			<CellTextField
+				key={0}
+				_ref={serverAddressRef}
+				onChangeText={handleOnChange}
+				placeholder={DEFAULT_URL}
+				value={serverAddress}
+			/>
+			<ButtonCell
+				disabled={errorMessage.length > 0}
+				onPress={refreshApp}
+				textStyle={styles.buttonCell}
+				title={errorMessage ? errorMessage : 'Save'}
+			/>
+		</Section>
 	)
 }
 


### PR DESCRIPTION
What this does
* Adds a component for getting/setting the server url to localstorage
* Switches the development settings screen to a functional component

General notes
* The demo had a _tiny_ bit of  🎩🪄 magic applied to it. I ended up having to bust `mem`'s cache inside `ccc-server` to get what you see here.
* You may stick urls in there that may or may not be servers. I won't stop you.
* What about android? It works. Don't you worry.

~ | ~ 
--|--
empty | ![empty](https://user-images.githubusercontent.com/5240843/117249972-ba5f3700-adff-11eb-8337-fb3d6f52f1bc.png)
invalid | ![invalid](https://user-images.githubusercontent.com/5240843/117249973-baf7cd80-adff-11eb-8bed-c6623261830d.png)
valid | ![valid](https://user-images.githubusercontent.com/5240843/117249975-bb906400-adff-11eb-87b9-7b029f85ea26.png)

Demo

https://user-images.githubusercontent.com/5240843/117249977-bc28fa80-adff-11eb-8d36-8ce2ee8f2c42.mov

