### PR TITLE
add eslint-plugin-jsx-expressions

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -8,6 +8,7 @@ parserOptions:
 plugins:
   - '@typescript-eslint'
   - babel
+  - jsx-expressions
   - react
   - react-native
   - react-hooks
@@ -119,3 +120,6 @@ rules:
   # TODO(rye): Follow-up: DENY these
   '@typescript-eslint/explicit-module-boundary-types': warn
   '@typescript-eslint/no-empty-function': warn
+
+  # eslint-plugin-jsx-expressions – https://github.com/hpersson/eslint-plugin-jsx-expressions/
+  jsx-expressions/strict-logical-expressions: warn

--- a/modules/tableview/cells/multi-line-detail.tsx
+++ b/modules/tableview/cells/multi-line-detail.tsx
@@ -17,7 +17,7 @@ export function MultiLineDetailCell(props: Props): JSX.Element {
 				<Text allowFontScaling={true} style={styles.cellTitle}>
 					{title}
 				</Text>
-				{leftDetail && (
+				{Boolean(leftDetail) && (
 					<Text allowFontScaling={true} style={styles.cellLeftDetail}>
 						{leftDetail}
 					</Text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "eslint": "8.14.0",
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-babel": "5.3.1",
+        "eslint-plugin-jsx-expressions": "1.3.1",
         "eslint-plugin-react": "7.29.4",
         "eslint-plugin-react-hooks": "4.5.0",
         "eslint-plugin-react-native": "4.0.0",
@@ -5916,6 +5917,25 @@
         }
       }
     },
+    "node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.22.0.tgz",
+      "integrity": "sha512-rKxoCUtAHwEH6IcAoVpqipY6Th+YKW7WFspAKu0IFdbdKZpveFBeqxxE9Xn+GWikhq1o03V3VXbxIe+GdhggiQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "5.22.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
@@ -8385,6 +8405,28 @@
       },
       "peerDependencies": {
         "eslint": ">=4.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-expressions": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-expressions/-/eslint-plugin-jsx-expressions-1.3.1.tgz",
+      "integrity": "sha512-7PTIx62Oy4l3Igtat361C/SCrJ4yXNNJRh/pzXMbzvPzFkvOpHBkTXITkH8PMLDu1RAdilDpjaOUv1m14DbY7w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.5.0",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "12.x || 14.x || >= 16"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^4.0.0 || ^5.0.0",
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -23456,6 +23498,15 @@
         "tsutils": "^3.21.0"
       }
     },
+    "@typescript-eslint/experimental-utils": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.22.0.tgz",
+      "integrity": "sha512-rKxoCUtAHwEH6IcAoVpqipY6Th+YKW7WFspAKu0IFdbdKZpveFBeqxxE9Xn+GWikhq1o03V3VXbxIe+GdhggiQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/utils": "5.22.0"
+      }
+    },
     "@typescript-eslint/parser": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
@@ -25412,6 +25463,16 @@
       "dev": true,
       "requires": {
         "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "eslint-plugin-jsx-expressions": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-expressions/-/eslint-plugin-jsx-expressions-1.3.1.tgz",
+      "integrity": "sha512-7PTIx62Oy4l3Igtat361C/SCrJ4yXNNJRh/pzXMbzvPzFkvOpHBkTXITkH8PMLDu1RAdilDpjaOUv1m14DbY7w==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.5.0",
+        "tsutils": "^3.21.0"
       }
     },
     "eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "eslint": "8.14.0",
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-babel": "5.3.1",
+    "eslint-plugin-jsx-expressions": "1.3.1",
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-react-hooks": "4.5.0",
     "eslint-plugin-react-native": "4.0.0",

--- a/source/views/settings/screens/overview/odds-and-ends.tsx
+++ b/source/views/settings/screens/overview/odds-and-ends.tsx
@@ -9,7 +9,7 @@ export const OddsAndEndsSection = (): JSX.Element => {
 	return (
 		<Section header="ODDS &amp; ENDS">
 			<Cell cellStyle="RightDetail" detail={version} title="Version" />
-			{build && (
+			{Boolean(build) && (
 				<Cell cellStyle="RightDetail" detail={build} title="Build Number" />
 			)}
 		</Section>

--- a/source/views/sis/components/recents-list.tsx
+++ b/source/views/sis/components/recents-list.tsx
@@ -26,7 +26,7 @@ function RecentItemsList(props: Props) {
 	return (
 		<>
 			<View style={styles.rowFlex}>
-				{title && <Text style={styles.subHeader}>{title}</Text>}
+				{Boolean(title) && <Text style={styles.subHeader}>{title}</Text>}
 				{onAction && (
 					<Text onPress={onAction} style={[foreground, styles.sideButton]}>
 						{actionLabel}

--- a/source/views/stoprint/print-release.tsx
+++ b/source/views/stoprint/print-release.tsx
@@ -61,8 +61,8 @@ function PrinterInformation({printer}: {printer: Printer}) {
 	return (
 		<Section header="PRINTER INFO" sectionTintColor={c.sectionBgColor}>
 			<LeftDetailCell detail="Name" title={printer.printerName} />
-			{printer.location && (
-				<LeftDetailCell detail="Location" title={printer.location} />
+			{Boolean(printer.location) && (
+				<LeftDetailCell detail="Location" title={printer.location ?? ''} />
 			)}
 		</Section>
 	)


### PR DESCRIPTION
There are similar eslint rules out there but this is one of the few rules the perform type checking on the arguments in the expression. There [is an example/explanation](https://github.com/hpersson/eslint-plugin-jsx-expressions/blob/master/docs/rules/strict-logical-expressions.md
) of what would be caught here. I have set this to be a warning for now. Should we consider this an error in the future?

---

> ### Strict JSX expressions for safe conditional renders. (strict-logical-expressions)
>
> Forbids the usage of potentially falsey string or number values in logical && expressions. Oftentimes, these logical expressions are used in jsx to enable conditional rendering behavior.
> 
> However, one can encounter unexpected behavior when a 0 or empty string values is returned as the result of the expression and rendered accidentally.

Examples of incorrect code for this rule:

```ts
// Potentially falsey strings are not allowed
let str
<App>{str && <Foo />}</App>

// Potentially falsey numbers are not allowed
let num
<App>{num && <Foo />}</App>

// Includes types that may be a string or number
let thisOrThat: Record<any, any> | string | number
<App>{thisOrThat && <Foo />}</App>
```

Examples of correct code for this rule:

```ts
// Coalescing to boolean is ok
let str = "Foo"
<App>{!!str && <Foo />}</App>

// Turning into a boolean is ok
let str = "Foo"
<App>{Boolean(str) && <Foo />}</App>

// Constant values are ok
const str = "Foo"
<App>{str && <Foo />}</App>
```

Options

```js
type Options = [
  {
    allowString?: boolean;
    allowNumber?: boolean;
  }
]

defaultOptions: [
  {
    allowString: false,
    allowNumber: false,
  },
]
```