### PR TITLE
Fix test coverage calculation pass by replacing last cases of `: ?string` with `?: string`

### DIFF
--- a/source/views/news/types.ts
+++ b/source/views/news/types.ts
@@ -2,10 +2,10 @@ export type StoryType = {
 	authors: string[]
 	categories: string[]
 	content: string
-	datePublished: ?string
+	datePublished?: string
 	excerpt: string
-	featuredImage: ?string
-	link: ?string
+	featuredImage?: string
+	link?: string
 	title: string
 }
 


### PR DESCRIPTION
I noticed in [this step](https://github.com/StoDevX/AAO-React-Native/runs/5709966164?check_suite_focus=true#step:10:34) that we were hitting an error while calculating coverage on un-tested files:

```
Failed to collect coverage from /home/runner/work/AAO-React-Native/AAO-React-Native/source/views/news/types.ts
ERROR: /home/runner/work/AAO-React-Native/AAO-React-Native/source/views/news/types.ts: Unexpected token (5:16)

  3 | 	categories: string[]
  4 | 	content: string
> 5 | 	datePublished: ?string
    | 	               ^
  6 | 	excerpt: string
  7 | 	featuredImage: ?string
  8 | 	link: ?string
STACK: SyntaxError: /home/runner/work/AAO-React-Native/AAO-React-Native/source/views/news/types.ts: Unexpected token (5:16)

  3 | 	categories: string[]
  4 | 	content: string
> 5 | 	datePublished: ?string
    | 	               ^
  6 | 	excerpt: string
  7 | 	featuredImage: ?string
  8 | 	link: ?string
```