### PR TITLE
ci: Set ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD to true

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -114,6 +114,7 @@ jobs:
           GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'
+          ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD: true
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf
           SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
Per fastlane/fastlane#20741, iTMSTransporter v3.0.0 appears to have broken package uploads ([example](https://github.com/StoDevX/AAO-React-Native/actions/runs/3302641497)) without this flag.  This is leading to iOS deployment failures.  This commit should resolve those deployment failures.