### PR TITLE
Publish Gradle build scans automatically (and accept Gradle's TOS in CI)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -418,7 +418,7 @@ jobs:
   
       - name: Run Gradle
         run: ./gradlew bundleRelease --scan
-        working-directory: androind 
+        working-directory: android
         env:
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,8 @@
 name: Check
 
 on:
-  push:
+  push: {branches: [master]}
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -409,25 +410,17 @@ jobs:
           echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_instances
           sudo sysctl -p
 
-      - name: Setup Gradle
+      - name: Gradle
+        id: gradle
         uses: gradle/gradle-build-action@v2
         with:
+          arguments: bundleRelease --scan
           build-root-directory: android
           gradle-home-cache-cleanup: true
-
-      - name: Gradle
-        run: ./gradlew bundleRelease
-        working-directory: android
         env:
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf
           SKIP_BUNDLING: 'true'
-
-      - name: Upload build reports
-        uses: actions/upload-artifact@v3
-        with:
-          name: build-reports
-          path: build/reports/
 
       - name: "Add build scan URL as PR comment"
         uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6
@@ -441,6 +434,12 @@ jobs:
               repo: context.repo.repo,
               body: '❌ ${{ github.workflow }} failed: ${{ steps.gradle.outputs.build-scan-url }}'
             })
+  
+      - name: Upload build reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-reports
+          path: build/reports/
 
   ios-build:
     name: Build for iOS

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -416,7 +416,7 @@ jobs:
           gradle-home-cache-cleanup: true
 
       - name: Gradle
-        run: ./gradlew bundleRelease --scan
+        run: ./gradlew bundleRelease
         working-directory: android
         env:
           SENTRY_ORG: frog-pond-labs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -410,31 +410,20 @@ jobs:
           echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_instances
           sudo sysctl -p
 
-      - name: Gradle
-        id: gradle
+      - name: Set Up Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: bundleRelease --scan
           build-root-directory: android
           gradle-home-cache-cleanup: true
+  
+      - name: Run Gradle
+        run: ./gradlew bundleRelease --scan
+        working-directory: androind 
         env:
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf
           SKIP_BUNDLING: 'true'
 
-      - name: "Add build scan URL as PR comment"
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6
-        if: github.event_name == 'pull_request' && failure()
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '❌ ${{ github.workflow }} failed: ${{ steps.gradle.outputs.build-scan-url }}'
-            })
-  
       - name: Upload build reports
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -410,15 +410,12 @@ jobs:
           echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_instances
           sudo sysctl -p
 
-      - name: Set Up Gradle
+      - name: Gradle
         uses: gradle/gradle-build-action@v2
         with:
+          arguments: bundleRelease --scan
           build-root-directory: android
           gradle-home-cache-cleanup: true
-  
-      - name: Run Gradle
-        run: ./gradlew bundleRelease --scan
-        working-directory: android
         env:
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -100,3 +100,20 @@ subprojects {
         }
     }
 }
+
+// Cache build artifacts, so expensive operations do not need to be re-computed
+def isCiServer = System.getenv().containsKey("CI")
+buildCache {
+    local {
+        enabled(!isCiServer)
+    }
+}
+
+// Auto-accept Gradle's TOS (but only in CI!)
+if (isCiServer && hasProperty('buildScan')) {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+        publishOnFailure()
+    }
+}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33
-        kotlinVersion = '1.8'
+        kotlinVersion = '1.6.10'
         // react-native-inappbrowser-reborn was using a 1.+ which pulled in an alpha which is very bad
         // - we will want to upgrade to 1.5.0 when we support minsdk 33
         // - we can delete this when inappbrowser-reborn changes their build script to avoid this pattern

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33
-        kotlinVersion = '1.6.10'
+        kotlinVersion = '1.8'
         // react-native-inappbrowser-reborn was using a 1.+ which pulled in an alpha which is very bad
         // - we will want to upgrade to 1.5.0 when we support minsdk 33
         // - we can delete this when inappbrowser-reborn changes their build script to avoid this pattern

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -101,14 +101,7 @@ subprojects {
     }
 }
 
-// Cache build artifacts, so expensive operations do not need to be re-computed
 def isCiServer = System.getenv().containsKey("CI")
-buildCache {
-    local {
-        enabled(!isCiServer)
-    }
-}
-
 // Auto-accept Gradle's TOS (but only in CI!)
 if (isCiServer && hasProperty('buildScan')) {
     buildScan {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -107,6 +107,5 @@ if (isCiServer && hasProperty('buildScan')) {
     buildScan {
         termsOfServiceUrl = 'https://gradle.com/terms-of-service'
         termsOfServiceAgree = 'yes'
-        publishOnFailure()
     }
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -17,3 +17,11 @@ buildCache {
        enabled(!isCiServer)
    }
 }
+
+// Auto-accept Gradle's TOS (but only in CI!)
+if (isCiServer && hasProperty('buildScan')) {
+    buildScan {
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -9,19 +9,3 @@ if (settings.hasProperty("newArchEnabled") && settings.newArchEnabled == "true")
     include(":ReactAndroid")
     project(":ReactAndroid").projectDir = file('../node_modules/react-native/ReactAndroid')
 }
-
-// Cache build artifacts, so expensive operations do not need to be re-computed
-boolean isCiServer = System.getenv().containsKey("CI")
-buildCache {
-   local {
-       enabled(!isCiServer)
-   }
-}
-
-// Auto-accept Gradle's TOS (but only in CI!)
-if (isCiServer && hasProperty('buildScan')) {
-    buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
-    }
-}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -9,6 +9,7 @@ if (settings.hasProperty("newArchEnabled") && settings.newArchEnabled == "true")
     include(":ReactAndroid")
     project(":ReactAndroid").projectDir = file('../node_modules/react-native/ReactAndroid')
 }
+
 // Cache build artifacts, so expensive operations do not need to be re-computed
 def isCiServer = System.getenv().containsKey("CI")
 buildCache {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -9,3 +9,10 @@ if (settings.hasProperty("newArchEnabled") && settings.newArchEnabled == "true")
     include(":ReactAndroid")
     project(":ReactAndroid").projectDir = file('../node_modules/react-native/ReactAndroid')
 }
+// Cache build artifacts, so expensive operations do not need to be re-computed
+def isCiServer = System.getenv().containsKey("CI")
+buildCache {
+    local {
+        enabled(!isCiServer)
+    }
+}


### PR DESCRIPTION
I've got the Android Build task set up to auto-publish Gradle scans, but we need to accept the Gradle TOS. I've now got that configured to only happen on CI.

Published Gradle scans expire after 90 days.