### PR TITLE
Add initial iOS scene manifest with empty configuration

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -89,6 +89,13 @@
 		<string>Entypo.ttf</string>
 		<string>Ionicons.ttf</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>


### PR DESCRIPTION
In the Xcode console logs. We can fix this within Info.plist.
>  Info.plist contained no UIScene configuration dictionary (looking for configuration named "(no name)")

What we're doing is defining a bare configuration so that the app does not complain about one being missing. If we choose to support multiple windows, we can change this config to support that type of feature.

Some background on scene manifests from [use your loaf](https://useyourloaf.com/blog/ios-scene-delegates-and-external-screens/).
>  - The presence of the “Application Scene Manifest” in Info.plist opts your app into supporting scenes. The scene delegate, not the app delegate, now owns the window.
> - In the UIKit app template, “Enable Multiple Windows” defaults to NO. You should change this to YES if you want to support multiple windows on the iPad. It’s not required to support a window on an external screen.
> - You’re not forced to use storyboards with scene delegates. If you prefer to build your layout in code, remove the storyboard name key from Info.plist and create the window and root view controller in the scene(_:willConnectTo:options:) delegate method.