### PR TITLE
Disable flipper from being included in iOS CI builds

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,7 +4,7 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+flipper_config = ENV['CI'] || ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil


### PR DESCRIPTION
Hawken noticed that the CI build for iOS was including flipper.

We can stop that from happening in the Podfile where flipper gets configured.

Counterpart to android's https://github.com/StoDevX/AAO-React-Native/commit/98dacf3753265e6fbc6bdce917634a5f60f8a175

