### PR TITLE
Set default react-native-paper theme in themeprovider

### DIFF
--- a/modules/app-theme/index.ts
+++ b/modules/app-theme/index.ts
@@ -1,5 +1,8 @@
 import type {ThemingType} from '@callstack/react-theme-provider'
 import {createTheming} from '@callstack/react-theme-provider'
+import {CombinedDefaultTheme, CombinedDarkTheme} from './paper'
+
+export {CombinedDefaultTheme, CombinedDarkTheme}
 
 export type AppTheme = {
 	accent: string

--- a/modules/app-theme/paper.ts
+++ b/modules/app-theme/paper.ts
@@ -1,0 +1,18 @@
+import merge from 'deepmerge'
+
+import {
+	DarkTheme as NavigationDarkTheme,
+	DefaultTheme as NavigationDefaultTheme,
+} from '@react-navigation/native'
+
+import {
+	DarkTheme as PaperDarkTheme,
+	DefaultTheme as PaperDefaultTheme,
+} from 'react-native-paper'
+
+export const CombinedDefaultTheme = merge(
+	PaperDefaultTheme,
+	NavigationDefaultTheme,
+)
+
+export const CombinedDarkTheme = merge(PaperDarkTheme, NavigationDarkTheme)

--- a/source/app.tsx
+++ b/source/app.tsx
@@ -15,7 +15,7 @@ import {Provider as ReduxProvider} from 'react-redux'
 import {Provider as PaperProvider} from 'react-native-paper'
 import {makeStore, initRedux} from './redux'
 import * as navigation from './navigation'
-import {ThemeProvider} from '@frogpond/app-theme'
+import {ThemeProvider, CombinedDefaultTheme} from '@frogpond/app-theme'
 import {ActionSheetProvider} from '@expo/react-native-action-sheet'
 import {NavigationContainer} from '@react-navigation/native'
 
@@ -28,7 +28,7 @@ export default class App extends React.Component {
 	render(): JSX.Element {
 		return (
 			<ReduxProvider store={store}>
-				<PaperProvider>
+				<PaperProvider theme={CombinedDefaultTheme}>
 					<ThemeProvider>
 						<ActionSheetProvider>
 							<NavigationContainer


### PR DESCRIPTION
Ensures `react-native-card` (and `react-native-paper`) shows components with a light theme.

Option A was used in this pull request [using the documentation](https://github.com/callstack/react-native-paper/blob/cf70dec1629e6c5f78c7c3f5f2a46603377752d7/docs/pages/8.theming-with-react-navigation.md) provided from callstack/react-native-paper.

Options:
  - (A) Pass a default theme into the `react-native-paper` theme provider
  - (B) Convert `<Card />` instances importing from `react-native-card` to `@frogpong/silly-card`. Downside is we lose the custom formatting options that the vanilla component allows.
  
 
 before | after
--|--
![2022-09-03 14 56 54](https://user-images.githubusercontent.com/5240843/188288831-4a5f4773-0ce6-454b-9fdc-96c9eb3058ec.jpg) | ![2022-09-03 16 13 45](https://user-images.githubusercontent.com/5240843/188290285-2b142e32-0afb-4add-aa3f-817ec0c691ac.jpg)

