### PR TITLE
Revert "Disable flipper from being included in iOS CI builds"

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -4,7 +4,7 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-flipper_config = ENV['CI'] || ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil


### PR DESCRIPTION
Reverts StoDevX/AAO-React-Native#6868

It broke ios builds