### PR TITLE
Add link support to the building hours

### DIFF
--- a/data/_schemas/building-hours.yaml
+++ b/data/_schemas/building-hours.yaml
@@ -11,6 +11,9 @@ properties:
   image: {type: string}
   isNotice: {type: boolean}
   noticeMessage: {type: string}
+  links:
+    type: array
+    items: {$ref: '#/definitions/links'}
   schedule:
     type: array
     items: {$ref: '#/definitions/schedule'}
@@ -19,6 +22,12 @@ properties:
 
 
 definitions:
+  links:
+    additionalProperties: false
+    required: [title, url]
+    properties:
+      title: {type: string}
+      url: {type: string}
   schedule:
     type: object
     additionalProperties: false

--- a/source/views/building-hours/detail/building.tsx
+++ b/source/views/building-hours/detail/building.tsx
@@ -10,6 +10,7 @@ import {SolidBadge as Badge} from '@frogpond/badge'
 import {Header} from './header'
 import {ScheduleTable} from './schedule-table'
 import {ListFooter} from '@frogpond/lists'
+import {LinkTable} from './link-table'
 
 const styles = StyleSheet.create({
 	container: {
@@ -52,6 +53,7 @@ export class BuildingDetail extends React.Component<Props> {
 
 		let openStatus = getShortBuildingStatus(info, now)
 		let schedules = info.schedule || []
+		let links = info.links || []
 
 		return (
 			<ScrollView contentContainerStyle={styles.container}>
@@ -71,6 +73,8 @@ export class BuildingDetail extends React.Component<Props> {
 					onProblemReport={onProblemReport}
 					schedules={schedules}
 				/>
+
+				{links.length ? <LinkTable links={links} /> : null}
 
 				<ListFooter
 					title={

--- a/source/views/building-hours/detail/link-table.android.tsx
+++ b/source/views/building-hours/detail/link-table.android.tsx
@@ -1,0 +1,36 @@
+/**
+ * @flow
+ *
+ * <LinkTable/> renders the table of building-related links.
+ */
+
+import * as React from 'react'
+import {StyleSheet} from 'react-native'
+import {Card} from '@frogpond/silly-card'
+import {ButtonCell} from '@frogpond/tableview/cells'
+import {openUrl} from '@frogpond/open-url'
+import type {BuildingLinkType} from '../types'
+
+type Props = {
+	links: BuildingLinkType[]
+}
+
+export function LinkTable(props: Props): React.ReactElement {
+	return (
+		<Card header="Resources" style={styles.scheduleContainer}>
+			{props.links.map((link, i) => (
+				<ButtonCell
+					key={i}
+					onPress={() => openUrl(link.url.toString())}
+					title={link.title}
+				/>
+			))}
+		</Card>
+	)
+}
+
+const styles = StyleSheet.create({
+	scheduleContainer: {
+		marginBottom: 20,
+	},
+})

--- a/source/views/building-hours/detail/link-table.ios.tsx
+++ b/source/views/building-hours/detail/link-table.ios.tsx
@@ -1,0 +1,31 @@
+/**
+ * @flow
+ *
+ * <LinkTable/> renders the table of building-related links.
+ */
+
+import * as React from 'react'
+import {TableView, Section} from 'react-native-tableview-simple'
+import {PushButtonCell} from '@frogpond/tableview/cells'
+import {openUrl} from '@frogpond/open-url'
+import type {BuildingLinkType} from '../types'
+
+type Props = {
+	links: BuildingLinkType[]
+}
+
+export function LinkTable(props: Props): React.ReactElement {
+	return (
+		<TableView>
+			<Section header="RESOURCES">
+				{props.links.map((link, i) => (
+					<PushButtonCell
+						key={i}
+						onPress={() => openUrl(link.url.toString())}
+						title={link.title}
+					/>
+				))}
+			</Section>
+		</TableView>
+	)
+}

--- a/source/views/building-hours/types.ts
+++ b/source/views/building-hours/types.ts
@@ -35,6 +35,11 @@ export type BreakScheduleContainerType = {
 	[key: BreakNameEnumType]: NamedBuildingScheduleType[]
 }
 
+export type BuildingLinkType = {
+	title: string
+	url: URL
+}
+
 export type BuildingType = {
 	name: string
 	subtitle?: string
@@ -43,6 +48,7 @@ export type BuildingType = {
 	noticeMessage?: string
 	image?: string
 	category: string
+	links?: BuildingLinkType[]
 	schedule: NamedBuildingScheduleType[]
 	breakSchedule?: BreakScheduleContainerType
 }


### PR DESCRIPTION
- Adds platform components to render urls in the spaces/hours data
- Updates schemas and types

Example usage:

```yaml
...

links:
  - title: BonAppetit
    url: https://stolaf.cafebonappetit.com/cafe/the-cage/
  - title: Somewhere else
    url: https://stolaf.cafebonappetit.com/cafe/somewhere-else/

... 
```

📸 Screenshots

~ | ~
--|--
<img src="https://user-images.githubusercontent.com/5240843/160269171-e54f681b-bbbd-43cf-bced-6b4ec9484a38.png" width=300 /> | <img src="https://user-images.githubusercontent.com/5240843/160269176-0a087c2f-f49c-41d0-9edc-4d5621be5ca9.png" width=250 />

