### PR TITLE
Loosen restrictions on TypeScript error codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ tsc-errors:
 	-npx tsc | sed "s:$$(git rev-parse --show-toplevel):.:g" | tee ${@}
 
 tsc-counts: tsc-errors
-	-cat ${<} | rg -or '$$1' 'error (TS\d{4})' | sort | uniq -c | sort -nr | sed 's/^ *//' | tee ${@}
+	-cat ${<} | rg -or '$$1' 'error (TS\d+)' | sort | uniq -c | sort -nr | sed 's/^ *//' | tee ${@}
 
 eslint-problems:
 	-npm run lint | sed "s:$$(git rev-parse --show-toplevel):.:g" | tee ${@}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ tsc-errors:
 	-npx tsc | sed "s:$$(git rev-parse --show-toplevel):.:g" | tee ${@}
 
 tsc-counts: tsc-errors
-	-cat ${<} | rg -or '$$1' 'error (TS\d+)' | sort | uniq -c | sort -nr | sed 's/^ *//' | tee ${@}
+	-cat ${<} | rg -or '$$1' 'error \b(TS\d+)\b' | sort | uniq -c | sort -nr | sed 's/^ *//' | tee ${@}
 
 eslint-problems:
 	-npm run lint | sed "s:$$(git rev-parse --show-toplevel):.:g" | tee ${@}


### PR DESCRIPTION
With the upgrade to TypeScript v4.9.3, a new 5-digit error is generated (TS18046) which gets snipped by the old `\d{4}` regex component which does not include any word-boundary detection.  This leads to a loss of information when trying to generate the list of TS error codes, and ultimately programmer confusion.

Fixes #6592.