### PR TITLE
🔖 streams filterbar

### DIFF
--- a/source/views/streaming/streams/list.tsx
+++ b/source/views/streaming/streams/list.tsx
@@ -4,6 +4,7 @@ import {timezone} from '@frogpond/constants'
 import * as c from '@frogpond/colors'
 import {ListSeparator, ListSectionHeader} from '@frogpond/lists'
 import {NoticeView, LoadingView} from '@frogpond/notice'
+import {FilterToolbar, ListType} from '@frogpond/filter'
 import {StreamRow} from './row'
 import toPairs from 'lodash/toPairs'
 import groupBy from 'lodash/groupBy'
@@ -12,7 +13,7 @@ import type {Moment} from 'moment-timezone'
 import {toLaxTitleCase as titleCase} from '@frogpond/titlecase'
 import type {StreamType} from './types'
 import {API} from '@frogpond/api'
-import {fetch} from '@frogpond/fetch'
+import {useFetch} from 'react-async'
 
 const styles = StyleSheet.create({
 	listContainer: {
@@ -23,99 +24,137 @@ const styles = StyleSheet.create({
 	},
 })
 
+let groupStreams = (entries: StreamType[]) => {
+	let grouped = groupBy(entries, (j) => j.$groupBy)
+	return toPairs(grouped).map(([title, data]) => ({title, data}))
+}
+
+let filterStreams = (entries: StreamType[], filters: ListType[]) => {
+	return entries.filter((stream) => {
+		let enabledCategories = filters.flatMap((f: ListType) =>
+			f.spec.selected.flatMap((s) => s.title),
+		)
+
+		if (enabledCategories.length === 0) {
+			return entries
+		}
+
+		return enabledCategories.includes(stream.category)
+	})
+}
+
+let useStreams = (date: Moment = moment.tz(timezone())) => {
+	let dateFrom = date.format('YYYY-MM-DD')
+	let dateTo = date.clone().add(2, 'month').format('YYYY-MM-DD')
+
+	return useFetch<StreamType[]>(
+		API('/streams/upcoming', {
+			sort: 'ascending',
+			dateFrom,
+			dateTo,
+		}),
+		{
+			headers: {accept: 'application/json'},
+		},
+	)
+}
+
 export const StreamListView = (): JSX.Element => {
-	let [error, setError] = React.useState<Error | null>(null)
-	let [loading, setLoading] = React.useState(true)
-	let [refreshing, setRefreshing] = React.useState(false)
-	let [streams, setStreams] = React.useState<
-		Array<{title: string; data: StreamType[]}>
-	>([])
+	let {data = [], error, reload, isPending, isInitial, isLoading} = useStreams()
+
+	let [filters, setFilters] = React.useState<ListType[]>([])
+
+	let entries = React.useMemo(() => {
+		return data.map((stream) => {
+			let date: Moment = moment(stream.starttime)
+			let dateGroup = date.format('dddd, MMMM Do')
+
+			let group = stream.status.toLowerCase() !== 'live' ? dateGroup : 'Live'
+
+			return {
+				...stream,
+				// force title-case on the stream types, to prevent not-actually-duplicate headings
+				category: titleCase(stream.category),
+				date: date,
+				$groupBy: group,
+			}
+		})
+	}, [data])
 
 	React.useEffect(() => {
-		try {
-			getStreams().then(() => {
-				setLoading(false)
-			})
-		} catch (error) {
-			if (error instanceof Error) {
-				setError(error)
-			} else {
-				setError(new Error('unknown error - not an Error'))
-			}
+		let allCategories = data.flatMap((stream) => titleCase(stream.category))
+
+		if (allCategories.length === 0) {
 			return
 		}
-	}, [])
 
-	let refresh = async (): Promise<void> => {
-		setRefreshing(true)
-		await getStreams(true)
-		setRefreshing(false)
-	}
+		let categories = [...new Set(allCategories)].sort()
+		let filterCategories = categories.map((c) => {
+			return {title: c}
+		})
 
-	let getStreams = async (
-		reload?: boolean,
-		date: Moment = moment.tz(timezone()),
-	) => {
-		let dateFrom = date.format('YYYY-MM-DD')
-		let dateTo = date.clone().add(2, 'month').format('YYYY-MM-DD')
-
-		let data = await fetch(API('/streams/upcoming'), {
-			searchParams: {
-				sort: 'ascending',
-				dateFrom,
-				dateTo,
+		let streamFilters: ListType[] = [
+			{
+				type: 'list',
+				key: 'category',
+				enabled: true,
+				spec: {
+					title: 'Categories',
+					options: filterCategories,
+					selected: filterCategories,
+					mode: 'OR',
+					displayTitle: true,
+				},
+				apply: {key: 'category'},
 			},
-			delay: reload ? 500 : 0,
-		}).json<Array<StreamType>>()
-
-		data = data
-			.filter((stream) => stream.category !== 'athletics')
-			.map((stream) => {
-				let date: Moment = moment(stream.starttime)
-				let dateGroup = date.format('dddd, MMMM Do')
-
-				let group = stream.status.toLowerCase() !== 'live' ? dateGroup : 'Live'
-
-				return {
-					...stream,
-					// force title-case on the stream types, to prevent not-actually-duplicate headings
-					category: titleCase(stream.category),
-					date: date,
-					$groupBy: group,
-				}
-			})
-
-		let grouped = groupBy(data, (j) => j.$groupBy)
-		let mapped = toPairs(grouped).map(([title, data]) => ({title, data}))
-
-		setStreams(mapped)
-	}
-
-	let keyExtractor = (item: StreamType) => item.eid
-
-	let renderItem = ({item}: {item: StreamType}) => <StreamRow stream={item} />
-
-	if (loading) {
-		return <LoadingView />
-	}
+		]
+		setFilters(streamFilters)
+	}, [data])
 
 	if (error) {
-		return <NoticeView text={`Error: ${error.message}`} />
+		return (
+			<NoticeView
+				buttonText="Try Again"
+				onPress={reload}
+				text={`A problem occured while loading the streams. ${error.message}`}
+			/>
+		)
 	}
+
+	const header = (
+		<FilterToolbar
+			filters={filters}
+			onPopoverDismiss={(newFilter) => {
+				let edited = filters.map((f) =>
+					f.key === newFilter.key ? newFilter : f,
+				)
+				setFilters(edited as ListType[])
+			}}
+		/>
+	)
 
 	return (
 		<SectionList
 			ItemSeparatorComponent={ListSeparator}
-			ListEmptyComponent={<NoticeView text="No Streams" />}
+			ListEmptyComponent={
+				isLoading ? (
+					<LoadingView />
+				) : filters.some((f: ListType) => f.spec.selected.length) ? (
+					<NoticeView text="No streams to show. Try changing the filters." />
+				) : (
+					<NoticeView text="No streams." />
+				)
+			}
+			ListHeaderComponent={header}
 			contentContainerStyle={styles.contentContainer}
-			keyExtractor={keyExtractor}
-			onRefresh={refresh}
-			refreshing={refreshing}
-			renderItem={renderItem}
+			keyExtractor={(item: StreamType) => item.eid}
+			onRefresh={reload}
+			refreshing={isPending && !isInitial}
+			renderItem={({item}: {item: StreamType}) => <StreamRow stream={item} />}
 			renderSectionHeader={({section: {title}}) => (
 				<ListSectionHeader title={title} />
 			)}
-			sections={streams}
+			sections={groupStreams(filterStreams(entries, filters))}
 			style={styles.listContainer}
 		/>
 	)


### PR DESCRIPTION
Replaced with:
- #6412 
- #6413 

---

These changes refactor streams list to accomplish a few ideas:

* refactor data fetching with `useFetch`
* add filter bar to show stream categories
* show athletics streams by default
* Part of #6142 

📸 Screenshots

~ | ~
--|--
![Simulator Screen Shot - iPhone 12 Pro - 2022-08-29 at 20 38 38](https://user-images.githubusercontent.com/5240843/187344859-7dfbbf67-243c-4b7c-a082-f187b45eb27f.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2022-08-29 at 20 38 52](https://user-images.githubusercontent.com/5240843/187344896-785beec0-eaf3-4db7-a3d8-d590c93287c4.png)
