### PR TITLE
upgrade htmlparser and cssselect

### DIFF
--- a/modules/html-lib/index.ts
+++ b/modules/html-lib/index.ts
@@ -1,6 +1,6 @@
 import {parseDocument} from 'htmlparser2'
 import {textContent} from 'domutils'
-import {Document, Node} from 'domhandler'
+import {AnyNode, Document} from 'domhandler'
 import cssSelect from 'css-select'
 
 export {textContent, cssSelect}
@@ -13,7 +13,7 @@ export function parseHtml(string: string): Document {
 	})
 }
 
-export function innerTextWithSpaces(elem: Node | Node[]): string {
+export function innerTextWithSpaces(elem: AnyNode | AnyNode[]): string {
 	return textContent(elem).split(/\s+/u).join(' ').trim()
 }
 

--- a/modules/html-lib/index.ts
+++ b/modules/html-lib/index.ts
@@ -8,7 +8,6 @@ export {encode, decode} from 'html-entities'
 
 export function parseHtml(string: string): Document {
 	return parseDocument(string, {
-		normalizeWhitespace: false,
 		xmlMode: false,
 		decodeEntities: true,
 	})

--- a/modules/html-lib/index.ts
+++ b/modules/html-lib/index.ts
@@ -13,7 +13,7 @@ export function parseHtml(string: string): Document {
 	})
 }
 
-export function innerTextWithSpaces(elem: AnyNode | AnyNode[]): string {
+export function innerTextWithSpaces(elem: AnyNode): string {
 	return textContent(elem).split(/\s+/u).join(' ').trim()
 }
 

--- a/modules/html-lib/index.ts
+++ b/modules/html-lib/index.ts
@@ -1,13 +1,9 @@
 import {parseDocument} from 'htmlparser2'
-
 import {textContent} from 'domutils'
-export {textContent}
-
-import type {Node, Document} from 'domhandler'
-
+import {Document, Node} from 'domhandler'
 import cssSelect from 'css-select'
-export {cssSelect}
 
+export {textContent, cssSelect}
 export {encode, decode} from 'html-entities'
 
 export function parseHtml(string: string): Document {

--- a/modules/html-lib/package.json
+++ b/modules/html-lib/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "css-select": "5.0.1",
+    "domhandler": "5.0.2",
+    "domutils": "3.0.1",
     "html-entities": "2.3.3",
     "htmlparser2": "8.0.0"
   }

--- a/modules/html-lib/package.json
+++ b/modules/html-lib/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "css-select": "4.3.0",
+    "css-select": "5.0.1",
     "html-entities": "2.3.3",
     "htmlparser2": "7.2.0"
   }

--- a/modules/html-lib/package.json
+++ b/modules/html-lib/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "css-select": "4.3.0",
     "html-entities": "2.3.3",
-    "htmlparser2": "7.2.0"
+    "htmlparser2": "8.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,6 +350,8 @@
       "license": "ISC",
       "dependencies": {
         "css-select": "5.0.1",
+        "domhandler": "5.0.2",
+        "domutils": "3.0.1",
         "html-entities": "2.3.3",
         "htmlparser2": "8.0.0"
       }
@@ -7805,57 +7807,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css-select/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/domhandler": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
-      "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
-      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -8184,22 +8135,25 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
     "node_modules/dom-serializer/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "engines": {
+        "node": ">=0.12"
+      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -8237,11 +8191,11 @@
       }
     },
     "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
+      "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
       "dependencies": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       },
       "engines": {
         "node": ">= 4"
@@ -8251,13 +8205,13 @@
       }
     },
     "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
       "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -10147,46 +10101,6 @@
         "domhandler": "^5.0.2",
         "domutils": "^3.0.1",
         "entities": "^4.3.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domhandler": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
-      "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
@@ -20545,6 +20459,8 @@
       "version": "file:modules/html-lib",
       "requires": {
         "css-select": "5.0.1",
+        "domhandler": "5.0.2",
+        "domutils": "3.0.1",
         "html-entities": "2.3.3",
         "htmlparser2": "8.0.0"
       }
@@ -24641,41 +24557,6 @@
         "domhandler": "^5.0.2",
         "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
-      },
-      "dependencies": {
-        "dom-serializer": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
-            "entities": "^4.2.0"
-          }
-        },
-        "domhandler": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
-          "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
-          "requires": {
-            "domelementtype": "^2.3.0"
-          }
-        },
-        "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-          "requires": {
-            "dom-serializer": "^2.0.0",
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
-          }
-        },
-        "entities": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
-          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
-        }
       }
     },
     "css-what": {
@@ -24923,19 +24804,19 @@
       }
     },
     "dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       },
       "dependencies": {
         "entities": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
         }
       }
     },
@@ -24962,21 +24843,21 @@
       }
     },
     "domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
+      "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
       "requires": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       }
     },
     "domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
       "requires": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
       }
     },
     "dtrace-provider": {
@@ -26408,34 +26289,6 @@
         "entities": "^4.3.0"
       },
       "dependencies": {
-        "dom-serializer": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
-            "entities": "^4.2.0"
-          }
-        },
-        "domhandler": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
-          "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
-          "requires": {
-            "domelementtype": "^2.3.0"
-          }
-        },
-        "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-          "requires": {
-            "dom-serializer": "^2.0.0",
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
-          }
-        },
         "entities": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -349,7 +349,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "css-select": "4.3.0",
+        "css-select": "5.0.1",
         "html-entities": "2.3.3",
         "htmlparser2": "7.2.0"
       }
@@ -7981,18 +7981,69 @@
       }
     },
     "node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.0.1.tgz",
+      "integrity": "sha512-0QQZQta641EzzHl+6+iyeKDVXvqvmhvwnZrX58Yf7mlmiilb3bbTtb86DYiCtxhUp+h9g4lULyIXMnOVPBhGhg==",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/domhandler": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
+      "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/entities": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/css-what": {
@@ -20771,7 +20822,7 @@
     "@frogpond/html-lib": {
       "version": "file:modules/html-lib",
       "requires": {
-        "css-select": "4.3.0",
+        "css-select": "5.0.1",
         "html-entities": "2.3.3",
         "htmlparser2": "7.2.0"
       }
@@ -24994,15 +25045,50 @@
       }
     },
     "css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.0.1.tgz",
+      "integrity": "sha512-0QQZQta641EzzHl+6+iyeKDVXvqvmhvwnZrX58Yf7mlmiilb3bbTtb86DYiCtxhUp+h9g4lULyIXMnOVPBhGhg==",
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
         "nth-check": "^2.0.1"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
+          "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.1"
+          }
+        },
+        "entities": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
+        }
       }
     },
     "css-what": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -351,7 +351,7 @@
       "dependencies": {
         "css-select": "4.3.0",
         "html-entities": "2.3.3",
-        "htmlparser2": "7.2.0"
+        "htmlparser2": "8.0.0"
       }
     },
     "modules/icon": {
@@ -10315,9 +10315,9 @@
       "dev": true
     },
     "node_modules/htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.0.tgz",
+      "integrity": "sha512-4wbT2/t9kITgTLhFoPPzIh4xW/fDXE4NKQDcBhWC0fPCraSA5K26W8D09K5NAqNqsBp/f7wDN2LR2rA4GhlGhA==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -10326,16 +10326,56 @@
         }
       ],
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
+      "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+      "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==",
       "engines": {
         "node": ">=0.12"
       },
@@ -20773,7 +20813,7 @@
       "requires": {
         "css-select": "4.3.0",
         "html-entities": "2.3.3",
-        "htmlparser2": "7.2.0"
+        "htmlparser2": "8.0.0"
       }
     },
     "@frogpond/icon": {
@@ -26750,20 +26790,48 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.0.tgz",
+      "integrity": "sha512-4wbT2/t9kITgTLhFoPPzIh4xW/fDXE4NKQDcBhWC0fPCraSA5K26W8D09K5NAqNqsBp/f7wDN2LR2rA4GhlGhA==",
       "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
       },
       "dependencies": {
-        "entities": {
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.2.tgz",
+          "integrity": "sha512-pr8ToPIuwBonzUy42STpc5Cf0m69zsQ7gtCLLvKrTbhVRnRohT2pLiJmGp3PAh16nDVWpYpcRpdjuk1vFmnQUg==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.1"
+          }
+        },
+        "entities": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.0.tgz",
+          "integrity": "sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg=="
         }
       }
     },


### PR DESCRIPTION
- Bump htmlparser2 from 7.2.0 to 8.0.0 (closes https://github.com/StoDevX/AAO-React-Native/pull/5993)
- Bump css-select from 4.3.0 to 5.0.1 (closes https://github.com/StoDevX/AAO-React-Native/pull/6004)
- add explicit dependency on domhandler and domutils
