### PR TITLE
Shorten schedule titles for the cage and the pause

### DIFF
--- a/data/building-hours/1-1-cage.yaml
+++ b/data/building-hours/1-1-cage.yaml
@@ -3,7 +3,7 @@ image: cage
 category: Food
 
 schedule:
-  - title: Cage Hours
+  - title: Hours
     notes: The kitchen stops cooking at 8 p.m.
     hours:
       - {days: [Mo, Tu, We, Th, Fr], from: '7:30am', to: '8:00pm'}

--- a/data/building-hours/1-2-pause-kitchen.yaml
+++ b/data/building-hours/1-2-pause-kitchen.yaml
@@ -3,7 +3,7 @@ image: pause-kitchen
 category: Food
 
 schedule:
-  - title: General Hours
+  - title: Hours
     hours:
       - {days: [Mo, Tu, We, Th, Fr], from: '4:00pm', to: '12:00am'}
       - {days: [Sa, Su], from: '12:00pm', to: '12:00am'}


### PR DESCRIPTION
This condenses the schedules since there are only one of each now.
