### PR TITLE
stop widening peerDep ranges for custom modules

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -45,6 +45,12 @@
     {
       "matchPackageNames": ["com.facebook.react:react-native", "org.webkit:android-jsc"],
       "enabled": false
+    },
+    // stop widening peerDep ranges for custom modules
+    {
+      "matchPaths": ["modules/**/package.json"],
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
as seen in https://github.com/StoDevX/AAO-React-Native/pull/6827

Once this merges, I'll ask Renovate to recreate #6827 and see what happens.