### PR TITLE
@frogpond/context-module initialization

### DIFF
--- a/modules/context-menu/index.tsx
+++ b/modules/context-menu/index.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import {StyleProp, ViewStyle} from 'react-native'
+import {Touchable} from '@frogpond/touchable'
+import {ContextMenuButton} from 'react-native-ios-context-menu'
+import {upperFirst} from 'lodash'
+
+interface ContextMenuProps {
+	actions: string[]
+	buttonStyle?: StyleProp<ViewStyle>
+	children?: React.ReactElement
+	disabled?: boolean
+	isMenuPrimaryAction?: boolean
+	onPress?: () => void
+	onPressMenuItem: (menuKey: string) => void | Promise<void>
+	title: string
+}
+
+export const ContextMenu = React.forwardRef<
+	ContextMenuButton,
+	ContextMenuProps
+>((props, ref): JSX.Element => {
+	const {
+		actions,
+		buttonStyle,
+		children,
+		disabled,
+		isMenuPrimaryAction,
+		onPress,
+		onPressMenuItem,
+		title,
+	} = props
+
+	let menuItems = React.useMemo(() => {
+		return actions.map((option) => ({
+			actionKey: option,
+			actionTitle: upperFirst(option),
+		}))
+	}, [actions])
+
+	return (
+		<ContextMenuButton
+			ref={ref}
+			enableContextMenu={!disabled ?? false}
+			isMenuPrimaryAction={isMenuPrimaryAction ?? false}
+			menuConfig={{
+				menuTitle: title ?? '',
+				menuItems,
+			}}
+			onPressMenuItem={({nativeEvent}) => {
+				onPressMenuItem(nativeEvent.actionKey)
+			}}
+			style={buttonStyle}
+		>
+			{onPress ? (
+				<Touchable highlight={false} onPress={onPress}>
+					{children}
+				</Touchable>
+			) : (
+				children
+			)}
+		</ContextMenuButton>
+	)
+})

--- a/modules/context-menu/package.json
+++ b/modules/context-menu/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@frogpond/context-menu",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.tsx",
+  "author": "",
+  "license": "ISC",
+  "scripts": {
+    "test": "jest"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-native": "^0.71.1"
+  },
+  "dependencies": {
+    "@frogpond/touchable": "^1.0.0",
+    "lodash": "4.17.21",
+    "react-native-ios-context-menu": "1.15.3"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -212,6 +212,19 @@
         "react-native": "^0.71.1"
       }
     },
+    "modules/context-menu": {
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@frogpond/touchable": "^1.0.0",
+        "lodash": "4.17.21",
+        "react-native-ios-context-menu": "1.15.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-native": "^0.71.1"
+      }
+    },
     "modules/datepicker": {
       "name": "@frogpond/datepicker",
       "version": "1.0.0",
@@ -2518,6 +2531,10 @@
     },
     "node_modules/@frogpond/constants": {
       "resolved": "modules/constants",
+      "link": true
+    },
+    "node_modules/@frogpond/context-menu": {
+      "resolved": "modules/context-menu",
       "link": true
     },
     "node_modules/@frogpond/datepicker": {


### PR DESCRIPTION
Pulls the context menu module into a reusable module
  - [x]  iOS wraps [`react-native-ios-context-menu`](https://github.com/dominicstop/react-native-ios-context-menu)

Out of scope
- Android will need to implement [`<FilterChip />`](https://m3.material.io/components/chips/overview)
- Limited to `ContextMenuButton` (very doable to add support for others)
- Limited to a single top-level menu (building out nested menus is very doable)