### PR TITLE
ci: unset ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -102,7 +102,6 @@ jobs:
           GIT_COMMIT_DESC: $(git log --format=oneline -n 1 $GITHUB_SHA)
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_DISABLE_ANIMATION: '1'
-          ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD: true
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf
           SENTRY_AUTH_TOKEN: ${{ secrets.HOSTED_SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
Should fix our nightly build issue for iOS.

This undoes #6526 which was needed for Xcode 13 and below and lower versions of Fastlane.

Per fastlane/fastlane#20741, iTMSTransporter is working correctly and does not require this workaround for updated versions of Xcode and fastlane.
