### PR TITLE
Re-link the datetime picker for iOS and Android

### DIFF
--- a/android/app/src/main/java/com/allaboutolaf/MainApplication.java
+++ b/android/app/src/main/java/com/allaboutolaf/MainApplication.java
@@ -1,8 +1,8 @@
 package com.allaboutolaf;
 
 import android.app.Application;
-import android.net.http.HttpResponseCache;
 import android.content.Context;
+import android.net.http.HttpResponseCache;
 import android.util.Log;
 
 import com.allaboutolaf.newarchitecture.MainApplicationReactNativeHost;
@@ -13,6 +13,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.soloader.SoLoader;
+import com.reactcommunity.rndatetimepicker.RNDateTimePickerPackage;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,6 +34,7 @@ public class MainApplication extends Application implements ReactApplication {
             List<ReactPackage> packages = new PackageList(this).getPackages();
             // Packages that cannot be autolinked yet can be added manually here, for example:
             // packages.add(new MyReactNativePackage());
+            packages.add(new RNDateTimePickerPackage());
             return packages;
         }
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -21,6 +21,8 @@ target 'AllAboutOlaf' do
 		:app_path => "#{Pod::Config.instance.installation_root}/.."
 	)
 
+	pod 'RNDateTimePicker', :path => '../node_modules/@react-native-community/datetimepicker'
+
 	target 'AllAboutOlafUITests' do
 		inherit! :complete
 		# Pods for testing

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -369,6 +369,8 @@ PODS:
     - React
   - RNCClipboard (1.5.1):
     - React-Core
+  - RNDateTimePicker (6.1.2):
+    - React-Core
   - RNDeviceInfo (8.7.0):
     - React-Core
   - RNGestureHandler (2.4.0):
@@ -484,6 +486,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNCalendarEvents (from `../node_modules/react-native-calendar-events`)
   - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
+  - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
@@ -592,6 +595,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-calendar-events"
   RNCClipboard:
     :path: "../node_modules/@react-native-community/clipboard"
+  RNDateTimePicker:
+    :path: "../node_modules/@react-native-community/datetimepicker"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
   RNGestureHandler:
@@ -664,6 +669,7 @@ SPEC CHECKSUMS:
   ReactCommon: bf2888a826ceedf54b99ad1b6182d1bc4a8a3984
   RNCalendarEvents: 7e65eb4a94f53c1744d1e275f7fafcfaa619f7a3
   RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
+  RNDateTimePicker: 6f1f0b4cf7c71b6e2aea7a3aa62969111084bbd1
   RNDeviceInfo: 36286df381fcaf1933ff9d2d3c34ba2abeb2d8d8
   RNGestureHandler: 50e6ffee79932d14ea747d4ea4cc99aac0f24e86
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
@@ -677,6 +683,6 @@ SPEC CHECKSUMS:
   Yoga: 17cd9a50243093b547c1e539c749928dd68152da
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 03b72f42f1070cecce9ba1f073c9dee9513b58fa
+PODFILE CHECKSUM: beadf17ef4e816508151c3d09fd800f19958dddc
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Fixes the crash on the platforms when trying to edit datetimes in the building hours editor.