### PR TITLE
add workflow to validate that a gradle wrapper is official

### DIFF
--- a/.github/workflows/validate-gradle-wrapper.yml
+++ b/.github/workflows/validate-gradle-wrapper.yml
@@ -1,0 +1,17 @@
+# example taken from https://github.com/marketplace/actions/gradle-wrapper-validation#add-a-new-dedicated-workflow
+
+name: "Validate Gradle Wrapper"
+
+on:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: "Validation"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
I still don't know why Gradle has this wrapper thing in the first place, but they have an official GitHub Action to validate it:

https://github.com/marketplace/actions/gradle-wrapper-validation

Seems like a good idea.