### PR TITLE
Fix props sorting in badge component library

### DIFF
--- a/source/views/settings/screens/overview/component-library/badge.tsx
+++ b/source/views/settings/screens/overview/component-library/badge.tsx
@@ -15,25 +15,25 @@ const OutlineBadgeExamples = (): JSX.Element => (
 			<OutlineBadge
 				accentColor={c.systemGreen}
 				style={styles.overriden}
+				text="Status"
 				textColor={c.label}
 				textStyle={styles.overridenText}
-				text="Status"
 			/>
 		</Example>
 
 		<Example title="Hours open">
 			<OutlineBadge
 				accentColor={c.systemGreen}
-				textColor={c.label}
 				text="Open"
+				textColor={c.label}
 			/>
 		</Example>
 
 		<Example title="Hours closed">
 			<OutlineBadge
 				accentColor={c.systemRed}
-				textColor={c.label}
 				text="Closed"
+				textColor={c.label}
 			/>
 		</Example>
 	</Section>


### PR DESCRIPTION
Fixes the following linter errors

```
source/views/settings/screens/overview/component-library/badge.tsx
  20:5  warning  Props should be sorted alphabetically  react/jsx-sort-props
  28:5  warning  Props should be sorted alphabetically  react/jsx-sort-props
  36:5  warning  Props should be sorted alphabetically  react/jsx-sort-props
```