### PR TITLE
Consolidate background and foreground colors for building hours

### DIFF
--- a/source/views/building-hours/detail/building.tsx
+++ b/source/views/building-hours/detail/building.tsx
@@ -4,7 +4,7 @@ import {images as buildingImages} from '../../../../images/spaces'
 import type {BuildingType} from '../types'
 import type {Moment} from 'moment-timezone'
 import * as c from '@frogpond/colors'
-import {getShortBuildingStatus} from '../lib'
+import {getShortBuildingStatus, hoursBackgroundColors} from '../lib'
 
 import {SolidBadge as Badge} from '@frogpond/badge'
 import {Header} from './header'
@@ -27,11 +27,6 @@ type Props = {
 	info: BuildingType
 	now: Moment
 	onProblemReport: () => void
-}
-
-const BG_COLORS: Record<string, string> = {
-	Open: c.moneyGreen,
-	Closed: c.salmon,
 }
 
 export const BuildingDetail = React.memo((props: Props): JSX.Element => {
@@ -58,7 +53,10 @@ export const BuildingDetail = React.memo((props: Props): JSX.Element => {
 			) : null}
 
 			<Header building={info} />
-			<Badge accentColor={BG_COLORS[openStatus]} status={openStatus} />
+			<Badge
+				accentColor={hoursBackgroundColors[openStatus]}
+				status={openStatus}
+			/>
 			<ScheduleTable
 				now={now}
 				onProblemReport={onProblemReport}

--- a/source/views/building-hours/lib/color-helpers.ts
+++ b/source/views/building-hours/lib/color-helpers.ts
@@ -10,8 +10,8 @@ export const FG_COLORS: Record<string, string> = {
 	Closed: c.brickRed,
 }
 
-export let getAccentBackgroundColor = (openStatus: string): string =>
+export const getAccentBackgroundColor = (openStatus: string): string =>
 	BG_COLORS[openStatus] ?? c.goldenrod
 
-export let getAccentTextColor = (openStatus: string): string =>
+export const getAccentTextColor = (openStatus: string): string =>
 	FG_COLORS[openStatus] ?? 'rgb(130, 82, 45)'

--- a/source/views/building-hours/lib/color-helpers.ts
+++ b/source/views/building-hours/lib/color-helpers.ts
@@ -1,0 +1,17 @@
+import * as c from '@frogpond/colors'
+
+export const BG_COLORS: Record<string, string> = {
+	Open: c.moneyGreen,
+	Closed: c.salmon,
+}
+
+export const FG_COLORS: Record<string, string> = {
+	Open: c.hollyGreen,
+	Closed: c.brickRed,
+}
+
+export let getAccentBackgroundColor = (openStatus: string): string =>
+	BG_COLORS[openStatus] ?? c.goldenrod
+
+export let getAccentTextColor = (openStatus: string): string =>
+	FG_COLORS[openStatus] ?? 'rgb(130, 82, 45)'

--- a/source/views/building-hours/lib/index.ts
+++ b/source/views/building-hours/lib/index.ts
@@ -6,3 +6,9 @@ export {isScheduleOpenAtMoment} from './is-schedule-open'
 export {getDayOfWeek} from './get-day-of-week'
 export {parseHours} from './parse-hours'
 export {blankSchedule} from './blank-schedule'
+export {
+	BG_COLORS as hoursBackgroundColors,
+	FG_COLORS as hoursForegroundColors,
+	getAccentBackgroundColor,
+	getAccentTextColor,
+} from './color-helpers'

--- a/source/views/building-hours/row.tsx
+++ b/source/views/building-hours/row.tsx
@@ -6,7 +6,12 @@ import type {BuildingType} from './types'
 import * as c from '@frogpond/colors'
 import {Row} from '@frogpond/layout'
 import {ListRow, Detail, Title} from '@frogpond/lists'
-import {getDetailedBuildingStatus, getShortBuildingStatus} from './lib'
+import {
+	getDetailedBuildingStatus,
+	getShortBuildingStatus,
+	getAccentBackgroundColor,
+	getAccentTextColor,
+} from './lib'
 
 const styles = StyleSheet.create({
 	title: {
@@ -34,16 +39,6 @@ const styles = StyleSheet.create({
 	},
 })
 
-const BG_COLORS: Record<string, string> = {
-	Open: c.moneyGreen,
-	Closed: c.salmon,
-}
-
-const FG_COLORS: Record<string, string> = {
-	Open: c.hollyGreen,
-	Closed: c.brickRed,
-}
-
 type Props = {
 	info: BuildingType
 	now: Moment
@@ -62,9 +57,6 @@ export function BuildingRow(props: Props): JSX.Element {
 		[now, info],
 	)
 
-	let accentBg = BG_COLORS[openStatus] ?? c.goldenrod
-	let accentText = FG_COLORS[openStatus] ?? 'rgb(130, 82, 45)'
-
 	return (
 		<ListRow arrowPosition="center" onPress={onPress}>
 			<Row style={styles.title}>
@@ -78,10 +70,10 @@ export function BuildingRow(props: Props): JSX.Element {
 
 				{!info.isNotice ? (
 					<Badge
-						accentColor={accentBg}
+						accentColor={getAccentBackgroundColor(openStatus)}
 						style={styles.accessoryBadge}
 						text={openStatus}
-						textColor={accentText}
+						textColor={getAccentTextColor(openStatus)}
 					/>
 				) : null}
 			</Row>


### PR DESCRIPTION
Niceties around foreground, background, and accent colors for buildings hours status badges.

- move background and foreground colors into `lib/color-helpers`
- colocate duplicate `BG_COLORS` definition 
- rename symbols for clarity when importing, exporting, and invoking

Renamings
old name | new name
-|-
`accentBg` | `getAccentBackgroundColor`
`accentText` | `getAccentTextColor`
`BG_COLORS` | `hoursBackgroundColors`
`FG_COLORS` | `hoursForegroundColors`