### PR TITLE
Codecov in GitHub Actions

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
 
   status:
     project: false
-    patch: false
+    patch: true
     changes: false
 
 parsers:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    require_ci_to_pass: yes
+    require_ci_to_pass: true
 
 coverage:
   precision: 2
@@ -8,19 +8,19 @@ coverage:
   range: '70...100'
 
   status:
-    project: no
-    patch: no
-    changes: no
+    project: false
+    patch: false
+    changes: false
 
 parsers:
   gcov:
     branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
+      conditional: true
+      loop: true
+      method: false
+      macro: false
 
 comment:
   layout: 'diff'
   behavior: default
-  require_changes: no
+  require_changes: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 coverage:
   precision: 2
   round: down
-  range: '8...100'
+  range: 8...100
 
   status:
     project: false
@@ -17,7 +17,7 @@ parsers:
       macro: false
 
 comment:
-  layout: 'diff'
+  layout: diff
   behavior: default
   require_changes: true
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,4 +23,3 @@ comment:
 
 github_checks:
   annotations: false
- 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 coverage:
   precision: 2
   round: down
-  range: '70...100'
+  range: '8...100'
 
   status:
     project: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,3 @@
-codecov:
-  notify:
-    require_ci_to_pass: true
-
 coverage:
   precision: 2
   round: down

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,4 +23,4 @@ parsers:
 comment:
   layout: 'diff'
   behavior: default
-  require_changes: false
+  require_changes: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 coverage:
   precision: 2
   round: down
-  range: "8...100"
+  range: '8...100'
 
   status:
     project: false
@@ -17,7 +17,7 @@ parsers:
       macro: false
 
 comment:
-  layout: "diff"
+  layout: 'diff'
   behavior: default
   require_changes: true
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,3 +20,6 @@ comment:
   layout: 'diff'
   behavior: default
   require_changes: true
+
+github_checks:
+  annotations: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 coverage:
   precision: 2
   round: down
-  range: '8...100'
+  range: "8...100"
 
   status:
     project: false
@@ -17,9 +17,10 @@ parsers:
       macro: false
 
 comment:
-  layout: 'diff'
+  layout: "diff"
   behavior: default
   require_changes: true
 
 github_checks:
   annotations: false
+ 


### PR DESCRIPTION
I want Codecov to report itself in the GitHub Checks section of a PR. I also made it not report a comment if the coverage has not changed. 

https://docs.codecov.com/docs/github-checks

I also cleaned up the config a bit. 

Finally, I increased the allowable coverage range to >= 8%, because that’s where we are today. As we increase our coverage, we should increase this number!

Example of what the check looks like:

<img src=https://user-images.githubusercontent.com/464441/215367085-4f254325-6701-4164-8e48-ba04b486306b.png width=320>