### PR TITLE
perf: use babel to remove console logs in production

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ module.exports = {
 	],
 	env: {
 		production: {
-			plugins: ['transform-remove-console']
-		}
-	},	
+			plugins: ['transform-remove-console'],
+		},
+	},
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -8,4 +8,9 @@ module.exports = {
 		// the react-native-reanimated plugin must come last
 		'react-native-reanimated/plugin',
 	],
+	env: {
+		production: {
+			plugins: ['transform-remove-console']
+		}
+	},	
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "ajv-keywords": "5.1.0",
         "babel-core": "7.0.0-bridge.0",
         "babel-jest": "29.4.3",
+        "babel-plugin-transform-remove-console": "6.9.4",
         "eslint": "8.39.0",
         "eslint-config-prettier": "8.6.0",
         "eslint-plugin-babel": "5.3.1",
@@ -6984,6 +6985,12 @@
       "version": "7.0.0-beta.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
       "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
+    },
+    "node_modules/babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha512-88blrUrMX3SPiGkT1GnvVY8E/7A+k6oj3MNvUtTIxJflFzXTw1bHkuJ/y039ouhFMp2prRn5cQGzokViYi1dsg==",
+      "dev": true
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "ajv-keywords": "5.1.0",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "29.4.3",
+    "babel-plugin-transform-remove-console": "6.9.4",
     "eslint": "8.39.0",
     "eslint-config-prettier": "8.6.0",
     "eslint-plugin-babel": "5.3.1",


### PR DESCRIPTION
Closes #6995 

This will automatically remove all console.* calls in the release versions of this project.

When running a bundled copy of the app, console statements can cause a big bottleneck in the JavaScript thread. [It is recommended to use the plugin](https://reactnative.dev/docs/performance#using-consolelog-statements) even if no console.* calls are made as a third party library could also call them.