### PR TITLE
ci: Make `yarn tsc` failures result in build failures

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -17,7 +17,7 @@ jobs:
       - run: yarn run validate-data
       - run: yarn run bundle-data
       - run: yarn run pretty --no-write --list-different
-      - run: yarn tsc || true
+      - run: yarn tsc
       - run: yarn run lint
       - name: Run tests
         run: yarn run test --coverage


### PR DESCRIPTION
This will be the conclusion of #5099, once all the standing TypeScript errors are resolved.