### PR TITLE
add link style to PushButtonCell

### DIFF
--- a/modules/tableview/cells/button.tsx
+++ b/modules/tableview/cells/button.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {StyleProp, StyleSheet, Text, TextStyle} from 'react-native'
-import {Cell} from 'react-native-tableview-simple'
+import {Cell} from '@frogpond/tableview'
 import * as c from '@frogpond/colors'
 
 const styles = StyleSheet.create({

--- a/modules/tableview/cells/delete-button.tsx
+++ b/modules/tableview/cells/delete-button.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {StyleSheet, Alert} from 'react-native'
-import {Cell} from 'react-native-tableview-simple'
+import {Cell} from '@frogpond/tableview'
 import * as c from '@frogpond/colors'
 import noop from 'lodash/noop'
 

--- a/modules/tableview/cells/multi-line-detail.tsx
+++ b/modules/tableview/cells/multi-line-detail.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {Cell} from 'react-native-tableview-simple'
+import {Cell} from '@frogpond/tableview'
 import {StyleSheet, Text, View} from 'react-native'
 import * as c from '@frogpond/colors'
 

--- a/modules/tableview/cells/multi-line-left-detail.tsx
+++ b/modules/tableview/cells/multi-line-left-detail.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {Cell} from 'react-native-tableview-simple'
+import {Cell} from '@frogpond/tableview'
 import {StyleSheet, Text, View} from 'react-native'
 import * as c from '@frogpond/colors'
 

--- a/modules/tableview/cells/push-button.tsx
+++ b/modules/tableview/cells/push-button.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react'
 import {Cell} from '@frogpond/tableview'
+import {infoBlue} from '@frogpond/colors'
 
 type Props = {
 	title: string
 	detail?: string | number
 	onPress: () => void
 	disabled?: boolean
+	showLinkStyle?: boolean
 }
 
 export const PushButtonCell = ({
@@ -13,13 +15,15 @@ export const PushButtonCell = ({
 	detail,
 	onPress,
 	disabled = false,
+	showLinkStyle = false,
 }: Props): JSX.Element => (
 	<Cell
-		accessory="DisclosureIndicator"
+		accessory={showLinkStyle ? undefined : 'DisclosureIndicator'}
 		cellStyle={detail ? 'RightDetail' : 'Basic'}
 		detail={detail}
 		isDisabled={disabled}
 		onPress={onPress}
 		title={title}
+		titleTextColor={showLinkStyle ? infoBlue : undefined}
 	/>
 )

--- a/modules/tableview/cells/push-button.tsx
+++ b/modules/tableview/cells/push-button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {Cell} from 'react-native-tableview-simple'
+import {Cell} from '@frogpond/tableview'
 
 type Props = {
 	title: string

--- a/modules/tableview/cells/textfield.tsx
+++ b/modules/tableview/cells/textfield.tsx
@@ -6,7 +6,7 @@ import {
 	TextInput,
 	TextInputProps,
 } from 'react-native'
-import {Cell} from 'react-native-tableview-simple'
+import {Cell} from '@frogpond/tableview'
 import * as c from '@frogpond/colors'
 
 const styles = StyleSheet.create({

--- a/modules/tableview/cells/toggle.tsx
+++ b/modules/tableview/cells/toggle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {Switch} from 'react-native'
-import {Cell} from 'react-native-tableview-simple'
+import {Cell} from '@frogpond/tableview'
 import type {AppTheme} from '@frogpond/app-theme'
 import {useTheme} from '@frogpond/app-theme'
 

--- a/source/views/building-hours/detail/link-table-ios.tsx
+++ b/source/views/building-hours/detail/link-table-ios.tsx
@@ -5,7 +5,7 @@
  */
 
 import * as React from 'react'
-import {TableView, Section} from 'react-native-tableview-simple'
+import {TableView, Section} from '@frogpond/tableview'
 import {PushButtonCell} from '@frogpond/tableview/cells'
 import {openUrl} from '@frogpond/open-url'
 import type {BuildingLinkType} from '../types'

--- a/source/views/building-hours/detail/link-table-ios.tsx
+++ b/source/views/building-hours/detail/link-table-ios.tsx
@@ -22,6 +22,7 @@ export function LinkTable(props: Props): React.ReactElement {
 					<PushButtonCell
 						key={i}
 						onPress={() => openUrl(link.url.toString())}
+						showLinkStyle={true}
 						title={link.title}
 					/>
 				))}

--- a/source/views/settings/screens/debug/row.tsx
+++ b/source/views/settings/screens/debug/row.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {Cell} from 'react-native-tableview-simple'
+import {Cell} from '@frogpond/tableview'
 import type {TopLevelViewPropsType} from '../../../types'
 
 type Props = TopLevelViewPropsType & {

--- a/source/views/settings/screens/overview/developer.tsx
+++ b/source/views/settings/screens/overview/developer.tsx
@@ -42,10 +42,12 @@ export const DeveloperSection = (): React.ReactElement => {
 				<PushButtonCell disabled={true} onPress={onDebugButton} title="Debug" />
 				<PushButtonCell
 					onPress={sendSentryMessage}
+					showLinkStyle={true}
 					title="Send a Sentry Message"
 				/>
 				<PushButtonCell
 					onPress={sendSentryException}
+					showLinkStyle={true}
 					title="Send a Sentry Exception"
 				/>
 			</Section>

--- a/source/views/settings/screens/overview/miscellany.tsx
+++ b/source/views/settings/screens/overview/miscellany.tsx
@@ -18,7 +18,11 @@ export let MiscellanySection = (): JSX.Element => {
 			<PushButtonCell onPress={onCreditsButton} title="Credits" />
 			<PushButtonCell onPress={onPrivacyButton} title="Privacy Policy" />
 			<PushButtonCell onPress={onLegalButton} title="Legal" />
-			<PushButtonCell onPress={onSourceButton} title="Contributing" />
+			<PushButtonCell
+				onPress={onSourceButton}
+				showLinkStyle={true}
+				title="Contributing"
+			/>
 		</Section>
 	)
 }

--- a/source/views/settings/screens/overview/support.tsx
+++ b/source/views/settings/screens/overview/support.tsx
@@ -55,9 +55,17 @@ export const SupportSection = (): JSX.Element => {
 
 	return (
 		<Section header="SUPPORT">
-			<PushButtonCell onPress={openEmail} title="Contact Us" />
 			<PushButtonCell onPress={() => navigation.navigate('Faq')} title="FAQs" />
-			<PushButtonCell onPress={onResetButton} title="Reset Everything" />
+			<PushButtonCell
+				onPress={openEmail}
+				showLinkStyle={true}
+				title="Contact Us"
+			/>
+			<PushButtonCell
+				onPress={onResetButton}
+				showLinkStyle={true}
+				title="Reset Everything"
+			/>
 			<Cell cellStyle="RightDetail" detail={getVersion()} title="Version" />
 		</Section>
 	)


### PR DESCRIPTION
Closes #6119 wherein we wanted to make rows that open elsewhere more button-like.

#### Changes to `<PushButtonCell />`
* adds `showLinkStyle` as an optional boolean prop
* if we apply the link style...
  * sets the title text color to be blue
  * removes the disclosure indicator

 📸 Screenshots

* Settings rows:
  * Contact Us
  * Reset Everything 
  * Contributing
  * Send a sentry message / exception

support | miscellany | developer
--|--|--
<img width="382" alt="support" src="https://user-images.githubusercontent.com/5240843/173736479-59725686-9b99-4441-9b9e-2779c5996c3f.png"> | <img width="382" alt="misc" src="https://user-images.githubusercontent.com/5240843/173736477-31d1be8b-0f10-4dfa-9128-3dc0d684a516.png">  | <img width="382" alt="developer" src="https://user-images.githubusercontent.com/5240843/173736476-72b741da-34e5-4f24-b344-b365fa49e923.png">

---

#### Changes across these components:

```diff
- import {Cell} from 'react-native-tableview-simple'
+ import {Cell} from @frogpond/tableview'
```

The import allows us to keep styles consistent.

`modules/tableview/cells`
- button
- delete-button
- push-button
- multi-line-detail
- multi-line-left-detail
- textfield
- toggle

`setttings/screens/debug`
- row

`building-hours/detail`
- link-table-ios

Among other things, this fixed the building hours detail view link rows which were lacking the new styles. While we do not currently have links in the hours data today, they will now show up with the correct padded and rounded styles.

<img src="https://user-images.githubusercontent.com/5240843/173737159-ff27799f-1ec0-4c27-beaa-0c186c321117.png" alt="building hours detail link-table-ios visual diff" width=282 />