### PR TITLE
allow running "build + deploy" manually

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -2,6 +2,7 @@ name: Build and Deploy
 
 on:
   # push:
+  workflow_dispatch:
   schedule:
     - cron: '17 8 * * *'
 


### PR DESCRIPTION
Per
https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow, we can choose the branch to run from when triggering this workflow.

Closes #6803