### PR TITLE
fix on-press list row background color

### DIFF
--- a/modules/lists/list-row.tsx
+++ b/modules/lists/list-row.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import {PropsWithChildren} from 'react'
 import {Platform, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
-import * as c from '@frogpond/colors'
 import {Touchable} from '@frogpond/touchable'
 import {DisclosureArrow} from './disclosure-arrow'
 
@@ -12,7 +11,6 @@ const styles = StyleSheet.create({
 	container: {
 		flexDirection: 'row',
 		paddingLeft: 15,
-		backgroundColor: c.white,
 		...Platform.select({
 			ios: {
 				paddingVertical: 8,

--- a/modules/touchable/index.tsx
+++ b/modules/touchable/index.tsx
@@ -9,6 +9,7 @@ import {
 	View,
 	ViewStyle,
 } from 'react-native'
+import {white} from '@frogpond/colors'
 
 type Props = PressableProps & {
 	borderless?: boolean
@@ -42,7 +43,7 @@ const CustomPressable = forwardRef<View, Props>((props, ref): JSX.Element => {
 			containerAdjustmentStyle = (state) =>
 				state.pressed
 					? [{backgroundColor: underlayColor}, containerStyle]
-					: [containerStyle]
+					: [{backgroundColor: white}, containerStyle]
 		} else {
 			containerAdjustmentStyle = (state) =>
 				state.pressed


### PR DESCRIPTION
This adds back the overriding style adjustments when pressing a list row item by moving the background color for the list row to the container style for touchable. We will default to the white background but overlay the pressed styles when needed.