### PR TITLE
skip bundling process on android native builds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -421,6 +421,7 @@ jobs:
         env:
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf
+          SKIP_BUNDLING: 'true'
 
       - name: Upload build reports
         uses: actions/upload-artifact@v3

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -78,12 +78,16 @@ import org.apache.tools.ant.taskdefs.condition.Os
  * ]
  */
 
+def skipBundling = System.getenv().containsKey("SKIP_BUNDLING")
+
 project.ext.react = [
     // ignore the ruby deps
     inputExcludes: ["android/**", "ios/**", "vendor/**"],
     // set the input file manually
     entryFile: "index.js",
     enableHermes: true,  // clean and rebuild if changing
+    bundleInDebug: !skipBundling,
+    bundleInRelease: !skipBundling,
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -11,7 +11,7 @@ if (settings.hasProperty("newArchEnabled") && settings.newArchEnabled == "true")
 }
 
 // Cache build artifacts, so expensive operations do not need to be re-computed
-boolean isCiServer = System.getenv().containsKey("CI")
+def isCiServer = System.getenv().containsKey("CI")
 buildCache {
    local {
        enabled(!isCiServer)


### PR DESCRIPTION
a followup to #6840

Because we manually insert a JSBundle for Detox testing and caching reasons, let's skip the bundling process at compile time!
