### PR TITLE
Set android appearances to light

### DIFF
--- a/modules/app-theme/index.ts
+++ b/modules/app-theme/index.ts
@@ -1,5 +1,8 @@
 import type {ThemingType} from '@callstack/react-theme-provider'
 import {createTheming} from '@callstack/react-theme-provider'
+import {CombinedDefaultTheme, CombinedDarkTheme} from './paper'
+
+export {CombinedDefaultTheme, CombinedDarkTheme}
 
 export type AppTheme = {
 	accent: string

--- a/modules/app-theme/paper.ts
+++ b/modules/app-theme/paper.ts
@@ -1,0 +1,18 @@
+import merge from 'deepmerge'
+
+import {
+	DarkTheme as NavigationDarkTheme,
+	DefaultTheme as NavigationDefaultTheme,
+} from '@react-navigation/native'
+
+import {
+	DarkTheme as PaperDarkTheme,
+	DefaultTheme as PaperDefaultTheme,
+} from 'react-native-paper'
+
+export const CombinedDefaultTheme = merge(
+	PaperDefaultTheme,
+	NavigationDefaultTheme,
+)
+
+export const CombinedDarkTheme = merge(PaperDarkTheme, NavigationDarkTheme)

--- a/modules/tableview/index.tsx
+++ b/modules/tableview/index.tsx
@@ -18,7 +18,7 @@ let Section = (props: SectionInterface): JSX.Element => (
 )
 
 let TableView = (props: TableViewInterface): JSX.Element => (
-	<RNTableView.TableView style={styles.tableview} {...props} />
+	<RNTableView.TableView appearance='light' style={styles.tableview} {...props} />
 )
 
 let Cell = (props: CellInterface): JSX.Element => (

--- a/modules/tableview/index.tsx
+++ b/modules/tableview/index.tsx
@@ -18,7 +18,11 @@ let Section = (props: SectionInterface): JSX.Element => (
 )
 
 let TableView = (props: TableViewInterface): JSX.Element => (
-	<RNTableView.TableView appearance='light' style={styles.tableview} {...props} />
+	<RNTableView.TableView
+		appearance="light"
+		style={styles.tableview}
+		{...props}
+	/>
 )
 
 let Cell = (props: CellInterface): JSX.Element => (

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -15,7 +15,7 @@ import {Provider as ReduxProvider} from 'react-redux'
 import {Provider as PaperProvider} from 'react-native-paper'
 import {makeStore, initRedux} from './redux'
 import * as navigation from './navigation'
-import {ThemeProvider} from '@frogpond/app-theme'
+import {ThemeProvider, CombinedDefaultTheme} from '@frogpond/app-theme'
 import {ActionSheetProvider} from '@expo/react-native-action-sheet'
 import {NavigationContainer} from '@react-navigation/native'
 
@@ -28,7 +28,7 @@ export default class App extends React.Component {
 	render(): JSX.Element {
 		return (
 			<ReduxProvider store={store}>
-				<PaperProvider>
+				<PaperProvider theme={CombinedDefaultTheme}>
 					<ThemeProvider>
 						<ActionSheetProvider>
 							<NavigationContainer


### PR DESCRIPTION
Android has an adaptive appearance that the react-native-tableview-simple plugin is picking up on. Until we put more thought into supporting dark/light themes and material you, we can continue to force a light theme for consistency.

Another PR was merged into this branch so it makes sense to only view https://github.com/StoDevX/AAO-React-Native/commit/954018fa816c08f00fd2155b3b85e473e7719a99    

- [x] Tableview wrapper (`Settings` and `Course Catalog` detail among other places)
- [x] Make sure `react-native-card` shows our light theme (see #6367)

before | after
--|--
![2022-09-03 14 27 56](https://user-images.githubusercontent.com/5240843/188288195-022b6e33-0820-411d-923f-7c4d636ec1ce.jpg) |  ![2022-09-03 14 27 59](https://user-images.githubusercontent.com/5240843/188288199-4153eca5-527f-450e-a3ef-a9dc28b49b67.jpg)  
| ![2022-09-03 14 27 47](https://user-images.githubusercontent.com/5240843/188288198-2738a10d-efab-48c7-b618-188fad8c4097.jpg) |  ![2022-09-03 14 28 03](https://user-images.githubusercontent.com/5240843/188288196-34a6288b-586d-46fc-8826-724802d8acd1.jpg)
