### PR TITLE
Update metro.config.js and bump @frogpond/titlecase

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -16,5 +16,5 @@ module.exports = {
 	},
 	resolver: {
 		sourceExts: ['ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs'],
-	}
+	},
 }

--- a/metro.config.js
+++ b/metro.config.js
@@ -14,4 +14,7 @@ module.exports = {
 			},
 		}),
 	},
+	resolver: {
+		sourceExts: ['ts', 'tsx', 'js', 'jsx', 'mjs', 'cjs'],
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@callstack/react-theme-provider": "3.0.7",
         "@expo/react-native-action-sheet": "3.13.0",
         "@frogpond/react-native-chrome-custom-tabs": "1.0.3",
-        "@frogpond/titlecase": "2.0.0",
+        "@frogpond/titlecase": "2.0.1",
         "@hawkrives/react-native-alternate-icons": "0.6.0",
         "@react-native-community/clipboard": "1.5.1",
         "@react-native-community/netinfo": "8.2.0",
@@ -2666,9 +2666,9 @@
       "link": true
     },
     "node_modules/@frogpond/titlecase": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@frogpond/titlecase/-/titlecase-2.0.0.tgz",
-      "integrity": "sha512-WOpEmdm0UD+A9tbkvRB+3cn3H0a6TsL2VtgP5ttbkKIiy8v8W2A3tRXernQyIHhKyHVZmgfVfyvdAQN5q+XtFw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@frogpond/titlecase/-/titlecase-2.0.1.tgz",
+      "integrity": "sha512-YicR3FrTf290GOIKdqMnf2rMOto9IAspxUohQAw8t/Py2zxSGMtz/tR2x9TrqCxMVooCY8hU8ELLSTkqmMyGIQ=="
     },
     "node_modules/@frogpond/toolbar": {
       "resolved": "modules/toolbar",
@@ -20807,9 +20807,9 @@
       "requires": {}
     },
     "@frogpond/titlecase": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@frogpond/titlecase/-/titlecase-2.0.0.tgz",
-      "integrity": "sha512-WOpEmdm0UD+A9tbkvRB+3cn3H0a6TsL2VtgP5ttbkKIiy8v8W2A3tRXernQyIHhKyHVZmgfVfyvdAQN5q+XtFw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@frogpond/titlecase/-/titlecase-2.0.1.tgz",
+      "integrity": "sha512-YicR3FrTf290GOIKdqMnf2rMOto9IAspxUohQAw8t/Py2zxSGMtz/tR2x9TrqCxMVooCY8hU8ELLSTkqmMyGIQ=="
     },
     "@frogpond/toolbar": {
       "version": "file:modules/toolbar",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@callstack/react-theme-provider": "3.0.7",
     "@expo/react-native-action-sheet": "3.13.0",
     "@frogpond/react-native-chrome-custom-tabs": "1.0.3",
-    "@frogpond/titlecase": "2.0.0",
+    "@frogpond/titlecase": "2.0.1",
     "@hawkrives/react-native-alternate-icons": "0.6.0",
     "@react-native-community/clipboard": "1.5.1",
     "@react-native-community/netinfo": "8.2.0",


### PR DESCRIPTION
Attempts to fix #5943

- bumps version of @frogpond/titlecase to use index.mjs import
- adds .mjs to our metro config extensions

Last resort is we actually add all of [the custom resolver fields](https://facebook.github.io/metro/docs/configuration) that metro provides.