### PR TITLE
Clean up some of our actions

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,36 @@
+# from https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+
+name: cleanup caches by a branch
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          REPO=${{ github.repository }}
+          BRANCH=${{ github.ref }}
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  node_version: '^16.0'
+  ruby_version: '2.6'
+  xcode_version: 'Xcode_13.1'
+
 jobs:
   format:
     name: Prettier
@@ -15,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: ^16.0
+          node-version: ${{ env.node_version }}
           cache: npm
       - run: npm ci
       - run: npm run pretty -- --no-write --list-different
@@ -27,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: ^16.0
+          node-version: ${{ env.node_version }}
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -39,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: ^16.0
+          node-version: ${{ env.node_version }}
           cache: npm
       - run: npm ci
       - run: npm run bundle-data
@@ -57,7 +62,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: ^16.0
+          node-version: ${{ env.node_version }}
           cache: npm
       - run: npm ci
       - run: npm run bundle-data
@@ -70,7 +75,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: ^16.0
+          node-version: ${{ env.node_version }}
           cache: npm
       - run: npm ci
       - run: npm run validate-data
@@ -83,11 +88,11 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: '^16.0'
+          node-version: ${{ env.node_version }}
           cache: npm
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: ${{ env.ruby_version }}
           bundler-cache: true
       - name: Restore Pods cache
         uses: actions/cache@v3
@@ -96,7 +101,7 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
-      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
+      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
       - run: npm ci
         env: {SKIP_POSTINSTALL: '1'}
       - run: bundle exec pod install --deployment
@@ -109,7 +114,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: ^16.0
+          node-version: ${{ env.node_version }}
           cache: npm
       - run: npm ci
       - run: npm run bundle-data
@@ -122,7 +127,7 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: ^16.0
+          node-version: ${{ env.node_version }}
           cache: npm
       - run: npm ci
       - run: npm run bundle-data
@@ -137,11 +142,11 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: ^16.0
+          node-version: ${{ env.node_version }}
           cache: npm
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: ${{ env.ruby_version }}
           bundler-cache: true
       - name: Restore Gradle cache
         uses: actions/cache@v3
@@ -181,11 +186,11 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
         with:
-          node-version: ^16.0
+          node-version: ${{ env.node_version }}
           cache: npm
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: ${{ env.ruby_version }}
           bundler-cache: true
       - name: Restore Pods cache
         uses: actions/cache@v3
@@ -197,7 +202,7 @@ jobs:
         continue-on-error: true
         with:
           cache_key: ${{ matrix.os }}
-      - run: sudo xcode-select -s /Applications/Xcode_13.1.app
+      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
       - run: npm ci
         env:
           SKIP_POSTINSTALL: '1'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ env:
   xcode_version: 'Xcode_13.1'
 
 jobs:
-  format:
+  prettier:
     name: Prettier
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,9 +62,7 @@ jobs:
         run: npm run test -- --coverage
 
       - name: Upload coverage
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: bash <(curl -s https://codecov.io/bash)
+        uses: codecov/codecov-action@v3
 
   tsc:
     name: TypeScript

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   format:
     name: Prettier
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
@@ -27,7 +27,7 @@ jobs:
 
   eslint:
     name: ESLint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
@@ -39,7 +39,7 @@ jobs:
 
   jest:
     name: Jest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
@@ -57,7 +57,7 @@ jobs:
 
   tsc:
     name: TypeScript
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
@@ -70,7 +70,7 @@ jobs:
 
   data:
     name: Data
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
@@ -109,7 +109,7 @@ jobs:
 
   ios-bundle:
     name: iOS Bundle
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
@@ -122,7 +122,7 @@ jobs:
 
   android-bundle:
     name: Android Bundle
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
       - uses: actions/setup-node@v3
@@ -136,7 +136,7 @@ jobs:
 
   android:
     name: Build for Android
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [jest, eslint, android-bundle]
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,11 +18,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - run: npm ci
+
       - run: npm run pretty -- --no-write --list-different
 
   eslint:
@@ -30,11 +33,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - run: npm ci
+
       - run: npm run lint
 
   jest:
@@ -42,14 +48,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - run: npm ci
+
       - run: npm run bundle-data
+
       - name: Run tests
         run: npm run test -- --coverage
+
       - name: Upload coverage
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -60,12 +71,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - run: npm ci
+
       - run: npm run bundle-data
+
       - run: npx tsc
 
   data:
@@ -73,12 +88,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - run: npm ci
+
       - run: npm run validate-data
+
       - run: npm run bundle-data
 
   ios-pods:
@@ -86,14 +105,17 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}
           bundler-cache: true
+
       - name: Restore Pods cache
         uses: actions/cache@v3
         with:
@@ -101,9 +123,12 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-pods-
+
       - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
+
       - run: npm ci
         env: {SKIP_POSTINSTALL: '1'}
+
       - run: bundle exec pod install --deployment
         working-directory: ./ios
 
@@ -112,12 +137,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - run: npm ci
+
       - run: npm run bundle-data
+
       - run: npm run bundle:ios
 
   android-bundle:
@@ -125,13 +154,18 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - run: npm ci
+
       - run: npm run bundle-data
+
       - run: mkdir -p ./android/app/src/main/assets/
+
       - run: npm run bundle:android
 
   android:
@@ -140,14 +174,17 @@ jobs:
     needs: [jest, eslint, android-bundle]
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}
           bundler-cache: true
+
       - name: Restore Gradle cache
         uses: actions/cache@v3
         with:
@@ -157,15 +194,20 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
       - run: npm ci
+
       - name: Raise the fs.inotify ulimits to 524288 watches/queued events/user instances
         run: |
           echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_watches
           echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_queued_events
           echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_instances
           sudo sysctl -p
+
       - run: echo 'org.gradle.workers.max=2' >> ./android/gradle.properties
+
       - run: cd android && ./gradlew androidDependencies --console=plain
+
       - run: bundle exec fastlane android ci-run
         env:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}
@@ -184,31 +226,42 @@ jobs:
     needs: [jest, eslint, ios-bundle, ios-pods]
     steps:
       - uses: actions/checkout@v3.3.0
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
           cache: npm
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}
           bundler-cache: true
+
       - name: Restore Pods cache
         uses: actions/cache@v3
         with:
           path: ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
           restore-keys: ${{ runner.os }}-pods-
+
       - uses: mikehardy/buildcache-action@v2
         continue-on-error: true
         with:
           cache_key: ${{ matrix.os }}
+
       - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
+
       - run: npm ci
         env:
           SKIP_POSTINSTALL: '1'
+
       - run: bundle exec pod install --deployment
         working-directory: ./ios
+
       - run: brew tap wix/brew
+
       - run: brew install applesimutils
+
       - run: npx detox build e2e --configuration ios.sim.release
+
       - run: npx detox test e2e --configuration ios.sim.release --cleanup  --debug-synchronization 500

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,10 @@ name: Check
 on:
   push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format:
     name: Prettier

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+# example taken from https://github.com/actions/dependency-review-action
+
+name: 'Dependency Review'
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v3

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -4,3 +4,5 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+# update sha256sum via https://gradle.org/release-checksums/#:~:text=v7.3.3-,Binary
+distributionSha256Sum=c9490e938b221daf0094982288e4038deed954a3f12fb54cbf270ddf4e37d879


### PR DESCRIPTION
extracted from #6761

## implement auto-cache-cleanup workflow
When a PR is merged, there's no point to keeping around the caches from that branch, as GitHub won't use them anywhere else.

This workflow, taken from https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries, automatically cleans up branch-specific cache entries.

## add `distributionSha256Sum` to `gradle-wrapper.properties`
Grab-bag item: this asks our gradle wrapper to validate the gradle download. Gradle has started to warn us about not having this.

## auto-cancel in-progress jobs on subsequent commit to the same branch
I figured this would be nice - there's not much point in keeping the old jobs around (aside from seeing all of the nice green checkmarks).

## centralize global versions for languages and Xcode
I figured out how to centralize and share the versions of languages and Xcode!

## upgrade linux runners to ubuntu-22.04
I wanted to upgrade our version of Ubuntu.

## make the Prettier job's ID match its name
It used to be `format:`; now it is `prettier:`.

## add whitespace to "check" workflow jobs
I did this on another branch, and it makes it much more pleasant to work with these jobs!

## add new "dependency review" workflow
> This action scans your pull requests for dependency changes, and will raise an error if any vulnerabilities or invalid licenses are being introduced.

from https://github.com/actions/dependency-review-action

## switch codecov from the bash uploader to their action
TIL that Codecov has deprecated their Bash uploader in favor of this action/an underlying binary uploader.

See https://about.codecov.io/blog/introducing-codecovs-new-uploader/ for more details.
