### PR TITLE
Fix Android `borderColor` crash when setting transparent border on bus screen

### DIFF
--- a/source/views/transportation/bus/components/bus-stop-row.tsx
+++ b/source/views/transportation/bus/components/bus-stop-row.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {Platform, StyleSheet} from 'react-native'
+import {ColorValue, Platform, StyleSheet} from 'react-native'
 import {Column} from '@frogpond/layout'
 import {Detail, ListRow, Title} from '@frogpond/lists'
 import type {BusTimetableEntry} from '../types'
@@ -36,8 +36,8 @@ type Props = {
 	stop: BusTimetableEntry
 	departureIndex: null | number
 	now: Moment
-	barColor: string
-	currentStopColor: string
+	barColor: ColorValue
+	currentStopColor: ColorValue
 	isFirstRow: boolean
 	isLastRow: boolean
 	status: BusStateEnum

--- a/source/views/transportation/bus/components/progress-chunk.tsx
+++ b/source/views/transportation/bus/components/progress-chunk.tsx
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
 	},
 	skippingStop: {
 		backgroundColor: c.clear,
-		borderColor: c.clear,
+		borderColor: c.transparent,
 	},
 	passedStop: {
 		height: 12,

--- a/source/views/transportation/bus/components/progress-chunk.tsx
+++ b/source/views/transportation/bus/components/progress-chunk.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as c from '@frogpond/colors'
-import {Platform, StyleSheet, View} from 'react-native'
+import {ColorValue, Platform, StyleSheet, View} from 'react-native'
 import type {BusStopStatusEnum} from '../lib'
 
 const isAndroid = Platform.OS === 'android'
@@ -47,8 +47,8 @@ const styles = StyleSheet.create({
 })
 
 type Props = {
-	barColor: string
-	currentStopColor: string
+	barColor: ColorValue
+	currentStopColor: ColorValue
 	isFirstChunk: boolean
 	isLastChunk: boolean
 	stopStatus: BusStopStatusEnum

--- a/source/views/transportation/bus/types.ts
+++ b/source/views/transportation/bus/types.ts
@@ -1,11 +1,12 @@
 import type {Moment} from 'moment'
+import {ColorValue} from 'react-native'
 
 export type DayOfWeek = 'Su' | 'Mo' | 'Tu' | 'We' | 'Th' | 'Fr' | 'Sa'
 export type Coordinates = [number, number]
 
 export type BusLineColors = {
-	bar: string
-	dot: string
+	bar: ColorValue
+	dot: ColorValue
 }
 
 export type UnprocessedDepartureTimeList = Array<string | false>


### PR DESCRIPTION
Closes #6990.

Previously, the `skippingStop` style set both `backgroundColor` and `borderColor` to `c.clear`, which was defined as
```ts
export const clear = Platform.select({
	ios: PlatformColor('clear'),
	android: PlatformColor('@android:color/transparent'),
})
```

This led to a crash, documented in #6990.


I tried two things to resolve this:

- _Entirely deleting_ the `borderColor` property that was referencing `c.clear`.
- Replacing the style referenced with `c.transparent`.

Both appeared to produce identical results, but given our use of `RecursiveArray` style, I wanted to make sure we had _some_ value for the `borderColor` so I set it to `c.transparent`, which is defined as `rgba(0,0,0,0)`. I'm happy to just delete the property instead if a reviewer would like me to try fixing that.

<details>
<summary>📸 Screenshots</summary>

Scenario | Android | iOS
---|---|---
Not yet at any stop | ![Screenshot_1693401944](https://github.com/StoDevX/AAO-React-Native/assets/1566689/7575a07d-97dc-444b-965f-92cf35d17682) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2023-08-30 at 08 25 43](https://github.com/StoDevX/AAO-React-Native/assets/1566689/3366eac6-b461-4209-a539-17251259d3ae)
Arrived at a stop | ![Screenshot_1693402016](https://github.com/StoDevX/AAO-React-Native/assets/1566689/16cf5dc2-6845-4adf-a21e-009a16c77e7b) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2023-08-30 at 08 26 41](https://github.com/StoDevX/AAO-React-Native/assets/1566689/b4633832-3a09-4c44-81bf-f2323df0ea79)
Skipped stop | ![Screenshot_1693402026](https://github.com/StoDevX/AAO-React-Native/assets/1566689/e372a773-f338-4c2a-ba16-f4b3eddcbae0) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2023-08-30 at 08 27 05](https://github.com/StoDevX/AAO-React-Native/assets/1566689/fde43d5c-c299-434b-9d97-94c31decd6c8)

</details>