### PR TITLE
Fix Jest issues so we can require Jest once again

### DIFF
--- a/modules/event-list/__tests__/__snapshots__/times.test.ts.snap
+++ b/modules/event-list/__tests__/__snapshots__/times.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ongoing events should be formatted 1`] = `
-Object {
+{
   "allDay": false,
   "end": "Aug. 7",
   "start": "Aug. 7",
@@ -9,7 +9,7 @@ Object {
 `;
 
 exports[`ongoing events should be formatted 2`] = `
-Object {
+{
   "allDay": false,
   "end": "Aug. 7",
   "start": "Aug. 7",

--- a/source/__mocks__/@react-native-async-storage/async-storage.ts
+++ b/source/__mocks__/@react-native-async-storage/async-storage.ts
@@ -1,0 +1,5 @@
+// Based on https://react-native-async-storage.github.io/async-storage/docs/advanced/jest/.
+//
+// Installs a mock for react-native-async-storage to prevent an "AsyncStorage is null" error
+// while the tests are running.
+export default from '@react-native-async-storage/async-storage/jest/async-storage-mock'

--- a/source/__mocks__/@react-native-async-storage/async-storage.ts
+++ b/source/__mocks__/@react-native-async-storage/async-storage.ts
@@ -2,4 +2,4 @@
 //
 // Installs a mock for react-native-async-storage to prevent an "AsyncStorage is null" error
 // while the tests are running.
-export default from '@react-native-async-storage/async-storage/jest/async-storage-mock'
+export * from '@react-native-async-storage/async-storage/jest/async-storage-mock'

--- a/source/views/building-hours/lib/__tests__/__snapshots__/get-detailed-building-status.test.ts.snap
+++ b/source/views/building-hours/lib/__tests__/__snapshots__/get-detailed-building-status.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`checks a list of schedules to see if any are open 1`] = `
-Array [
-  Object {
+[
+  {
     "isActive": true,
     "label": "Hours",
     "status": "10:30 AM — 2:00 AM",
@@ -11,13 +11,13 @@ Array [
 `;
 
 exports[`handles multiple internal schedules for the same timeframe 1`] = `
-Array [
-  Object {
+[
+  {
     "isActive": false,
     "label": "Hours",
     "status": "10:30 AM — Noon",
   },
-  Object {
+  {
     "isActive": true,
     "label": "Hours",
     "status": "1:00 PM — 3:00 PM",
@@ -26,18 +26,18 @@ Array [
 `;
 
 exports[`handles multiple named schedules for the same timeframe 1`] = `
-Array [
-  Object {
+[
+  {
     "isActive": false,
     "label": "Hours",
     "status": "10:30 AM — Noon",
   },
-  Object {
+  {
     "isActive": false,
     "label": "Hours2",
     "status": "10:30 AM — Noon",
   },
-  Object {
+  {
     "isActive": true,
     "label": "Hours2",
     "status": "1:00 PM — 3:00 PM",
@@ -46,8 +46,8 @@ Array [
 `;
 
 exports[`returns a list of [isOpen, scheduleName, verboseStatus] tuples 1`] = `
-Array [
-  Object {
+[
+  {
     "isActive": true,
     "label": "Hours",
     "status": "10:30 AM — 2:00 AM",
@@ -56,8 +56,8 @@ Array [
 `;
 
 exports[`returns false if none are available for this day 1`] = `
-Array [
-  Object {
+[
+  {
     "isActive": false,
     "label": "Hours",
     "status": "Closed today",
@@ -66,8 +66,8 @@ Array [
 `;
 
 exports[`returns false if none are open 1`] = `
-Array [
-  Object {
+[
+  {
     "isActive": false,
     "label": "Hours",
     "status": "10:30 AM — 2:00 PM",

--- a/source/views/transportation/bus/lib/__tests__/__snapshots__/find-remaining-departures-for-stop.test.ts.snap
+++ b/source/views/transportation/bus/lib/__tests__/__snapshots__/find-remaining-departures-for-stop.test.ts.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`handles a stop that will be skipped 1`] = `
-Array [
+[
   undefined,
   "3:05pm",
 ]
 `;
 
 exports[`handles a time after the bus runs 1`] = `
-Array [
+[
   "3:00pm",
 ]
 `;
 
 exports[`handles a time at the last stop 1`] = `
-Array [
+[
   "1:10pm",
   "2:10pm",
   "3:10pm",
@@ -22,7 +22,7 @@ Array [
 `;
 
 exports[`handles a time at the second stop 1`] = `
-Array [
+[
   "1:05pm",
   undefined,
   "3:05pm",
@@ -30,7 +30,7 @@ Array [
 `;
 
 exports[`handles a time before the bus runs 1`] = `
-Array [
+[
   "1:00pm",
   "2:00pm",
   "3:00pm",
@@ -38,14 +38,14 @@ Array [
 `;
 
 exports[`handles a time between two iterations 1`] = `
-Array [
+[
   "2:00pm",
   "3:00pm",
 ]
 `;
 
 exports[`handles a time between two stops 1`] = `
-Array [
+[
   "1:05pm",
   undefined,
   "3:05pm",
@@ -53,36 +53,36 @@ Array [
 `;
 
 exports[`handles a time on another day 1`] = `
-Array [
+[
   "12:00pm",
 ]
 `;
 
 exports[`handles a time right when the bus starts 1`] = `
-Array [
+[
   "1:00pm",
   "2:00pm",
   "3:00pm",
 ]
 `;
 
-exports[`handles a time when the bus is not running 1`] = `Array []`;
+exports[`handles a time when the bus is not running 1`] = `[]`;
 
 exports[`handles the first stop of the last iteration 1`] = `
-Array [
+[
   "3:00pm",
 ]
 `;
 
 exports[`handles the first stop of the second iteration 1`] = `
-Array [
+[
   "2:00pm",
   "3:00pm",
 ]
 `;
 
 exports[`handles the last stop of the last iteration 1`] = `
-Array [
+[
   "3:10pm",
 ]
 `;

--- a/source/views/transportation/bus/lib/__tests__/__snapshots__/get-schedule-for-now.test.ts.snap
+++ b/source/views/transportation/bus/lib/__tests__/__snapshots__/get-schedule-for-now.test.ts.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns an empty schedule if there is no schedule for today 1`] = `
-Object {
-  "coordinates": Object {},
-  "days": Array [
+{
+  "coordinates": {},
+  "days": [
     "Su",
   ],
-  "stops": Array [],
-  "times": Array [],
-  "timetable": Array [],
+  "stops": [],
+  "times": [],
+  "timetable": [],
 }
 `;
 
 exports[`returns the bus schedule for today 1`] = `
-Object {
-  "coordinates": Object {},
-  "days": Array [
+{
+  "coordinates": {},
+  "days": [
     "Fr",
     "Sa",
   ],
-  "stops": Array [
+  "stops": [
     "St. Olaf",
     "Carleton",
     "Food Co-op",
@@ -29,8 +29,8 @@ Object {
     "Carleton",
     "St. Olaf",
   ],
-  "times": Array [
-    Array [
+  "times": [
+    [
       "2017-11-19T02:15:00.000Z",
       "2017-11-19T02:22:00.000Z",
       "2017-11-19T02:23:00.000Z",
@@ -40,7 +40,7 @@ Object {
       "2017-11-19T02:44:00.000Z",
       "2017-11-19T02:52:00.000Z",
     ],
-    Array [
+    [
       "2017-11-19T02:55:00.000Z",
       "2017-11-19T03:02:00.000Z",
       "2017-11-19T03:03:00.000Z",
@@ -50,7 +50,7 @@ Object {
       "2017-11-19T03:24:00.000Z",
       "2017-11-19T03:32:00.000Z",
     ],
-    Array [
+    [
       "2017-11-19T03:35:00.000Z",
       "2017-11-19T03:42:00.000Z",
       "2017-11-19T03:43:00.000Z",
@@ -61,65 +61,65 @@ Object {
       "2017-11-19T04:12:00.000Z",
     ],
   ],
-  "timetable": Array [
-    Object {
-      "departures": Array [
+  "timetable": [
+    {
+      "departures": [
         "2017-11-19T02:15:00.000Z",
         "2017-11-19T02:55:00.000Z",
         "2017-11-19T03:35:00.000Z",
       ],
       "name": "St. Olaf",
     },
-    Object {
-      "departures": Array [
+    {
+      "departures": [
         "2017-11-19T02:22:00.000Z",
         "2017-11-19T03:02:00.000Z",
         "2017-11-19T03:42:00.000Z",
       ],
       "name": "Carleton",
     },
-    Object {
-      "departures": Array [
+    {
+      "departures": [
         "2017-11-19T02:23:00.000Z",
         "2017-11-19T03:03:00.000Z",
         "2017-11-19T03:43:00.000Z",
       ],
       "name": "Food Co-op",
     },
-    Object {
-      "departures": Array [
+    {
+      "departures": [
         "2017-11-19T02:33:00.000Z",
         "2017-11-19T03:13:00.000Z",
         "2017-11-19T03:53:00.000Z",
       ],
       "name": "Cub/Target",
     },
-    Object {
-      "departures": Array [
+    {
+      "departures": [
         "2017-11-19T02:37:00.000Z",
         "2017-11-19T03:17:00.000Z",
         "2017-11-19T03:57:00.000Z",
       ],
       "name": "El Tequila",
     },
-    Object {
-      "departures": Array [
+    {
+      "departures": [
         "2017-11-19T02:43:00.000Z",
         "2017-11-19T03:23:00.000Z",
         "2017-11-19T04:03:00.000Z",
       ],
       "name": "Food Co-op",
     },
-    Object {
-      "departures": Array [
+    {
+      "departures": [
         "2017-11-19T02:44:00.000Z",
         "2017-11-19T03:24:00.000Z",
         "2017-11-19T04:04:00.000Z",
       ],
       "name": "Carleton",
     },
-    Object {
-      "departures": Array [
+    {
+      "departures": [
         "2017-11-19T02:52:00.000Z",
         "2017-11-19T03:32:00.000Z",
         "2017-11-19T04:12:00.000Z",


### PR DESCRIPTION
- Fixes #6436 by running `jest -u`. No substantial changes appear to have happened besides the removal of `Array` and `Object` annotations.
- Fixes #6437 by adding a mock for react-native-async-storage. Might not have been failing in CI, but it was failing locally and this is apparently a recommended approach according to the documentation.