### PR TITLE
put "import React" back

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -15,7 +15,6 @@ plugins:
 extends:
   - eslint:recommended
   - plugin:react/recommended
-  - plugin:react/jsx-runtime
   - 'plugin:@typescript-eslint/recommended'
   - prettier
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ verify: files
 tsc-errors:
 	-npx tsc | sed "s:$$(git rev-parse --show-toplevel):.:g" | tee ${@}
 
-tsc-counts:
-	-npx tsc | rg -or '$$1' 'error (TS\d{4})' | sort | uniq -c | sort -nr | sed 's/^ *//' | tee ${@}
+tsc-counts: tsc-errors
+	-cat ${<} | rg -or '$$1' 'error (TS\d{4})' | sort | uniq -c | sort -nr | sed 's/^ *//' | tee ${@}
 
 eslint-problems:
 	-npm run lint | sed "s:$$(git rev-parse --show-toplevel):.:g" | tee ${@}

--- a/eslint-problems
+++ b/eslint-problems
@@ -22,10 +22,9 @@
   11:2   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./modules/markdown/heading.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  40:24  warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
-  40:25  warning  Argument 'props' should be typed with a non-any type                     @typescript-eslint/explicit-module-boundary-types
-  40:32  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
+  40:24  warning  Missing return type on function                       @typescript-eslint/explicit-module-boundary-types
+  40:25  warning  Argument 'props' should be typed with a non-any type  @typescript-eslint/explicit-module-boundary-types
+  40:32  warning  Unexpected any. Specify a different type              @typescript-eslint/no-explicit-any
 
 ./modules/markdown/link.tsx
   19:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
@@ -40,37 +39,23 @@
   46:2   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./modules/markdown/selectable.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  6:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+  6:8  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./modules/navigation-buttons/close-screen.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  13:16  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  16:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
-
-./modules/navigation-buttons/favorite.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
-./modules/navigation-buttons/open-settings.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
-./modules/navigation-buttons/share.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+  13:16  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  16:8   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./modules/navigation-tabs/tabbar-icon.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  22:2   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+  22:2  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./modules/notice/loading.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  4:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+  4:8  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./modules/notice/notice.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  30:10  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  33:18  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  34:14  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  37:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+  30:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  33:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  34:14  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  37:8   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./modules/searchbar/animated.tsx
   20:2   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
@@ -115,26 +100,20 @@
    9:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   11:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
-./modules/separator/index.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
 ./modules/silly-card/index.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  42:13  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  43:10  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  46:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+  42:13  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  43:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  46:8   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./modules/tableview/cells/button.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  18:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
-  27:17  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  28:14  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
+  18:8   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
+  27:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  28:14  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 ./modules/tableview/cells/delete-button.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  17:18  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  19:50  warning  Unexpected empty arrow function                                          @typescript-eslint/no-empty-function
-  24:38  warning  Unexpected empty method 'onPress'                                        @typescript-eslint/no-empty-function
+  17:18  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  19:50  warning  Unexpected empty arrow function           @typescript-eslint/no-empty-function
+  24:38  warning  Unexpected empty method 'onPress'         @typescript-eslint/no-empty-function
 
 ./modules/tableview/cells/multi-line-detail.tsx
    9:15  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
@@ -144,13 +123,11 @@
   12:2  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./modules/tableview/cells/push-button.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-   7:17  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  10:31  warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+   7:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  10:31  warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./modules/tableview/cells/selectable.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  15:31  warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+  15:31  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./modules/tableview/cells/textfield.tsx
   45:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
@@ -159,11 +136,7 @@
   70:13  warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./modules/tableview/cells/toggle.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  10:30  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-
-./modules/tableview/index.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+  10:30  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 ./modules/timer/index.ts
    6:8   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
@@ -175,23 +148,13 @@
   86:2   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./modules/toolbar/toolbar-button.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  37:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
-
-./modules/toolbar/toolbar.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
-./modules/touchable/index.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+  37:8  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./modules/viewport/index.ts
   19:2   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
   23:2   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
   27:22  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
   31:2   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
-
-./source/navigation/routes.tsx
-  1:8  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
 
 ./source/redux/init.ts
   11:41  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
@@ -253,9 +216,6 @@
   103:12  warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
   107:2   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
-./source/views/calendar/index.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
 ./source/views/contacts/detail.tsx
   45:35  warning  Unexpected empty method 'onPress'  @typescript-eslint/no-empty-function
   53:12  warning  Missing return type on function    @typescript-eslint/explicit-module-boundary-types
@@ -305,20 +265,15 @@
   13:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   16:8   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
-./source/views/home/index.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
 ./source/views/home/notice.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  29:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+  29:8  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./source/views/menus/carleton-menus.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-   9:41  warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
-  24:38  warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
-  37:40  warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
-  52:41  warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
-  69:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+   9:41  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
+  24:38  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
+  37:40  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
+  52:41  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
+  69:8   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./source/views/menus/dev-bonapp-picker.tsx
   39:15  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
@@ -330,9 +285,6 @@
 
 ./source/views/menus/types.ts
   35:29  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
-
-./source/views/news/index.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
 
 ./source/views/news/news-container.tsx
   28:2   warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
@@ -375,9 +327,6 @@
   73:2   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
   95:42  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
-./source/views/settings/screens/credits.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
 ./source/views/settings/screens/debug/list.tsx
   16:9   warning  Unexpected any. Specify a different type             @typescript-eslint/no-explicit-any
   20:29  warning  Missing return type on function                      @typescript-eslint/explicit-module-boundary-types
@@ -404,13 +353,11 @@
   10:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 ./source/views/settings/screens/overview/index.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  22:35  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
+  22:35  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
 ./source/views/settings/screens/overview/login-button.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-   8:17  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  12:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+   8:17  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  12:8   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./source/views/settings/screens/overview/login-credentials.tsx
    12:8  warning  'noop' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
@@ -450,10 +397,9 @@
   204:8  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./source/views/sis/components/recents-list.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  13:19  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  14:33  warning  Unexpected any. Specify a different type                                 @typescript-eslint/no-explicit-any
-  20:1   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+  13:19  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  14:33  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  20:1   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./source/views/sis/course-search/detail/index.tsx
   193:29  warning  Missing return type on function                              @typescript-eslint/explicit-module-boundary-types
@@ -569,27 +515,10 @@
   169:8   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
 
 ./source/views/streaming/movie.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  5:16  warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
-
-./source/views/streaming/radio/buttons.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
-./source/views/streaming/radio/controller.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
-./source/views/streaming/radio/player.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
-./source/views/streaming/radio/schedule.tsx
-  1:8  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-
-./source/views/streaming/radio/station-krlx.tsx
-  1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+  5:16  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./source/views/streaming/radio/station-ksto.tsx
-   1:13  warning  'React' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
-  25:8   warning  Missing return type on function                                          @typescript-eslint/explicit-module-boundary-types
+  25:8  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./source/views/streaming/streams/list.tsx
    49:2   warning  Missing return type on function                              @typescript-eslint/explicit-module-boundary-types
@@ -636,7 +565,7 @@
   46:12  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
 
 ./source/views/transportation/other-modes/detail.tsx
-  51:57  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
+  52:57  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
 
-✖ 381 problems (0 errors, 381 warnings)
+✖ 344 problems (0 errors, 344 warnings)
 

--- a/modules/badge/outline.tsx
+++ b/modules/badge/outline.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {
 	StyleProp,
 	StyleSheet,

--- a/modules/badge/solid.tsx
+++ b/modules/badge/solid.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {Platform, StyleSheet, Text, View} from 'react-native'
 import * as c from '@frogpond/colors'
 

--- a/modules/button/index.tsx
+++ b/modules/button/index.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {
 	Platform,
 	StyleProp,

--- a/modules/datepicker/datepicker-ios.tsx
+++ b/modules/datepicker/datepicker-ios.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import {BaseDateTimePicker} from './basepicker'
 import {IosDatetimePickerProps} from './types'

--- a/modules/datepicker/types.ts
+++ b/modules/datepicker/types.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {ViewStyle} from 'react-native'
 import type {Moment} from 'moment-timezone'
 import type {

--- a/modules/event-list/event-detail-android.tsx
+++ b/modules/event-list/event-detail-android.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {ScrollView, StyleSheet, Text} from 'react-native'
 import {openUrl} from '@frogpond/open-url'
 import {Card} from '@frogpond/silly-card'

--- a/modules/event-list/event-detail-ios.tsx
+++ b/modules/event-list/event-detail-ios.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {ScrollView} from 'react-native'
 import {
 	ButtonCell,

--- a/modules/event-list/vertical-bar.tsx
+++ b/modules/event-list/vertical-bar.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {Platform, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import * as c from '@frogpond/colors'
 import type {AppTheme} from '@frogpond/app-theme'

--- a/modules/filter/active-filter-button.tsx
+++ b/modules/filter/active-filter-button.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import type {FilterType} from './types'
 import {
 	Platform,

--- a/modules/filter/filter-popover.tsx
+++ b/modules/filter/filter-popover.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {RefObject, useState} from 'react'
 import Popover, {PopoverPlacement} from 'react-native-popover-view'
 import {FilterSection} from './section'

--- a/modules/filter/section-list.tsx
+++ b/modules/filter/section-list.tsx
@@ -5,6 +5,7 @@ import {Column} from '@frogpond/layout'
 import concat from 'lodash/concat'
 import isEqual from 'lodash/isEqual'
 import reject from 'lodash/reject'
+import * as React from 'react'
 import {useCallback} from 'react'
 
 type PropsType = {

--- a/modules/filter/section-picker.tsx
+++ b/modules/filter/section-picker.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import * as c from '@frogpond/colors'
 import type {PickerType} from './types'

--- a/modules/filter/section-toggle.tsx
+++ b/modules/filter/section-toggle.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import type {ToggleType} from './types'
 import {CellToggle, Section} from '@frogpond/tableview'
 

--- a/modules/filter/section.tsx
+++ b/modules/filter/section.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {ScrollView} from 'react-native'
 import type {FilterType} from './types'
 import {SingleToggleSection} from './section-toggle'

--- a/modules/food-menu/dietary-tags-detail.tsx
+++ b/modules/food-menu/dietary-tags-detail.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {Image, StyleProp, StyleSheet, Text, View, ViewStyle} from 'react-native'
 import {Row} from '@frogpond/layout'
 import type {ItemCorIconMapType, MasterCorIconMapType} from './types'

--- a/modules/food-menu/dietary-tags.tsx
+++ b/modules/food-menu/dietary-tags.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {Image, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 
 import type {ItemCorIconMapType, MasterCorIconMapType} from './types'

--- a/modules/food-menu/fancy-menu.tsx
+++ b/modules/food-menu/fancy-menu.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {useEffect, useState} from 'react'
 import {SectionList, StyleSheet} from 'react-native'
 import * as c from '@frogpond/colors'

--- a/modules/food-menu/filter-menu-toolbar.tsx
+++ b/modules/food-menu/filter-menu-toolbar.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {StyleSheet, Text, View} from 'react-native'
 import type {Moment} from 'moment'
 import type {FilterType} from '@frogpond/filter'

--- a/modules/food-menu/food-item-row.tsx
+++ b/modules/food-menu/food-item-row.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {Platform, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {DietaryTags} from './dietary-tags'
 import {Column, Row} from '@frogpond/layout'

--- a/modules/html-content/index.tsx
+++ b/modules/html-content/index.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {useCallback, useRef} from 'react'
 import {WebView, WebViewNavigation} from 'react-native-webview'
 import type {StyleProp, ViewStyle} from 'react-native'

--- a/modules/info-header/index.tsx
+++ b/modules/info-header/index.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {StyleSheet, Text, View} from 'react-native'
 import * as c from '@frogpond/colors'
 

--- a/modules/layout/column.tsx
+++ b/modules/layout/column.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {StyleSheet, View, ViewProps} from 'react-native'
 
 type PropsType = {

--- a/modules/layout/row.tsx
+++ b/modules/layout/row.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {FlexStyle, StyleSheet, View, ViewProps} from 'react-native'
 
 type PropsType = {

--- a/modules/lists/disclosure-arrow.tsx
+++ b/modules/lists/disclosure-arrow.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {Platform, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import * as c from '@frogpond/colors'
 import Icon from 'react-native-vector-icons/Ionicons'

--- a/modules/lists/list-empty.tsx
+++ b/modules/lists/list-empty.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {NoticeView} from '@frogpond/notice'
 
 type Props = {

--- a/modules/lists/list-footer.tsx
+++ b/modules/lists/list-footer.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {StyleSheet, Text} from 'react-native'
 import * as c from '@frogpond/colors'
 

--- a/modules/lists/list-item-detail.tsx
+++ b/modules/lists/list-item-detail.tsx
@@ -1,5 +1,6 @@
 import {Platform, StyleProp, StyleSheet, Text, TextStyle} from 'react-native'
 import * as c from '@frogpond/colors'
+import * as React from 'react'
 import {PropsWithChildren} from 'react'
 
 const FONT_SIZE = 14

--- a/modules/lists/list-item-title.tsx
+++ b/modules/lists/list-item-title.tsx
@@ -1,6 +1,7 @@
+import * as React from 'react'
+import {PropsWithChildren} from 'react'
 import {Platform, StyleProp, StyleSheet, Text, TextStyle} from 'react-native'
 import * as c from '@frogpond/colors'
-import {PropsWithChildren} from 'react'
 
 const styles = StyleSheet.create({
 	title: {

--- a/modules/lists/list-row.tsx
+++ b/modules/lists/list-row.tsx
@@ -1,6 +1,6 @@
+import * as React from 'react'
 import {PropsWithChildren} from 'react'
-import type {ViewStyle} from 'react-native'
-import {Platform, StyleProp, StyleSheet, View} from 'react-native'
+import {Platform, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import * as c from '@frogpond/colors'
 import {Touchable} from '@frogpond/touchable'
 import {DisclosureArrow} from './disclosure-arrow'

--- a/modules/lists/list-section-header.tsx
+++ b/modules/lists/list-section-header.tsx
@@ -1,5 +1,13 @@
-import type {StyleProp, TextStyle, ViewStyle} from 'react-native'
-import {Platform, StyleSheet, Text, View} from 'react-native'
+import * as React from 'react'
+import {
+	Platform,
+	StyleProp,
+	StyleSheet,
+	Text,
+	TextStyle,
+	View,
+	ViewStyle,
+} from 'react-native'
 import * as c from '@frogpond/colors'
 import type {AppTheme} from '@frogpond/app-theme'
 import {getTheme} from '@frogpond/app-theme'

--- a/modules/lists/list-separator.tsx
+++ b/modules/lists/list-separator.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {Platform, StyleProp, StyleSheet, ViewStyle} from 'react-native'
 import {Separator} from '@frogpond/separator'
 

--- a/modules/tableview/cells/multi-line-detail.tsx
+++ b/modules/tableview/cells/multi-line-detail.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {Cell} from 'react-native-tableview-simple'
 import {StyleSheet, Text, View} from 'react-native'
 import * as c from '@frogpond/colors'

--- a/modules/tableview/cells/multi-line-left-detail.tsx
+++ b/modules/tableview/cells/multi-line-left-detail.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {Cell} from 'react-native-tableview-simple'
 import {StyleSheet, Text, View} from 'react-native'
 import * as c from '@frogpond/colors'

--- a/source/navigation/routes.tsx
+++ b/source/navigation/routes.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {createNativeStackNavigator} from '@react-navigation/native-stack'
 
 import * as home from '../views/home'
@@ -56,9 +56,9 @@ import * as settings from '../views/settings/'
 // 	PrintJobRelease,
 // 	PrintJobs,
 // } from '../views/stoprint'
-
 import {StyleSheet} from 'react-native'
 import {getTheme} from '@frogpond/app-theme'
+import {RootStackParamList} from './types'
 
 const theme = getTheme()
 
@@ -67,8 +67,6 @@ const styles = StyleSheet.create({
 		backgroundColor: theme.navigationBackground,
 	},
 })
-
-import {RootStackParamList} from './types'
 
 const Stack = createNativeStackNavigator<RootStackParamList>()
 

--- a/source/navigation/types.tsx
+++ b/source/navigation/types.tsx
@@ -1,5 +1,3 @@
-// import React from 'react'
-
 // import {HomeView} from '../views/home'
 // import * as Calendar from '../views/calendar'
 import {EventType} from '@frogpond/event-type'

--- a/source/views/menus/index.tsx
+++ b/source/views/menus/index.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react'
+
 import {TabBarIcon, TabNavigator} from '@frogpond/navigation-tabs'
 
 import {BonAppHostedMenu} from './menu-bonapp'

--- a/source/views/menus/menu-bonapp.tsx
+++ b/source/views/menus/menu-bonapp.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react'
+import {useEffect, useState} from 'react'
 import {timezone} from '@frogpond/constants'
 import {SUPPORT_EMAIL} from '../../lib/constants'
 import {LoadingView, NoticeView} from '@frogpond/notice'
@@ -15,14 +17,12 @@ import type {
 import sample from 'lodash/sample'
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
-import type {Moment} from 'moment-timezone'
-import moment from 'moment-timezone'
+import moment, {type Moment} from 'moment-timezone'
 import {trimItemLabel, trimStationName} from './lib/trim-names'
 import {decode, innerTextWithSpaces, parseHtml} from '@frogpond/html-lib'
 import {toLaxTitleCase} from '@frogpond/titlecase'
 import {API} from '@frogpond/api'
 import {fetch} from '@frogpond/fetch'
-import {useEffect, useState} from 'react'
 
 const BONAPP_HTML_ERROR_CODE = 'bonapp-html'
 

--- a/source/views/menus/menu-github.tsx
+++ b/source/views/menus/menu-github.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {useEffect, useState} from 'react'
 import {timezone} from '@frogpond/constants'
 import {LoadingView, NoticeView} from '@frogpond/notice'

--- a/source/views/settings/screens/change-icon.tsx
+++ b/source/views/settings/screens/change-icon.tsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import {ScrollView, Image, StyleSheet} from 'react-native'
+import * as React from 'react'
+import {Image, ScrollView, StyleSheet} from 'react-native'
 import * as Icons from '@hawkrives/react-native-alternate-icons'
-import {Section, Cell} from '@frogpond/tableview'
+import {Cell, Section} from '@frogpond/tableview'
 import {icons as appIcons} from '../../../../images/icons'
 import * as c from '@frogpond/colors'
 

--- a/source/views/stoprint/components/error.tsx
+++ b/source/views/stoprint/components/error.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import * as React from 'react'
 import type {TopLevelViewPropsType} from '../../types'
-import {ScrollView, RefreshControl, StyleSheet, Platform} from 'react-native'
+import {Platform, RefreshControl, ScrollView, StyleSheet} from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {NoticeView} from '@frogpond/notice'
 import {sto} from '../../../lib/colors'

--- a/source/views/stoprint/components/notice.tsx
+++ b/source/views/stoprint/components/notice.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import * as React from 'react'
 import {
 	Platform,
-	Text,
+	RefreshControl,
 	ScrollView,
 	StyleSheet,
-	RefreshControl,
+	Text,
 } from 'react-native'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {NoticeView} from '@frogpond/notice'

--- a/source/views/stoprint/print-jobs.tsx
+++ b/source/views/stoprint/print-jobs.tsx
@@ -1,19 +1,19 @@
-import React from 'react'
+import * as React from 'react'
 import {timezone} from '@frogpond/constants'
 import {Platform, SectionList} from 'react-native'
 import {useDispatch, useSelector} from 'react-redux'
 import type {ReduxState} from '../../redux'
 import {updatePrintJobs} from '../../redux/parts/stoprint'
-import {logInViaCredentials} from '../../redux/parts/login'
 import type {LoginStateEnum} from '../../redux/parts/login'
+import {logInViaCredentials} from '../../redux/parts/login'
 import {loadLoginCredentials} from '../../lib/login'
-import {STOPRINT_HELP_PAGE} from '../../lib/stoprint'
 import type {PrintJob} from '../../lib/stoprint'
+import {STOPRINT_HELP_PAGE} from '../../lib/stoprint'
 import {
-	ListRow,
-	ListSeparator,
-	ListSectionHeader,
 	Detail,
+	ListRow,
+	ListSectionHeader,
+	ListSeparator,
 	Title,
 } from '@frogpond/lists'
 import {LoadingView} from '@frogpond/notice'

--- a/source/views/stoprint/printers.tsx
+++ b/source/views/stoprint/printers.tsx
@@ -1,14 +1,14 @@
-import React from 'react'
+import * as React from 'react'
 import {SectionList, StyleSheet} from 'react-native'
 import {useDispatch, useSelector} from 'react-redux'
 import type {ReduxState} from '../../redux'
 import {updatePrinters} from '../../redux/parts/stoprint'
 import type {Printer, PrintJob} from '../../lib/stoprint'
 import {
-	ListRow,
-	ListSeparator,
-	ListSectionHeader,
 	Detail,
+	ListRow,
+	ListSectionHeader,
+	ListSeparator,
 	Title,
 } from '@frogpond/lists'
 import {LoadingView} from '@frogpond/notice'

--- a/source/views/streaming/radio/schedule.tsx
+++ b/source/views/streaming/radio/schedule.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import {CccCalendarView} from '@frogpond/ccc-calendar'
 import type {TopLevelViewPropsType} from '../../types'
 

--- a/source/views/transportation/bus/components/bus-stop-row.tsx
+++ b/source/views/transportation/bus/components/bus-stop-row.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {Platform, StyleSheet} from 'react-native'
 import {Column} from '@frogpond/layout'
 import {Detail, ListRow, Title} from '@frogpond/lists'
@@ -5,8 +6,8 @@ import type {BusTimetableEntry} from '../types'
 import * as c from '@frogpond/colors'
 import {ProgressChunk} from './progress-chunk'
 import {ScheduleTimes} from './times'
-import type {BusStateEnum} from '../lib'
 import {
+	BusStateEnum,
 	findBusStopStatus as findStopStatus,
 	findRemainingDeparturesForStop as findRemainingDepartures,
 } from '../lib'

--- a/source/views/transportation/bus/components/progress-chunk.tsx
+++ b/source/views/transportation/bus/components/progress-chunk.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import * as c from '@frogpond/colors'
 import {Platform, StyleSheet, View} from 'react-native'
 import type {BusStopStatusEnum} from '../lib'

--- a/source/views/transportation/bus/components/times.tsx
+++ b/source/views/transportation/bus/components/times.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react'
+
 import {StyleProp, Text, TextStyle} from 'react-native'
 import type {DepartureTimeList} from '../types'
 

--- a/source/views/transportation/bus/line.tsx
+++ b/source/views/transportation/bus/line.tsx
@@ -1,7 +1,13 @@
+import * as React from 'react'
+import {useEffect, useState} from 'react'
 import {FlatList, Platform, StyleSheet, Text} from 'react-native'
 import type {BusSchedule, UnprocessedBusLine} from './types'
-import type {BusStateEnum} from './lib'
-import {getCurrentBusIteration, getScheduleForNow, processBusLine} from './lib'
+import {
+	BusStateEnum,
+	getCurrentBusIteration,
+	getScheduleForNow,
+	processBusLine,
+} from './lib'
 import type {Moment} from 'moment-timezone'
 import find from 'lodash/find'
 import findLast from 'lodash/findLast'
@@ -9,7 +15,6 @@ import {Separator} from '@frogpond/separator'
 import {BusStopRow} from './components/bus-stop-row'
 import {ListFooter, ListRow, ListSectionHeader} from '@frogpond/lists'
 import {InfoHeader} from '@frogpond/info-header'
-import {useEffect, useState} from 'react'
 
 const styles = StyleSheet.create({
 	separator: {

--- a/source/views/transportation/index.tsx
+++ b/source/views/transportation/index.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react'
+
 import {TabBarIcon, TabNavigator} from '@frogpond/navigation-tabs'
 
 import {OtherModesView} from './other-modes'

--- a/source/views/transportation/other-modes/detail.tsx
+++ b/source/views/transportation/other-modes/detail.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import {Markdown} from '@frogpond/markdown'
 import {ListFooter} from '@frogpond/lists'

--- a/source/views/transportation/other-modes/row.tsx
+++ b/source/views/transportation/other-modes/row.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import type {OtherModeType} from '../types'
 import {Detail, ListRow, Title} from '@frogpond/lists'
 import {Column, Row} from '@frogpond/layout'

--- a/tsc-errors
+++ b/tsc-errors
@@ -1,5 +1,5 @@
 modules/event-list/types.ts(2,41): error TS2307: Cannot find module 'react-navigation' or its corresponding type declarations.
-modules/food-menu/fancy-menu.tsx(15,8): error TS2307: Cannot find module 'react-navigation' or its corresponding type declarations.
+modules/food-menu/fancy-menu.tsx(16,8): error TS2307: Cannot find module 'react-navigation' or its corresponding type declarations.
 modules/food-menu/food-item-detail.tsx(14,8): error TS2307: Cannot find module 'react-navigation' or its corresponding type declarations.
 modules/markdown/code.tsx(14,29): error TS2322: Type '{ children: Element; key: any; language: string | undefined; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & TextProps, any, any>> & Readonly<...> & Readonly<...>'.
   Property 'language' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & TextProps, any, any>> & Readonly<...> & Readonly<...>'.
@@ -81,7 +81,7 @@ source/navigation/track.ts(11,12): error TS2339: Property 'routes' does not exis
 source/navigation/track.ts(12,30): error TS2345: Argument of type 'NavigationRoute<ParamListBase, string>' is not assignable to parameter of type 'Readonly<{ key: string; index: number; routeNames: string[]; history?: unknown[] | undefined; routes: NavigationRoute<ParamListBase, string>[]; type: string; stale: false; }>'.
   Type 'NavigationRoute<ParamListBase, string>' is missing the following properties from type 'Readonly<{ key: string; index: number; routeNames: string[]; history?: unknown[] | undefined; routes: NavigationRoute<ParamListBase, string>[]; type: string; stale: false; }>': index, routeNames, routes, type, stale
 source/navigation/track.ts(14,15): error TS2339: Property 'routeName' does not exist on type 'NavigationRoute<ParamListBase, string>'.
-source/navigation/types.tsx(11,9): error TS2459: Module '"../views/building-hours/report/editor"' declares 'Props' locally, but it is not exported.
+source/navigation/types.tsx(9,9): error TS2459: Module '"../views/building-hours/report/editor"' declares 'Props' locally, but it is not exported.
 source/redux/init.ts(27,36): error TS2345: Argument of type 'ThunkAction<GetEnabledToolsAction>' is not assignable to parameter of type 'AnyAction'.
   Property 'type' is missing in type 'ThunkAction<GetEnabledToolsAction>' but required in type 'AnyAction'.
 source/redux/parts/help.ts(61,22): error TS2322: Type '{ fetching: boolean; tools: never[]; lastFetchError: null; }' is not assignable to type 'State'.
@@ -145,10 +145,10 @@ source/views/home/notice.tsx(37,16): error TS2339: Property 'Text' does not exis
 source/views/home/notice.tsx(39,17): error TS2339: Property 'Text' does not exist on type 'typeof import("./node_modules/glamorous-native/typings/glamorous")'.
 source/views/home/notice.tsx(40,16): error TS2339: Property 'View' does not exist on type 'typeof import("./node_modules/glamorous-native/typings/glamorous")'.
 source/views/home/notice.tsx(41,15): error TS2339: Property 'View' does not exist on type 'typeof import("./node_modules/glamorous-native/typings/glamorous")'.
-source/views/menus/index.tsx(16,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
-source/views/menus/index.tsx(38,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
-source/views/menus/index.tsx(60,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
-source/views/menus/index.tsx(88,1): error TS2571: Object is of type 'unknown'.
+source/views/menus/index.tsx(18,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
+source/views/menus/index.tsx(40,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
+source/views/menus/index.tsx(62,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
+source/views/menus/index.tsx(90,1): error TS2571: Object is of type 'unknown'.
 source/views/menus/lib/__tests__/menu-item.mock.ts(20,2): error TS2739: Type '{}' is missing the following properties from type 'MonotonyContainer': id, name, image
 source/views/menus/lib/__tests__/menu-item.mock.ts(22,2): error TS2739: Type '{}' is missing the following properties from type 'NutritionContainer': kcal, well_being, well_being_image
 source/views/menus/lib/__tests__/menu-item.mock.ts(23,2): error TS2740: Type '{}' is missing the following properties from type 'NutritionDetailContainer': calories, servingSize, fatContent, saturatedFatContent, and 7 more.
@@ -295,9 +295,9 @@ source/views/student-orgs/list.tsx(27,10): error TS2503: Cannot find namespace '
 source/views/student-orgs/list.tsx(64,12): error TS2345: Argument of type '(args: {    signal: window.AbortController;}) => Promise<Array<StudentOrgType>>' is not assignable to parameter of type 'PromiseFn<StudentOrgType[]>'.
   Types of parameters 'args' and 'props' are incompatible.
     Property 'signal' is missing in type 'AsyncProps<StudentOrgType[]>' but required in type '{ signal: window.AbortController; }'.
-source/views/transportation/index.tsx(10,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
-source/views/transportation/index.tsx(20,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
-source/views/transportation/index.tsx(30,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
-source/views/transportation/index.tsx(40,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
-source/views/transportation/index.tsx(54,1): error TS2571: Object is of type 'unknown'.
+source/views/transportation/index.tsx(12,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
+source/views/transportation/index.tsx(22,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
+source/views/transportation/index.tsx(32,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
+source/views/transportation/index.tsx(42,13): error TS7031: Binding element 'navigation' implicitly has an 'any' type.
+source/views/transportation/index.tsx(56,1): error TS2571: Object is of type 'unknown'.
 source/views/types.ts(5,8): error TS2307: Cannot find module 'react-navigation' or its corresponding type declarations.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "lib": [
       "DOM",
       "ESNext"


### PR DESCRIPTION
Somewhere in the React docs, they recommended `import * as React`, so that's what I did.
