### PR TITLE
Support mocking functionality for detox builds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -510,7 +510,7 @@ jobs:
         if: steps.app-cache.outputs.cache-hit != 'true'
         env:
           SKIP_BUNDLING: 'true'
-        run: APP_MODE=mocked npx detox build e2e --configuration ios.sim.release
+        run: npx detox build e2e --configuration ios.sim.release
 
       - name: Cache the iOS app
         uses: actions/cache/save@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3
@@ -579,7 +579,7 @@ jobs:
       - run: brew install applesimutils
 
       - name: Run the Detox tests
-        run: APP_MODE=mocked npx detox test e2e --configuration ios.sim.release --cleanup --record-logs failing --record-videos failing --record-performance all --capture-view-hierarchy enabled --take-screenshots failing
+        run: npx detox test e2e --configuration ios.sim.release --cleanup --record-logs failing --record-videos failing --record-performance all --capture-view-hierarchy enabled --take-screenshots failing
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         if: always()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -311,7 +311,7 @@ jobs:
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         run: |
           npm run bundle-data
-          npm run bundle:ios
+          APP_MODE=mocked npm run bundle:ios
 
       - name: Cache the jsbundle
         uses: actions/cache/save@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3
@@ -364,7 +364,7 @@ jobs:
         run: |
           mkdir -p ./android/app/src/main/assets/
           npm run bundle-data
-          npm run bundle:android
+          APP_MODE=mocked npm run bundle:android
 
       - name: Cache the jsbundle
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -507,7 +507,7 @@ jobs:
 
       - name: Build the iOS app
         if: steps.app-cache.outputs.cache-hit != 'true'
-        run: npx detox build e2e --configuration ios.sim.release
+        run: APP_MODE=mocked npx detox build e2e --configuration ios.sim.release
 
       - name: Cache the iOS app
         uses: actions/cache/save@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # v3
@@ -576,7 +576,7 @@ jobs:
       - run: brew install applesimutils
 
       - name: Run the Detox tests
-        run: npx detox test e2e --configuration ios.sim.release --cleanup --record-logs failing --record-videos failing --record-performance all --capture-view-hierarchy enabled --take-screenshots failing
+        run: APP_MODE=mocked npx detox test e2e --configuration ios.sim.release --cleanup --record-logs failing --record-videos failing --record-performance all --capture-view-hierarchy enabled --take-screenshots failing
 
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         if: always()

--- a/metro.config.js
+++ b/metro.config.js
@@ -5,7 +5,17 @@
  * @format
  */
 
+const defaultSourceExts =
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	require('metro-config/src/defaults/defaults').sourceExts
+
 module.exports = {
+	resolver: {
+		sourceExts:
+			process.env.APP_MODE === 'mocked'
+				? ['mock.ts', ...defaultSourceExts]
+				: defaultSourceExts,
+	},
 	transformer: {
 		getTransformOptions: () => ({
 			transform: {

--- a/source/init/sentry.mock.ts
+++ b/source/init/sentry.mock.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+/**
+ * Mocked sentry.ts functionality goes in this file
+ *
+ * We are timing out in our Detox tests due to timers going on
+ * within Sentry. When we call NavigationContainer.onReady and
+ * instantiate Sentry's instrumentation, we end up in a place
+ * where timers are not finishing and we end up timing out our
+ * Detox tests.
+ *
+ * We can handle this by doing the following:
+ * 1. Set up a metro resolver for files ending in .mock.ts
+ * 2. Stub out calls and values in the .mock.ts file
+ * 3. Let metro handle resolving things when it comes across
+ *    process.env.APP_MODE='mocked'
+ *
+ * https://github.com/wix/Detox/blob/master/docs/guide/mocking.md
+ */
+
+export * from './sentry'
+
+export const install = (): void => {}
+
+export const routingInstrumentation = {
+	registerNavigationContainer: (
+		navigationRef: React.MutableRefObject<undefined>,
+	) => {},
+}


### PR DESCRIPTION
We are timing out in our Detox tests due to timers going on within Sentry.

When we call `NavigationContainer.onReady` in `App` and instantiate Sentry's instrumentation, we end up in a place where timers are not finishing and we end up timing out our Detox tests.

We can handle this by doing the following:
1. Set up a metro resolver for files ending in `.mock.ts` when `APP_MODE=mocked`
2. Stub out calls and values in the `.mock.ts` file
3. Let metro handle resolving things when it comes across `process.env.APP_MODE='mocked'`

https://github.com/wix/Detox/blob/master/docs/guide/mocking.md