### PR TITLE
Patch react-native to fix image assets not loading for iOS

### DIFF
--- a/contrib/rn-fixes.patch
+++ b/contrib/rn-fixes.patch
@@ -21,3 +21,16 @@
      }
    }
  
+
+--- ./node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m
++++ ./node_modules/react-native/Libraries/Image/RCTUIImageViewAnimated.m
+@@ -270,6 +270,9 @@
+     layer.contentsScale = self.animatedImageScale;
+     layer.contents = (__bridge id)_currentFrame.CGImage;
+   }
++  else {
++    [super displayLayer:layer];
++  }
+ }
+ 
+ #pragma mark - Util


### PR DESCRIPTION
Assets are failing to load on iOS builds.

* There is [an issue about this upstream](https://github.com/facebook/react-native/issues/32180).
* Our version of react-native@0.61.5 [lacks this patch](https://github.com/facebook/react-native/blob/86cad7d69099baaaeae10ac7c0912a023101f257/Libraries/Image/RCTUIImageViewAnimated.m#L267-L273). 
* Assets load properly with this patch.