### PR TITLE
put back native ios and android builds on the PR pipelines

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,4 @@
-name: Analyze and Build
+name: Build and Deploy
 
 on:
   # push:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -84,3 +84,111 @@ jobs:
       - run: npm ci
       - run: npm run bundle-data
       - run: npm run bundle:ios
+
+  android-bundle:
+    name: Android Bundle
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ^16.0
+          cache: npm
+      - run: npm ci
+      - run: npm run bundle-data
+      - run: npm run bundle:android
+
+  android:
+    name: Build for Android
+    runs-on: ubuntu-20.04
+    needs: [tsc, jest, eslint, android-bundle]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ^16.0
+          cache: npm
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+          bundler-cache: true
+      - name: Restore Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - run: npm ci
+      - name: Raise the fs.inotify ulimits to 524288 watches/queued events/user instances
+        run: |
+          echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_watches
+          echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_queued_events
+          echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_instances
+          sudo sysctl -p
+      - run: echo 'org.gradle.workers.max=2' >> ./android/gradle.properties
+      - run: cd android && ./gradlew androidDependencies --console=plain
+      - run: bundle exec fastlane android ci-run
+        env:
+          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_DISABLE_ANIMATION: '1'
+          SENTRY_ORG: frog-pond-labs
+          SENTRY_PROJECT: all-about-olaf
+          SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_SENTRY_AUTH_TOKEN }}
+          GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
+
+  ios:
+    name: Build for iOS
+    runs-on: macos-11
+    needs: [tsc, jest, eslint, ios-bundle]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ^16.0
+          cache: npm
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+          bundler-cache: true
+      # - name: Restore Pods cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ios/Pods
+      #       ~/Library/Caches/CocoaPods
+      #       ~/.cocoapods
+      #     key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-pods-
+      # - uses: mikehardy/buildcache-action@v1
+      #   continue-on-error: true
+      #   with:
+      #     cache_key: ${{ matrix.os }}
+      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
+      - run: git fetch --prune --unshallow
+      - run: npm ci
+        env:
+          SKIP_POSTINSTALL: '1'
+      - run: bundle exec pod install --deployment
+        working-directory: ./ios
+      - run: brew tap wix/brew
+      - run: brew install applesimutils
+      - run: bundle exec fastlane ios ci-run
+        env:
+          FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_DISABLE_ANIMATION: '1'
+          SENTRY_ORG: frog-pond-labs
+          SENTRY_PROJECT: all-about-olaf
+          SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_SENTRY_AUTH_TOKEN }}
+          GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
+      - run: npx detox build e2e --configuration ios.sim.release
+      - run: npx detox test e2e --configuration ios.sim.release --cleanup

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -96,6 +96,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run bundle-data
+      - run: mkdir -p ./android/app/src/main/assets/
       - run: npm run bundle:android
 
   android:


### PR DESCRIPTION
gated behind jest, tsc, eslint, and the bundling

A followup to #5961
