### PR TITLE
ci: Use Ruby 3.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ruby_version: '2.6'
+  ruby_version: '3.0'
   xcode_version: 'Xcode_14.2'
   java_version: '11'
   java_distribution: temurin


### PR DESCRIPTION
This is a cherry-pick of 77bdac8f238244ac2d7872002aa505370343f32a out of the `renovate/react-native-0.x` branch. Ruby 2.6 is very old, and most of the tooling we're built on should support Ruby 3.0 now.