### PR TITLE
add react-native-reanimated/plugin to babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,5 +3,8 @@ module.exports = {
 		'module:metro-react-native-babel-preset',
 		'@babel/preset-typescript',
 	],
-	plugins: ['@babel/plugin-proposal-export-namespace-from'],
+	plugins: [
+		'@babel/plugin-proposal-export-namespace-from',
+		'react-native-reanimated/plugin',
+	],
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,7 @@ module.exports = {
 	],
 	plugins: [
 		'@babel/plugin-proposal-export-namespace-from',
+		// the react-native-reanimated plugin must come last
 		'react-native-reanimated/plugin',
 	],
 }


### PR DESCRIPTION
Adds Reanimated's Babel plugin to our babel.config.js. [Docs](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/#babel-plugin).

A note on order

> Caution:
> Reanimated plugin has to be listed last.

A note if errors arise

> Troubleshooting:
> After adding the react-native-reanimated/plugin to your project you may encounter a false-positive "Reanimated 2 failed to create a worklet" error. In most cases, this can be fixed by cleaning the application's cache. Depending on your workflow or favourite package manager that could be done by:
>
> `npm start -- --reset-cache`