### PR TITLE
add logic to pull down the ios app store api token

### DIFF
--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -131,8 +131,43 @@ platform :ios do
 		# set up things so they can run
 		authorize_ci_for_keys
 
+		# hook up the app store connect api token
+		load_app_store_connect_api_token
+
 		# and run
 		auto_beta
+	end
+
+	desc 'properly load the iOS App Store Connect API token'
+	lane :load_app_store_connect_api_token do
+		match_dir = clone_match
+
+		# we'll be copying files out of the tempdir from the git-clone operation
+		src = "#{match_dir}/ios"
+		# don't forget: lanes run inside of ./fastlane, so we go up a level for our basedir
+		dest = File.expand_path('..', '.')
+
+		# we export this variable so that Gradle knows where to find the .properties file
+		token_dest = "#{dest}/ios/AuthKey_WPMP85A826.p8"
+
+		pairs = [
+			{:from => "#{src}/AuthKey_WPMP85A826.p8", :to => token_dest},
+		]
+
+		pairs.each do |pair|
+			UI.command "cp #{pair[:from]} #{pair[:to]}"
+			FileUtils.cp(pair[:from], pair[:to])
+		end
+
+		remove_match_clone(dir: match_dir)
+
+		app_store_connect_api_key(
+			key_id: "WPMP85A826",
+			issuer_id: "69a6de94-2cd3-47e3-e053-5b8c7c11a4d1",
+			key_filepath: token_dest,
+			duration: 1200, # optional (maximum 1200)
+			in_house: false, # optional but may be required if using match/sigh
+		)
 	end
 
 	desc 'Fetch certs for both the app and any extensions'
@@ -153,14 +188,12 @@ platform :ios do
 
 	desc 'Generate the app and any extensions on the Apple Developer Portal / App Store Connect'
 	private_lane :generate_apps do
-		produce(
-		        app_identifier: lane_context[:APPLE_APP_ID],
+		produce(app_identifier: lane_context[:APPLE_APP_ID],
 		        app_name: lane_context[:APPLE_APP_NAME],
 		        language: 'English',
 		        enable_services: {
 			        app_group: 'on',
-		        },
-		        )
+		        })
 	end
 
 	desc 'Generate certs for the app and for any extensions'


### PR DESCRIPTION
hopefully this fixes our nightly woes? I followed https://docs.fastlane.tools/app-store-connect-api/ for the implementation. I stored the actual key in the secure repo.