### PR TITLE
Sentry tweaks

### DIFF
--- a/source/views/settings/screens/overview/developer.tsx
+++ b/source/views/settings/screens/overview/developer.tsx
@@ -29,9 +29,10 @@ export const DeveloperSection = ({navigation}: Props): React.ReactElement => {
 				'Nothing will appear in the dashboard during development.',
 			)
 		} else {
-			Sentry.setEventSentSuccessfully((event) => {
-				Alert.alert(`Sent an event to Sentry: ${event.event_id}`)
-			})
+			Alert.alert(
+				'Sent an event to Sentry.',
+				'The dashboard should show a new event since this is not development.',
+			)
 		}
 	}
 

--- a/source/views/settings/screens/overview/developer.tsx
+++ b/source/views/settings/screens/overview/developer.tsx
@@ -15,7 +15,7 @@ export const DeveloperSection = ({navigation}: Props): React.ReactElement => {
 	const onBonAppButton = () => navigation.navigate('BonAppPickerView')
 	const onDebugButton = () => navigation.navigate('DebugView')
 	const sendSentryMessage = () => {
-		Sentry.captureMessage('A Sentry Message', {level: 'info'})
+		Sentry.captureMessage('A Sentry Message', {level: Sentry.Severity.Info})
 		showSentryAlert()
 	}
 	const sendSentryException = () => {


### PR DESCRIPTION
This changeset fixes two issues as a result of sentry updating its package. 

1. This opts to use sentry's severity type for the message info level, and
1. Removes a deprecated `setEventSentSuccessfully` callback.

Regarding the callback: Rather than opt-in to sentry's beforeSend hook to capture an event id and store it somewhere (provider, localstorage), we will most likely be able to identify the new event id on the dashboard when we call this method outside of development within the app. This allows us to avoid adding more branching or complexity for the time being. 

If we do want to go the path of capturing this event id, we can look at adding the beforeSend hook to get the last-sent-event-id by calling Sentry.getCurrentHub().lastEventId(). See this issue for more context. https://github.com/getsentry/sentry-react-native/issues/787