### PR TITLE
types 5: more building hours types

### DIFF
--- a/source/navigation/types.tsx
+++ b/source/navigation/types.tsx
@@ -8,6 +8,7 @@ import {BuildingType} from '../views/building-hours/types'
 
 import * as calendar from '../views/calendar'
 import {ContactType} from '../views/contacts/types'
+import {Props as HoursEditorProps} from '../views/building-hours/report/editor'
 
 export type RootStackParamList = {
 	Home: undefined
@@ -17,7 +18,7 @@ export type RootStackParamList = {
 	BuildingHoursDetail: {building: BuildingType}
 	BuildingHours: undefined
 	BuildingHoursProblemReport: {initialBuilding: BuildingType}
-	BuildingHoursScheduleEditor: undefined
+	BuildingHoursScheduleEditor: HoursEditorProps
 	[calendar.NavigationKey]: calendar.NavigationParams
 	Contacts: undefined
 	ContactsDetail: {contact: ContactType}

--- a/source/views/building-hours/list.tsx
+++ b/source/views/building-hours/list.tsx
@@ -23,11 +23,11 @@ const styles = StyleSheet.create({
 type Props = TopLevelViewPropsType & {
 	now: Moment
 	loading: boolean
-	onRefresh: () => any
+	onRefresh: () => unknown
 	buildings: Array<{title: string; data: BuildingType[]}>
 }
 
-export function BuildingHoursList(props: Props) {
+export function BuildingHoursList(props: Props): JSX.Element {
 	let navigation = useNavigation()
 
 	let onPressRow = React.useCallback(
@@ -35,7 +35,7 @@ export function BuildingHoursList(props: Props) {
 			navigation.navigate('BuildingHoursDetail', {
 				building: data,
 			}),
-		[],
+		[navigation],
 	)
 
 	let keyExtractor = (item: BuildingType) => item.name

--- a/source/views/building-hours/report/editor.tsx
+++ b/source/views/building-hours/report/editor.tsx
@@ -133,6 +133,7 @@ function WeekToggles(props: WeekTogglesProps) {
 				))}
 			</View>
 		),
+		default: <></>,
 	})
 }
 

--- a/source/views/building-hours/report/editor.tsx
+++ b/source/views/building-hours/report/editor.tsx
@@ -27,7 +27,7 @@ import {Touchable} from '@frogpond/touchable'
 import {ListSeparator} from '@frogpond/lists'
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
 
-type Props = TopLevelViewPropsType & {
+export type Props = TopLevelViewPropsType & {
 	navigation: {
 		state: {
 			params: {

--- a/source/views/building-hours/report/overview.tsx
+++ b/source/views/building-hours/report/overview.tsx
@@ -164,7 +164,7 @@ export let BuildingHoursProblemReportView = (props: Props): JSX.Element => {
 				</Section>
 
 				{schedules.map(
-					(s: NamedBuildingScheduleType, i: React.Key | null | undefined) => (
+					(s: NamedBuildingScheduleType, i) => (
 						<EditableSchedule
 							key={i}
 							addRow={addHoursRow}

--- a/source/views/building-hours/report/overview.tsx
+++ b/source/views/building-hours/report/overview.tsx
@@ -27,208 +27,170 @@ import type {TopLevelViewPropsType} from '../../types'
 import {summarizeDays, formatBuildingTimes, blankSchedule} from '../lib'
 import {submitReport} from './submit'
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
-import {RouteProp} from '@react-navigation/native'
+import {RouteProp, useNavigation} from '@react-navigation/native'
 import {RootStackParamList} from '../../../navigation/types'
 
 type Props = TopLevelViewPropsType & {
-	navigation: {state: {params: {initialBuilding: BuildingType}}}
+	route: {params: {initialBuilding: BuildingType}}
 }
 
-type State = {
-	building: BuildingType
-}
+export let BuildingHoursProblemReportView = (props: Props): JSX.Element => {
+	let [building, setBuilding] = React.useState<BuildingType>(
+		props.route.params.initialBuilding,
+	)
 
-// TODO: convert this class to a functional component (useState, useNavigation)
-export class BuildingHoursProblemReportView extends React.PureComponent<
-	Props,
-	State
-> {
-	state = {
-		building: this.props.route.params.initialBuilding,
-	}
+	let navigation = useNavigation()
 
-	openEditor = (
-		scheduleIdx: number,
-		setIdx: number,
-		set?: SingleBuildingScheduleType,
-	) => {
-		// TODO: refactor this to useNavigation
-		this.props.navigation.navigate('BuildingHoursScheduleEditor', {
-			initialSet: set,
-			onEditSet: (editedData: SingleBuildingScheduleType) =>
-				this.editHoursRow(scheduleIdx, setIdx, editedData),
-			onDeleteSet: () => this.deleteHoursRow(scheduleIdx, setIdx),
+	let editName = (newName: BuildingType['name']) => {
+		setBuilding({
+			...building,
+			name: newName,
 		})
 	}
 
-	editName = (newName: BuildingType['name']) => {
-		this.setState((state) => {
-			return {
-				...state,
-				building: {
-					...state.building,
-					name: newName,
+	let editSchedule = (idx: number, newSchedule: NamedBuildingScheduleType) => {
+		let schedules = [...building.schedule]
+		schedules.splice(idx, 1, newSchedule)
+
+		setBuilding({
+			...building,
+			schedule: schedules,
+		})
+	}
+
+	let deleteSchedule = (idx: number) => {
+		let schedules = [...building.schedule]
+		schedules.splice(idx, 1)
+
+		setBuilding({
+			...building,
+			schedule: schedules,
+		})
+	}
+
+	let addSchedule = () => {
+		setBuilding({
+			...building,
+			schedule: [
+				...building.schedule,
+				{
+					title: 'Hours',
+					hours: [blankSchedule()],
 				},
-			}
+			],
 		})
 	}
 
-	editSchedule = (idx: number, newSchedule: NamedBuildingScheduleType) => {
-		this.setState((state) => {
-			let schedules = [...state.building.schedule]
-			schedules.splice(idx, 1, newSchedule)
+	let addHoursRow = (idx: number) => {
+		let schedules = [...building.schedule]
 
-			return {
-				...state,
-				building: {
-					...state.building,
-					schedule: schedules,
-				},
-			}
+		schedules[idx] = {
+			...schedules[idx],
+			hours: [...schedules[idx].hours, blankSchedule()],
+		}
+
+		setBuilding({
+			...building,
+			schedule: schedules,
 		})
 	}
 
-	deleteSchedule = (idx: number) => {
-		this.setState((state) => {
-			let schedules = [...state.building.schedule]
-			schedules.splice(idx, 1)
-
-			return {
-				...state,
-				building: {
-					...state.building,
-					schedule: schedules,
-				},
-			}
-		})
-	}
-
-	addSchedule = () => {
-		this.setState((state) => {
-			return {
-				...state,
-				building: {
-					...state.building,
-					schedule: [
-						...state.building.schedule,
-						{
-							title: 'Hours',
-							hours: [blankSchedule()],
-						},
-					],
-				},
-			}
-		})
-	}
-
-	addHoursRow = (idx: number) => {
-		this.setState((state) => {
-			let schedules = [...state.building.schedule]
-
-			schedules[idx] = {
-				...schedules[idx],
-				hours: [...schedules[idx].hours, blankSchedule()],
-			}
-
-			return {
-				...state,
-				building: {
-					...state.building,
-					schedule: schedules,
-				},
-			}
-		})
-	}
-
-	editHoursRow = (
-		scheduleIdx: number,
-		setIdx: number,
-		newData: SingleBuildingScheduleType,
-	) => {
-		this.setState((state) => {
-			let schedules = [...state.building.schedule]
+	let editHoursRow = React.useCallback(
+		(
+			scheduleIdx: number,
+			setIdx: number,
+			newData: SingleBuildingScheduleType,
+		) => {
+			let schedules = [...building.schedule]
 
 			let hours = [...schedules[scheduleIdx].hours]
 			hours.splice(setIdx, 1, newData)
 
 			schedules[scheduleIdx] = {...schedules[scheduleIdx], hours}
 
-			return {
-				...state,
-				building: {
-					...state.building,
-					schedule: schedules,
-				},
-			}
-		})
-	}
+			setBuilding({
+				...building,
+				schedule: schedules,
+			})
+		},
+		[building],
+	)
 
-	deleteHoursRow = (scheduleIdx: number, setIdx: number) => {
-		this.setState((state) => {
-			let schedules = [...state.building.schedule]
+	let deleteHoursRow = React.useCallback(
+		(scheduleIdx: number, setIdx: number) => {
+			let schedules = [...building.schedule]
 
 			let hours = [...schedules[scheduleIdx].hours]
 			hours.splice(setIdx, 1)
 
 			schedules[scheduleIdx] = {...schedules[scheduleIdx], hours}
 
-			return {
-				...state,
-				building: {
-					...state.building,
-					schedule: schedules,
-				},
-			}
-		})
+			setBuilding({
+				...building,
+				schedule: schedules,
+			})
+		},
+		[building],
+	)
+
+	let openEditor = React.useCallback(
+		(scheduleIdx: number, setIdx: number, set?: SingleBuildingScheduleType) =>
+			navigation.navigate('BuildingHoursScheduleEditor', {
+				initialSet: set,
+				onEditSet: (editedData: SingleBuildingScheduleType) =>
+					editHoursRow(scheduleIdx, setIdx, editedData),
+				onDeleteSet: () => deleteHoursRow(scheduleIdx, setIdx),
+			}),
+		[deleteHoursRow, editHoursRow, navigation],
+	)
+
+	let submit = (): void => {
+		console.log(JSON.stringify(building))
+		submitReport(props.route.params.initialBuilding, building)
 	}
 
-	submit = () => {
-		console.log(JSON.stringify(this.state.building))
-		submitReport(this.props.route.params.initialBuilding, this.state.building)
-	}
+	let {schedule: schedules = [], name} = building
 
-	render() {
-		let {schedule: schedules = [], name} = this.state.building
+	return (
+		<ScrollView>
+			<InfoHeader
+				message="If you could tell us what the new times are, we&rsquo;d greatly appreciate it."
+				title="Thanks for spotting a problem!"
+			/>
 
-		return (
-			<ScrollView>
-				<InfoHeader
-					message="If you could tell us what the new times are, we&rsquo;d greatly appreciate it."
-					title="Thanks for spotting a problem!"
-				/>
+			<TableView>
+				<Section header="NAME">
+					<TitleCell onChange={editName} text={name || ''} />
+				</Section>
 
-				<TableView>
-					<Section header="NAME">
-						<TitleCell onChange={this.editName} text={name || ''} />
-					</Section>
-
-					{schedules.map((s, i) => (
+				{schedules.map(
+					(s: NamedBuildingScheduleType, i: React.Key | null | undefined) => (
 						<EditableSchedule
 							key={i}
-							addRow={this.addHoursRow}
-							editRow={this.openEditor}
-							onDelete={this.deleteSchedule}
-							onEditSchedule={this.editSchedule}
+							addRow={addHoursRow}
+							editRow={openEditor}
+							onDelete={deleteSchedule}
+							onEditSchedule={editSchedule}
 							schedule={s}
 							scheduleIndex={i}
 						/>
-					))}
+					),
+				)}
 
-					<Section>
-						<Cell
-							accessory="DisclosureIndicator"
-							onPress={this.addSchedule}
-							title="Add New Schedule"
-						/>
-					</Section>
+				<Section>
+					<Cell
+						accessory="DisclosureIndicator"
+						onPress={addSchedule}
+						title="Add New Schedule"
+					/>
+				</Section>
 
-					<Section footer="Thanks for reporting!">
-						<ButtonCell onPress={this.submit} title="Submit Report" />
-					</Section>
-				</TableView>
-			</ScrollView>
-		)
-	}
+				<Section footer="Thanks for reporting!">
+					<ButtonCell onPress={submit} title="Submit Report" />
+				</Section>
+			</TableView>
+		</ScrollView>
+	)
 }
 
 type EditableScheduleProps = {
@@ -245,7 +207,7 @@ type EditableScheduleProps = {
 }
 
 class EditableSchedule extends React.PureComponent<EditableScheduleProps> {
-	onEdit = (data) => {
+	onEdit = (data: Partial<NamedBuildingScheduleType>) => {
 		let idx = this.props.scheduleIndex
 		this.props.onEditSchedule(idx, {
 			...this.props.schedule,


### PR DESCRIPTION
* opt navigation to use the reporter/editor via the useNavigation hook
* export and use hours editor view props in root stack
* switch to state hooks for storing the building state
* use partial on NamedBuildingScheduleType when editing