### PR TITLE
Implement job caching in GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -276,10 +276,15 @@ jobs:
 
   ios-bundle:
     name: iOS Bundle
-    needs: [cache-npm-linux]
-    runs-on: ubuntu-22.04
+    needs: [cache-npm-macos]
+    runs-on: macos-11
+    outputs:
+      cache-key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
     steps:
       - uses: actions/checkout@v3.3.0
+
+      - name: Extract job definition
+        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
       - uses: actions/setup-node@v3
         with:
@@ -290,14 +295,35 @@ jobs:
         id: node-cache
         with:
           path: node_modules/
-          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
+          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
 
       - if: steps.node-cache.outputs.cache-hit != 'true'
         run: exit 1
 
-      - run: npm run bundle-data
+      - name: Cache the jsbundle
+        uses: actions/cache/restore@v3
+        id: jsbundle-cache
+        with:
+          path: |
+            ios/AllAboutOlaf/main.jsbundle
+            ios/AllAboutOlaf/main.jsbundle.map
+            ios/assets/
+          key: ${{ runner.os }}-jsbundle-node@${{ env.node_version }}-${{ hashFiles('package.json', 'package-lock.json', '.github/job.yml','tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
 
-      - run: npm run bundle:ios
+      - name: Generate jsbundle
+        if: steps.jsbundle-cache.outputs.cache-hit != 'true'
+        run: |
+          npm run bundle-data
+          npm run bundle:ios
+
+      - uses: actions/cache/save@v3
+        if: steps.jsbundle-cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            ios/AllAboutOlaf/main.jsbundle
+            ios/AllAboutOlaf/main.jsbundle.map
+            ios/assets/
+          key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
 
   android-bundle:
     name: Android Bundle

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,8 +13,71 @@ env:
   xcode_version: 'Xcode_13.1'
 
 jobs:
+  cache-npm-linux:
+    name: Cache npm for Linux
+    runs-on: ubuntu-22.04
+    outputs:
+      cache-key: ${{ steps.node-cache.outputs.cache-primary-key }}
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - name: Extract job definition
+        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
+
+      - uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ runner.os }}-npm-node@${{ env.node_version }}-${{ hashFiles('package-lock.json', '.github/job.yml') }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - uses: actions/cache/save@v3
+        with:
+          path: node_modules/
+          key: ${{ steps.node-cache.outputs.cache-primary-key }}
+
+  cache-npm-macos:
+    name: Cache npm for macOS
+    runs-on: macos-11
+    outputs:
+      cache-key: ${{ steps.node-cache.outputs.cache-primary-key }}
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - name: Extract job definition
+        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
+
+      - uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ runner.os }}-npm-node@${{ env.node_version }}-${{ hashFiles('package-lock.json', '.github/job.yml') }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node_version }}
+          cache: npm
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - uses: actions/cache/save@v3
+        with:
+          path: node_modules/
+          key: ${{ steps.node-cache.outputs.cache-primary-key }}
+
   prettier:
     name: Prettier
+    needs: [cache-npm-linux]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
@@ -22,14 +85,22 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
 
-      - run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - run: npm run pretty -- --no-write --list-different
 
   eslint:
     name: ESLint
+    needs: [cache-npm-linux]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
@@ -37,14 +108,22 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
 
-      - run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - run: npm run lint
 
   jest:
     name: Jest
+    needs: [cache-npm-linux]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
@@ -52,9 +131,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
 
-      - run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - run: npm run bundle-data
 
@@ -66,6 +152,7 @@ jobs:
 
   tsc:
     name: TypeScript
+    needs: [cache-npm-linux]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
@@ -73,9 +160,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
 
-      - run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - run: npm run bundle-data
 
@@ -83,6 +177,7 @@ jobs:
 
   data:
     name: Data
+    needs: [cache-npm-linux]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
@@ -90,9 +185,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
 
-      - run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - run: npm run validate-data
 
@@ -100,6 +202,7 @@ jobs:
 
   ios-pods:
     name: iOS Cocoapods
+    needs: [cache-npm-macos]
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3.3.0
@@ -107,7 +210,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -124,14 +236,12 @@ jobs:
 
       - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
 
-      - run: npm ci
-        env: {SKIP_POSTINSTALL: '1'}
-
       - run: bundle exec pod install --deployment
         working-directory: ./ios
 
   ios-bundle:
     name: iOS Bundle
+    needs: [cache-npm-linux]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
@@ -139,9 +249,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
 
-      - run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - run: npm run bundle-data
 
@@ -149,6 +266,7 @@ jobs:
 
   android-bundle:
     name: Android Bundle
+    needs: [cache-npm-linux]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
@@ -156,9 +274,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
 
-      - run: npm ci
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - run: npm run bundle-data
 
@@ -168,15 +293,24 @@ jobs:
 
   android:
     name: Build for Android
+    needs: [jest, eslint, android-bundle, cache-npm-linux]
     runs-on: ubuntu-22.04
-    needs: [jest, eslint, android-bundle]
     steps:
       - uses: actions/checkout@v3.3.0
 
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -192,8 +326,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-
-      - run: npm ci
 
       - name: Raise the fs.inotify ulimits to 524288 watches/queued events/user instances
         run: |
@@ -220,15 +352,24 @@ jobs:
 
   ios:
     name: Build for iOS
+    needs: [jest, eslint, ios-bundle, ios-pods, cache-npm-macos]
     runs-on: macos-11
-    needs: [jest, eslint, ios-bundle, ios-pods]
     steps:
       - uses: actions/checkout@v3.3.0
 
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          cache: npm
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
+
+      - if: steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -248,10 +389,6 @@ jobs:
           cache_key: ${{ matrix.os }}
 
       - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
-
-      - run: npm ci
-        env:
-          SKIP_POSTINSTALL: '1'
 
       - run: bundle exec pod install --deployment
         working-directory: ./ios

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -570,4 +570,10 @@ jobs:
       - run: brew install applesimutils
 
       - name: Run the Detox tests
-        run: npx detox test e2e --configuration ios.sim.release --cleanup
+        run: npx detox test e2e --configuration ios.sim.release --cleanup --record-logs failing --record-videos failing --record-performance all --capture-view-hierarchy enabled --take-screenshots failing
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: detox-ios
+          path: artifacts/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -75,6 +75,28 @@ jobs:
           path: node_modules/
           key: ${{ steps.node-cache.outputs.cache-primary-key }}
 
+  cache-bundler-linux:
+    name: Cache bundler for Linux
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.ruby_version }}
+          bundler-cache: true
+
+  cache-bundler-macos:
+    name: Cache bundler for macOS
+    runs-on: macos-11
+    steps:
+      - uses: actions/checkout@v3.3.0
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.ruby_version }}
+          bundler-cache: true
+
   prettier:
     name: Prettier
     needs: [cache-npm-linux]
@@ -202,7 +224,7 @@ jobs:
 
   ios-pods:
     name: iOS Cocoapods
-    needs: [cache-npm-macos]
+    needs: [cache-npm-macos, cache-bundler-macos]
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3.3.0
@@ -293,7 +315,7 @@ jobs:
 
   android:
     name: Build for Android
-    needs: [jest, eslint, android-bundle, cache-npm-linux]
+    needs: [jest, eslint, android-bundle, cache-npm-linux, cache-bundler-linux]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3.3.0
@@ -352,7 +374,7 @@ jobs:
 
   ios:
     name: Build for iOS
-    needs: [jest, eslint, ios-bundle, ios-pods, cache-npm-macos]
+    needs: [jest, eslint, ios-bundle, ios-pods, cache-npm-macos, cache-bundler-macos]
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v3.3.0

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -369,7 +369,7 @@ jobs:
           npm run bundle:android
 
       - name: Cache the jsbundle
-        uses: actions/cache/restore@v3
+        uses: actions/cache/save@v3
         with:
           path: |
             ./android/app/src/main/assets/index.android.bundle

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -300,7 +300,7 @@ jobs:
       - if: steps.node-cache.outputs.cache-hit != 'true'
         run: exit 1
 
-      - name: Cache the jsbundle
+      - name: Load the cached jsbundle
         uses: actions/cache/restore@v3
         id: jsbundle-cache
         with:
@@ -316,7 +316,8 @@ jobs:
           npm run bundle-data
           npm run bundle:ios
 
-      - uses: actions/cache/save@v3
+      - name: Cache the jsbundle
+        uses: actions/cache/save@v3
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         with:
           path: |
@@ -351,7 +352,7 @@ jobs:
       - if: steps.node-cache.outputs.cache-hit != 'true'
         run: exit 1
 
-      - name: Restore the jsbundle
+      - name: Load the cached jsbundle
         uses: actions/cache/restore@v3
         id: jsbundle-cache
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,6 +97,58 @@ jobs:
           ruby-version: ${{ env.ruby_version }}
           bundler-cache: true
 
+  cache-cocoapods:
+    name: iOS Cocoapods
+    needs: [cache-npm-macos, cache-bundler-macos]
+    runs-on: macos-11
+    outputs:
+      cache-key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
+    steps:
+      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
+
+      - uses: actions/checkout@v3.3.0
+
+      - name: Extract job definition
+        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
+
+      - name: Restore Cocoapods cache
+        uses: actions/cache/restore@v3
+        id: cocoapods-cache
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-cocoapods-ruby@${{ env.ruby_version }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/Podfile.lock', 'package-lock.json', '.github/job.yml') }}
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.node_version }}
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.ruby_version }}
+          bundler-cache: true
+
+      - name: Restore node_modules cache
+        if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true' && steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        run: bundle exec pod install --deployment
+        working-directory: ./ios
+
+      - uses: actions/cache/save@v3
+        with:
+          path: ios/Pods
+          key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
+
   prettier:
     name: Prettier
     needs: [cache-npm-linux]
@@ -221,45 +273,6 @@ jobs:
       - run: npm run validate-data
 
       - run: npm run bundle-data
-
-  ios-pods:
-    name: iOS Cocoapods
-    needs: [cache-npm-macos, cache-bundler-macos]
-    runs-on: macos-11
-    steps:
-      - uses: actions/checkout@v3.3.0
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.node_version }}
-
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@v3
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.ruby_version }}
-          bundler-cache: true
-
-      - name: Restore Pods cache
-        uses: actions/cache@v3
-        with:
-          path: ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pods-
-
-      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
-
-      - run: bundle exec pod install --deployment
-        working-directory: ./ios
 
   ios-bundle:
     name: iOS Bundle
@@ -398,12 +411,16 @@ jobs:
           ruby-version: ${{ env.ruby_version }}
           bundler-cache: true
 
-      - name: Restore Pods cache
-        uses: actions/cache@v3
+      - name: Restore Cocoapods cache
+        uses: actions/cache/restore@v3
+        id: pods-cache
         with:
           path: ios/Pods
-          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
-          restore-keys: ${{ runner.os }}-pods-
+          key: ${{ needs.cache-cocoapods.outputs.cache-key }}
+
+      - name: exit if the Cocoapods cache did not load
+        if: steps.pods-cache.outputs.cache-hit != 'true'
+        run: exit 1
 
       - uses: mikehardy/buildcache-action@v2
         continue-on-error: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -329,8 +329,13 @@ jobs:
     name: Android Bundle
     needs: [cache-npm-linux]
     runs-on: ubuntu-22.04
+    outputs:
+      cache-key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
     steps:
       - uses: actions/checkout@v3.3.0
+
+      - name: Extract job definition
+        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
       - uses: actions/setup-node@v3
         with:
@@ -346,11 +351,31 @@ jobs:
       - if: steps.node-cache.outputs.cache-hit != 'true'
         run: exit 1
 
-      - run: npm run bundle-data
+      - name: Restore the jsbundle
+        uses: actions/cache/restore@v3
+        id: jsbundle-cache
+        with:
+          path: |
+            ./android/app/src/main/assets/index.android.bundle
+            ./android/app/src/main/assets/index.android.bundle.map
+            ./android/app/src/main/res/
+          key: ${{ runner.os }}-npm-node@${{ env.node_version }}-pkg@${{ hashFiles('package.json', 'package-lock.json', '.github/job.yml') }}-files@${{ hashFiles('tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
 
-      - run: mkdir -p ./android/app/src/main/assets/
+      - name: Generate jsbundle
+        if: steps.jsbundle-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ./android/app/src/main/assets/
+          npm run bundle-data
+          npm run bundle:android
 
-      - run: npm run bundle:android
+      - name: Cache the jsbundle
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ./android/app/src/main/assets/index.android.bundle
+            ./android/app/src/main/assets/index.android.bundle.map
+            ./android/app/src/main/res/
+          key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
 
   android:
     name: Build for Android

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -308,7 +308,7 @@ jobs:
             ios/AllAboutOlaf/main.jsbundle
             ios/AllAboutOlaf/main.jsbundle.map
             ios/assets/
-          key: ${{ runner.os }}-jsbundle-node@${{ env.node_version }}-${{ hashFiles('package.json', 'package-lock.json', '.github/job.yml','tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
+          key: ${{ runner.os }}-jsbundle-node@${{ env.node_version }}-${{ hashFiles('package.json', 'package-lock.json', '.github/job.yml', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
 
       - name: Generate jsbundle
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,6 +40,7 @@ jobs:
         run: npm ci
 
       - uses: actions/cache/save@v3
+        if: steps.node-cache.outputs.cache-hit != 'true'
         with:
           path: node_modules/
           key: ${{ steps.node-cache.outputs.cache-primary-key }}
@@ -71,6 +72,7 @@ jobs:
         run: npm ci
 
       - uses: actions/cache/save@v3
+        if: steps.node-cache.outputs.cache-hit != 'true'
         with:
           path: node_modules/
           key: ${{ steps.node-cache.outputs.cache-primary-key }}
@@ -144,7 +146,9 @@ jobs:
         run: bundle exec pod install --deployment
         working-directory: ./ios
 
-      - uses: actions/cache/save@v3
+      - name: Save Cocoapods cache
+        uses: actions/cache/save@v3
+        if: steps.cocoapods-cache.outputs.cache-hit != 'true'
         with:
           path: ios/Pods
           key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
@@ -370,6 +374,7 @@ jobs:
           npm run bundle:android
 
       - name: Cache the jsbundle
+        if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v3
         with:
           path: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -570,4 +570,4 @@ jobs:
       - run: brew install applesimutils
 
       - name: Run the Detox tests
-        run: npx detox test e2e --configuration ios.sim.release --cleanup --debug-synchronization 500
+        run: npx detox test e2e --configuration ios.sim.release --cleanup

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -436,12 +436,118 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_SENTRY_AUTH_TOKEN }}
           GITHUB_KEYS_REPOSITORY_TOKEN: ${{ secrets.GITHUB_KEYS_REPOSITORY_TOKEN }}
 
-  ios:
+  ios-build:
     name: Build for iOS
-    needs: [jest, eslint, ios-bundle, ios-pods, cache-npm-macos, cache-bundler-macos]
+    needs: [jest, eslint, cache-cocoapods, cache-npm-macos, cache-bundler-macos]
+    runs-on: macos-11
+    outputs:
+      cache-key: ${{ steps.app-cache.outputs.cache-primary-key }}
+    steps:
+      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
+
+      - uses: actions/checkout@v3.3.0
+
+      - name: Extract job definition
+        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
+
+      - name: Check for cached iOS app
+        id: app-cache
+        uses: actions/cache/restore@v3
+        with:
+          path: ios/build/Build/Products/
+          key: ${{ runner.os }}-ios-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', '**/Podfile.lock', 'package-lock.json', '.github/job.yml') }}
+
+      - uses: actions/setup-node@v3
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        with:
+          node-version: ${{ env.node_version }}
+
+      - name: Restore node_modules cache
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@v3
+        id: node-cache
+        with:
+          path: node_modules/
+          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
+
+      - name: exit if the node_modules cache did not load
+        if: steps.app-cache.outputs.cache-hit != 'true' && steps.node-cache.outputs.cache-hit != 'true'
+        run: exit 1
+
+      - uses: ruby/setup-ruby@v1
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        with:
+          ruby-version: ${{ env.ruby_version }}
+          bundler-cache: true
+
+      - name: Restore Cocoapods cache
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@v3
+        id: pods-cache
+        with:
+          path: ios/Pods
+          key: ${{ needs.cache-cocoapods.outputs.cache-key }}
+
+      - name: exit if the Cocoapods cache did not load
+        if: steps.app-cache.outputs.cache-hit != 'true' && steps.pods-cache.outputs.cache-hit != 'true'
+        run: exit 1
+
+      - uses: mikehardy/buildcache-action@v2
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        continue-on-error: true
+        with:
+          cache_key: ${{ matrix.os }}
+
+      - name: Build the iOS app
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        run: npx detox build e2e --configuration ios.sim.release
+
+      - name: Cache the iOS app
+        uses: actions/cache/save@v3
+        with:
+          path: ios/build/Build/Products/
+          key: ${{ steps.app-cache.outputs.cache-primary-key }}
+
+  ios-detox:
+    name: Detox E2E for iOS
+    needs: [cache-npm-macos, ios-build, ios-bundle]
     runs-on: macos-11
     steps:
+      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
+
       - uses: actions/checkout@v3.3.0
+
+      - # load the app before reinstalling detox, so that the package-lock cannot change
+        name: Load the cached iOS app
+        uses: actions/cache/restore@v3
+        id: app-cache
+        with:
+          path: ios/build/Build/Products/
+          key: ${{ needs.ios-build.outputs.cache-key }}
+
+      - if: steps.app-cache.outputs.cache-hit != 'true'
+        run: exit 1
+
+      - # load the jsbundle before reinstalling detox, so that the package-lock cannot change
+        name: Load the cached iOS jsbundle
+        uses: actions/cache/restore@v3
+        id: jsbundle-cache
+        with:
+          path: |
+            ios/AllAboutOlaf/main.jsbundle
+            ios/AllAboutOlaf/main.jsbundle.map
+            ios/assets/
+          key: ${{ needs.ios-bundle.outputs.cache-key }}
+
+      - if: steps.jsbundle-cache.outputs.cache-hit != 'true'
+        run: exit 1
+
+      - name: Move cached jsbundle into place
+        run: |
+          mv ios/AllAboutOlaf/main.jsbundle ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+          mv ios/AllAboutOlaf/main.jsbundle.map ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+          rm -rf ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/assets
+          mv ios/assets ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
 
       - uses: actions/setup-node@v3
         with:
@@ -454,39 +560,13 @@ jobs:
           path: node_modules/
           key: ${{ needs.cache-npm-macos.outputs.cache-key }}
 
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.ruby_version }}
-          bundler-cache: true
-
-      - name: Restore Cocoapods cache
-        uses: actions/cache/restore@v3
-        id: pods-cache
-        with:
-          path: ios/Pods
-          key: ${{ needs.cache-cocoapods.outputs.cache-key }}
-
-      - name: exit if the Cocoapods cache did not load
-        if: steps.pods-cache.outputs.cache-hit != 'true'
-        run: exit 1
-
-      - uses: mikehardy/buildcache-action@v2
-        continue-on-error: true
-        with:
-          cache_key: ${{ matrix.os }}
-
-      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
-
-      - run: bundle exec pod install --deployment
-        working-directory: ./ios
+      - # We have to poke Detox because it installs things outside of node_modules/detox/…
+        name: Re-install Detox
+        run: npx detox clean-framework-cache && npx detox build-framework-cache
 
       - run: brew tap wix/brew
 
       - run: brew install applesimutils
 
-      - run: npx detox build e2e --configuration ios.sim.release
-
-      - run: npx detox test e2e --configuration ios.sim.release --cleanup  --debug-synchronization 500
+      - name: Run the Detox tests
+        run: npx detox test e2e --configuration ios.sim.release --cleanup --debug-synchronization 500


### PR DESCRIPTION
the rest of #6761

## add (and use) "cache npm" jobs for each platform
Turns out, we can cache the `node_modules` folder itself! It's a lot faster(™) to unpack one tarball than to invoke npm and have it unpack everything.

## create "cache bundler" jobs for each platform
While we're at it, I went ahead and made early jobs to prime the Bundler cache.

## rework the "cache cocoapods" job
I used a lot of new knowledge about GitHub Actions caching to improve caching in the Cocoapods job.

## generate the iOS jsbundle on macos, and cache it for later use (and "make android-bundle step cache itself like the iOS one does")
It turns out that we can just ... replace the .jsbundle in the compiled app, instead of having to compile the native world on every commit!

So now the iOS (and Android) bundle jobs save their artifacts for a later step to use (Android's build process doesn't inject the new bundle yet, though.)

## rework the iOS "build" phase
1. split up the "build app" and "detox app" tasks into two jobs
2. during detox, insert the cached jsbundle into the compiled app
3. only recompile the app on an Xcode, project, package-lock, or podfile.lock change

---

The short version is, if you only change some JS code, we can finish the e2e tests in about 6 minutes because we don't have to recompile the app!

&nbsp;                | Before    | After (no cache) | After (cached) |
--------------------- | ---------:| ----------------:| --------------:|
Duration - Wall Clock | `33m 47s` | `51m 11s`                 | `10m 11s` |
Duration - Sum        | `51m 40s` |        `1h 8m 42s` |  `19m 52s`              |
Cache Bundler (Linux) | n/a       | `20s` | `21s` |
Cache Bundler (macOS) | n/a       | `26s` | `23s` |
Cache npm (Linux)     | n/a       | `40s` | `11s` |
Cache npm (macOS)     | n/a       | `1m 58s` | `40s` |
ESLint                | `58s` |          `33s` |   `22s`             |
Validate Data         | `36s` |          `15s` |         `14s`       |
Jest                  | `1m 25s` |          `42s` |       `53s`         |
Prettier              | `51s` |          `15s` |       `20s`         |
tsc                   | `46s` |          `25s` |      `33s`          |
Android Bundle        | `2m 44s` |          `2m 22s` |     `1m 48s`           |
Android Build         | `7m 43s` |          `8m 38s` |        `4m 32s`        |
iOS Bundle            | `3m 52s` |          `4m 12s` |      `2m 52s`          |
iOS Cocoapods Check   | `3m 14s` |          `7m 48s` |        `26s`        |
iOS Build             | `29m 31s` |          `34m 52s` |        `22s`        |
iOS Detox             | ~(9m 21s) |          `5m 16s` |         `5m 55s`       |

> These times don't fully make sense because we had some limited caching in the old system as well, so I don't full have un-cached times for that one. Also, the "bundle" times above are incorrect - there was a bug where they wouldn't early-exit if the cache was hit, so they ran every time. I don't know why iOS' bundle went from 4m12s to 2m52s…