### PR TITLE
more view (part 2): ccc-ified

### DIFF
--- a/data/_schemas/a-to-z.yaml
+++ b/data/_schemas/a-to-z.yaml
@@ -1,0 +1,19 @@
+$schema: http://json-schema.org/draft-07/schema#
+
+type: object
+additionalProperties: false
+required: [letter, values]
+properties:
+  letter: {type: string}
+  values:
+    type: array
+    items: {$ref: '#/definitions/item'}
+
+definitions:
+  item:
+    type: object
+    additionalProperties: false
+    required: [label, url]
+    properties:
+      label: {type: string}
+      url: {type: string}

--- a/data/a-to-z/m.yaml
+++ b/data/a-to-z/m.yaml
@@ -1,0 +1,5 @@
+letter: M
+
+values:
+  - label: Moodle
+    url: 'https://moodle.stolaf.edu'

--- a/data/a-to-z/t.yaml
+++ b/data/a-to-z/t.yaml
@@ -1,0 +1,5 @@
+letter: T
+
+values:
+  - label: TES (Time Entry System)
+    url: 'https://stolaf.edu/apps/tes'

--- a/source/init/data.ts
+++ b/source/init/data.ts
@@ -3,6 +3,10 @@ import {insertForUrl} from '@frogpond/fetch'
 
 const dataSets = [
 	{
+		url: '/a-to-z',
+		data: require('../../docs/a-to-z.json'),
+	},
+	{
 		url: API('/spaces/hours'),
 		data: require('../../docs/building-hours.json'),
 	},

--- a/source/init/data.ts
+++ b/source/init/data.ts
@@ -3,7 +3,7 @@ import {insertForUrl} from '@frogpond/fetch'
 
 const dataSets = [
 	{
-		url: '/a-to-z',
+		url: API('/a-to-z'),
 		data: require('../../docs/a-to-z.json'),
 	},
 	{

--- a/source/views/more/index.tsx
+++ b/source/views/more/index.tsx
@@ -45,17 +45,13 @@ function linkToArray(data: LinkValue) {
 	return Array.from(new Set([...splitToArray(data.label)]))
 }
 
-let groupResults = (
-	searchQuery: string,
-	rawData: LinkGroup[],
-	groupedOriginal: LinkGroup[],
-) => {
+let groupResults = (searchQuery: string, rawData: LinkGroup[]) => {
 	if (!rawData) {
 		return emptyList
 	}
 
 	if (searchQuery.length < 3) {
-		return groupedOriginal
+		return rawData
 	}
 
 	let filtered = rawData.flatMap(({data}) =>
@@ -95,11 +91,9 @@ function MoreView(): JSX.Element {
 		isLoading,
 	} = useSearchLinks()
 
-	let groupedOriginal = React.useMemo(() => data, [data])
-
 	let grouped = React.useMemo(
-		() => groupResults(searchQuery, data, groupedOriginal),
-		[searchQuery, data, groupedOriginal],
+		() => groupResults(searchQuery, data),
+		[searchQuery, data],
 	)
 
 	React.useLayoutEffect(() => {

--- a/source/views/more/types.ts
+++ b/source/views/more/types.ts
@@ -1,14 +1,3 @@
-export interface SearchData {
-	az_nav: {
-		menu_items: LinkResults[]
-	}
-}
-
-export interface LinkResults {
-	letter: string
-	values: LinkValue[]
-}
-
 export interface LinkGroup {
 	title: string
 	data: LinkValue[]


### PR DESCRIPTION
- follow-up to #6175 
- add schema and definition yaml to generate a-to-z json
- utilize the caching server to proxy a new `/a-to-z` endpoint
  - endpoint implementation located at https://github.com/frog-pond/ccc-server/pull/617