### PR TITLE
ci: Fix other GitHub Actions workflows with new version of Ruby

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           cache: npm
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.0'
           bundler-cache: true
       - name: Restore Gradle cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
@@ -84,7 +84,7 @@ jobs:
           cache: npm
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.0'
           bundler-cache: true
       - run: sudo xcode-select -s /Applications/Xcode_14.2.app
       - run: git fetch --prune --unshallow

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.0'
           bundler-cache: true
 
       - run: sudo xcode-select -s /Applications/Xcode_14.2.app


### PR DESCRIPTION
Wild to me that I didn't see a build failure on #7015, but other PRs are also failing due to the same issue.