### PR TITLE
ci: Run checks on merge groups

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,7 @@ name: Check
 on:
   push: {branches: [master]}
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
In addition to running the full suite of checks on PRs, this will also run the checks on merge groups (stacked PRs).