### PR TITLE
fix android bundling on deploy workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -60,6 +60,7 @@ jobs:
           sudo sysctl -p
       - run: echo 'org.gradle.workers.max=2' >> ./android/gradle.properties
       - run: cd android && ./gradlew androidDependencies --console=plain
+      - run: npm run bundle-data
       - run: bundle exec fastlane android ci-run
         env:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}


### PR DESCRIPTION
https://github.com/StoDevX/AAO-React-Native/actions/runs/4038275500/jobs/6942159080

Maybe bundle-data isn’t being processed as a required step anymore?