### PR TITLE
fastlane: Add the bundle code to the version number as well

### DIFF
--- a/fastlane/lib/sourcemaps.rb
+++ b/fastlane/lib/sourcemaps.rb
@@ -42,7 +42,7 @@ def generate_sourcemap
 end
 
 def sentry_release
-	"#{bundle_identifier}@#{current_bundle_version}"
+	"#{bundle_identifier}@#{current_bundle_version}+#{current_bundle_code}"
 end
 
 def sentry_dist


### PR DESCRIPTION
Last night's nightlies seem to have correctly uploaded source maps, but they uploaded them for a version code like

```
package@X.Y.Z
```

rather than 

```
package@X.Y.Z+#########
```

![Screenshot from 2022-03-28 05-27-28](https://user-images.githubusercontent.com/1566689/160379652-032ea480-1953-4e4c-b79e-9c5943cf085f.png)

While this may match the _native_ part of the app, the version actually encoded in package.json (and hence actually used by Sentry) appears to include the dist code.

This commit adds the dist code to the sentry release identifier, which I think should deduplicate the entries in the above screenshot.