### PR TITLE
fastlane: Fix sentry release identification so that it matches the app

### DIFF
--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -49,6 +49,10 @@ def sentry_release
 	"#{sentry_project_name}@#{current_bundle_version}"
 end
 
+def sentry_dist
+	current_bundle_code
+end
+
 def bundle_identifier
 	case lane_context[:PLATFORM_NAME]
 	when :android
@@ -68,7 +72,7 @@ def upload_sourcemap_to_sentry
 	       'files',
 	       sentry_release,
 	       'upload-sourcemaps',
-	       "--dist #{current_bundle_code}",
+	       "--dist #{sentry_dist}",
 	       "--strip-prefix #{File.expand_path(File.join(__FILE__, '..', '..', '..'))}",
 	       '--rewrite',
 	       args[:bundle_output],

--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -41,12 +41,8 @@ def generate_sourcemap
 	                                      print_command: true)
 end
 
-def sentry_project_name
-	ENV['SENTRY_PROJECT'] || "all-about-olaf"
-end
-
 def sentry_release
-	"#{sentry_project_name}@#{current_bundle_version}"
+	"#{bundle_identifier}@#{current_bundle_version}"
 end
 
 def sentry_dist

--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -41,6 +41,14 @@ def generate_sourcemap
 	                                      print_command: true)
 end
 
+def sentry_project_name
+	ENV['SENTRY_PROJECT'] || "all-about-olaf"
+end
+
+def sentry_release
+	"#{sentry_project_name}@#{current_bundle_version}"
+end
+
 def bundle_identifier
 	case lane_context[:PLATFORM_NAME]
 	when :android
@@ -58,7 +66,7 @@ def upload_sourcemap_to_sentry
 	       'npx sentry-cli',
 	       'releases',
 	       'files',
-	       "#{bundle_identifier}-#{current_bundle_version}",
+	       sentry_release,
 	       'upload-sourcemaps',
 	       "--dist #{current_bundle_code}",
 	       "--strip-prefix #{File.expand_path(File.join(__FILE__, '..', '..', '..'))}",


### PR DESCRIPTION
We are making use of Sentry's automatic source map handling, but our version identifiers don't seem to be correctly recognized on sentry.io.

These are the releases on sentry.io, but none of these have any _artifacts_ associated with them:

![Screenshot from 2022-03-27 10-28-26](https://user-images.githubusercontent.com/1566689/160288763-5a8aec29-48c5-43a1-8ac2-c01514771e0e.png)

I think these are getting generated because of _new sessions_, actually — it doesn't seem like we have any artifacts associated with these releases. This might be because the version number formatting is a bit off!

Previously, we generated identifiers like `com.allaboutolaf-2.8.0-pre` and `NFMTHAZVS9.com.drewvolz.stolaf-2.8.0`.

Because we are making use of the built-in support for the iOS and Android Sentry SDKs (which automatically set the version number and dist codes from the gradle and Info.plist entries respectively), I think we need to use an `@` symbol instead to separate the project identifier from the version code.