### PR TITLE
Refactor authentication error and loading state messaging

### DIFF
--- a/source/views/settings/screens/overview/login-button.tsx
+++ b/source/views/settings/screens/overview/login-button.tsx
@@ -11,13 +11,13 @@ type Props = {
 
 export function LoginButton(props: Props): JSX.Element {
 	let {loading, disabled, loggedIn, onPress, label} = props
-	let innerText = loggedIn ? 'Signing out of' : 'Signing in to'
 
-	let message = loading
-		? `${innerText} ${label}…`
-		: loggedIn
-		? `Sign Out of ${label}`
-		: `Sign In to ${label}`
+	let message
+	if (loading) {
+		message = loggedIn ? `Signing out of ${label}` : `Signing in to ${label}`
+	} else {
+		message = loggedIn ? `Sign out of ${label}` : `Sign in to ${label}`
+	}
 
 	return (
 		<ButtonCell

--- a/source/views/settings/screens/overview/login-button.tsx
+++ b/source/views/settings/screens/overview/login-button.tsx
@@ -11,9 +11,10 @@ type Props = {
 
 export function LoginButton(props: Props): JSX.Element {
 	let {loading, disabled, loggedIn, onPress, label} = props
+	let innerText = loggedIn ? 'Signing out of' : 'Signing in to'
 
 	let message = loading
-		? `Logging in to ${label}…`
+		? `${innerText} ${label}…`
 		: loggedIn
 		? `Sign Out of ${label}`
 		: `Sign In to ${label}`


### PR DESCRIPTION
Targets #6938 
- Unwraps the credentials form from error message overlays
  - Integrates error status at the bottom of the login form
  - Remove checks for `instanceof NoCredentialsError`
- Updates the footer to communicate whether login is needed
- Updates indeterminate loading text to reflect login state


https://user-images.githubusercontent.com/5240843/218292927-986d05fb-ca38-4e31-95ac-fba3476e0b42.mp4