### PR TITLE
Show department results natively in directory view

### DIFF
--- a/source/navigation/types.tsx
+++ b/source/navigation/types.tsx
@@ -39,7 +39,7 @@ export type RootStackParamList = {
 	DictionaryDetail: {item: WordType}
 	Dictionary: undefined
 	DictionaryEditor: {item: WordType}
-	Directory: {queryType: DirectorySearchTypeEnum, queryParam?: string}
+	Directory: {queryType: DirectorySearchTypeEnum; queryParam?: string}
 	DirectoryDetail: {contact: DirectoryItem}
 	Faq: undefined
 	Help: undefined

--- a/source/navigation/types.tsx
+++ b/source/navigation/types.tsx
@@ -39,7 +39,7 @@ export type RootStackParamList = {
 	DictionaryDetail: {item: WordType}
 	Dictionary: undefined
 	DictionaryEditor: {item: WordType}
-	Directory: {queryType: DirectorySearchTypeEnum; queryParam?: string}
+	Directory: {queryType?: DirectorySearchTypeEnum; queryParam?: string}
 	DirectoryDetail: {contact: DirectoryItem}
 	Faq: undefined
 	Help: undefined

--- a/source/navigation/types.tsx
+++ b/source/navigation/types.tsx
@@ -20,7 +20,7 @@ import type {
 import {Printer, PrintJob} from '../lib/stoprint/types'
 import {JobType} from '../views/sis/student-work/types'
 import {CourseType} from '../lib/course-search/types'
-import {DirectoryItem} from '../views/directory/types'
+import {DirectoryItem, DirectorySearchTypeEnum} from '../views/directory/types'
 
 export type RootStackParamList = {
 	Home: undefined
@@ -39,7 +39,7 @@ export type RootStackParamList = {
 	DictionaryDetail: {item: WordType}
 	Dictionary: undefined
 	DictionaryEditor: {item: WordType}
-	Directory: undefined
+	Directory: {queryType: DirectorySearchTypeEnum, queryParam?: string}
 	DirectoryDetail: {contact: DirectoryItem}
 	Faq: undefined
 	Help: undefined

--- a/source/views/directory/detail.android.tsx
+++ b/source/views/directory/detail.android.tsx
@@ -16,7 +16,10 @@ import {
 	Portal,
 } from 'react-native-paper'
 import {RouteProp, useRoute, useNavigation} from '@react-navigation/native'
-import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
+import {
+	NativeStackNavigationOptions,
+	NativeStackNavigationProp,
+} from '@react-navigation/native-stack'
 import {RootStackParamList} from '../../../source/navigation/types'
 
 export const DetailNavigationOptions: NativeStackNavigationOptions = {
@@ -24,7 +27,9 @@ export const DetailNavigationOptions: NativeStackNavigationOptions = {
 }
 
 export function DirectoryDetailView(): JSX.Element {
-	let navigation = useNavigation()
+	// typing useNavigation's props to inform typescript about `push`
+	let navigation =
+		useNavigation<NativeStackNavigationProp<RootStackParamList>>()
 
 	let route = useRoute<RouteProp<RootStackParamList, 'DirectoryDetail'>>()
 	const {

--- a/source/views/directory/detail.android.tsx
+++ b/source/views/directory/detail.android.tsx
@@ -15,7 +15,7 @@ import {
 	List,
 	Portal,
 } from 'react-native-paper'
-import {RouteProp, useRoute} from '@react-navigation/native'
+import {RouteProp, useRoute, useNavigation} from '@react-navigation/native'
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
 import {RootStackParamList} from '../../../source/navigation/types'
 
@@ -24,6 +24,8 @@ export const DetailNavigationOptions: NativeStackNavigationOptions = {
 }
 
 export function DirectoryDetailView(): JSX.Element {
+	let navigation = useNavigation()
+
 	let route = useRoute<RouteProp<RootStackParamList, 'DirectoryDetail'>>()
 	const {
 		displayName,
@@ -77,7 +79,12 @@ export function DirectoryDetailView(): JSX.Element {
 							key={key}
 							accessibilityLabel={`Department: ${dept.name}`}
 							icon="account-multiple-outline"
-							onPress={() => openUrl(dept.href)}
+							onPress={() => {
+								navigation.push('Directory', {
+									queryType: 'Department',
+									queryParam: dept.name,
+								})
+							}}
 							style={styles.departmentChip}
 						>
 							{dept.name}

--- a/source/views/directory/detail.ios.tsx
+++ b/source/views/directory/detail.ios.tsx
@@ -9,7 +9,10 @@ import {MultiLineLeftDetailCell} from '@frogpond/tableview/cells'
 import * as c from '@frogpond/colors'
 import type {Department, CampusLocation} from './types'
 import {RouteProp, useRoute, useNavigation} from '@react-navigation/native'
-import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
+import {
+	NativeStackNavigationOptions,
+	NativeStackNavigationProp,
+} from '@react-navigation/native-stack'
 import {RootStackParamList} from '../../../source/navigation/types'
 
 export const DetailNavigationOptions: NativeStackNavigationOptions = {
@@ -17,7 +20,9 @@ export const DetailNavigationOptions: NativeStackNavigationOptions = {
 }
 
 export function DirectoryDetailView(): JSX.Element {
-	let navigation = useNavigation()
+	// typing useNavigation's props to inform typescript about `push`
+	let navigation =
+		useNavigation<NativeStackNavigationProp<RootStackParamList>>()
 
 	let route = useRoute<RouteProp<RootStackParamList, 'DirectoryDetail'>>()
 	const {

--- a/source/views/directory/detail.ios.tsx
+++ b/source/views/directory/detail.ios.tsx
@@ -4,11 +4,7 @@ import {openUrl} from '@frogpond/open-url'
 import {callPhone} from '../../components/call-phone'
 import {sendEmail} from '../../components/send-email'
 import {Title, Detail} from '@frogpond/lists'
-import {
-	TableView,
-	Section,
-	Cell,
-} from '@frogpond/tableview'
+import {TableView, Section, Cell} from '@frogpond/tableview'
 import {MultiLineLeftDetailCell} from '@frogpond/tableview/cells'
 import * as c from '@frogpond/colors'
 import type {Department, CampusLocation} from './types'

--- a/source/views/directory/detail.ios.tsx
+++ b/source/views/directory/detail.ios.tsx
@@ -118,7 +118,7 @@ export function DirectoryDetailView(): JSX.Element {
 								cellStyle="Basic"
 								detail="Department"
 								onPress={() => {
-									navigation.navigate('Directory', {
+									navigation.push('Directory', {
 										queryType: 'Department',
 										queryParam: dept.name,
 									})

--- a/source/views/directory/detail.ios.tsx
+++ b/source/views/directory/detail.ios.tsx
@@ -12,7 +12,7 @@ import {
 import {MultiLineLeftDetailCell} from '@frogpond/tableview/cells'
 import * as c from '@frogpond/colors'
 import type {Department, CampusLocation} from './types'
-import {RouteProp, useRoute} from '@react-navigation/native'
+import {RouteProp, useRoute, useNavigation} from '@react-navigation/native'
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
 import {RootStackParamList} from '../../../source/navigation/types'
 
@@ -21,6 +21,8 @@ export const DetailNavigationOptions: NativeStackNavigationOptions = {
 }
 
 export function DirectoryDetailView(): JSX.Element {
+	let navigation = useNavigation()
+
 	let route = useRoute<RouteProp<RootStackParamList, 'DirectoryDetail'>>()
 	const {
 		displayName,
@@ -115,7 +117,12 @@ export function DirectoryDetailView(): JSX.Element {
 								accessory="DisclosureIndicator"
 								cellStyle="Basic"
 								detail="Department"
-								onPress={() => openUrl(dept.href)}
+								onPress={() => {
+									navigation.navigate('Directory', {
+										queryType: 'Department',
+										queryParam: dept.name,
+									})
+								}}
 								title={dept.name}
 							/>
 						))}

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -42,7 +42,7 @@ const getDirectoryUrl = (query: string, type: DirectorySearchTypeEnum) => {
 		case 'LastName':
 			return `${baseUrl}&lastname=${query.trim()}`
 		case 'Major':
-			return `${baseUrl}&major=${query.trim()}`	
+			return `${baseUrl}&major=${query.trim()}`
 		case 'Query':
 			return `${baseUrl}&query=${query.trim()}`
 		case 'Title':

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -65,6 +65,8 @@ export const NavigationOptions = (props: {
 
 export function DirectoryView(): JSX.Element {
 	let [errorMessage, setErrorMessage] = React.useState<string | null>(null)
+	let [searchQueryType, setSearchQueryType] =
+		React.useState<DirectorySearchTypeEnum>('Query')
 	let [typedQuery, setTypedQuery] = React.useState('')
 	let searchQuery = useDebounce(typedQuery, 500)
 
@@ -80,14 +82,16 @@ export function DirectoryView(): JSX.Element {
 		isPending,
 		isInitial,
 		isLoading,
-	} = useDirectory(searchQuery, params?.queryType ?? 'Query')
+	} = useDirectory(searchQuery, searchQueryType)
 
 	React.useLayoutEffect(() => {
 		navigation.setOptions({
 			headerSearchBarOptions: {
 				barTintColor: c.white,
-				onChangeText: (event: ChangeTextEvent) =>
-					setTypedQuery(event.nativeEvent.text),
+				onChangeText: (event: ChangeTextEvent) => {
+					setSearchQueryType('Query')
+					setTypedQuery(event.nativeEvent.text)
+				},
 			},
 		})
 	}, [navigation])
@@ -100,6 +104,7 @@ export function DirectoryView(): JSX.Element {
 
 	React.useEffect(() => {
 		if (params?.queryType === 'Department' && params?.queryParam) {
+			setSearchQueryType('Department')
 			setTypedQuery(params.queryParam)
 		}
 	}, [params])

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -23,7 +23,10 @@ import type {
 } from './types'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native'
-import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
+import {
+	NativeStackNavigationOptions,
+	NativeStackNavigationProp,
+} from '@react-navigation/native-stack'
 import {ChangeTextEvent, RootStackParamList} from '../../navigation/types'
 
 const getDirectoryUrl = (query: string, type: DirectorySearchTypeEnum) => {
@@ -70,7 +73,9 @@ export function DirectoryView(): JSX.Element {
 	let [typedQuery, setTypedQuery] = React.useState('')
 	let searchQuery = useDebounce(typedQuery, 500)
 
-	let navigation = useNavigation()
+	// typing useNavigation's props to inform typescript about `push`
+	let navigation =
+		useNavigation<NativeStackNavigationProp<RootStackParamList>>()
 
 	let route = useRoute<RouteProp<RootStackParamList, typeof NavigationKey>>()
 	let {params} = route

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -108,7 +108,7 @@ export function DirectoryView(): JSX.Element {
 		<DirectoryItemRow
 			item={item}
 			onPress={() => {
-				navigation.navigate('DirectoryDetail', {contact: item})
+				navigation.push('DirectoryDetail', {contact: item})
 			}}
 		/>
 	)

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -73,7 +73,7 @@ export function DirectoryView(): JSX.Element {
 		isPending,
 		isInitial,
 		isLoading,
-	} = useDirectory(searchQuery, params ? params.queryType : 'Query')
+	} = useDirectory(searchQuery, params?.queryType ?? 'Query')
 
 	React.useLayoutEffect(() => {
 		navigation.setOptions({
@@ -92,7 +92,7 @@ export function DirectoryView(): JSX.Element {
 	}, [error])
 
 	React.useEffect(() => {
-		if (params && params.queryType === 'Department' && params.queryParam) {
+		if (params?.queryType === 'Department' && params?.queryParam) {
 			setTypedQuery(params.queryParam)
 		}
 	}, [params])

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -16,7 +16,11 @@ import {NoticeView, LoadingView} from '@frogpond/notice'
 import {formatResults} from './helpers'
 import {useFetch} from 'react-async'
 import {List, Avatar} from 'react-native-paper'
-import type {DirectorySearchTypeEnum, DirectoryItem, SearchResults} from './types'
+import type {
+	DirectorySearchTypeEnum,
+	DirectoryItem,
+	SearchResults,
+} from './types'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native'
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
@@ -33,7 +37,9 @@ const getDirectoryUrl = (query: string, type: DirectorySearchTypeEnum) => {
 			return `${baseUrl}&department=${formattedDepartment}`
 		}
 		default:
-			console.error('Unknown directory search type found when constructing directory url.')
+			console.warn(
+				'Unknown directory search type found when constructing directory url.',
+			)
 			return `${baseUrl}&query=${query.trim()}`
 	}
 }
@@ -57,8 +63,7 @@ export function DirectoryView(): JSX.Element {
 
 	let navigation = useNavigation()
 
-	let route =
-	useRoute<RouteProp<RootStackParamList, 'Directory'>>()
+	let route = useRoute<RouteProp<RootStackParamList, typeof NavigationKey>>()
 	let {params} = route
 
 	console.warn(params)

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -52,8 +52,15 @@ const useDirectory = (query: string, type: DirectorySearchTypeEnum) => {
 	})
 }
 
-export const NavigationOptions: NativeStackNavigationOptions = {
-	title: 'Directory',
+export const NavigationKey = 'Directory'
+
+export const NavigationOptions = (props: {
+	route: RouteProp<RootStackParamList, typeof NavigationKey>
+}): NativeStackNavigationOptions => {
+	let {params} = props.route
+	return {
+		title: params?.queryParam ?? 'Directory',
+	}
 }
 
 export function DirectoryView(): JSX.Element {

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -33,12 +33,22 @@ const getDirectoryUrl = (query: string, type: DirectorySearchTypeEnum) => {
 	let baseUrl = 'https://www.stolaf.edu/directory/search?format=json'
 
 	switch (type) {
-		case 'Query':
-			return `${baseUrl}&query=${query.trim()}`
 		case 'Department': {
 			let formattedDepartment = query.split(' ').join('+')
 			return `${baseUrl}&department=${formattedDepartment}`
 		}
+		case 'FirstName':
+			return `${baseUrl}&firstname=${query.trim()}`
+		case 'LastName':
+			return `${baseUrl}&lastname=${query.trim()}`
+		case 'Major':
+			return `${baseUrl}&major=${query.trim()}`	
+		case 'Query':
+			return `${baseUrl}&query=${query.trim()}`
+		case 'Title':
+			return `${baseUrl}&title=${query.trim()}`
+		case 'Username':
+			return `${baseUrl}&email=${query.trim()}`
 		default:
 			console.warn(
 				'Unknown directory search type found when constructing directory url.',

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -66,8 +66,6 @@ export function DirectoryView(): JSX.Element {
 	let route = useRoute<RouteProp<RootStackParamList, typeof NavigationKey>>()
 	let {params} = route
 
-	console.warn(params)
-
 	let {
 		data: {results = []} = {},
 		error,

--- a/source/views/directory/types.ts
+++ b/source/views/directory/types.ts
@@ -67,3 +67,5 @@ export type SearchResults = {
 	}
 	results: Array<DirectoryItem>
 }
+
+export type DirectorySearchTypeEnum = 'Query'|'Department'

--- a/source/views/directory/types.ts
+++ b/source/views/directory/types.ts
@@ -68,4 +68,4 @@ export type SearchResults = {
 	results: Array<DirectoryItem>
 }
 
-export type DirectorySearchTypeEnum = 'Query' | 'Department'
+export type DirectorySearchTypeEnum = 'Department' | 'FirstName' | 'LastName' | 'Major' | 'Query' | 'Title' | 'Username'

--- a/source/views/directory/types.ts
+++ b/source/views/directory/types.ts
@@ -68,4 +68,4 @@ export type SearchResults = {
 	results: Array<DirectoryItem>
 }
 
-export type DirectorySearchTypeEnum = 'Query'|'Department'
+export type DirectorySearchTypeEnum = 'Query' | 'Department'

--- a/source/views/directory/types.ts
+++ b/source/views/directory/types.ts
@@ -68,4 +68,11 @@ export type SearchResults = {
 	results: Array<DirectoryItem>
 }
 
-export type DirectorySearchTypeEnum = 'Department' | 'FirstName' | 'LastName' | 'Major' | 'Query' | 'Title' | 'Username'
+export type DirectorySearchTypeEnum =
+	| 'Department'
+	| 'FirstName'
+	| 'LastName'
+	| 'Major'
+	| 'Query'
+	| 'Title'
+	| 'Username'


### PR DESCRIPTION
- Closes https://github.com/StoDevX/AAO-React-Native/discussions/6430
- Closes #6429 

This PR accomplishes a few ideas:
- [x] Tapping on a department fetches department data and renders it natively
- [x] Navigating to a department pushes a new view on to the stack
- [x] Navigating between Query and Department listings works as expected

old | new
--|--
 <img alt="old" src="https://user-images.githubusercontent.com/5240843/201222160-eaf3f3ec-eb9c-4616-b744-1a7e6fc84321.gif" />| <img alt="new" src="https://user-images.githubusercontent.com/5240843/201233480-ee87cae1-f560-4d97-abc1-b411306369be.gif" />