### PR TITLE
ci: Upgrade macOS from 10.15 to 11.6 and Xcode 11.7 to to 12.5.1

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -60,7 +60,7 @@ jobs:
 
   ios:
     name: Build for iOS
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - uses: actions/setup-node@master
         with: {node-version: ^16.0}

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/setup-node@master
         with: {node-version: ^16.0}
-      - run: sudo xcode-select -s /Applications/Xcode_11.7.app
+      - run: sudo xcode-select -s /Applications/Xcode_12.5.1.app
       - uses: actions/checkout@master
       - run: git fetch --prune --unshallow
       - run: gem install bundler:2.2.22

--- a/package.json
+++ b/package.json
@@ -56,13 +56,13 @@
     "configurations": {
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/AllAboutOlaf.app",
-        "build": "xcodebuild -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.7' -derivedDataPath ios/build build",
+        "build": "xcodebuild -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 8,OS=14.5' -derivedDataPath ios/build build",
         "type": "ios.simulator",
         "name": "iPhone 8"
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app",
-        "build": "xcodebuild -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -configuration Release -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.7' -derivedDataPath ios/build build",
+        "build": "xcodebuild -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf -configuration Release -destination 'platform=iOS Simulator,name=iPhone 8,OS=14.5' -derivedDataPath ios/build build",
         "type": "ios.simulator",
         "name": "iPhone 8"
       }


### PR DESCRIPTION
This increases our SDK version from 13.7 to 14.5, and the detox configurations to match.

This is the intermediate step I think we should take before #5503 — and would enable us to do #5501.