### PR TITLE
continue work on automatically updated Podfile.lock

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -139,35 +139,6 @@ jobs:
       - run: bundle exec pod install --deployment
         working-directory: ./ios
 
-  ios-podfile-update:
-    # Adapted from https://gist.github.com/A-Tokyo/0d811e818513fc4d3272335d2847d748
-    name: iOS Update Cocoapods
-    runs-on: macos-11
-    if: startsWith(github.ref_name, 'dependabot/npm_and_yarn/') && contains(github.ref_name, 'react-native')
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.COCOAPODS_LOCKFILE_GH_PUSH_TOKEN }}
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '^16.0'
-          cache: npm
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.6'
-          bundler-cache: true
-      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
-      - run: npm ci
-        env: {SKIP_POSTINSTALL: '1'}
-      - run: bundle exec -- pod install --verbose
-        working-directory: ./ios
-      - name: push-on-podfile-change
-        run: bash scripts/push-on-podfile-change.sh
-        env:
-          branch: ${{ github.ref_name }}
-          actor: ${{ github.actor }}
-          head_ref: ${{ github.ref }}
-
   ios-bundle:
     name: iOS Bundle
     runs-on: ubuntu-20.04

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -1,0 +1,34 @@
+name: Check & Update Cocoapods
+
+on:
+  pull_request_target: ~
+
+jobs:
+  ios-podfile-update:
+    # Adapted from https://gist.github.com/A-Tokyo/0d811e818513fc4d3272335d2847d748
+    name: iOS Update Cocoapods
+    runs-on: macos-11
+    if: startsWith(github.ref_name, 'dependabot/npm_and_yarn/') && contains(github.ref_name, 'react-native') && github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.COCOAPODS_LOCKFILE_GH_PUSH_TOKEN }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '^16.0'
+          cache: npm
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+          bundler-cache: true
+      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
+      - run: npm ci
+        env: {SKIP_POSTINSTALL: '1'}
+      - run: bundle exec -- pod install --verbose
+        working-directory: ./ios
+      - name: push-on-podfile-change
+        run: bash scripts/push-on-podfile-change.sh
+        env:
+          branch: ${{ github.ref_name }}
+          actor: ${{ github.actor }}
+          head_ref: ${{ github.ref }}


### PR DESCRIPTION
Attempt to try to expose the secrets properly.

https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/

> ## GitHub Actions: Workflows triggered by Dependabot PRs will run with read-only permissions
> Starting March 1st, 2021 workflow runs that are triggered by Dependabot from push, pull_request, pull_request_review, or pull_request_review_comment events will be treated as if they were opened from a repository fork. This means they will receive a read-only GITHUB_TOKEN and **will not have access to any secrets available in the repository**. This will cause any workflows that attempt to write to the repository to fail.

In https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544, it is recommended that we try `pull_request_target`, which exposes repository secrets in the PR builds. This makes it dangerous, which is why we scope to "author == dependabot[bot]". Technically, we are still vulnerable to exposing our secrets to malicious npm packages, so… (however, dependabot doesn't run postinstall scripts [see part of the above github comment].)

> #### Doesn't Dependabot not run postinstall scripts to prevent this?
> Yes, though the ability to prevent this type of arbitrary execution doesn't exist for all ecosystems. This prevents exfiltration by not having secrets present in the first place (and downscoping tokens to reduce the risk).