### PR TITLE
auto-push Podfile.lock changes on dependabot PRs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -134,7 +134,7 @@ jobs:
           bundler-cache: true
       - run: sudo xcode-select -s /Applications/Xcode_13.1.app
       - run: npm ci
-        env: { SKIP_POSTINSTALL: '1' }
+        env: {SKIP_POSTINSTALL: '1'}
       - run: bundle exec pod install --deployment
         working-directory: ./ios
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -138,6 +138,34 @@ jobs:
       - run: bundle exec pod install --deployment
         working-directory: ./ios
 
+  ios-podfile-update:
+    # Adapted from https://gist.github.com/A-Tokyo/0d811e818513fc4d3272335d2847d748
+    name: iOS Update Cocoapods
+    runs-on: macos-11
+    if: startsWith(github.ref_name, 'dependabot/npm_and_yarn/') && contains(github.ref_name, 'react-native')
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '^16.0'
+          cache: npm
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+          bundler-cache: true
+      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
+      - run: npm ci
+        env: {SKIP_POSTINSTALL: '1'}
+      - run: bundle exec -- pod install --verbose
+        working-directory: ./ios
+      - name: push-if-podfile-changes
+        run: bash scripts/push-if-podfile-changes.sh
+        env:
+          branch: ${{ github.ref_name }}
+          actor: ${{ github.actor }}
+          head_ref: ${{ github.head_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   ios-bundle:
     name: iOS Bundle
     runs-on: ubuntu-20.04

--- a/scripts/push-if-podfile-changed.sh
+++ b/scripts/push-if-podfile-changed.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e -v -u -o pipefail
+
+if [ -z "${!branch}" ]; then
+    echo 'Need to set environment variable "branch"' && exit 1;
+fi
+
+if [ -z "${!actor}" ]; then
+    echo 'Need to set environment variable "actor"' && exit 1;
+fi
+
+if [ -z "${!head_ref}" ]; then
+    echo 'Need to set environment variable "head_ref"' && exit 1;
+fi
+
+FILE=ios/Podfile.lock
+
+if [[ -n "$(git status -s -- $FILE)" ]]; then
+    exit 0
+fi
+
+# eg, "Bump apple-signin-auth-1.4.0 cocoapods packages"
+# add `[dependabot skip]` to the body so Dependabot force-pushes any rebases over our changes, triggering the action again
+message="Bump ""${branch//dependabot\/npm_and_yarn\// }"" cocoapods packages
+
+[dependabot skip]"
+
+git add "$FILE"
+
+git commit user.name 'github-actions[bot]'
+git commit user.email 'github-actions[bot]@users.noreply.github.com'
+
+author="""${actor}"" <${actor}@users.noreply.github.com>"
+git commit --author="$author" -m "$message"
+
+git push origin "$head_ref"


### PR DESCRIPTION
While Github has not accepted new dependency systems for at least two years, there is a [script that someone wrote](https://gist.github.com/A-Tokyo/0d811e818513fc4d3272335d2847d748) which should be able to help with our issues. See also: https://github.com/dependabot/dependabot-core/issues/935

I've updated the script to inline it inside of our job, and to avoid 3rd-party github actions.
