### PR TITLE
Fix detox smoke test

### DIFF
--- a/e2e/basic-smoke.spec.js
+++ b/e2e/basic-smoke.spec.js
@@ -19,7 +19,7 @@ describe('Basic smoke tests', () => {
 	it('should show home screen after tap to exit settings screen', async () => {
 		await element(by.id('button-open-settings')).tap()
 		await expect(element(by.id('screen-homescreen'))).toBeNotVisible()
-		await element(by.id('header-back')).tap()
+		await element(by.text('Back')).tap()
 		await expect(element(by.id('screen-homescreen'))).toBeVisible()
 	})
 })


### PR DESCRIPTION
Closes #5972, explanation and possible fixes are detailed in that issue.

Looks for back button text instead of testID.