### PR TITLE
dependabot: Use a higher limit on the number of open pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,14 @@ updates:
   schedule:
     interval: weekly
     time: '11:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 100
   commit-message: { prefix: "" }
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
     time: '11:00'
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 100
   commit-message: { prefix: "" }
   ignore:
   - dependency-name: react-markdown


### PR DESCRIPTION
There are a number of major/minor bumps that require manual testing and are stalled, while we could definitely continue merging patch updates.

Up the limit to 100.
