### PR TITLE
Restore privacy policy for GitHub pages

### DIFF
--- a/data/privacy.md
+++ b/data/privacy.md
@@ -1,0 +1,67 @@
+# All About Olaf Privacy Policy
+
+We respect your right to privacy when using our app, All About Olaf.
+
+Our policy towards privacy is simple: we aim to collect no data other than what
+we need to keep the app functional and ensure a smooth experience for all users.
+
+## Who runs this app?
+
+This app is developed and maintained by a mixed team of current students at St.
+Olaf College and alumni of St. Olaf College.  Anyone is welcome to make
+contributions to the app, and the source code for the app is publicly available
+[on GitHub][repo].  All contributions go through code review by maintainers.
+
+This app is entirely self-funded, and we do not include advertisements on our
+app.  As such, our privacy policy is quite simple.
+
+[repo]: https://github.com/StoDevX/AAO-React-Native
+
+## What data do you collect?
+
+When you "Sign in with St. Olaf" in the settings, your St. Olaf username and
+password are stored locally, on your device, in the encrypted keychain storage
+mechanism available on your device.  _We do not transmit these credentials to or
+through any servers that we control, and we do not have the ability to remotely
+access these credentials_.  These credentials become inaccessible when you delete
+the app.  We only transmit these credentials to on-campus servers, and the
+security of those servers is not controlled by us.
+
+When you fetch any data besides your personal information, your requests may
+reach servers that we control.  Whenever your app makes such a request, the
+following information is logged:
+
+1. _Your public IP address_.  We do not use this to identify you or for tracking
+  purposes, and this is logged only for diagnostic purposes.
+2. _The version of All About Olaf you are using and information about your
+  phone_, which is sent as part of your device's request.  This data is
+  intentionally vague so that we can also not use this to identify you.
+3. _What you requested and how long it took_, which is widely considered to be
+  fully anonymous.
+
+We also use _Sentry_, which collects crash reports and cannot be disabled
+currently. Sentry collects in-depth information about the device and
+circumstances leading up to a given crash.
+
+If you send us suggestions for updates to building hours, we will anonymously add
+them to the app if we determine that they are correct.  We do not currently give
+credit for these contributions, primarily because we don't have an easy way of
+attributing these.  In its current form, the "suggest an update" feature requires
+you to send an email, and this email is sent to our developer mailing list.
+
+If you choose to use the "Submit a Wi-Fi problem" feature or other features and
+tools that use college systems such as StoPrint, your data is transmitted to
+those systems exclusively, and we do not have the ability to see it.
+
+Most importantly: **the developers and maintainers of All About Olaf _will not_,
+under any circumstances, grant access to any personally identifiable information
+that we may have collected to a third party, unless as required by law**.  We
+treat your data as confidential and have the utmost respect for your privacy, and
+we think that sharing data with other companies for marketing purposes or
+compensation is a blatant violation of trust; we will never share this data.
+
+### Contact Us
+
+If you have any questions, comments, or concerns about this privacy policy,
+please reach out to us via email at <allaboutolaf@frogpond.tech>.  This
+mailing list contains all active maintainers and developers.


### PR DESCRIPTION
Part of #6890

In #6861 we removed the privacy policy and inlined it into the view itself. Google app review points out that we no longer have a privacy policy to point to as a result. This restores that file and we can probably generate both the tsx and md in the future but this helps us become compliant for now.