### PR TITLE
slight tweaks to github workflows

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -97,6 +97,10 @@ jobs:
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
       - run: git fetch --prune --unshallow
       - run: npm ci
+        env:
+          SKIP_POSTINSTALL: '1'
+      - run: bundle exec pod check || bundle exec pod install
+        working-directory: ./ios
       - run: brew tap wix/brew
       - run: brew install applesimutils
       - run: bundle exec fastlane ios ci-run

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -41,6 +41,15 @@ jobs:
         with: 
           ruby-version: '2.6'
           bundler-cache: true
+      - name: Restore Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - run: npm ci
       - name: Raise the fs.inotify ulimits to 524288 watches/queued events/user instances
         run: |

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -75,6 +75,16 @@ jobs:
         with: 
           ruby-version: '2.6'
           bundler-cache: true
+      - name: Restore Pods cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ios/Pods
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
       - run: git fetch --prune --unshallow
       - run: npm ci

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -10,11 +10,11 @@ jobs:
     name: JavaScript Checks
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
           cache: npm
-      - uses: actions/checkout@v2
       - run: npm ci
       - run: npm run validate-data
       - run: npm run bundle-data
@@ -32,6 +32,7 @@ jobs:
     name: Build for Android
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
@@ -39,7 +40,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with: 
           ruby-version: ^2.6
-      - uses: actions/checkout@v2
       - run: npm ci
       - run: gem install bundler:2.2.22
       - run: bundle check || bundle install
@@ -67,12 +67,12 @@ jobs:
     name: Build for iOS
     runs-on: macos-11
     steps:
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
           cache: npm
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
-      - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
       - run: gem install bundler:2.2.22
       - run: bundle check || bundle install

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -39,7 +39,7 @@ jobs:
           cache: npm
       - uses: ruby/setup-ruby@v1
         with: 
-          ruby-version: ^2.6
+          ruby-version: '2.6'
           bundler-cache: true
       - run: npm ci
       - name: Raise the fs.inotify ulimits to 524288 watches/queued events/user instances
@@ -73,7 +73,7 @@ jobs:
           cache: npm
       - uses: ruby/setup-ruby@v1
         with: 
-          ruby-version: ^2.6
+          ruby-version: '2.6'
           bundler-cache: true
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
       - run: git fetch --prune --unshallow

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-node@master
         with: 
           node-version: ^16.0
-      - uses: actions/setup-ruby@master
+      - uses: ruby/setup-ruby@v1
         with: 
           ruby-version: ^2.6
       - uses: actions/checkout@master

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -94,6 +94,10 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
+      - uses: mikehardy/buildcache-action@v1
+        continue-on-error: true
+        with:
+          cache_key: ${{ matrix.os }}
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
       - run: git fetch --prune --unshallow
       - run: npm ci

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - run: npm ci
       - run: npm run validate-data
       - run: npm run bundle-data
@@ -37,7 +37,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with: 
           ruby-version: ^2.6
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - run: npm ci
       - run: gem install bundler:2.2.22
       - run: bundle check || bundle install
@@ -69,7 +69,7 @@ jobs:
         with: 
           node-version: ^16.0
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
       - run: gem install bundler:2.2.22
       - run: bundle check || bundle install

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -77,7 +77,6 @@ jobs:
           bundler-cache: true
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
       - run: git fetch --prune --unshallow
-      # try installing node_modules twice
       - run: npm ci
       - run: brew tap wix/brew
       - run: brew install applesimutils

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -10,7 +10,7 @@ jobs:
     name: JavaScript Checks
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
       - uses: actions/checkout@master
@@ -31,7 +31,7 @@ jobs:
     name: Build for Android
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
       - uses: ruby/setup-ruby@v1
@@ -65,7 +65,7 @@ jobs:
     name: Build for iOS
     runs-on: macos-11
     steps:
-      - uses: actions/setup-node@master
+      - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -40,9 +40,8 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with: 
           ruby-version: ^2.6
+          bundler-cache: true
       - run: npm ci
-      - run: gem install bundler:2.2.22
-      - run: bundle check || bundle install
       - name: Raise the fs.inotify ulimits to 524288 watches/queued events/user instances
         run: |
           echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_watches
@@ -72,10 +71,12 @@ jobs:
         with: 
           node-version: ^16.0
           cache: npm
+      - uses: ruby/setup-ruby@v1
+        with: 
+          ruby-version: ^2.6
+          bundler-cache: true
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
       - run: git fetch --prune --unshallow
-      - run: gem install bundler:2.2.22
-      - run: bundle check || bundle install
       # try installing node_modules twice
       - run: npm ci
       - run: brew tap wix/brew

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -103,7 +103,7 @@ jobs:
       - run: npm ci
         env:
           SKIP_POSTINSTALL: '1'
-      - run: bundle exec pod check || bundle exec pod install
+      - run: bundle exec pod install
         working-directory: ./ios
       - run: brew tap wix/brew
       - run: brew install applesimutils

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
+          cache: npm
       - uses: actions/checkout@v2
       - run: npm ci
       - run: npm run validate-data
@@ -34,6 +35,7 @@ jobs:
       - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
+          cache: npm
       - uses: ruby/setup-ruby@v1
         with: 
           ruby-version: ^2.6
@@ -68,6 +70,7 @@ jobs:
       - uses: actions/setup-node@v2
         with: 
           node-version: ^16.0
+          cache: npm
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -91,5 +91,5 @@ jobs:
           SENTRY_PROJECT: all-about-olaf
           SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_SENTRY_AUTH_TOKEN }}
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
-      - run: npx detox build e2e --configuration ios.sim.release | xcpretty
+      - run: npx detox build e2e --configuration ios.sim.release
       - run: npx detox test e2e --configuration ios.sim.release --cleanup

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -11,7 +11,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/setup-node@master
-        with: {node-version: ^16.0}
+        with: 
+          node-version: ^16.0
       - uses: actions/checkout@master
       - run: npm ci
       - run: npm run validate-data
@@ -31,9 +32,11 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/setup-node@master
-        with: {node-version: ^16.0}
+        with: 
+          node-version: ^16.0
       - uses: actions/setup-ruby@master
-        with: {ruby-version: ^2.6}
+        with: 
+          ruby-version: ^2.6
       - uses: actions/checkout@master
       - run: npm ci
       - run: gem install bundler:2.2.22
@@ -63,7 +66,8 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: actions/setup-node@master
-        with: {node-version: ^16.0}
+        with: 
+          node-version: ^16.0
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
       - uses: actions/checkout@master
       - run: git fetch --prune --unshallow

--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   js:
     name: JavaScript Checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -30,7 +30,7 @@ jobs:
 
   android:
     name: Build for Android
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -40,6 +40,11 @@ target 'AllAboutOlaf' do
 		# Pods for testing
 	end
 
+	use_native_modules!
+	inhibit_all_warnings!
+end
+
+post_install do |installer|
 	# this looks redundant, but it should help xcode use the buildcache wrappers in CI
 	installer.pods_project.targets.each do |target|
 		target.build_configurations.each do |config|
@@ -49,7 +54,4 @@ target 'AllAboutOlaf' do
 			config.build_settings["LDPLUSPLUS"] = "clang++"
 		end
 	end
-
-	use_native_modules!
-	inhibit_all_warnings!
 end

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -40,6 +40,16 @@ target 'AllAboutOlaf' do
 		# Pods for testing
 	end
 
+	# this looks redundant, but it should help xcode use the buildcache wrappers in CI
+	installer.pods_project.targets.each do |target|
+		target.build_configurations.each do |config|
+			config.build_settings["CC"] = "clang"
+			config.build_settings["LD"] = "clang"
+			config.build_settings["CXX"] = "clang++"
+			config.build_settings["LDPLUSPLUS"] = "clang++"
+		end
+	end
+
 	use_native_modules!
 	inhibit_all_warnings!
 end

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pretty": "prettier --write '{source,modules,scripts,images,e2e}/**/*.{js,ts,tsx,json}' 'data/**/*.css' '{*,.*}.{yaml,yml,json,js,ts,tsx}'",
     "p": "pretty-quick",
     "pods": "scripts/pods.sh",
-    "postinstall": "jetify && npm run pods",
+    "postinstall": "if [ -z \"$SKIP_POSTINSTALL\" ]; then jetify && npm run pods; fi",
     "start": "react-native start",
     "test": "jest",
     "validate-bus-data": "node scripts/validate-bus-schedules.mjs",


### PR DESCRIPTION
- I reformatted the file a little, because I needed to add some additional keys to some actions
- I started caching `npm`'s dependencies
- I started caching `bundler`'s dependencies
- I started caching `gradle`'s dependencies
- I switched to the "action" for setting up ruby on macOS
- I pinned the versions of any actions that were pointing `action@master`
- I upgraded the linux workers to Ubuntu 20.04
- I dropped our use of `xcpretty`
- I added cocoapods caching
- I added xcode build caching

## JS Checks
| step                  | before | after | change |
| --------------------- | -----: | ----: | -----: |
| `setup node`          |     1s |    4s |    +3s |
| `npm ci`              |    57s |   25s |   -32s |
| total                 |    58s |   29s |   -29s |

## Android
| step                  | before | after | change |
| --------------------- | -----: | ----: | -----: |
| `setup node`          |     1s |    7s |    +6s |
| `setup ruby`          |     1s |    3s |    +2s |
| `npm ci`              |    53s |   26s |   -27s |
| `gem install bundler` |     8s |    0s |    -8s |
| `bundle install`      |    40s |    0s |   -40s |
| total                 |   103s |   36s |   -67s |

## iOS
| step                  | before | after | change |
| --------------------- | -----: | ----: | -----: |
| `setup node`          |     1s |    7s |    +6s |
| `setup ruby`          |     0s |   10s |   +10s |
| `setup pods`          |     0s |   12s |   +12s |
| restore xcode cache   |     0s |    7s |    +7s |
| `npm ci`              |   159s |   54s |  -105s |
| `pod install`         |     0s |   11s |   +11s |
| `gem install bundler` |     8s |    0s |    -8s |
| `bundle install`      |    48s |    0s |   -48s |
| `detox build`         |   543s |  339s |  -204s |
| total                 |   759s |  440s |  -319s |
