### PR TITLE
ci: Run bundle-data before running tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,6 +87,7 @@ jobs:
           node-version: ^16.0
           cache: npm
       - run: npm ci
+      - run: npm run bundle-data
       - name: Run tests
         run: npm run test -- --coverage
       - name: Upload coverage


### PR DESCRIPTION
When we split the workflows, we made it so that the files will no longer be present when the tests are run. This led to a test failure when the `.json` files are not generated to be loaded by the tests.

Now, call `npm run bundle-data` to generate the .json files before the tests are run. This leads Jest to pass now.