### PR TITLE
move dev bonapp picker to fix navigation transition from modal settings

### DIFF
--- a/source/navigation/routes.tsx
+++ b/source/navigation/routes.tsx
@@ -138,11 +138,6 @@ const HomeStackScreens = () => (
 		</Stack.Group>
 		<Stack.Group>
 			<Stack.Screen
-				component={DevBonAppPickerView}
-				name="BonAppPicker"
-				options={DevBonAppNavigationOptions}
-			/>
-			<Stack.Screen
 				component={menus.View}
 				name="Menus"
 				options={menus.NavigationOptions}
@@ -277,6 +272,11 @@ const SettingsStackScreens = () => (
 		<SettingsStack.Screen component={settings.PrivacyView} name="Privacy" />
 		<SettingsStack.Screen component={settings.LegalView} name="Legal" />
 		<SettingsStack.Screen component={settings.APITestView} name="APITest" />
+		<Stack.Screen
+			component={DevBonAppPickerView}
+			name="BonAppPicker"
+			options={DevBonAppNavigationOptions}
+		/>
 		<SettingsStack.Screen component={settings.DebugView} name="Debug" />
 	</SettingsStack.Navigator>
 )

--- a/source/navigation/routes.tsx
+++ b/source/navigation/routes.tsx
@@ -272,7 +272,7 @@ const SettingsStackScreens = () => (
 		<SettingsStack.Screen component={settings.PrivacyView} name="Privacy" />
 		<SettingsStack.Screen component={settings.LegalView} name="Legal" />
 		<SettingsStack.Screen component={settings.APITestView} name="APITest" />
-		<Stack.Screen
+		<SettingsStack.Screen
 			component={DevBonAppPickerView}
 			name="BonAppPicker"
 			options={DevBonAppNavigationOptions}

--- a/source/navigation/types.tsx
+++ b/source/navigation/types.tsx
@@ -41,7 +41,6 @@ export type RootStackParamList = {
 	Job: undefined
 	JobDetail: {job: JobType}
 	Menus: undefined
-	BonAppPicker: undefined
 	News: undefined
 	SIS: undefined
 	CourseSearchResults: {initialQuery?: string; initialFilters?: FilterType[]}
@@ -66,6 +65,7 @@ export type RootStackParamList = {
 
 export type SettingsStackParamList = {
 	APITest: undefined
+	BonAppPicker: undefined
 	Credits: undefined
 	Debug: undefined
 	Faq: undefined


### PR DESCRIPTION
Grouping this view with the settings navigation fixes how the navigator pushes it onto the stack, so this fixes the dev bonapp view transition by keeping it on the modal stack.