### PR TITLE
Adopt iOS 14 tableview styles

### DIFF
--- a/modules/tableview/index.tsx
+++ b/modules/tableview/index.tsx
@@ -2,17 +2,14 @@ import * as React from 'react'
 import {Platform, StyleSheet} from 'react-native'
 import {sectionBgColor} from '@frogpond/colors'
 
-import {
-	TableView as ActualTableView,
-	Section as ActualSection,
-	Cell,
-} from 'react-native-tableview-simple'
+import * as RNTableView from 'react-native-tableview-simple'
 import type {SectionInterface} from 'react-native-tableview-simple/lib/typescript/components/Section'
 import type {TableViewInterface} from 'react-native-tableview-simple/lib/typescript/components/TableView'
+import {CellInterface} from 'react-native-tableview-simple/lib/typescript/components/Cell'
 export * from './cells'
 
 let Section = (props: SectionInterface): JSX.Element => (
-	<ActualSection
+	<RNTableView.Section
 		hideSurroundingSeparators={Platform.OS === 'ios'}
 		roundedCorners={Platform.OS === 'ios'}
 		sectionTintColor={sectionBgColor}
@@ -22,7 +19,11 @@ let Section = (props: SectionInterface): JSX.Element => (
 )
 
 let TableView = (props: TableViewInterface): JSX.Element => (
-	<ActualTableView style={styles.tableview} {...props} />
+	<RNTableView.TableView style={styles.tableview} {...props} />
+)
+
+let Cell = (props: CellInterface): JSX.Element => (
+	<RNTableView.Cell {...props} />
 )
 
 const styles = StyleSheet.create({

--- a/modules/tableview/index.tsx
+++ b/modules/tableview/index.tsx
@@ -1,17 +1,34 @@
 import * as React from 'react'
+import {Platform, StyleSheet} from 'react-native'
 import {sectionBgColor} from '@frogpond/colors'
 
 import {
-	TableView,
+	TableView as ActualTableView,
 	Section as ActualSection,
 	Cell,
 } from 'react-native-tableview-simple'
-import type {SectionInterface} from 'react-native-tableview-simple/src/components/Section'
-
+import type {SectionInterface} from 'react-native-tableview-simple/lib/typescript/components/Section'
+import type {TableViewInterface} from 'react-native-tableview-simple/lib/typescript/components/TableView'
 export * from './cells'
 
 let Section = (props: SectionInterface): JSX.Element => (
-	<ActualSection sectionTintColor={sectionBgColor} withSafeAreaView={false} {...props} />
+	<ActualSection
+		hideSurroundingSeparators={Platform.OS === 'ios'}
+		roundedCorners={Platform.OS === 'ios'}
+		sectionTintColor={sectionBgColor}
+		withSafeAreaView={false}
+		{...props}
+	/>
 )
+
+let TableView = (props: TableViewInterface): JSX.Element => (
+	<ActualTableView style={styles.tableview} {...props} />
+)
+
+const styles = StyleSheet.create({
+	tableview: {
+		marginHorizontal: Platform.OS === 'ios' ? 15 : 0,
+	},
+})
 
 export {TableView, Section, Cell}


### PR DESCRIPTION
A sample of what this has accomplished for iOS:

~ | ~ | ~ 
--|--|--
 ![Simulator Screen Shot - iPhone 13 - 2022-04-19 at 23 35 06](https://user-images.githubusercontent.com/5240843/164166472-3187a6a3-3718-4a13-b211-d5df40813e1e.png) | ![Simulator Screen Shot - iPhone 13 - 2022-04-19 at 23 25 59](https://user-images.githubusercontent.com/5240843/164166455-9455387a-90da-4434-9407-1720eb2a7c76.png) | ![Simulator Screen Shot - iPhone 13 - 2022-04-19 at 23 32 16](https://user-images.githubusercontent.com/5240843/164166465-64ade682-8f34-429a-bd35-0b57c755c4da.png)
 ![Simulator Screen Shot - iPhone 13 - 2022-04-19 at 23 34 08](https://user-images.githubusercontent.com/5240843/164166467-6b66126f-ce7b-4e46-ad2f-487d63b20656.png) | ![Simulator Screen Shot - iPhone 13 - 2022-04-19 at 23 34 42](https://user-images.githubusercontent.com/5240843/164166470-0d66ea28-dce4-493d-98d2-e9dc9e54f932.png)
