### PR TITLE
Provide fallback for key path if not defined

### DIFF
--- a/source/views/settings/screens/debug/list.tsx
+++ b/source/views/settings/screens/debug/list.tsx
@@ -87,7 +87,7 @@ export const DebugToStringItem = ({item}: {item: unknown}): JSX.Element => {
 let useKeyPath = () => {
 	let route =
 		useRoute<RouteProp<SettingsStackParamList, typeof NavigationKey>>()
-	let {keyPath} = route.params
+	let {keyPath} = route.params ?? []
 	return keyPath
 }
 


### PR DESCRIPTION
Part of #6740 

- This prevents a crash when toggling between json and parsed output in the APITest component.
- This does not fix the ApiTester component which still has keypath requirements to be implemented. That will still crash if the debug row or the parsed row is tapped.