### PR TITLE
Resolve a TS2459 error and two related TS2339 errors

### DIFF
--- a/images/streaming/index.ts
+++ b/images/streaming/index.ts
@@ -1,2 +1,4 @@
 import ksto from './ksto.png'
 import krlx from './krlx.png'
+
+export { ksto, krlx }

--- a/images/streaming/index.ts
+++ b/images/streaming/index.ts
@@ -1,4 +1,4 @@
 import krlx from './krlx.png'
 import ksto from './ksto.png'
 
-export { krlx, ksto }
+export {krlx, ksto}

--- a/images/streaming/index.ts
+++ b/images/streaming/index.ts
@@ -1,4 +1,4 @@
-import ksto from './ksto.png'
 import krlx from './krlx.png'
+import ksto from './ksto.png'
 
-export { ksto, krlx }
+export { krlx, ksto }


### PR DESCRIPTION
Part of #5099.

Added `export` definitions to make it explicit that the images are getting re-exported.  This also resolved two TS2339 errors.

```diff
--- tsc-errors.master        2021-10-09 11:19:05.533295862 -0500
+++ tsc-errors.ts2459        2021-10-09 11:25:36.262159940 -0500
@@ -1,6 +1,5 @@
 yarn run v1.22.10
 $ /home/kristofer/Git/StoDevX/AAO-React-Native/node_modules/.bin/tsc
-images/news-sources/index.ts(6,9): error TS2459: Module '"../streaming"' declares 'ksto' locally, but it is not exported.
 modules/ccc-calendar/index.tsx(82,6): error TS2339: Property 'json' does not exist on type 'Fetch'.
 modules/datepicker/datepicker.android.tsx(73,4): error TS2322: Type '"default" | "calendar" | "spinner"' is not assignable to type '"default" | "clock" | "spinner" | undefined'.
   Type '"calendar"' is not assignable to type '"default" | "clock" | "spinner" | undefined'.
@@ -1191,11 +1190,9 @@
 source/views/streaming/radio/station-krlx.tsx(30,19): error TS2322: Type 'PlayerTheme' is not assignable to type 'AppTheme'.
 source/views/streaming/radio/station-krlx.tsx(32,6): error TS2322: Type '{ image: any; navigation: NavType; playerUrl: string; scheduleViewName: string; source: { useEmbeddedPlayer: boolean; embeddedPlayerUrl: string; streamSourceUrl: string; }; stationName: string; stationNumber: string; title: string; }' is not assignable to type 'IntrinsicAttributes & Pick<{ theme: AppTheme | undefined; }, never> & { theme?: $DeepPartial<AppTheme | undefined>; } & { ...; }'.
   Property 'image' does not exist on type 'IntrinsicAttributes & Pick<{ theme: AppTheme | undefined; }, never> & { theme?: $DeepPartial<AppTheme | undefined>; } & { ...; }'.
-source/views/streaming/radio/station-krlx.tsx(32,19): error TS2339: Property 'krlx' does not exist on type 'typeof import("/home/kristofer/Git/StoDevX/AAO-React-Native/images/streaming/index")'.
 source/views/streaming/radio/station-ksto.tsx(33,19): error TS2740: Type 'PlayerTheme' is missing the following properties from type 'AppTheme': accent, androidListHeaderBackground, androidListHeaderForeground, androidStatusBarColor, and 13 more.
 source/views/streaming/radio/station-ksto.tsx(35,6): error TS2322: Type '{ image: any; navigation: NavType; playerUrl: string; scheduleViewName: string; source: { useEmbeddedPlayer: boolean; embeddedPlayerUrl: string; streamSourceUrl: string; }; stationName: string; stationNumber: string; title: string; }' is not assignable to type 'IntrinsicAttributes & Pick<{ theme: AppTheme | undefined; }, never> & { theme?: $DeepPartial<AppTheme | undefined>; } & { ...; }'.
   Property 'image' does not exist on type 'IntrinsicAttributes & Pick<{ theme: AppTheme | undefined; }, never> & { theme?: $DeepPartial<AppTheme | undefined>; } & { ...; }'.
-source/views/streaming/radio/station-ksto.tsx(35,19): error TS2339: Property 'ksto' does not exist on type 'typeof import("/home/kristofer/Git/StoDevX/AAO-React-Native/images/streaming/index")'.
 source/views/streaming/streams/list.tsx(12,43): error TS7016: Could not find a declaration file for module '@frogpond/titlecase'. '/home/kristofer/Git/StoDevX/AAO-React-Native/node_modules/@frogpond/titlecase/to-title-case.js' implicitly has an 'any' type.
   Try `npm i --save-dev @types/frogpond__titlecase` if it exists or add a new declaration (.d.ts) file containing `declare module '@frogpond/titlecase';`
 source/views/streaming/streams/list.tsx(41,2): error TS2416: Property 'state' in type 'StreamListView' is not assignable to the same property in base type 'PureComponent<unknown, State, any>'.
```