### PR TITLE
Add a network timeout when installing node_modules on ios ci builds

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -70,7 +70,7 @@ jobs:
       - run: gem install bundler:1.17.2
       - run: bundle check || bundle install --frozen --path vendor/bundle
       # try installing node_modules twice
-      - run: yarn install --frozen-lockfile || yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --network-timeout 60000
       - run: brew tap wix/brew
       - run: brew install applesimutils
       - run: bundle exec fastlane ios ci-run

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -69,7 +69,8 @@ jobs:
       - run: git fetch --prune --unshallow
       - run: gem install bundler:1.17.2
       - run: bundle check || bundle install --frozen --path vendor/bundle
-      - run: yarn install --frozen-lockfile
+      # try installing node_modules twice
+      - run: yarn install --frozen-lockfile || yarn install --frozen-lockfile
       - run: brew tap wix/brew
       - run: brew install applesimutils
       - run: bundle exec fastlane ios ci-run


### PR DESCRIPTION
yarn fails so often…