### PR TITLE
Add react-native-network-logger dev-only view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-native-inappbrowser-reborn": "3.7.0",
         "react-native-ios-context-menu": "1.15.3",
         "react-native-keychain": "8.1.1",
+        "react-native-network-logger": "1.13.0",
         "react-native-paper": "4.12.4",
         "react-native-popover-view": "4.1.0",
         "react-native-reanimated": "2.14.4",
@@ -17036,6 +17037,15 @@
       "resolved": "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-8.1.1.tgz",
       "integrity": "sha512-8fxgeHKwGcL657eAYpdBTkDIxNhbIHI+kyyO0Yac2dgVAN184JoIwQcW2z6snahwDaCObQOu0biLFHnsH+4KSg=="
     },
+    "node_modules/react-native-network-logger": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/react-native-network-logger/-/react-native-network-logger-1.13.0.tgz",
+      "integrity": "sha512-OZErs122HdOCuK4HcWKPcqQarTBulo7lsOrvaUGlXPlcQOc8povYSHs78xkoHAiO+eYuAQ4O/ecG0mrHAE7EGw==",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-pager-view": {
       "version": "5.4.15",
       "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-5.4.15.tgz",
@@ -32120,6 +32130,12 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-8.1.1.tgz",
       "integrity": "sha512-8fxgeHKwGcL657eAYpdBTkDIxNhbIHI+kyyO0Yac2dgVAN184JoIwQcW2z6snahwDaCObQOu0biLFHnsH+4KSg=="
+    },
+    "react-native-network-logger": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/react-native-network-logger/-/react-native-network-logger-1.13.0.tgz",
+      "integrity": "sha512-OZErs122HdOCuK4HcWKPcqQarTBulo7lsOrvaUGlXPlcQOc8povYSHs78xkoHAiO+eYuAQ4O/ecG0mrHAE7EGw==",
+      "requires": {}
     },
     "react-native-pager-view": {
       "version": "5.4.15",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-native-inappbrowser-reborn": "3.7.0",
     "react-native-ios-context-menu": "1.15.3",
     "react-native-keychain": "8.1.1",
+    "react-native-network-logger": "1.13.0",
     "react-native-paper": "4.12.4",
     "react-native-popover-view": "4.1.0",
     "react-native-reanimated": "2.14.4",

--- a/source/init/network.ts
+++ b/source/init/network.ts
@@ -1,0 +1,15 @@
+import {isDevMode} from '@frogpond/constants'
+import {startNetworkLogging} from 'react-native-network-logger'
+
+function initNetworkLogging() {
+	if (!isDevMode()) {
+		return
+	}
+
+	startNetworkLogging({
+		ignoredHosts: ['0.0.0.0', '127.0.0.1'],
+		forceEnable: true,
+	})
+}
+
+initNetworkLogging()

--- a/source/navigation/routes.tsx
+++ b/source/navigation/routes.tsx
@@ -306,6 +306,11 @@ const SettingsStackScreens = () => (
 				},
 			}) => ({title: toLaxTitleCase(keyPath?.[keyPath?.length - 1])})}
 		/>
+		<SettingsStack.Screen
+			component={settings.NetworkLoggerView}
+			name="NetworkLogger"
+			options={settings.NetworkLoggerNavigationOptions}
+		/>
 	</SettingsStack.Navigator>
 )
 

--- a/source/navigation/types.tsx
+++ b/source/navigation/types.tsx
@@ -102,6 +102,7 @@ export type SettingsStackParamList = {
 	Faq: undefined
 	IconSettings: undefined
 	Legal: undefined
+	NetworkLogger: undefined
 	Privacy: undefined
 	Settings: undefined
 	SettingsRoot: undefined

--- a/source/views/settings/index.ts
+++ b/source/views/settings/index.ts
@@ -12,3 +12,7 @@ export {
 	ColorsInfoView,
 	NavigationKey as ColorsInfoNavigationKey,
 } from './screens/debug/colors'
+export {
+	NetworkLoggerView,
+	NavigationOptions as NetworkLoggerNavigationOptions,
+} from './screens/network-logger'

--- a/source/views/settings/screens/network-logger/index.tsx
+++ b/source/views/settings/screens/network-logger/index.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react'
+import {
+	StyleSheet,
+	Button,
+	Platform,
+	View,
+	Text,
+	TouchableOpacity,
+} from 'react-native'
+import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
+import {useNavigation} from '@react-navigation/native'
+import NetworkLogger, {getBackHandler} from 'react-native-network-logger'
+import {CloseScreenButton} from '@frogpond/navigation-buttons'
+import * as c from '@frogpond/colors'
+
+export const NetworkLoggerView = (props) => {
+	const goBack = () => setUnmountNetworkLogger(true)
+	const [unmountNetworkLogger, setUnmountNetworkLogger] = React.useState(false)
+	const backHandler = getBackHandler(goBack)
+
+	const remountButton = (
+		<View>
+			<Button
+				title={'Re-open the network logger'}
+				onPress={() => setUnmountNetworkLogger(false)}
+			>
+				Re-open network logger
+			</Button>
+		</View>
+	)
+
+	return (
+		<>
+			<View style={styles.header}>
+				<TouchableOpacity
+					style={styles.navButton}
+					onPress={backHandler}
+					hitSlop={styles.hitSlop}
+				>
+					<Text style={styles.backButtonText}>{'‹'}</Text>
+				</TouchableOpacity>
+
+				<Text style={styles.title} accessibilityRole="header">
+					react-native-network-logger
+				</Text>
+
+				<View style={styles.navButton} />
+			</View>
+
+			{(unmountNetworkLogger && remountButton) || <NetworkLogger />}
+		</>
+	)
+}
+
+export const NavigationOptions: NativeStackNavigationOptions = {
+	title: 'Network Logger',
+	headerRight: () => Platform.OS === 'ios' && <CloseScreenButton />,
+	presentation: 'modal',
+	gestureEnabled: false,
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		paddingTop: Platform.OS === 'android' ? 25 : 0,
+	},
+	header: {
+		flexDirection: 'row',
+	},
+	navButton: {
+		flex: 1,
+	},
+	hitSlop: {
+		top: 20,
+		left: 20,
+		bottom: 20,
+		right: 20,
+	},
+	backButtonText: {
+		color: c.black,
+		paddingHorizontal: 20,
+		fontSize: 30,
+		fontWeight: 'bold',
+	},
+	title: {
+		flex: 5,
+		color: c.black,
+		textAlign: 'center',
+		padding: 10,
+		fontSize: 18,
+		fontWeight: 'bold',
+	},
+})

--- a/source/views/settings/screens/network-logger/index.tsx
+++ b/source/views/settings/screens/network-logger/index.tsx
@@ -1,46 +1,35 @@
 import * as React from 'react'
-import {
-	StyleSheet,
-	Button,
-	Platform,
-	View,
-	Text,
-	TouchableOpacity,
-} from 'react-native'
+import {StyleSheet, Platform, View, Text, TouchableOpacity} from 'react-native'
+import {Button} from '@frogpond/button'
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
-import {useNavigation} from '@react-navigation/native'
 import NetworkLogger, {getBackHandler} from 'react-native-network-logger'
 import {CloseScreenButton} from '@frogpond/navigation-buttons'
 import * as c from '@frogpond/colors'
 
-export const NetworkLoggerView = (props) => {
+export const NetworkLoggerView = (): JSX.Element => {
 	const goBack = () => setUnmountNetworkLogger(true)
 	const [unmountNetworkLogger, setUnmountNetworkLogger] = React.useState(false)
 	const backHandler = getBackHandler(goBack)
 
 	const remountButton = (
-		<View>
-			<Button
-				title={'Re-open the network logger'}
-				onPress={() => setUnmountNetworkLogger(false)}
-			>
-				Re-open network logger
-			</Button>
-		</View>
+		<Button
+			onPress={() => setUnmountNetworkLogger(false)}
+			title="Re-open the network logger"
+		/>
 	)
 
 	return (
 		<>
 			<View style={styles.header}>
 				<TouchableOpacity
-					style={styles.navButton}
-					onPress={backHandler}
 					hitSlop={styles.hitSlop}
+					onPress={backHandler}
+					style={styles.navButton}
 				>
-					<Text style={styles.backButtonText}>{'‹'}</Text>
+					<Text style={styles.backButtonText}>‹</Text>
 				</TouchableOpacity>
 
-				<Text style={styles.title} accessibilityRole="header">
+				<Text accessibilityRole="header" style={styles.title}>
 					react-native-network-logger
 				</Text>
 
@@ -60,10 +49,6 @@ export const NavigationOptions: NativeStackNavigationOptions = {
 }
 
 const styles = StyleSheet.create({
-	container: {
-		flex: 1,
-		paddingTop: Platform.OS === 'android' ? 25 : 0,
-	},
 	header: {
 		flexDirection: 'row',
 	},

--- a/source/views/settings/screens/overview/developer.tsx
+++ b/source/views/settings/screens/overview/developer.tsx
@@ -16,6 +16,7 @@ export const DeveloperSection = (): React.ReactElement => {
 	const onColorsButton = () => navigation.navigate(ColorsInfoNavigationKey)
 	const onBonAppButton = () => navigation.navigate('BonAppPicker')
 	const onDebugButton = () => navigation.navigate(DebugKey, {keyPath: ['Root']})
+	const onNetworkLoggerButton = () => navigation.navigate('NetworkLogger')
 	const sendSentryMessage = () => {
 		Sentry.captureMessage('A Sentry Message', {level: 'info'})
 		showSentryAlert()
@@ -45,6 +46,10 @@ export const DeveloperSection = (): React.ReactElement => {
 				<PushButtonCell onPress={onAPIButton} title="API Tester" />
 				<PushButtonCell onPress={onBonAppButton} title="Bon Appetit Picker" />
 				<PushButtonCell disabled={true} onPress={onDebugButton} title="Debug" />
+				<PushButtonCell
+					onPress={onNetworkLoggerButton}
+					title="Network Logger"
+				/>
 				<PushButtonCell
 					onPress={sendSentryMessage}
 					showLinkStyle={true}


### PR DESCRIPTION
Adds [`react-native-network-logger`](https://github.com/alexbrazier/react-native-network-logger) to our internal views.
Closes #5230 

---

How to use this tool
1. Open settings > Network Logger
2. Move around the app
3. Return to settings > Network Logger
