### PR TITLE
Set LSMinimumSystemVersion to 13.3

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -67,6 +67,8 @@
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSMinimumSystemVersion</key>
+	<string>13.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
We received this message from App Store Connect
> **ITMS-90899: Apple silicon Mac support issue**
> The app is not compatible with the provided minimum macOS version of 13.1. It can run on macOS 13.3 or later. Please specify an LSMinimumSystemVersion value of 13.3 or later in a new build, or select a compatible version in App Store Connect. For details, visit: https://developer.apple.com/help/app-store-connect/manage-your-apps-availability/manage-availability-of-iphone-and-ipad-apps-on-macs-with-apple-silicon.

We first set the minimum version to 13.3 in App Store Connect itself. This looks like it was not good enough because we are still getting notified.

This changeset adds the minimum version for our catalyst app to the info.plist, which Apple has listed is the other way of setting this value.