### PR TITLE
More backend parsing of endpoint data

### DIFF
--- a/source/views/sis/student-work/detail.ios.tsx
+++ b/source/views/sis/student-work/detail.ios.tsx
@@ -16,7 +16,6 @@ import type {JobType} from './types'
 import glamorous from 'glamorous-native'
 import {ShareButton} from '@frogpond/navigation-buttons'
 import {shareJob, createJobFullUrl} from './lib'
-import {decode} from '@frogpond/html-lib'
 
 const styles = StyleSheet.create({
 	lastUpdated: {
@@ -120,7 +119,7 @@ function JobInformation({job}: {job: JobType}) {
 function Description({job}: {job: JobType}) {
 	return job.description ? (
 		<Section header="DESCRIPTION">
-			<SelectableCell text={decode(job.description)} />
+			<SelectableCell text={job.description} />
 		</Section>
 	) : null
 }
@@ -128,7 +127,7 @@ function Description({job}: {job: JobType}) {
 function Skills({job}: {job: JobType}) {
 	return job.skills ? (
 		<Section header="SKILLS">
-			<SelectableCell text={decode(job.skills)} />
+			<SelectableCell text={job.skills} />
 		</Section>
 	) : null
 }
@@ -136,7 +135,7 @@ function Skills({job}: {job: JobType}) {
 function Comments({job}: {job: JobType}) {
 	return job.comments ? (
 		<Section header="COMMENTS">
-			<SelectableCell text={decode(job.comments)} />
+			<SelectableCell text={job.comments} />
 		</Section>
 	) : null
 }
@@ -152,7 +151,7 @@ function FirstYearAppropriate({job}: {job: JobType}) {
 function Timeline({job}: {job: JobType}) {
 	return job.timeline ? (
 		<Section header="TIMELINE">
-			<SelectableCell text={decode(job.timeline)} />
+			<SelectableCell text={job.timeline} />
 		</Section>
 	) : null
 }
@@ -171,7 +170,7 @@ function OpenWebpage({job}: {job: JobType}) {
 function HowToApply({job}: {job: JobType}) {
 	return job.howToApply ? (
 		<Section header="HOW TO APPLY">
-			<SelectableCell text={decode(job.howToApply)} />
+			<SelectableCell text={job.howToApply} />
 		</Section>
 	) : null
 }

--- a/source/views/sis/student-work/job-row.tsx
+++ b/source/views/sis/student-work/job-row.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import {Column, Row} from '@frogpond/layout'
 import {ListRow, Detail, Title} from '@frogpond/lists'
-import {fastGetTrimmedText} from '@frogpond/html-lib'
 import type {JobType} from './types'
 
 type Props = {
@@ -14,19 +13,16 @@ export class JobRow extends React.PureComponent<Props> {
 
 	render() {
 		let {job} = this.props
-		let title = fastGetTrimmedText(job.title)
-		let office = fastGetTrimmedText(job.office)
-		let hours = fastGetTrimmedText(job.hoursPerWeek)
-		let ending = hours === 'Full-time' ? '' : 'hrs/week'
+		let ending = job.hoursPerWeek === 'Full-time' ? '' : 'hrs/week'
 
 		return (
 			<ListRow arrowPosition="top" onPress={this._onPress}>
 				<Row alignItems="center">
 					<Column flex={1}>
-						<Title lines={1}>{title}</Title>
-						<Detail lines={1}>{office}</Detail>
+						<Title lines={1}>{job.title}</Title>
+						<Detail lines={1}>{job.office}</Detail>
 						<Detail lines={1}>
-							{hours} {ending}
+							{job.hoursPerWeek} {ending}
 						</Detail>
 					</Column>
 				</Row>

--- a/source/views/streaming/streams/row.tsx
+++ b/source/views/streaming/streams/row.tsx
@@ -3,7 +3,6 @@ import {StyleSheet, Image} from 'react-native'
 
 import {ListRow, Detail, Title} from '@frogpond/lists'
 import {Column, Row} from '@frogpond/layout'
-import {innerTextWithSpaces, parseHtml} from '@frogpond/html-lib'
 import {trackedOpenUrl} from '@frogpond/open-url'
 import moment from 'moment'
 import type {StreamType} from './types'
@@ -17,15 +16,13 @@ const styles = StyleSheet.create({
 })
 
 function Name({item}: {item: StreamType}) {
-	let title = innerTextWithSpaces(parseHtml(item.title))
+	let {title} = item
 	return title ? <Title>{title}</Title> : null
 }
 
 function Info({item}: {item: StreamType}) {
-	let detail = innerTextWithSpaces(
-		parseHtml(item.subtitle || item.performer || ''),
-	)
-	return detail ? <Detail>{detail}</Detail> : null
+	let {subtitle} = item
+	return subtitle ? <Detail>{subtitle}</Detail> : null
 }
 
 function Time({item}: {item: StreamType}) {


### PR DESCRIPTION
Continues the frontend half of https://github.com/frog-pond/ccc-server/pull/575. This PR aims to move more of the on-device string and html parsing to the server-side. Overall, transferring the module `@frogpond/html-lib` to the backend impacts the following modules.

Status
- [x] Student work postings
- [x] Streams
- [ ] Calendars
- [ ] Organizations
- [ ] Food menus