### PR TITLE
allow overridden fallback values to apply correctly in storage module

### DIFF
--- a/modules/storage/__tests__/storage.test.ts
+++ b/modules/storage/__tests__/storage.test.ts
@@ -1,0 +1,32 @@
+/* eslint-env jest */
+
+import {getItemAsBoolean, getItemAsString, getItemAsArray} from '../index'
+
+describe('getItemAsBoolean', () => {
+	test('returns fallback value', async () => {
+		expect(await getItemAsBoolean('non-existent')).toBe(false)
+	})
+	test('returns overridden fallback value', async () => {
+		expect(await getItemAsBoolean('non-existent', true)).toBe(true)
+	})
+})
+
+describe('getItemAsString', () => {
+	test('returns fallback value', async () => {
+		expect(await getItemAsString('non-existent')).toBe('')
+	})
+	test('returns overridden fallback value', async () => {
+		expect(await getItemAsString('non-existent', 'fallback')).toBe('fallback')
+	})
+})
+
+describe('getItemAsArray', () => {
+	test('returns fallback value', async () => {
+		expect(await getItemAsArray('non-existent')).toStrictEqual([])
+	})
+	test('returns overridden fallback value', async () => {
+		expect(await getItemAsArray('non-existent', ['fallback'])).toStrictEqual([
+			'fallback',
+		])
+	})
+})

--- a/modules/storage/index.ts
+++ b/modules/storage/index.ts
@@ -40,7 +40,13 @@ export async function getItemAsBoolean(
 	key: string,
 	defaultValue = false,
 ): Promise<boolean> {
-	return (await getItem(key)) || defaultValue
+	const savedValue: boolean | null = await getItem(key)
+
+	if (savedValue === null) {
+		return defaultValue
+	}
+
+	return savedValue
 }
 export async function getItemAsArray<T>(
 	key: string,

--- a/source/__mocks__/@react-native-async-storage/async-storage.ts
+++ b/source/__mocks__/@react-native-async-storage/async-storage.ts
@@ -2,4 +2,4 @@
 //
 // Installs a mock for react-native-async-storage to prevent an "AsyncStorage is null" error
 // while the tests are running.
-export * from '@react-native-async-storage/async-storage/jest/async-storage-mock'
+export {default} from '@react-native-async-storage/async-storage/jest/async-storage-mock'

--- a/source/lib/storage.ts
+++ b/source/lib/storage.ts
@@ -54,7 +54,7 @@ export function setLinkPreference(
 	return setItem(openLinksInAppKey, preference)
 }
 export function getInAppLinkPreference(): Promise<openLinksInAppType> {
-	return getItemAsBoolean(openLinksInAppKey)
+	return getItemAsBoolean(openLinksInAppKey, true)
 }
 
 const serverAddressKey = 'settings:server-address'


### PR DESCRIPTION
* Fixes a logic checking issue with `getItemAsBoolean`.
* Fixes `async-storage` mock export.
* Adds basic tests around the default values for `getItemAsString`, `getItemAsBoolean`, and  `getItemAsArray`.

When fetching the saved value for `getItemAsBoolean`, we were not falling back to the default value due to a logic check to see if the value was defined as "saved or default". Since these values are booleans, it is problematic to check for a non-null value this way!

Where this was visible in the app was the "Open links in-app" toggle in Settings. The desired state is enabled, and overriding the default state for the saved value appeared to fail.