### PR TITLE
Update xcode version to 14.1

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -98,7 +98,7 @@ jobs:
       #   continue-on-error: true
       #   with:
       #     cache_key: ${{ matrix.os }}
-      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_14.1.app
       - run: git fetch --prune --unshallow
       - run: npm ci
         env:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -73,7 +73,7 @@ jobs:
 
   ios:
     name: Build for iOS
-    runs-on: macos-11
+    runs-on: macos-12   
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-node@v3

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -73,7 +73,7 @@ jobs:
 
   ios:
     name: Build for iOS
-    runs-on: macos-12   
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-node@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -122,7 +122,7 @@ jobs:
 
   ios-pods:
     name: iOS Cocoapods
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3.1.0
       - uses: actions/setup-node@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           ruby-version: '2.6'
           bundler-cache: true
-      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_14.1.app
       - run: npm ci
         env: {SKIP_POSTINSTALL: '1'}
       - run: bundle exec pod install --deployment
@@ -238,7 +238,7 @@ jobs:
         continue-on-error: true
         with:
           cache_key: ${{ matrix.os }}
-      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_14.1.app
       - run: git fetch --prune --unshallow
       - run: npm ci
         env:

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -13,7 +13,7 @@ jobs:
   ios-podfile-update:
     # Adapted from https://gist.github.com/A-Tokyo/0d811e818513fc4d3272335d2847d748
     name: iOS Update Cocoapods
-    runs-on: macos-11
+    runs-on: macos-12
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v3.1.0

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           ruby-version: '2.6'
           bundler-cache: true
-      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
+      - run: sudo xcode-select -s /Applications/Xcode_14.1.app
       - run: npm ci
         env: {SKIP_POSTINSTALL: '1'}
       - run: bundle exec -- pod install --verbose

--- a/fastlane/platforms/ios.rb
+++ b/fastlane/platforms/ios.rb
@@ -41,8 +41,7 @@ platform :ios do
 		# build the .app
 		build_status = 0
 		begin
-			gym(include_bitcode: true,
-			    include_symbols: true,
+			gym(include_symbols: true,
 			    skip_codesigning: true,
 			    skip_package_ipa: true,
 			    skip_package_pkg: true,
@@ -65,8 +64,7 @@ platform :ios do
 		File.open('../logs/products', 'w') { |file| file.write('[]') }
 		build_status = 0
 		begin
-			gym(include_bitcode: true,
-			    include_symbols: true)
+			gym(include_symbols: true)
 		rescue IOError => e
 			build_status = 1
 			raise e


### PR DESCRIPTION
We're now using Xcode 14.1 to build on our machines so we should be able to set CI/CD to match.

- bump xcode to 14.1
- bump macOS to 12
- remove mentions of bitcode

Here are the available versions for future reference:
- https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode