### PR TITLE
fix pushing updated Podfile.lock on rn PRs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -165,7 +165,7 @@ jobs:
           branch: ${{ github.ref_name }}
           actor: ${{ github.actor }}
           head_ref: ${{ github.ref }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.COCOAPODS_LOCKFILE_GH_PUSH_TOKEN }}
 
   ios-bundle:
     name: iOS Bundle


### PR DESCRIPTION
use custom gh token for pushing cocoapods changes, instead of gh_token - this allows validating the pushed commit
