### PR TITLE
remove prompting from link behavior

### DIFF
--- a/modules/open-url/index.ts
+++ b/modules/open-url/index.ts
@@ -1,1 +1,1 @@
-export {openUrl, trackedOpenUrl, canOpenUrl, openUrlInBrowser} from './open-url'
+export {openUrl, trackedOpenUrl, canOpenUrl} from './open-url'

--- a/modules/open-url/open-url.ts
+++ b/modules/open-url/open-url.ts
@@ -1,6 +1,5 @@
-import {Alert, Linking, Platform} from 'react-native'
+import {Linking, Platform} from 'react-native'
 
-import {appName} from '@frogpond/constants'
 import SafariView from 'react-native-safari-view'
 import {openURL} from '@frogpond/react-native-chrome-custom-tabs'
 
@@ -72,18 +71,4 @@ export function canOpenUrl(url: string): boolean {
 		return false
 	}
 	return true
-}
-
-export function openUrlInBrowser({url}: {url: string; id?: string}): void {
-	return promptConfirm(url)
-}
-
-function promptConfirm(url: string): void {
-	let app = appName()
-	let title = `Leaving ${app}`
-	let detail = `A web page will be opened in a browser outside of ${app}.`
-	Alert.alert(title, detail, [
-		{text: 'Cancel', onPress: () => null},
-		{text: 'Open', onPress: () => genericOpen(url)},
-	])
 }

--- a/source/views/home/index.tsx
+++ b/source/views/home/index.tsx
@@ -13,7 +13,7 @@ import {allViews} from '../views'
 import {Column} from '@frogpond/layout'
 import {partitionByIndex} from '../../lib/partition-by-index'
 import {HomeScreenButton, CELL_MARGIN} from './button'
-import {trackedOpenUrl, openUrlInBrowser} from '@frogpond/open-url'
+import {trackedOpenUrl} from '@frogpond/open-url'
 import {OpenSettingsButton} from '@frogpond/navigation-buttons'
 import {UnofficialAppNotice} from './notice'
 import {useNavigation} from '@react-navigation/native'
@@ -63,8 +63,6 @@ function HomePage({views = allViews}: Props): JSX.Element {
 									onPress={() => {
 										if (view.type === 'url') {
 											return trackedOpenUrl({url: view.url, id: view.view})
-										} else if (view.type === 'browser-url') {
-											return openUrlInBrowser({url: view.url, id: view.view})
 										} else if (view.type === 'view') {
 											return navigation.navigate(view.view)
 										} else {

--- a/source/views/views.ts
+++ b/source/views/views.ts
@@ -163,7 +163,7 @@ export const allViews: Array<ViewType> = [
 		gradient: c.tealToSeafoam,
 	},
 	{
-		type: 'browser-url',
+		type: 'url',
 		url: 'https://oleville.com/',
 		view: 'Oleville',
 		title: 'Oleville',


### PR DESCRIPTION
Context: this was more useful for the safety browser-url view which opened a browser window pretty immediately. We've since removed that view from the app and Oleville is the last view to make use of this behavior.

We opted to add an alert before jumping but when we keep the url in the app it feels less jarring and more natural.

So removing this UX altogether seems like an okay thing to do now.

* Removes `promptConfirm` and `openUrlInBrowser` functions
* Marks the url type of the oleville view as a `url` instead of `browser-url`
  * Changes the UX to open the link within the app's session 
