### PR TITLE
Fix tableview jitters by turning off safeareaview in tableview-simple

### DIFF
--- a/modules/tableview/index.tsx
+++ b/modules/tableview/index.tsx
@@ -10,8 +10,8 @@ import type {SectionInterface} from 'react-native-tableview-simple/src/component
 
 export * from './cells'
 
-let Section = (props: SectionInterface) => (
-	<ActualSection sectionTintColor={sectionBgColor} {...props} />
+let Section = (props: SectionInterface): JSX.Element => (
+	<ActualSection sectionTintColor={sectionBgColor} withSafeAreaView={false} {...props} />
 )
 
 export {TableView, Section, Cell}


### PR DESCRIPTION
Closes #5921 

Although we like safeareaview calculations, it appears that the tableview-simple component is doing something pretty intensive under the hood. This appears to fix the jittery behavior and thousands of logs for missing shadow views when scrolling a tableview section generated by this component.

## Background

This solution came up from this comment https://github.com/Purii/react-native-tableview-simple/issues/70#issuecomment-524535453

> In short: Set withSafeAreaView explicitly to false on Section to avoid 100% CPU load.
> 
> I had a view with table view within scroll view, and I noticed when I was pushed to that view the second or the third time(push, pop, then push again), CPU load went crazy to 100%, after a while the console prints info:

## Testing

Just as the link mentions, we are also seeing a log for a very large amount of shadow view errors with `withSafeAreaView` enabled

```diff
(2.8k) Could not locate shadow view with tag # this is probably caused by a temporary inconsistency between native views and shadow views.
```

...which go away when `safeareaview={false}` is applied. The scrolling behavior also returns to normal.