### PR TITLE
update react-native-popover-view

### DIFF
--- a/modules/filter/filter-popover.tsx
+++ b/modules/filter/filter-popover.tsx
@@ -30,7 +30,10 @@ export function FilterPopover(props: Props): JSX.Element {
 		>
 			{/* This view wrapper shouldn't be needed but it does appear to fix a rendering issue */}
 			<View style={popoverContainer}>
-				<FilterSection filter={filter} onChange={(filter) => setFilter(filter)} />
+				<FilterSection
+					filter={filter}
+					onChange={(filter) => setFilter(filter)}
+				/>
 			</View>
 		</Popover>
 	)

--- a/modules/filter/filter-popover.tsx
+++ b/modules/filter/filter-popover.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import {RefObject, useState} from 'react'
 import Popover, {PopoverPlacement} from 'react-native-popover-view'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {FilterSection} from './section'
 import type {FilterType} from './types'
 import * as c from '@frogpond/colors'
@@ -16,6 +17,7 @@ type Props = {
 export function FilterPopover(props: Props): JSX.Element {
 	let {anchor, onClosePopover, visible} = props
 	let [filter, setFilter] = useState<FilterType>(props.filter)
+	let safeareaInsets = useSafeAreaInsets()
 
 	return (
 		<Popover
@@ -24,6 +26,7 @@ export function FilterPopover(props: Props): JSX.Element {
 			onRequestClose={() => onClosePopover(filter)}
 			placement={PopoverPlacement.BOTTOM}
 			popoverStyle={popoverContainer}
+			displayAreaInsets={safeareaInsets}
 		>
 			<FilterSection filter={filter} onChange={(filter) => setFilter(filter)} />
 		</Popover>

--- a/modules/filter/filter-popover.tsx
+++ b/modules/filter/filter-popover.tsx
@@ -28,7 +28,10 @@ export function FilterPopover(props: Props): JSX.Element {
 			popoverStyle={popoverContainer}
 			displayAreaInsets={safeareaInsets}
 		>
-			<FilterSection filter={filter} onChange={(filter) => setFilter(filter)} />
+			{/* This view wrapper shouldn't be needed but it does appear to fix a rendering issue */}
+			<View style={popoverContainer}>
+				<FilterSection filter={filter} onChange={(filter) => setFilter(filter)} />
+			</View>
 		</Popover>
 	)
 }

--- a/modules/filter/filter-popover.tsx
+++ b/modules/filter/filter-popover.tsx
@@ -21,12 +21,12 @@ export function FilterPopover(props: Props): JSX.Element {
 
 	return (
 		<Popover
+			displayAreaInsets={safeareaInsets}
 			from={anchor}
 			isVisible={visible}
 			onRequestClose={() => onClosePopover(filter)}
 			placement={PopoverPlacement.BOTTOM}
 			popoverStyle={popoverContainer}
-			displayAreaInsets={safeareaInsets}
 		>
 			{/* This view wrapper shouldn't be needed but it does appear to fix a rendering issue */}
 			<View style={popoverContainer}>

--- a/modules/filter/package.json
+++ b/modules/filter/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "react": "^18.0.0",
     "react-native": "^0.71.0",
-    "react-native-popover-view": "^5.0.0",
+    "react-native-popover-view": "^5.1.7",
     "react-native-vector-icons": "^9.0.0"
   },
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "react-native-keychain": "8.1.1",
         "react-native-linear-gradient": "2.6.2",
         "react-native-paper": "4.12.4",
-        "react-native-popover-view": "5.0.0",
+        "react-native-popover-view": "5.1.7",
         "react-native-reanimated": "2.14.1",
         "react-native-restart": "0.0.24",
         "react-native-safe-area-context": "4.4.1",
@@ -306,7 +306,7 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-native": "^0.71.0",
-        "react-native-popover-view": "^5.0.0",
+        "react-native-popover-view": "^5.1.7",
         "react-native-vector-icons": "^9.0.0"
       }
     },
@@ -17510,9 +17510,23 @@
       }
     },
     "node_modules/react-native-popover-view": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-popover-view/-/react-native-popover-view-5.0.0.tgz",
-      "integrity": "sha512-wG+ZmfUQM/L+Uu7Qw61ixrEsS/hGOQ+nueH8obVo5i/+xymPgtJGwLGKva5xTEV3Ug7ghgPDy8s/FXD/ernYsw=="
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-popover-view/-/react-native-popover-view-5.1.7.tgz",
+      "integrity": "sha512-Xa+zKYp9x62UNezT8o9SnqQaBQEHdGwGHZnFnA2bsXLneVRvvlBopNwMNj+p7N65qnPf3mmzWj+57ThtM1qFuw==",
+      "dependencies": {
+        "deprecated-react-native-prop-types": "^2.3.0",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "node_modules/react-native-popover-view/node_modules/deprecated-react-native-prop-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz",
+      "integrity": "sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==",
+      "dependencies": {
+        "@react-native/normalize-color": "*",
+        "invariant": "*",
+        "prop-types": "*"
+      }
     },
     "node_modules/react-native-reanimated": {
       "version": "2.14.1",
@@ -32933,9 +32947,25 @@
       }
     },
     "react-native-popover-view": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-popover-view/-/react-native-popover-view-5.0.0.tgz",
-      "integrity": "sha512-wG+ZmfUQM/L+Uu7Qw61ixrEsS/hGOQ+nueH8obVo5i/+xymPgtJGwLGKva5xTEV3Ug7ghgPDy8s/FXD/ernYsw=="
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-popover-view/-/react-native-popover-view-5.1.7.tgz",
+      "integrity": "sha512-Xa+zKYp9x62UNezT8o9SnqQaBQEHdGwGHZnFnA2bsXLneVRvvlBopNwMNj+p7N65qnPf3mmzWj+57ThtM1qFuw==",
+      "requires": {
+        "deprecated-react-native-prop-types": "^2.3.0",
+        "prop-types": "^15.8.1"
+      },
+      "dependencies": {
+        "deprecated-react-native-prop-types": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz",
+          "integrity": "sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==",
+          "requires": {
+            "@react-native/normalize-color": "*",
+            "invariant": "*",
+            "prop-types": "*"
+          }
+        }
+      }
     },
     "react-native-reanimated": {
       "version": "2.14.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "react-native-keychain": "8.1.1",
     "react-native-linear-gradient": "2.6.2",
     "react-native-paper": "4.12.4",
-    "react-native-popover-view": "5.0.0",
+    "react-native-popover-view": "5.1.7",
     "react-native-reanimated": "2.14.1",
     "react-native-restart": "0.0.24",
     "react-native-safe-area-context": "4.4.1",


### PR DESCRIPTION
- This targets #6719 
- Popover v5.1.7 fixes crashes that I saw on v4.0. 
- V5.x [upgrade guide from the popover ](https://github.com/SteffeyDev/react-native-popover-view#4x-to-50)

## Issue tracking
  - [x] 6e7fae2b update `react-native-popover-view` to 5.0.0 in filter module
  - [x] 24efc8b The width does not contain the content container size
  - [x] 693f309 Add safearea insets to mind the notch and bottom bar
  - [x] b497b97 No view presented when the popover is partially off-screen on the left (solved with 5.0.0~>5.1.7)
  
## Visual fixes

Scenario | Before | After
--|--|--
Safe area  | ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-17 at 20 32 28](https://user-images.githubusercontent.com/5240843/213087073-7c3e2f90-0718-4bb3-9018-13f3ce5ec863.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-17 at 20 33 13](https://user-images.githubusercontent.com/5240843/213086979-298f057f-24d2-4ade-97d8-fc3de029defc.png)
Content overflowing | ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-17 at 20 33 30](https://user-images.githubusercontent.com/5240843/213087180-080d5a7f-381b-465a-a916-22a3d84864e0.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-17 at 20 33 48](https://user-images.githubusercontent.com/5240843/213087190-9afa7f03-ca16-4509-ae68-38bf1e85fa94.png)

## Last big issue 

Fixed! Solved with upgrading grom 5.0.0 ~> 5.1.7

<details>
<summary>See more info...</summary>

Out last issue is: "no view presented when the popover is partially off-screen on the left". Tapping a filter toolbar button that's partially hidden on the left of the screen can freeze up the view (nothing presented)

Expectation | Actuality
--|--
<img src="https://user-images.githubusercontent.com/5240843/213085249-db806d5f-cc5e-442e-ade0-7cad4b28329f.mp4" width=300 />  | <img src="https://user-images.githubusercontent.com/5240843/213086766-31a9e91b-8678-4487-a15e-c931fbaaeb5c.mp4" width=300 />

### Debugging
This last one is tricky.
- The package does provide a `debug={true}` param which gives us some data to look at.
- There is [a troubleshooting section on the readme](https://github.com/SteffeyDev/react-native-popover-view#troubleshooting)
 
**Repro**: Current logging when opening the filter toolbar button from the far left, partially obscured.
 ```
LOG  [2023-01-18T04:13:44.854Z] calculateRectFromRef - waiting for ref
LOG  [2023-01-18T04:13:44.854Z] calculateRectFromRef - waiting for ref to move
 ```
 
I've tried [looking at open issues](https://github.com/SteffeyDev/react-native-popover-view/search?q=calculateRectFromRef+-+waiting+for+ref+to+move&type=issues) related to these logs. The idea that our ref isn't available and we're in an odd position on the far left makes me think bounds of the ref's rect could be an issue?
 
**Repro**: A normal log of opening the popover

<details>
<summary>Expand to see the larger log contents…</summary>

```
LOG  [2023-01-18T04:28:40.637Z] calculateRectFromRef - waiting for ref
LOG  [2023-01-18T04:28:40.637Z] calculateRectFromRef - waiting for ref to move
LOG  [2023-01-18T04:28:40.654Z] calculateRectFromRef - calculated Rect: {"x":10,"y":159.99999872843426,"width":152.3333282470703,"height":31.333332061767578}
LOG  [2023-01-18T04:28:40.656Z] [AdaptivePopover] getDisplayArea - displayAreaInsets: {"left":0,"top":59,"right":0,"bottom":34}
LOG  [2023-01-18T04:28:40.677Z] setDefaultDisplayArea - newDisplayArea: {"x":0,"y":0,"width":393,"height":852}
LOG  [2023-01-18T04:28:40.678Z] setDefaultDisplayArea - displayAreaOffset: {"x":0,"y":0}
LOG  [2023-01-18T04:28:40.679Z] [AdaptivePopover] getDisplayArea - displayAreaInsets: {"left":0,"top":59,"right":0,"bottom":34}
LOG  [2023-01-18T04:28:40.682Z] calculateRectFromRef - waiting for ref
LOG  [2023-01-18T04:28:40.682Z] calculateRectFromRef - waiting for ref to move
LOG  [2023-01-18T04:28:40.690Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":151.333251953125} (used to be null)
LOG  [2023-01-18T04:28:40.693Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.706Z] [AdaptivePopover] getDisplayArea - displayAreaInsets: {"left":0,"top":59,"right":0,"bottom":34}
LOG  [2023-01-18T04:28:40.706Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":163} (used to be {"width":291.3333435058594,"height":151.333251953125})
LOG  [2023-01-18T04:28:40.710Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.711Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":174.6666259765625} (used to be {"width":291.3333435058594,"height":163})
LOG  [2023-01-18T04:28:40.714Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.714Z] measureContent - Skipping, content size did not change
LOG  [2023-01-18T04:28:40.714Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":169} (used to be {"width":291.3333435058594,"height":174.6666259765625})
LOG  [2023-01-18T04:28:40.717Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.717Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":174.6666259765625} (used to be {"width":291.3333435058594,"height":169})
LOG  [2023-01-18T04:28:40.721Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.722Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":172} (used to be {"width":291.3333435058594,"height":174.6666259765625})
LOG  [2023-01-18T04:28:40.725Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.725Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":174.6666259765625} (used to be {"width":291.3333435058594,"height":172})
LOG  [2023-01-18T04:28:40.728Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.728Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":173.333251953125} (used to be {"width":291.3333435058594,"height":174.6666259765625})
LOG  [2023-01-18T04:28:40.731Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.731Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":174.6666259765625} (used to be {"width":291.3333435058594,"height":173.333251953125})
LOG  [2023-01-18T04:28:40.735Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.735Z] measureContent - new requestedContentSize: {"width":291.3333435058594,"height":151.333251953125} (used to be {"width":291.3333435058594,"height":174.6666259765625})
LOG  [2023-01-18T04:28:40.738Z] handleChange - waiting 100ms to accumulate all changes
LOG  [2023-01-18T04:28:40.840Z] handleChange - requestedContentSize: {"width":291.3333435058594,"height":151.333251953125}
LOG  [2023-01-18T04:28:40.840Z] handleChange - displayArea: {"x":0,"y":59,"width":393,"height":759}
LOG  [2023-01-18T04:28:40.840Z] handleChange - fromRect: {"x":10,"y":159.99999872843426,"width":152.3333282470703,"height":31.333332061767578}
LOG  [2023-01-18T04:28:40.840Z] handleChange - placement: "bottom"
LOG  [2023-01-18T04:28:40.842Z] computeGeometry - initial chosen geometry: {"popoverOrigin":{"x":10,"y":191.33333079020184},"anchorPoint":{"x":86.16666412353516,"y":191.33333079020184},"placement":"bottom","forcedContentSize":{"width":373,"height":616.6666692097981},"viewLargerThanDisplayArea":{"height":false,"width":false}}
LOG  [2023-01-18T04:28:40.842Z] computeGeometry - final chosen geometry: {"popoverOrigin":{"x":10,"y":191.33333079020184},"anchorPoint":{"x":86.16666412353516,"y":191.33333079020184},"placement":"bottom","forcedContentSize":{"width":373,"height":616.6666692097981},"viewLargerThanDisplayArea":{"height":false,"width":false}}
LOG  [2023-01-18T04:28:40.848Z] handleChange - animating in
LOG  [2023-01-18T04:28:40.848Z] getTranslateOrigin - popoverSize: {"width":291.3333435058594,"height":159.333251953125}
LOG  [2023-01-18T04:28:40.848Z] getTranslateOrigin - anchorPoint: {"x":86.16666412353516,"y":191.33333079020184}
LOG  [2023-01-18T04:28:40.850Z] animateIn - translateStart: {"x":-59.50000762939453,"y":1815.6667048136394}
LOG  [2023-01-18T04:28:40.850Z] animateIn - translatePoint: {"x":10,"y":191.33333079020184}
LOG  [2023-01-18T04:28:40.855Z] Setting up keyboard listeners
LOG  [2023-01-18T04:28:40.855Z] [AdaptivePopover] getDisplayArea - displayAreaInsets: {"left":0,"top":59,"right":0,"bottom":34}
LOG  [2023-01-18T04:28:40.857Z] [AdaptivePopover] getDisplayArea - displayAreaInsets: {"left":0,"top":59,"right":0,"bottom":34}
LOG  [2023-01-18T04:28:40.873Z] measureContent - Skipping, content size did not change
LOG  [2023-01-18T04:28:41.222Z] animateIn - onOpenComplete - Calculated Popover Rect: {"x":10,"y":199.3333740234375,"width":291.3333435058594,"height":151.333251953125}
LOG  [2023-01-18T04:28:41.222Z] animateIn - onOpenComplete - Calculated Arrow Rect: {"x":78.33333587646484,"y":191.3333740234375,"width":18,"height":10}
```
</details>
 
</details>
