### PR TITLE
bump delay to v5

### DIFF
--- a/modules/add-to-device-calendar/package.json
+++ b/modules/add-to-device-calendar/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "delay": "^4.1.0",
+    "delay": "^5.0.0",
     "react": "^16.0.0",
     "react-native": "^0.61.0",
     "react-native-calendar-events": "^1.6.3"

--- a/modules/ccc-calendar/package.json
+++ b/modules/ccc-calendar/package.json
@@ -12,7 +12,7 @@
     "react": "^16.0.0",
     "react-navigation": "^4.0.10",
     "moment-timezone": "^0.5.21",
-    "delay": "^4.1.0"
+    "delay": "^5.0.0"
   },
   "dependencies": {
     "@frogpond/api": "^1.0.0",

--- a/modules/fetch/package.json
+++ b/modules/fetch/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@frogpond/constants": "^1.0.0",
-    "delay": "^4.4.1",
+    "delay": "^5.0.0",
     "http-cache-semantics": "^4.1.0",
     "lodash": "^4.17.21",
     "query-string": "^7.0.1"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@sentry/react-native": "2.4.3",
     "base-64": "1.0.0",
     "buffer": "6.0.3",
-    "delay": "4.4.1",
+    "delay": "5.0.0",
     "events": "3.3.0",
     "glamorous-native": "2.0.0",
     "jsc-android": "250230.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3563,10 +3563,10 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-delay@4.4.1, delay@^4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/delay/-/delay-4.4.1.tgz#6e02d02946a1b6ab98b39262ced965acba2ac4d1"
-  integrity sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ==
+delay@5.0.0, delay@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/delay/-/delay-5.0.0.tgz#137045ef1b96e5071060dd5be60bf9334436bd1d"
+  integrity sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==
 
 delayed-stream@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
The only breaking change was some object rest/spread syntax, which bumped the required node version from 6 to 10. Not an issue for us.﻿
