### PR TITLE
ci: Make `yarn tsc` failures result in build failures

### DIFF
--- a/.github/workflows/analyze-and-build.yml
+++ b/.github/workflows/analyze-and-build.yml
@@ -19,7 +19,7 @@ jobs:
       - run: npm run validate-data
       - run: npm run bundle-data
       - run: npm run pretty --no-write --list-different
-      - run: npx tsc || true
+      - run: npx tsc
       - run: npm run lint
       - name: Run tests
         run: npm run test -- --coverage


### PR DESCRIPTION
I'm pulling this out of #5482 so that we can merge the partial fixes we have there.

This will enable us to upgrade react-native and react-navigation while we're fixing the type errors there — due to the way that things were timed, it seems like that's probably the right way to go about fixing those type errors rather than try to fix the type errors for an old version only to have to rewrite it upon the upgrade.