### PR TITLE
update cocoapods workflow permissions

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -1,14 +1,17 @@
 name: Check & Update Cocoapods
 
-on:
-  pull_request_target: ~
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   ios-podfile-update:
     # Adapted from https://gist.github.com/A-Tokyo/0d811e818513fc4d3272335d2847d748
     name: iOS Update Cocoapods
     runs-on: macos-11
-    if: startsWith(github.ref_name, 'dependabot/npm_and_yarn/') && contains(github.ref_name, 'react-native') && github.actor == 'dependabot[bot]'
+    if: ${{ startsWith(github.ref_name, 'dependabot/npm_and_yarn/') && contains(github.ref_name, 'react-native') && github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
We will have to end up merging this one to see if it triggers on dependabot PRs.

- The permissions key may help solve this
- Removing `~` from pull_request_target may also help our syntax