### PR TITLE
Resolve a TS2571 error by constraining TextInput createRef type

### DIFF
--- a/source/views/settings/screens/overview/login-credentials.tsx
+++ b/source/views/settings/screens/overview/login-credentials.tsx
@@ -45,8 +45,7 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 	_usernameInput = React.createRef<TextInput>()
 	_passwordInput = React.createRef<TextInput>()
 
-	focusPassword = () =>
-		this._passwordInput.current && this._passwordInput.current.focus()
+	focusPassword = () => this._passwordInput.current?.focus()
 
 	loadCredentialsFromKeychain = async () => {
 		let {username = '', password = ''} = await loadLoginCredentials()

--- a/source/views/settings/screens/overview/login-credentials.tsx
+++ b/source/views/settings/screens/overview/login-credentials.tsx
@@ -10,6 +10,7 @@ import {loadLoginCredentials} from '../../../../lib/login'
 import type {ReduxState} from '../../../../redux'
 import {useSelector, useDispatch} from 'react-redux'
 import noop from 'lodash/noop'
+import type {TextInput} from 'react-native'
 
 type ReduxStateProps = {
 	status: LoginStateEnum
@@ -41,8 +42,8 @@ class CredentialsLoginSection extends React.Component<Props, State> {
 		this.loadCredentialsFromKeychain()
 	}
 
-	_usernameInput = React.createRef()
-	_passwordInput = React.createRef()
+	_usernameInput = React.createRef<TextInput>()
+	_passwordInput = React.createRef<TextInput>()
 
 	focusPassword = () =>
 		this._passwordInput.current && this._passwordInput.current.focus()


### PR DESCRIPTION
Part of #5099.

Forces the `createRef` return value for the `_usernameInput` and `_passwordInput` ref objects to be a `ReactRef<TextInput>` rather than `ReactRef<unknown>`.  This means it is sound to call `focus` as long as the ref value is not `undefined`/`null`, too!  This eliminates the "object is of type 'unknown'" error, as well as a "no overload matches this call" error.

There are two related "duplicate identifier" and "parameter has a name but no type" errors, but those were resolved in #5390.

```diff
--- tsc-errors.master        2021-10-09 11:53:43.916571678 -0500
+++ tsc-errors.ts2571        2021-10-09 13:06:36.369908768 -0500
@@ -980,24 +980,10 @@
 source/views/settings/screens/overview/developer.tsx(18,46): error TS2322: Type '"info"' is not assignable to type 'Severity | undefined'.
 source/views/settings/screens/overview/developer.tsx(32,11): error TS2339: Property 'setEventSentSuccessfully' does not exist on type 'typeof import("/home/kristofer/Git/StoDevX/AAO-React-Native/node_modules/@sentry/react-native/dist/js/index")'.
 source/views/settings/screens/overview/developer.tsx(32,37): error TS7006: Parameter 'event' implicitly has an 'any' type.
-source/views/settings/screens/overview/login-credentials.tsx(19,24): error TS2300: Duplicate identifier 'string'.
-source/views/settings/screens/overview/login-credentials.tsx(19,24): error TS7051: Parameter has a name but no type. Did you mean 'arg0: string'?
-source/views/settings/screens/overview/login-credentials.tsx(19,32): error TS2300: Duplicate identifier 'string'.
-source/views/settings/screens/overview/login-credentials.tsx(19,32): error TS7051: Parameter has a name but no type. Did you mean 'arg1: string'?
-source/views/settings/screens/overview/login-credentials.tsx(48,34): error TS2571: Object is of type 'unknown'.
-source/views/settings/screens/overview/login-credentials.tsx(96,8): error TS2769: No overload matches this call.
-  Overload 1 of 2, '(props: Props | Readonly<Props>): CellTextField', gave the following error.
-    Type 'RefObject<unknown>' is not assignable to type '{ current: TextInput | null; }'.
-      Types of property 'current' are incompatible.
-        Type 'unknown' is not assignable to type 'TextInput | null'.
-          Type 'unknown' is not assignable to type 'TextInput'.
-  Overload 2 of 2, '(props: Props, context: any): CellTextField', gave the following error.
-    Type 'RefObject<unknown>' is not assignable to type '{ current: TextInput | null; }'.
-source/views/settings/screens/overview/login-credentials.tsx(108,8): error TS2769: No overload matches this call.
-  Overload 1 of 2, '(props: Props | Readonly<Props>): CellTextField', gave the following error.
-    Type 'RefObject<unknown>' is not assignable to type '{ current: TextInput | null; }'.
-  Overload 2 of 2, '(props: Props, context: any): CellTextField', gave the following error.
-    Type 'RefObject<unknown>' is not assignable to type '{ current: TextInput | null; }'.
+source/views/settings/screens/overview/login-credentials.tsx(20,24): error TS2300: Duplicate identifier 'string'.
+source/views/settings/screens/overview/login-credentials.tsx(20,24): error TS7051: Parameter has a name but no type. Did you mean 'arg0: string'?
+source/views/settings/screens/overview/login-credentials.tsx(20,32): error TS2300: Duplicate identifier 'string'.
+source/views/settings/screens/overview/login-credentials.tsx(20,32): error TS7051: Parameter has a name but no type. Did you mean 'arg1: string'?
 source/views/settings/screens/overview/miscellany.tsx(5,24): error TS7016: Could not find a declaration file for module '@hawkrives/react-native-alternate-icons'. '/home/kristofer/Git/StoDevX/AAO-React-Native/node_modules/@hawkrives/react-native-alternate-icons/index.js' implicitly has an 'any' type.
   Try `npm i --save-dev @types/hawkrives__react-native-alternate-icons` if it exists or add a new declaration (.d.ts) file containing `declare module '@hawkrives/react-native-alternate-icons';`
 source/views/settings/screens/overview/server-url.tsx(46,5): error TS2769: No overload matches this call.
```