### PR TITLE
inhibit all build warnings from native deps

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -40,4 +40,5 @@ target 'AllAboutOlaf' do
 	end
 
 	use_native_modules!
+	inhibit_all_warnings!
 end


### PR DESCRIPTION
We really don't care that FB can't seem to write C++ code without warnings. So let's ignore them.﻿
