### PR TITLE
fix android compilation error caused by upstream alpha version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,9 @@ buildscript {
         targetSdkVersion = 31
         kotlinVersion = '1.6.10'
         // react-native-inappbrowser-reborn was using a 1.+ which pulled in an alpha which is very bad
+        // - we will want to upgrade to 1.5.0 when we support minsdk 33
+        // - we can delete this when inappbrowser-reborn changes their build script to avoid this pattern
+        //   but until then, we'll keep it pinned since a future alpha release could cause this problem. 
         androidXBrowser = "1.4.0"
 
         if (System.properties['os.arch'] == "aarch64") {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,8 @@ buildscript {
         compileSdkVersion = 31
         targetSdkVersion = 31
         kotlinVersion = '1.6.10'
+        // react-native-inappbrowser-reborn was using a 1.+ which pulled in an alpha which is very bad
+        androidXBrowser = "1.4.0"
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64


### PR DESCRIPTION
## Context 

Our android build got broken from underneath us. If you tried to build, you would be faced with this error:

```
One or more issues found when checking AAR metadata values:

The minCompileSdk (33) specified in a
dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
is greater than this module's compileSdkVersion (android-31).
Dependency: androidx.browser:browser:1.5.0-alpha01.
AAR metadata file: /Users/Drew/.gradle/caches/transforms-3/ecd503eb58bbe291cae118c0c0a65d8f/transformed/browser-1.5.0-alpha01/META-INF/com/android/build/gradle/aar-metadata.properties.
```

A few things are going on in that error:

1. We don't target a min compile sdk of 33.
2. We aren't dependent upon an alpha version of ` androidx.browser:browser`.
3. We haven't updated anything to do with this recently.

Strange, right? So what is going on?

## The problem

The 1.+ logic in `react-native-inappbrowser-reborn`'s build.gradle allows for upstream releases to be pulled in. It allowed the 1.5.* alpha of `androidx.browser.browser` from google, released 10/24/2022, to break our app.

This requires android sdk 33 which we are not set up to support.

```gradle
// https://github.com/proyecto26/react-native-inappbrowser/blob/e028173df5ffea7b8c1f3214669cdde33981ee14/android/build.gradle#L61
def defaultAndroidXVersion = "1.+"
```

## Fixing this

We can and need to override the `androidXBrowser` property in our project so android correctly builds with 1.4.

--- 

- Fixes #6546
- https://github.com/proyecto26/react-native-inappbrowser/issues/386