### PR TITLE
Partially fix jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "./scripts/jest-setup.js"
     ],
     "transformIgnorePatterns": [
-      "node_modules/(?!(jest-)?react-native|glamorous-native|react-navigation)"
+      "node_modules/(?!(jest-)?react-native|@react-native|glamorous-native|react-navigation)"
     ],
     "preset": "react-native"
   },

--- a/source/views/building-hours/lib/__tests__/summarize-days.test.ts
+++ b/source/views/building-hours/lib/__tests__/summarize-days.test.ts
@@ -45,24 +45,24 @@ describe('returns the provided days if non-contiguous', () => {
 
 	test('handles a two-day set (full)', () => {
 		let actual = summarizeDays(['Mo', 'We'], true)
-		expect(actual).toEqual('Monday, Wednesday')
+		expect(actual).toEqual('Monday and Wednesday')
 	})
 	test('handles a three-day set (full)', () => {
 		let actual = summarizeDays(['Mo', 'Tu', 'Th'], true)
-		expect(actual).toEqual('Monday, Tuesday, Thursday')
+		expect(actual).toEqual('Monday, Tuesday, and Thursday')
 	})
 	test('handles a four-day set (full)', () => {
 		let actual = summarizeDays(['Mo', 'Tu', 'Th', 'Fr'], true)
-		expect(actual).toEqual('Monday, Tuesday, Thursday, Friday')
+		expect(actual).toEqual('Monday, Tuesday, Thursday, and Friday')
 	})
 	test('handles a five-day set (full)', () => {
 		let actual = summarizeDays(['Mo', 'Tu', 'We', 'Fr', 'Su'], true)
-		expect(actual).toEqual('Monday, Tuesday, Wednesday, Friday, Sunday')
+		expect(actual).toEqual('Monday, Tuesday, Wednesday, Friday, and Sunday')
 	})
 	test('handles a six-day set (full)', () => {
 		let actual = summarizeDays(['Mo', 'We', 'Th', 'Fr', 'Sa', 'Su'], true)
 		expect(actual).toEqual(
-			'Monday, Wednesday, Thursday, Friday, Saturday, Sunday',
+			'Monday, Wednesday, Thursday, Friday, Saturday, and Sunday',
 		)
 	})
 })
@@ -148,11 +148,11 @@ describe('returns summary for combination days and hours', () => {
 
 	test('handles "weekends"', () => {
 		let actual = summarizeDaysAndHours({
-			days: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
+			days: ['Sa', 'Su'],
 			from: '9:00am',
 			to: '5:00pm',
 		})
-		expect(actual).toEqual('Opens at 9:00am and closes at 5:00pm on weekends.')
+		expect(actual).toEqual('Opens at 9:00am and closes at 5:00pm on Weekends.')
 	})
 
 	test('handles "single day"', () => {
@@ -171,7 +171,7 @@ describe('returns summary for combination days and hours', () => {
 			to: '5:00pm',
 		})
 		expect(actual).toEqual(
-			'Opens at 9:00am and closes at 5:00pm on Monday - Thursday.',
+			'Opens at 9:00am and closes at 5:00pm every Monday — Thursday.',
 		)
 	})
 
@@ -182,7 +182,7 @@ describe('returns summary for combination days and hours', () => {
 			to: '5:00pm',
 		})
 		expect(actual).toEqual(
-			'Opens at 9:00am and closes at 5:00pm on Monday, Wednesday, and Saturday.',
+			'Opens at 9:00am and closes at 5:00pm every Monday, Wednesday, and Saturday.',
 		)
 	})
 })

--- a/source/views/transportation/bus/lib/__tests__/__snapshots__/find-remaining-departures-for-stop.test.ts.snap
+++ b/source/views/transportation/bus/lib/__tests__/__snapshots__/find-remaining-departures-for-stop.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`handles a stop that will be skipped 1`] = `
 Array [
-  null,
+  undefined,
   "3:05pm",
 ]
 `;
@@ -24,7 +24,7 @@ Array [
 exports[`handles a time at the second stop 1`] = `
 Array [
   "1:05pm",
-  null,
+  undefined,
   "3:05pm",
 ]
 `;
@@ -47,7 +47,7 @@ Array [
 exports[`handles a time between two stops 1`] = `
 Array [
   "1:05pm",
-  null,
+  undefined,
   "3:05pm",
 ]
 `;


### PR DESCRIPTION
Partially resolves #6153 

- Jest now runs again by adding `@react-native` to `transformIgnorePatterns`
- Updates tests created for building hours summary that were created when jest was not working
- Updates snapshots for departures (why did these change?)

**Remaining issues:**
- A test failure is still happening when parsing `import` statements. Our configuration still needs an update to fix this.

**Current state:**
```
Test Suites: 1 failed, 24 passed, 25 total
Tests:       3 skipped, 149 passed, 152 total
Snapshots:   27 passed, 27 total
Time:        4.073 s, estimated 6 s
```
