### PR TITLE
Bus Updates

### DIFF
--- a/data/bus-times/blue-line.yaml
+++ b/data/bus-times/blue-line.yaml
@@ -18,7 +18,7 @@ schedules:
       'Viking Terrace':                  [44.469744, -93.163290]
     stops:
       - City Hall on Washington
-      - Econo Foods
+      - Family Fare
       - Carleton College
       - Northfield Estates
       - Viking Terrace

--- a/data/bus-times/express.yaml
+++ b/data/bus-times/express.yaml
@@ -19,7 +19,6 @@ schedules:
       - St. Olaf College
       - Carleton College
       - Food Co-op
-      - Express Care Clinic
       - Cub/Target
       - Aldi
       - Cinema 10
@@ -28,13 +27,13 @@ schedules:
       - Carleton College
       - St. Olaf College
     times:
-      - [ '3:00pm',  '3:07pm',  '3:12pm',  '3:13pm',  '3:20pm',  '3:26pm',  '3:32pm',  '3:38pm',  '3:41pm',  '3:49pm',  '3:55pm']
-      - [ '4:00pm',  '4:07pm',  '4:12pm',  '4:13pm',  '4:20pm',  '4:26pm',  '4:32pm',  '4:38pm',  '4:41pm',  '4:49pm',  '4:55pm']
-      - [ '5:00pm',  '5:07pm',  '5:12pm',  '5:13pm',  '5:20pm',  '5:26pm',  '5:32pm',  '5:38pm',  '5:41pm',  '5:49pm',  '5:55pm']
-      - [ '6:00pm',  '6:07pm',  '6:12pm',  '6:13pm',  '6:20pm',  '6:26pm',  '6:32pm',  '6:38pm',  '6:41pm',  '6:49pm',  '6:55pm']
-      - [ '7:00pm',  '7:07pm',  '7:12pm',  '7:13pm',  '7:20pm',  '7:26pm',  '7:32pm',  '7:38pm',  '7:41pm',  '7:49pm',  '7:55pm']
-      - [ '8:00pm',  '8:07pm',  '8:12pm',  '8:13pm',  '8:20pm',  '8:26pm',  '8:32pm',  '8:38pm',  '8:41pm',  '8:49pm',  '8:55pm']
-      - [ '9:00pm',  '9:07pm',  '9:12pm',  '9:13pm',  '9:20pm',  '9:26pm',  '9:32pm',  '9:38pm',  '9:41pm',  '9:49pm',  '9:55pm']
+      - [ '3:00pm',  '3:07pm',  '3:12pm',  '3:20pm',  '3:26pm',  '3:32pm',  '3:38pm',  '3:41pm',  '3:49pm',  '3:55pm']
+      - [ '4:00pm',  '4:07pm',  '4:12pm',  '4:20pm',  '4:26pm',  '4:32pm',  '4:38pm',  '4:41pm',  '4:49pm',  '4:55pm']
+      - [ '5:00pm',  '5:07pm',  '5:12pm',  '5:20pm',  '5:26pm',  '5:32pm',  '5:38pm',  '5:41pm',  '5:49pm',  '5:55pm']
+      - [ '6:00pm',  '6:07pm',  '6:12pm',  '6:20pm',  '6:26pm',  '6:32pm',  '6:38pm',  '6:41pm',  '6:49pm',  '6:55pm']
+      - [ '7:00pm',  '7:07pm',  '7:12pm',  '7:20pm',  '7:26pm',  '7:32pm',  '7:38pm',  '7:41pm',  '7:49pm',  '7:55pm']
+      - [ '8:00pm',  '8:07pm',  '8:12pm',  '8:20pm',  '8:26pm',  '8:32pm',  '8:38pm',  '8:41pm',  '8:49pm',  '8:55pm']
+      - [ '9:00pm',  '9:07pm',  '9:12pm',  '9:20pm',  '9:26pm',  '9:32pm',  '9:38pm',  '9:41pm',  '9:49pm',  '9:55pm']
 
   - days: [Su]
     coordinates:
@@ -50,7 +49,6 @@ schedules:
       - St. Olaf College
       - Carleton College
       - Food Co-op
-      - Express Care Clinic
       - Cub/Target
       - Aldi
       - Cinema 10
@@ -59,6 +57,6 @@ schedules:
       - Carleton College
       - St. Olaf College
     times:
-      - ['11:00am', '11:07am', '11:12am', '11:13am', '11:20am', '11:26am',     false, '11:38am', '11:41am', '11:49am', '11:55am']
-      - ['12:00pm', '12:07pm', '12:12pm', '12:13pm', '12:20pm', '12:26pm',     false, '12:38pm', '12:41pm', '12:49pm', '12:55pm']
-      - [ '1:00pm',  '1:07pm',  '1:12pm',  '1:13pm',  '1:20pm',  '1:26pm',     false,  '1:38pm',  '1:41pm',  '1:49pm',  '1:55pm']
+      - ['11:00am', '11:07am', '11:12am', '11:20am', '11:26am',     false, '11:38am', '11:41am', '11:49am', '11:55am']
+      - ['12:00pm', '12:07pm', '12:12pm', '12:20pm', '12:26pm',     false, '12:38pm', '12:41pm', '12:49pm', '12:55pm']
+      - [ '1:00pm',  '1:07pm',  '1:12pm',  '1:20pm',  '1:26pm',     false,  '1:38pm',  '1:41pm',  '1:49pm',  '1:55pm']

--- a/data/bus-times/red-line.yaml
+++ b/data/bus-times/red-line.yaml
@@ -12,9 +12,9 @@ schedules:
       - NCRC (Outbound)
       - Allina Clinic
       - Culvers
+      - Dollar Tree
       - Target/Cub
-      - Allina Clinic
-      - Senior Center
+      - YMCA
       - Koester Court (Inbound)
       - NCRC (Inbound)
       - Senior Center
@@ -34,6 +34,6 @@ schedules:
       - [ '1:30pm',  '1:34pm',  '1:35pm',  '1:38pm',  '1:41pm',  '1:46pm',  '1:49pm',  '1:51pm',  '1:55pm',  '1:56pm',      false,   '2:04pm',   '2:10pm']
       - [ '2:15pm',  '2:19pm',  '2:20pm',  '2:23pm',  '2:26pm',  '2:31pm',  '2:34pm',  '2:36pm',  '2:40pm',  '2:41pm',      false,   '2:49pm',   '2:55pm']
       - [ '3:00pm',  '3:04pm',  '3:05pm',  '3:08pm',  '3:11pm',  '3:16pm',  '3:19pm',  '3:21pm',  '3:25pm',  '3:26pm',      false,   '3:34pm',   '3:40pm']
-      - ['3:45pm',   '3:49pm',  '3:50pm',  '3:53pm',  '3:56pm',  '4:01pm',  '4:04pm',  '4:06pm',  '4:10pm',  '4:11pm',      false,   '4:19pm',   '4:25pm']
+      - [ '3:45pm',  '3:49pm',  '3:50pm',  '3:53pm',  '3:56pm',  '4:01pm',  '4:04pm',  '4:06pm',  '4:10pm',  '4:11pm',      false,   '4:19pm',   '4:25pm']
       - [ '4:30pm',  '4:34pm',  '4:35pm',  '4:38pm',  '4:41pm',  '4:46pm',  '4:49pm',  '4:51pm',  '4:55pm',  '4:56pm',      false,   '5:04pm',   '5:10pm']
       - [ '5:15pm',  '5:19pm',  '5:20pm',  '5:23pm',  '5:26pm',  '5:31pm',  '5:34pm',  '5:36pm',  '5:40pm',  '5:41pm',      false,   '5:49pm',   '5:55pm']


### PR DESCRIPTION
## Express Bus

- Removed the Express Care Clinic stop, it appears.

The rest of the schedule appears to run on the same times, just with one less stop. I deleted the "column" of times (all ending in `:13`) and that seems to have done the trick.

## Red Line

- Dollar Tree and the YMCA were added.
- Allina Clinic and one of the stops at the Senior Center were removed.

I could use some manual review of this one, as I didn't bother to update the times. I spot-checked, and it _looked_ like all the gaps lined up correctly, but I'm not 100% sure.

## Blue Line

- [Econo Foods is renamed to Family Fare](https://www.southernminn.com/northfield_news/news/new-name-new-look-northfield-econo-planning-remodel/article_f2dd8fc2-bb79-5697-8f7f-4005904a3d48.html). (remodeling)