### PR TITLE
Resolve TS1015 errors by adjusting `arg? = <initializer>` cases

### DIFF
--- a/modules/fetch/index.ts
+++ b/modules/fetch/index.ts
@@ -54,7 +54,7 @@ class Fetch {
 
 	startMs: number
 
-	constructor(input: RequestInfo = '', init?: ExpandedFetchArgs = {}) {
+	constructor(input: RequestInfo = '', init: ExpandedFetchArgs = {}) {
 		let {searchParams = null} = init
 
 		this.options = {

--- a/source/views/building-hours/lib/__tests__/moment.helper.ts
+++ b/source/views/building-hours/lib/__tests__/moment.helper.ts
@@ -4,7 +4,7 @@ export {moment}
 const CENTRAL_TZ = 'America/Chicago'
 const baseTime = moment('2019-12-18T18:39:45').tz(CENTRAL_TZ)
 
-export const dayMoment = (time: string, format? = 'ddd h:mma') => {
+export const dayMoment = (time: string, format = 'ddd h:mma') => {
 	let parsed = moment.tz(time, format, false, CENTRAL_TZ)
 
 	let dayOfWeek = parsed.day()

--- a/source/views/building-hours/report/overview.tsx
+++ b/source/views/building-hours/report/overview.tsx
@@ -50,7 +50,7 @@ export class BuildingHoursProblemReportView extends React.PureComponent<
 	openEditor = (
 		scheduleIdx: number,
 		setIdx: number,
-		set?: SingleBuildingScheduleType = undefined,
+		set?: SingleBuildingScheduleType,
 	) => {
 		this.props.navigation.navigate('BuildingHoursScheduleEditorView', {
 			initialSet: set,


### PR DESCRIPTION
Part of #5099.

```diff
--- tsc-errors.master	2021-10-13 06:22:12.844994281 -0500
+++ tsc-errors.ts1015	2021-10-13 06:49:08.082870587 -0500
@@ -79,7 +79,6 @@
 modules/fetch/cached.ts(197,11): error TS2540: Cannot assign to 'headers' because it is a read-only property.
 modules/fetch/cached.ts(197,33): error TS2345: Argument of type 'Headers' is not assignable to parameter of type 'HeadersInit | undefined'.
 modules/fetch/index.ts(14,14): error TS7006: Parameter 'response' implicitly has an 'any' type.
-modules/fetch/index.ts(57,39): error TS1015: Parameter cannot have question mark and initializer.
 modules/fetch/index.ts(72,17): error TS2540: Cannot assign to 'url' because it is a read-only property.
 modules/fetch/index.ts(81,3): error TS2740: Type 'Promise<any>' is missing the following properties from type 'Response': headers, ok, redirected, status, and 12 more.
 modules/fetch/index.ts(93,3): error TS2409: Return type of constructor signature must be assignable to the instance type of the class.
@@ -630,7 +629,6 @@
 source/views/building-hours/lib/__tests__/is-schedule-open-at-moment.test.ts(36,32): error TS2345: Argument of type '{ days: string[]; from: string; to: string; }' is not assignable to parameter of type 'SingleBuildingScheduleType'.
   Types of property 'days' are incompatible.
     Type 'string[]' is not assignable to type 'DayOfWeekEnumType[]'.
-source/views/building-hours/lib/__tests__/moment.helper.ts(7,41): error TS1015: Parameter cannot have question mark and initializer.
 source/views/building-hours/lib/__tests__/parse-hours.test.ts(62,34): error TS2345: Argument of type '{ days: string[]; from: string; to: string; }' is not assignable to parameter of type 'SingleBuildingScheduleType'.
   Types of property 'days' are incompatible.
     Type 'string[]' is not assignable to type 'DayOfWeekEnumType[]'.
@@ -681,7 +679,6 @@
 source/views/building-hours/report/editor.tsx(163,40): error TS2345: Argument of type 'string' is not assignable to parameter of type 'DayOfWeekEnumType'.
 source/views/building-hours/report/editor.tsx(186,5): error TS2559: Type '(false | { backgroundColor: string; })[]' has no properties in common with type 'ViewStyle'.
 source/views/building-hours/report/editor.tsx(190,5): error TS2322: Type 'Element' is not assignable to type '[View]'.
-source/views/building-hours/report/overview.tsx(53,3): error TS1015: Parameter cannot have question mark and initializer.
 source/views/building-hours/report/overview.tsx(234,12): error TS7006: Parameter 'data' implicitly has an 'any' type.
 source/views/building-hours/report/submit.ts(35,27): error TS7006: Parameter 'before' implicitly has an 'any' type.
 source/views/building-hours/report/submit.ts(35,35): error TS7006: Parameter 'after' implicitly has an 'any' type.
```