### PR TITLE
apply bundler's complaints

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_FROZEN: "true"
+BUNDLE_PATH: "vendor/bundle"

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
       - run: gem install bundler:1.17.2
-      - run: bundle check || bundle install --frozen --path vendor/bundle
+      - run: bundle check || bundle install
       - name: Raise the fs.inotify ulimits to 524288 watches/queued events/user instances
         run: |
           echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_watches
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@master
       - run: git fetch --prune --unshallow
       - run: gem install bundler:1.17.2
-      - run: bundle check || bundle install --frozen --path vendor/bundle
+      - run: bundle check || bundle install
       # try installing node_modules twice
       - run: yarn install --frozen-lockfile --network-timeout 60000
       - run: brew tap wix/brew

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -36,7 +36,7 @@ jobs:
         with: {ruby-version: ^2.6}
       - uses: actions/checkout@master
       - run: yarn install --frozen-lockfile
-      - run: gem install bundler:1.17.2
+      - run: gem install bundler:2.2.22
       - run: bundle check || bundle install
       - name: Raise the fs.inotify ulimits to 524288 watches/queued events/user instances
         run: |
@@ -67,7 +67,7 @@ jobs:
       - run: sudo xcode-select -s /Applications/Xcode_11.7.app
       - uses: actions/checkout@master
       - run: git fetch --prune --unshallow
-      - run: gem install bundler:1.17.2
+      - run: gem install bundler:2.2.22
       - run: bundle check || bundle install
       # try installing node_modules twice
       - run: yarn install --frozen-lockfile --network-timeout 60000

--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ fastlane/play-private-key.json
 
 # rubygems bundle
 /vendor/bundle/
-/.bundle/
 
 # detox artifacts folder
 /artifacts


### PR DESCRIPTION
- stop ignoring /.bundle
- use the bundle config file

Bundler was complaining about us using deprecated flags, so let's do as it asks and stop using them.

```
[DEPRECATED] The `--frozen` flag is deprecated because it relies on being 
remembered across bundler invocations, which bundler will no longer do in 
future versions. Instead please use `bundle config set --local frozen 'true'`, 
and stop using this flag
```

```
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered 
across bundler invocations, which bundler will no longer do in future versions. 
Instead please use `bundle config set --local path 'vendor/bundle'`, and stop using 
this flag
```
