### PR TITLE
Add support email to FAQs, make support email dynamic elsewhere

### DIFF
--- a/data/faqs.md
+++ b/data/faqs.md
@@ -1,2 +1,5 @@
+# Support
+Say hello to us at [allaboutolaf@frogpond.tech](mailto:allaboutolaf@frogpond.tech).
+
 # Known Issues
 - Building Hours: It reports the 2am buildings as open too often; for instance, the Pause is open on Saturday at 2am, continuing from Friday, but the app reports it as being open on Friday at 2am, as well. This is incorrect.

--- a/source/lib/constants.ts
+++ b/source/lib/constants.ts
@@ -1,3 +1,4 @@
 export const GH_BASE_URL = 'https://github.com/StoDevX/AAO-React-Native'
 export const GH_NEW_ISSUE_URL = `${GH_BASE_URL}/issues/new`
 export const DEFAULT_URL = 'https://stolaf.api.frogpond.tech/v1'
+export const SUPPORT_EMAIL = 'allaboutolaf@frogpond.tech'

--- a/source/views/building-hours/report/submit.ts
+++ b/source/views/building-hours/report/submit.ts
@@ -2,7 +2,7 @@ import jsYaml from 'js-yaml'
 import type {BuildingType} from '../types'
 import {sendEmail} from '../../../components/send-email'
 import querystring from 'query-string'
-import {GH_NEW_ISSUE_URL} from '../../../lib/constants'
+import {GH_NEW_ISSUE_URL, SUPPORT_EMAIL} from '../../../lib/constants'
 
 export function submitReport(current: BuildingType, suggestion: BuildingType) {
 	// calling trim() on these to remove the trailing newlines
@@ -12,7 +12,7 @@ export function submitReport(current: BuildingType, suggestion: BuildingType) {
 	let body = makeEmailBody(before, after, current.name)
 
 	return sendEmail({
-		to: ['allaboutolaf@frogpond.tech'],
+		to: [SUPPORT_EMAIL],
 		subject: `[building] Suggestion for ${current.name}`,
 		body,
 	})

--- a/source/views/dictionary/report/submit.ts
+++ b/source/views/dictionary/report/submit.ts
@@ -2,7 +2,7 @@ import jsYaml from 'js-yaml'
 import type {WordType} from '../types'
 import {sendEmail} from '../../../components/send-email'
 import querystring from 'query-string'
-import {GH_NEW_ISSUE_URL} from '../../../lib/constants'
+import {GH_NEW_ISSUE_URL, SUPPORT_EMAIL} from '../../../lib/constants'
 import wrap from 'wordwrap'
 
 export function submitReport(current: WordType, suggestion: WordType) {
@@ -12,7 +12,7 @@ export function submitReport(current: WordType, suggestion: WordType) {
 	let body = makeEmailBody(before, after, current.word)
 
 	return sendEmail({
-		to: ['allaboutolaf@frogpond.tech'],
+		to: [SUPPORT_EMAIL],
 		subject: `[dictionary] Suggestion for ${current.word}`,
 		body,
 	})

--- a/source/views/menus/menu-bonapp.tsx
+++ b/source/views/menus/menu-bonapp.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {timezone} from '@frogpond/constants'
+import {SUPPORT_EMAIL} from '../../lib/constants'
 import {NoticeView, LoadingView} from '@frogpond/notice'
 import type {TopLevelViewPropsType} from '../types'
 import {FoodMenu} from '@frogpond/food-menu'
@@ -258,8 +259,7 @@ export class BonAppHostedMenu extends React.PureComponent<Props, State> {
 			typeof this.props.cafe === 'string' ? this.props.cafe : this.props.cafe.id
 
 		if (!this.state.cafeMenu || !this.state.cafeInfo) {
-			let msg =
-				'Something went wrong. Email allaboutolaf@frogpond.tech to let them know?'
+			let msg = `Something went wrong. Email ${SUPPORT_EMAIL} to let them know?`
 			return <NoticeView text={msg} />
 		}
 


### PR DESCRIPTION
Follow-up to #5362
* Moves the support email into a constant and uses it within hours, dictionary, and bonapp report/error views.
* Adds a support link in the FAQs since the bundled support email has not yet updated.