### PR TITLE
remove isPending and isInitial checks for list refreshing

### DIFF
--- a/source/views/building-hours/list.tsx
+++ b/source/views/building-hours/list.tsx
@@ -62,8 +62,6 @@ export function BuildingHoursView(): JSX.Element {
 
 	let {
 		data: {data: buildings = []} = {},
-		isPending,
-		isInitial,
 		isLoading,
 		reload,
 	} = useBuildingHours()
@@ -94,7 +92,7 @@ export function BuildingHoursView(): JSX.Element {
 			contentContainerStyle={styles.container}
 			keyExtractor={(item) => item.name}
 			onRefresh={reload}
-			refreshing={isPending && !isInitial}
+			refreshing={false}
 			renderItem={({item}) => (
 				<BuildingRow info={item} now={now} onPress={() => onPressRow(item)} />
 			)}

--- a/source/views/dictionary/list.tsx
+++ b/source/views/dictionary/list.tsx
@@ -88,8 +88,6 @@ function DictionaryView(): JSX.Element {
 		data: {data: words = []} = {},
 		error,
 		reload,
-		isPending,
-		isInitial,
 		isLoading,
 	} = useDictionary()
 
@@ -141,7 +139,7 @@ function DictionaryView(): JSX.Element {
 			keyboardDismissMode="on-drag"
 			keyboardShouldPersistTaps="never"
 			onRefresh={reload}
-			refreshing={isPending && !isInitial}
+			refreshing={false}
 			renderItem={({item}) => {
 				return (
 					<ListRow

--- a/source/views/menus/menu-bonapp.tsx
+++ b/source/views/menus/menu-bonapp.tsx
@@ -206,8 +206,6 @@ export function BonAppHostedMenu(props: Props): JSX.Element {
 		data: cafeMenu,
 		error: menuError,
 		reload: menuReload,
-		isPending: isMenuPending,
-		isInitial: isMenuInitial,
 		isLoading: isMenuLoading,
 	} = useCafeMenu(menuUrl)
 
@@ -215,8 +213,6 @@ export function BonAppHostedMenu(props: Props): JSX.Element {
 		data: cafeInfo,
 		error: cafeError,
 		reload: cafeReload,
-		isPending: isCafePending,
-		isInitial: isCafeInitial,
 		isLoading: isCafeLoading,
 	} = useCafeInfo(cafeUrl)
 
@@ -229,9 +225,6 @@ export function BonAppHostedMenu(props: Props): JSX.Element {
 			setErrorMessage(getErrorMessage(menuError))
 		}
 	}, [cafeError, menuError])
-
-	let refreshing =
-		(isCafePending && !isCafeInitial) || (isMenuPending && !isMenuInitial)
 
 	if (isMenuLoading || isCafeLoading) {
 		return <LoadingView text={sample(props.loadingMessage)} />
@@ -291,7 +284,7 @@ export function BonAppHostedMenu(props: Props): JSX.Element {
 				cafeReload()
 				menuReload()
 			}}
-			refreshing={refreshing}
+			refreshing={false}
 		/>
 	)
 }

--- a/source/views/news/news-list.tsx
+++ b/source/views/news/news-list.tsx
@@ -45,8 +45,6 @@ export const NewsList = (props: Props): JSX.Element => {
 		data = [],
 		error,
 		reload,
-		isPending,
-		isInitial,
 		isLoading,
 	} = useNews(props.source)
 
@@ -80,7 +78,7 @@ export const NewsList = (props: Props): JSX.Element => {
 			data={entries}
 			keyExtractor={(item: StoryType) => item.title}
 			onRefresh={reload}
-			refreshing={isPending && !isInitial}
+			refreshing={false}
 			renderItem={({item}: {item: StoryType}) => (
 				<NewsRow
 					onPress={(url: string) => openUrl(url)}

--- a/source/views/student-orgs/list.tsx
+++ b/source/views/student-orgs/list.tsx
@@ -63,8 +63,6 @@ function StudentOrgsView(): JSX.Element {
 		data: orgs = [],
 		error,
 		reload,
-		isPending,
-		isInitial,
 		isLoading,
 	} = useStudentOrgs()
 
@@ -132,7 +130,7 @@ function StudentOrgsView(): JSX.Element {
 			keyboardDismissMode="on-drag"
 			keyboardShouldPersistTaps="never"
 			onRefresh={reload}
-			refreshing={isPending && !isInitial}
+			refreshing={false}
 			renderItem={({item}) => (
 				<ListRow arrowPosition="top" onPress={() => onPressOrg(item)}>
 					<Column flex={1}>


### PR DESCRIPTION
Potentially fixes:
- #6116 

This seemingly fixes the battle that LoadingView and useAsync have going on for showing off their loading indicators.

Do we lose anything by setting the `refreshing` state to false? 

Perhaps LoadingView isn't needed on these views if we have another way to show a loading indicator? I would vote to set refreshing to false (this PR changeset) but I am wary something might be happening under the hood as a side effect. Maybe accessibility is changed by this.

The documentation has this to say about `onRefresh` and `refreshing`. It says "make sure to also set the refreshing prop correctly" and "set this as true while waiting for new data".

> ### [onRefresh](https://reactnative.dev/docs/sectionlist#onrefresh)
> If provided, a standard RefreshControl will be added for "Pull to Refresh" functionality. Make sure to also set the refreshing prop correctly. To offset the RefreshControl from the top (e.g. by 100 pts), use progressViewOffset={100}.

>### [refreshing](https://reactnative.dev/docs/sectionlist#refreshing)
> Set this as true while waiting for new data from a refresh.