### PR TITLE
Fix course fetching on Android

### DIFF
--- a/source/lib/course-search/update-course-storage.ts
+++ b/source/lib/course-search/update-course-storage.ts
@@ -1,4 +1,5 @@
 import {fetch} from '@frogpond/fetch'
+import * as Sentry from '@sentry/react-native'
 import type {RawCourseType, CourseType, TermType} from './types'
 import {COURSE_DATA_PAGE, INFO_PAGE} from './urls'
 import * as storage from '../storage'
@@ -46,10 +47,14 @@ async function loadCurrentTermsFromServer(): Promise<Array<TermType>> {
 	const thisYear = today.getFullYear()
 	const resp: TermInfoType = await fetch(INFO_PAGE, {cache: 'no-store'})
 		.json<TermInfoType>()
-		.catch(() => ({
-			files: [],
-			type: 'error',
-		}))
+		.catch((error) => {
+			console.warn(`Error from loadCurrentTermsFromServer: ${error}`)
+			Sentry.captureException(error)
+			return {
+				files: [],
+				type: 'error',
+			}
+		})
 	const terms: Array<TermType> = resp.files.filter(
 		(file) => file.type === 'json' && file.year > thisYear - 5,
 	)

--- a/source/lib/course-search/urls.ts
+++ b/source/lib/course-search/urls.ts
@@ -1,12 +1,11 @@
-export const COURSE_DATA_PAGE = 'https://stodevx.github.io/course-data/'
+const BASE_URL = 'https://stolaf.dev'
 
-export const INFO_PAGE = 'https://stodevx.github.io/course-data/info.json'
+export const COURSE_DATA_PAGE = `${BASE_URL}/course-data/`
 
-export const GE_DATA =
-	'https://stodevx.github.io/course-data/data-lists/valid_gereqs.json'
+export const INFO_PAGE = `${BASE_URL}/course-data/info.json`
 
-export const DEPT_DATA =
-	'https://stodevx.github.io/course-data/data-lists/valid_departments.json'
+export const GE_DATA = `${BASE_URL}/course-data/data-lists/valid_gereqs.json`
 
-export const TIMES_DATA =
-	'https://stodevx.github.io/course-data/data-lists/valid_times.json'
+export const DEPT_DATA = `${BASE_URL}/course-data/data-lists/valid_departments.json`
+
+export const TIMES_DATA = `${BASE_URL}/course-data/data-lists/valid_times.json`


### PR DESCRIPTION
- Fixes #6288 
- Replaces the base url of `stodevx.github.io` for `stolaf.dev` for course fetching
- Increased error logging for course fetch failure in the term fetching (console and Sentry)

---

Switching the url so that the `301 Moved Permanently` does not break android is a bandaid. That should not have broken things, but if it turns out that the issue resolves itself in the future (e.g. via upgrading react native) then we can undo the base url change. Thoughts?
