### PR TITLE
Resolve TS1361 errors by un-typing some imports

### DIFF
--- a/source/views/stoprint/print-jobs.tsx
+++ b/source/views/stoprint/print-jobs.tsx
@@ -4,9 +4,11 @@ import {Platform, SectionList} from 'react-native'
 import {useDispatch, useSelector} from 'react-redux'
 import type {ReduxState} from '../../redux'
 import {updatePrintJobs} from '../../redux/parts/stoprint'
-import type {LoginStateEnum, logInViaCredentials} from '../../redux/parts/login'
+import {logInViaCredentials} from '../../redux/parts/login'
+import type {LoginStateEnum} from '../../redux/parts/login'
 import {loadLoginCredentials} from '../../lib/login'
-import type {PrintJob, STOPRINT_HELP_PAGE} from '../../lib/stoprint'
+import {STOPRINT_HELP_PAGE} from '../../lib/stoprint'
+import type {PrintJob} from '../../lib/stoprint'
 import {
 	ListRow,
 	ListSeparator,


### PR DESCRIPTION
Part of #5099.

```diff
--- tsc-errors.master	2021-10-13 06:22:12.844994281 -0500
+++ tsc-errors.ts1361	2021-10-13 06:35:56.857430919 -0500
@@ -991,9 +991,7 @@
   Overload 2 of 2, '(props: IconProps, context: any): Icon', gave the following error.
     Type 'string | undefined' is not assignable to type 'string'.
       Type 'undefined' is not assignable to type 'string'.
-source/views/stoprint/print-jobs.tsx(179,29): error TS1361: 'STOPRINT_HELP_PAGE' cannot be used as a value because it was imported using 'import type'.
-source/views/stoprint/print-jobs.tsx(221,36): error TS1361: 'logInViaCredentials' cannot be used as a value because it was imported using 'import type'.
-source/views/stoprint/print-jobs.tsx(230,3): error TS2769: No overload matches this call.
+source/views/stoprint/print-jobs.tsx(232,3): error TS2769: No overload matches this call.
   Overload 2 of 2, '(props: Props, context: any): PrintJobsView', gave the following error.
     Type 'string | null' is not assignable to type 'string | undefined'.
   Overload 2 of 2, '(props: Props, context: any): PrintJobsView', gave the following error.
```