### PR TITLE
bus schedule tweaks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,6 @@
 node_modules/
 /flow-typed/
 /docs/
+/data/bus-times/*.yaml
 /android/
 /ios/

--- a/data/bus-times/blue-line.yaml
+++ b/data/bus-times/blue-line.yaml
@@ -8,7 +8,7 @@ schedules:
     coordinates:
       'Carleton College':                [44.460753, -93.155708]
       'City Hall on Washington':         [44.451472, -93.158529]
-      'Econo Foods':                     [44.453983, -93.159477]
+      'Family Fare':                     [44.453983, -93.159477]
       'Ensley Apartments':               [44.470640, -93.174975]
       'Greenvale Apartments':            [44.463705, -93.163021]
       'Library':                         [44.457857, -93.158634]

--- a/scripts/validate-bus-schedules.mjs
+++ b/scripts/validate-bus-schedules.mjs
@@ -32,7 +32,7 @@ function* validate(data) {
 		for (let [i, times] of enumerate(schedule.times)) {
 			// prettier-ignore
 			let thisRowNote = `in row ${i+1} of the ${data.line} schedule for [${schedule.days.join(',')}]`
-			if (times.length !== schedule.stops.length) {
+			if (times.length !== schedule.stops.length && schedule.stops.length > 1) {
 				// prettier-ignore
 				yield `There are ${schedule.stops.length} named stops but ${times.length} arrival times ${thisRowNote}`
 			}

--- a/source/views/transportation/bus/lib/__tests__/process-bus-line.test.ts
+++ b/source/views/transportation/bus/lib/__tests__/process-bus-line.test.ts
@@ -11,11 +11,11 @@ const line: UnprocessedBusLine = {
       days: ['Mo', 'Tu', 'We', 'Th', 'Fr'],
       coordinates: {
         'City Hall on Washington': [44.451472, -93.158529],
-        'Econo Foods': [44.453983, -93.159477],
+        'Family Fare': [44.453983, -93.159477],
       },
       stops: [
         'City Hall on Washington',
-        'Econo Foods',
+        'Family Fare',
       ],
       times: [
         ['6:00am', '6:01am'],


### PR DESCRIPTION
follow-up to #6407 
* more renaming from econo foods to family fare
* do not flag single-stops that have more scheduled times than stops
    * fixes oles go yielding `There are 1 named stops but 2 arrival times in row 1 of the Oles Go schedule for [Mo,Tu,We,Th,Fr]`
* ignore prettier formatting for bus-times yaml to preserve the intentional whitespace


---

Side note: I also thought about a check to see if stop names had defined coordinated names but then realized blue line had coordinates and red line and oles go did not.

<details>
<summary>validate-bus-schedules.mjs</summary>

```mjs
let coordinateKeys = Object.keys(schedule.coordinates)
for (let [_, stop] of enumerate(schedule.stops)) {
	if (!(stop in coordinateKeys)) {
		// prettier-ignore
		yield `"${stop}" is missing coordinates for the "${data.line}" schedule${schedule.days.join()}`
	}
}
```
</details>