### PR TITLE
Patch react-native files to fix the build

### DIFF
--- a/contrib/rn-fixes.patch
+++ b/contrib/rn-fixes.patch
@@ -1,0 +1,23 @@
+--- ./node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
++++ ./node_modules/react-native/React/CxxBridge/RCTCxxBridge.mm
+@@ -767,7 +767,7 @@
+ #endif
+ }
+ 
+-- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<id<RCTBridgeModule>> *)modules
++- (NSArray<RCTModuleData *> *)_initializeModules:(NSArray<Class> *)modules
+                                withDispatchGroup:(dispatch_group_t)dispatchGroup
+                                 lazilyDiscovered:(BOOL)lazilyDiscovered
+ {
+
+--- ./node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
++++ ./node_modules/react-native/ReactCommon/turbomodule/core/platform/ios/RCTTurboModuleManager.mm
+@@ -297,7 +297,7 @@
+           @"%@ has no setter or ivar for its bridge, which is not "
+            "permitted. You must either @synthesize the bridge property, "
+            "or provide your own setter method.",
+-          RCTBridgeModuleNameForClass(module));
++          RCTBridgeModuleNameForClass(Class(module)));
+     }
+   }
+ 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "d": "yarn-deduplicate && yarn",
     "ios": "react-native run-ios",
     "lint": "eslint --report-unused-disable-directives --cache source/ modules/ scripts/ images/",
+    "prepare": "patch -p0 -Nfsi contrib/rn-fixes.patch || true",
     "pretty": "prettier --write '{source,modules,scripts,images,e2e}/**/*.{js,ts,tsx,json}' 'data/**/*.css' '{*,.*}.{yaml,yml,json,js,ts,tsx}'",
     "p": "pretty-quick",
     "pods": "scripts/pods.sh",


### PR DESCRIPTION
Two patches have been added and are called inside of a prepare step as part of the app's build process. Short of a react native upgrade, we can update both `RCTCxxBridge` and `RCTTurboModuleManager` in order to fix the build.