### PR TITLE
Icons for loading and notice views

### DIFF
--- a/modules/notice/loading.tsx
+++ b/modules/notice/loading.tsx
@@ -1,6 +1,14 @@
 import * as React from 'react'
 import {NoticeView} from './notice'
 
-export function LoadingView({text = 'Loading…'}: {text?: string}): JSX.Element {
-	return <NoticeView spinner={true} text={text} />
+interface Props {
+	text?: string
+	icon?: string
+}
+
+export function LoadingView({
+	text = 'Loading…',
+	icon = '',
+}: Props): JSX.Element {
+	return <NoticeView icon={icon} spinner={true} text={text} />
 }

--- a/modules/notice/notice.tsx
+++ b/modules/notice/notice.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import {
 	ActivityIndicator,
+	ScrollView,
 	StyleProp,
 	StyleSheet,
 	Text,
 	TextStyle,
-	View,
 	ViewStyle,
 } from 'react-native'
 import * as c from '@frogpond/colors'
@@ -47,7 +47,7 @@ export function NoticeView(props: Props): JSX.Element {
 	let {spinner} = props
 
 	return (
-		<View style={[styles.container, style]}>
+		<ScrollView contentContainerStyle={[styles.container, style]}>
 			{spinner ? <ActivityIndicator style={styles.spinner} /> : null}
 
 			{header ? (
@@ -67,6 +67,6 @@ export function NoticeView(props: Props): JSX.Element {
 					title={buttonText}
 				/>
 			) : null}
-		</View>
+		</ScrollView>
 	)
 }

--- a/modules/notice/notice.tsx
+++ b/modules/notice/notice.tsx
@@ -37,6 +37,7 @@ type Props = {
 	buttonDisabled?: boolean
 	header?: string
 	icon?: string
+	iconColor?: string
 	text?: string
 	style?: StyleProp<ViewStyle>
 	spinner?: boolean
@@ -46,19 +47,20 @@ type Props = {
 }
 
 export function NoticeView(props: Props): JSX.Element {
-	let {header, icon, text, style, textStyle} = props
+	let {header, text, style, textStyle} = props
 	let {buttonDisabled, buttonText, onPress} = props
 	let {spinner} = props
+	let {icon, iconColor} = props
 
 	let theme: AppTheme = getTheme()
 
-	let iconColor = {
-		color: theme.accent,
+	let iconStyles = {
+		color: iconColor ? iconColor : theme.accent,
 	}
 
 	return (
 		<ScrollView contentContainerStyle={[styles.container, style]}>
-			{icon ? <Icon name={icon} size={89} style={iconColor} /> : null}
+			{icon ? <Icon name={icon} size={89} style={iconStyles} /> : null}
 
 			{spinner ? <ActivityIndicator style={styles.spinner} /> : null}
 

--- a/modules/notice/notice.tsx
+++ b/modules/notice/notice.tsx
@@ -11,6 +11,9 @@ import {
 import * as c from '@frogpond/colors'
 import {Button} from '@frogpond/button'
 import {Heading} from '@frogpond/markdown'
+import {Icon} from '@frogpond/icon'
+import {getTheme} from '@frogpond/app-theme'
+import type {AppTheme} from '@frogpond/app-theme'
 
 const styles = StyleSheet.create({
 	container: {
@@ -33,6 +36,7 @@ const styles = StyleSheet.create({
 type Props = {
 	buttonDisabled?: boolean
 	header?: string
+	icon?: string
 	text?: string
 	style?: StyleProp<ViewStyle>
 	spinner?: boolean
@@ -42,12 +46,20 @@ type Props = {
 }
 
 export function NoticeView(props: Props): JSX.Element {
-	let {header, text, style, textStyle} = props
+	let {header, icon, text, style, textStyle} = props
 	let {buttonDisabled, buttonText, onPress} = props
 	let {spinner} = props
 
+	let theme: AppTheme = getTheme()
+
+	let iconColor = {
+		color: theme.accent,
+	}
+
 	return (
 		<ScrollView contentContainerStyle={[styles.container, style]}>
+			{icon ? <Icon name={icon} size={89} style={iconColor} /> : null}
+
 			{spinner ? <ActivityIndicator style={styles.spinner} /> : null}
 
 			{header ? (

--- a/source/views/menus/menu-bonapp.tsx
+++ b/source/views/menus/menu-bonapp.tsx
@@ -239,7 +239,7 @@ export function BonAppHostedMenu(props: Props): JSX.Element {
 
 	if (!cafeMenu || !cafeInfo) {
 		let msg = `Something went wrong. Email ${SUPPORT_EMAIL} to let them know?`
-		return <NoticeView text={msg} />
+		return <NoticeView icon="warning-outline" text={msg} />
 	}
 
 	let {ignoreProvidedMenus = false} = props

--- a/source/views/sis/course-search/search.tsx
+++ b/source/views/sis/course-search/search.tsx
@@ -137,7 +137,12 @@ class CourseSearchView extends React.Component<Props, State> {
 		let {typedQuery, mode, isSearchbarActive} = this.state
 
 		if (mode === 'loading') {
-			return <LoadingView text="Loading Course Data…" />
+			return (
+				<LoadingView
+					icon="cloud-download-outline"
+					text="Loading Course Data…"
+				/>
+			)
 		}
 
 		if (this.props.courseDataState === 'not-loaded') {


### PR DESCRIPTION
This opts to not use SFSymbols for iOS for now.

* add scrollview to `NoticeView`
* add icon support to loading and notice views
  * default is theme accent with support for overriding
* add warning icon to menu's noticeview in the error screen
* add download icon to course search's first-time loading screen

📸 Screenshots
~ | ~ | ~
--|--|--
![Simulator Screen Shot - iPhone 13 - 2022-05-23 at 23 35 28](https://user-images.githubusercontent.com/5240843/169965054-601fc694-2e89-4b14-b35f-9b65088a86c7.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-23 at 23 35 52](https://user-images.githubusercontent.com/5240843/169965062-de3e7233-a9d6-4f78-97ca-eff7f62301bb.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-23 at 23 36 06](https://user-images.githubusercontent.com/5240843/169965063-ea7189ba-a026-4e6c-b976-e1548244d86f.png)

