### PR TITLE
Fix directory and stoPrint loading

### DIFF
--- a/source/lib/stoprint/api.ts
+++ b/source/lib/stoprint/api.ts
@@ -2,8 +2,8 @@ import {mobileReleaseApi, papercutApi} from './urls'
 import {encode} from 'base-64'
 import {
 	fetchAllPrinters as mockFetchAllPrinters,
-	fetchRecentPrinters as mockFetchRecentPrinters,
 	fetchJobs as mockFetchJobs,
+	fetchRecentPrinters as mockFetchRecentPrinters,
 	heldJobsAvailableAtPrinterForUser as mockHeldJobsAvailableAtPrinterForUser,
 	logIn as mockLogIn,
 	releasePrintJobToPrinterForUser as mockReleasePrintJobToPrinterForUser,
@@ -11,14 +11,14 @@ import {
 import {isStoprintMocked} from '../../lib/stoprint'
 
 import type {
-	LoginResponse,
-	PrintJobsResponse,
 	AllPrintersResponse,
-	RecentPopularPrintersResponse,
+	CancelResponse,
 	ColorPrintersResponse,
 	HeldJobsResponse,
+	LoginResponse,
+	PrintJobsResponse,
+	RecentPopularPrintersResponse,
 	ReleaseResponse,
-	CancelResponse,
 } from './types'
 import {Options} from 'ky'
 import {SharedWebCredentials} from 'react-native-keychain'
@@ -41,8 +41,9 @@ export async function logIn(
 	const result = (await papercutApi
 		.post(`webclient/users/${username}/log-in`, {
 			...options,
+			// use URLSearchParams to auto-set Content-Type: application/x-www-form-urlencoded
 			body: new URLSearchParams({password: encode(password)}),
-			searchParams: new URLSearchParams({nocache: String(now)}),
+			searchParams: {nocache: String(now)},
 		})
 		.json()) as LoginResponse
 
@@ -77,7 +78,7 @@ export async function fetchAllPrinters(
 	return (await mobileReleaseApi
 		.get('all-printers', {
 			...options,
-			searchParams: new URLSearchParams({username: username}),
+			searchParams: {username: username},
 		})
 		.json()) as AllPrintersResponse
 }
@@ -93,7 +94,7 @@ export async function fetchRecentPrinters(
 	return (await mobileReleaseApi
 		.get('recent-popular-printers', {
 			...options,
-			searchParams: new URLSearchParams({username: username}),
+			searchParams: {username: username},
 		})
 		.json()) as RecentPopularPrintersResponse
 }
@@ -118,10 +119,10 @@ export async function heldJobsAvailableAtPrinterForUser(
 	return (await mobileReleaseApi
 		.get('held-jobs', {
 			...options,
-			searchParams: new URLSearchParams({
+			searchParams: {
 				username: username,
 				printerName: `printers\\${printerName}`,
-			}),
+			},
 		})
 		.json()) as HeldJobsResponse
 }
@@ -134,7 +135,8 @@ export async function cancelPrintJobForUser(
 	return (await mobileReleaseApi
 		.post('held-jobs/cancel', {
 			...options,
-			searchParams: new URLSearchParams({username: username}),
+			searchParams: {username: username},
+			// use URLSearchParams to auto-set Content-Type: application/x-www-form-urlencoded
 			body: new URLSearchParams({'jobIds[]': jobId}),
 		})
 		.json()) as CancelResponse
@@ -157,7 +159,8 @@ export async function releasePrintJobToPrinterForUser(
 	let response = (await mobileReleaseApi
 		.post('held-jobs/release', {
 			...options,
-			searchParams: new URLSearchParams({username: username}),
+			searchParams: {username: username},
+			// use URLSearchParams to auto-set Content-Type: application/x-www-form-urlencoded
 			body: new URLSearchParams({
 				printerName: `printers\\${printerName}`,
 				'jobIds[]': jobId,

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -91,7 +91,7 @@ export function DirectoryView(): JSX.Element {
 			{isLoading ? (
 				<LoadingView />
 			) : isError && error instanceof Error ? (
-				<NoticeView text={parseErrorMessage(getErrorMessage(error))} />
+				<NoticeView text={String(error)} />
 			) : !items.length ? (
 				<NoticeView text={`No results found for "${searchQuery}".`} />
 			) : (
@@ -172,29 +172,6 @@ function AndroidDirectoryItemRow({item, onPress}: DirectoryItemRowProps) {
 			title={item.displayName}
 		/>
 	)
-}
-
-const DIRECTORY_HTML_ERROR_CODE = 'directory-html'
-
-const getErrorMessage = (error: Error | undefined) => {
-	if (!(error instanceof Error)) {
-		return 'Unknown Error: Not an Error'
-	}
-
-	if (error.message === "JSON Parse error: Unrecognized token '<'") {
-		return DIRECTORY_HTML_ERROR_CODE
-	} else {
-		return error.message
-	}
-}
-
-const parseErrorMessage = (errorMessage: string) => {
-	let message = `Error: ${errorMessage}`
-	if (errorMessage === DIRECTORY_HTML_ERROR_CODE) {
-		message =
-			'Something between you and the directory is having problems. Try again in a minute or two?'
-	}
-	return message
 }
 
 const DirectoryItemRow =

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -1,22 +1,22 @@
 import React from 'react'
 import {
-	StyleSheet,
-	View,
-	Text,
-	Image,
 	FlatList,
+	Image,
 	Platform,
 	SafeAreaView,
+	StyleSheet,
+	Text,
+	View,
 } from 'react-native'
 import {Column} from '@frogpond/layout'
-import {ListRow, ListSeparator, Detail, Title} from '@frogpond/lists'
+import {Detail, ListRow, ListSeparator, Title} from '@frogpond/lists'
 import * as c from '@frogpond/colors'
 import {useDebounce} from '@frogpond/use-debounce'
-import {NoticeView, LoadingView} from '@frogpond/notice'
+import {LoadingView, NoticeView} from '@frogpond/notice'
 import {formatResults} from './helpers'
 import {useDirectoryEntries} from './query'
-import {List, Avatar} from 'react-native-paper'
-import type {DirectorySearchTypeEnum, DirectoryItem} from './types'
+import {Avatar, List} from 'react-native-paper'
+import type {DirectoryItem, DirectorySearchTypeEnum} from './types'
 import Icon from 'react-native-vector-icons/Ionicons'
 import {RouteProp, useNavigation, useRoute} from '@react-navigation/native'
 import {

--- a/source/views/directory/query.ts
+++ b/source/views/directory/query.ts
@@ -4,45 +4,39 @@ import {DirectorySearchTypeEnum, SearchResults} from './types'
 
 let directory = ky.create({prefixUrl: 'https://www.stolaf.edu/directory'})
 
-const getDirectoryParams = (query: string, type: DirectorySearchTypeEnum) => {
-	let p = new URLSearchParams()
-	p.append('format', 'json')
+type GetDirectoryQueryArgs = {
+	query: string
+	type: DirectorySearchTypeEnum
+}
 
+const getDirectoryQuery = ({query, type}: GetDirectoryQueryArgs) => {
+	let common = {format: 'json'}
 	query = query.trim()
 
 	switch (type) {
 		case 'department':
-			p.append('department', query)
-			break
+			return {...common, department: query}
 		case 'firstName':
-			p.append('firstname', query)
-			break
+			return {...common, firstname: query}
 		case 'lastName':
-			p.append('lastname', query)
-			break
+			return {...common, lastname: query}
 		case 'major':
-			p.append('major', query)
-			break
+			return {...common, major: query}
 		case 'query':
-			p.append('query', query)
-			break
+			return {...common, query: query}
 		case 'title':
-			p.append('title', query)
-			break
+			return {...common, title: query}
 		case 'username':
-			p.append('email', query)
-			break
+			return {...common, email: query}
 		default: {
 			let _neverHitMe: never = type
 		}
 	}
-
-	return p
 }
 
 export const keys = {
-	all: (query: string, type: DirectorySearchTypeEnum) =>
-		['directory', type, query] as const,
+	all: (query: ReturnType<typeof getDirectoryQuery>) =>
+		['directory', query] as const,
 }
 
 export function useDirectoryEntries(
@@ -50,10 +44,10 @@ export function useDirectoryEntries(
 	type: DirectorySearchTypeEnum,
 ): UseQueryResult<SearchResults, unknown> {
 	return useQuery({
-		queryKey: keys.all(query, type),
-		queryFn: async ({queryKey: [_, type, query], signal}) => {
+		queryKey: keys.all(getDirectoryQuery({query, type})),
+		queryFn: async ({queryKey: [_, query], signal}) => {
 			let response = await directory
-				.get('search', {searchParams: getDirectoryParams(query, type), signal})
+				.get('search', {searchParams: query, signal})
 				.json()
 			return response as SearchResults
 		},


### PR DESCRIPTION
1. I removed the custom error message from the directory
2. Ky/RN is doing something strange with URLSearchParams. If we use the Ky-specific shorthand of just passing an object, it works properly... 
3. As such, I went ahead and cleaned up the stoPrint loading to use the same shorthands.

closes #6746
closes #6756
