### PR TITLE
allow section lists in filter popups to expand their content

### DIFF
--- a/modules/filter/section-list.tsx
+++ b/modules/filter/section-list.tsx
@@ -127,6 +127,7 @@ export function ListSection<T extends object>({
 const styles = StyleSheet.create({
 	content: {
 		flex: 1,
+		flexShrink: 1,
 		paddingVertical: 10,
 	},
 	title: {


### PR DESCRIPTION
- Closes #7081 

Looks like `flex: 1` is not enough to handle a layout we want to grow in RN.

> `flexShrink` accepts any floating point value >= 0, with 0 being the default value (on the web, the default is 1)

We can update our filter list rows to have a styling of `flex: 1` and `flexShrink: 1` to both (i) layout content and (ii) present overflowing content.

Before | After
--|--
![Simulator Screen Shot - iPhone 14 Pro - 2023-10-08 at 18 43 14](https://github.com/StoDevX/AAO-React-Native/assets/5240843/6e7a3c0e-7938-4de1-a491-8596675d5357) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-08 at 18 42 47](https://github.com/StoDevX/AAO-React-Native/assets/5240843/0ea64864-8072-419f-9213-5251b891a4ca)
