### PR TITLE
Update message for orgs error noticeview

### DIFF
--- a/source/views/student-orgs/list.tsx
+++ b/source/views/student-orgs/list.tsx
@@ -89,7 +89,7 @@ export function StudentOrgsView(props: Props) {
 			<NoticeView
 				buttonText="Try Again"
 				onPress={reload}
-				text="A problem occured while loading the definitions"
+				text="A problem occured while loading the orgs"
 			/>
 		)
 	}


### PR DESCRIPTION
I think the message came originally from the dictionary noticeview error. This looks better if it says orgs.