### PR TITLE
fastlane: Change build_number logic to use hours instead of seconds after a changeover point

### DIFF
--- a/fastlane/lib/versions.rb
+++ b/fastlane/lib/versions.rb
@@ -27,7 +27,26 @@ end
 # Generate build number
 def build_number
 	# Should last until ~2080 for Android.
-	DateTime.now.to_time.to_i - DateTime.parse("2014-01-01").to_time.to_i
+	old_version_number = DateTime.now.to_time.to_i - DateTime.parse("2014-01-01").to_time.to_i
+
+	# With the old version number scheme, we'll pass this version number at 2022-03-29T06:13:20Z.
+	changeover = 260000000
+
+	# Instead of using up a version number every second, now compute the number of hours since
+	# the changeover point and add that to the changeover.
+	#
+	# This means that as long as the iOS and Android builds start within an hour of each other,
+	# they will use the same distribution code.
+	new_version_number = ((old_version_number - changeover) / 3600) + changeover
+
+	if old_version_number > changeover
+		new_version_number
+	else
+		old_version_number
+	end
+
+	# After the changeover point, we could adjust the logic to just
+	# (DateTime.now.to_time.to_i - DateTime.parse("2022-03-29T06:13:20Z").to_time.to_i) / 3600 + 260000000
 end
 
 # Copy the package.json version into the other version locations


### PR DESCRIPTION
A possible change-over point to adjust our version number generation logic is coming up in just a couple of days. Version Code 260,000,000 will be generated at `2022-03-29T06:13:20Z`.

We have potential issues arising because our iOS and Android builds get different _dist_ codes generated for source-map upload. Also, it's a bit wasteful to rip through 86,400 version codes per day.

This change does the following:

- We still generate the old version number. If we're before the changeover point, this gets returned.
- Otherwise, we generate the new version number, which is calculated as follows:
  - Take the number of seconds that have elapsed since the changeover point.
  - Divide this by 3600 to get the next lowest whole number of hours that have elapsed since the changeover point. (4800 / 3600 = 1)
  - Add this to the changeover point to get the new version code.

What this means in practice:

- Up until 2022-03-29T06:13:20Z, `build_number` will continue incrementing every second.
- After 2022-03-29T06:13:20Z, `build_number` will return the number of hours that have completely elapsed since that date.

So, our nightly version codes will look like:

- On 2022-03-27, iOS got dist code **259835905**, and Android got dist code **259835681**
- On 2022-03-28, a similar spread will exist between the dist codes.
- On 2022-03-29, assuming Android and iOS both build between 08:17:00Z and 09:13:19Z (which is reasonable in my view), they will both get the version number **260000002**.