### PR TITLE
Fix course search filtering by term, level, and gereq

### DIFF
--- a/source/lib/course-search/urls.ts
+++ b/source/lib/course-search/urls.ts
@@ -1,5 +1,6 @@
 import ky, {Options} from 'ky'
 import {CourseType, RawCourseType, TermInfoType, TermType} from './types'
+import intersection from 'lodash/intersection'
 
 const BASE_URL = 'https://stolaf.dev'
 export const COURSE_DATA_PAGE = `${BASE_URL}/course-data/`
@@ -19,13 +20,48 @@ export let timeData = (options?: Options): Promise<string[]> =>
 	client.get('data-lists/valid_times.json', options).json()
 export let coursesForTerm = async (
 	term: TermType,
+	levels: Array<CourseType['level']>,
+	gereqs: string[] = [],
 	options?: Options,
 ): Promise<Array<CourseType>> => {
 	let data = (await client
 		.get(`${term.path}`, options)
 		.json()) as RawCourseType[]
-	return data.map((course) => ({
-		spaceAvailable: course.enrolled < course.max,
-		...course,
-	})) as CourseType[]
+	return data
+		.map((course) => ({
+			spaceAvailable: course.enrolled < course.max,
+			...course,
+		}))
+		.filter((c) => {
+			return findMatches(c.level, levels, c.gereqs, gereqs)
+		}) as CourseType[]
+}
+
+const findMatches = (
+	findLevel: number,
+	levels: Array<number>,
+	findgereqs: Array<string> = [],
+	gereqs: Array<string>,
+) => {
+	let foundLevels = matchesLevels(findLevel, levels)
+	let foundGEs = matchesGEs(findgereqs, gereqs)
+
+	if (levels.length && gereqs.length) {
+		return foundLevels && foundGEs
+	} else if (levels.length) {
+		return foundLevels
+	} else if (gereqs.length) {
+		return foundGEs
+	}
+
+	return true
+}
+
+const matchesLevels = (item: number, levels: Array<CourseType['level']>) => {
+	let levelRoundedDown = Math.floor(item / 100) * 100
+	return levels.includes(levelRoundedDown)
+}
+
+const matchesGEs = (items: string[] | undefined, gereqs: string[]) => {
+	return items ? intersection(gereqs, items).length > 0 : false
 }

--- a/source/lib/course-search/urls.ts
+++ b/source/lib/course-search/urls.ts
@@ -43,15 +43,16 @@ const findMatches = (
 	findgereqs: Array<string> = [],
 	gereqs: Array<string>,
 ) => {
-	let foundLevels = matchesLevels(findLevel, levels)
-	let foundGEs = matchesGEs(findgereqs, gereqs)
+	if (!levels.length && !gereqs.length) {
+		return true
+	}
 
 	if (levels.length && gereqs.length) {
-		return foundLevels && foundGEs
+		return matchesLevels(findLevel, levels) && matchesGEs(findgereqs, gereqs)
 	} else if (levels.length) {
-		return foundLevels
+		return matchesLevels(findLevel, levels)
 	} else if (gereqs.length) {
-		return foundGEs
+		return matchesGEs(findgereqs, gereqs)
 	}
 
 	return true

--- a/source/views/sis/course-search/query.ts
+++ b/source/views/sis/course-search/query.ts
@@ -10,7 +10,6 @@ import {
 	deptData,
 	geData,
 	infoJson,
-	timeData,
 } from '../../../lib/course-search/urls'
 
 const ONE_SECOND = 1000
@@ -43,40 +42,7 @@ export function useAvailableTerms(): UseQueryResult<TermType[], unknown> {
 	})
 }
 
-export function useCourseDataForTerm(
-	term: TermType,
-): UseQueryResult<CourseType[], unknown> {
-	return useQuery({
-		queryKey: keys.courses(term),
-		queryFn: ({queryKey: [_group, _courses, term], signal}) =>
-			coursesForTerm(term, {signal}),
-		staleTime: ONE_HOUR,
-	})
-}
-
-export function useCourseDataForTerms(
-	terms: TermType[],
 ): UseQueryResult<CourseType[], unknown>[] {
-	let query = (
-		term: TermType,
-	): UseQueryOptions<
-		CourseType[],
-		unknown,
-		CourseType[],
-		ReturnType<(typeof keys)['courses']>
-	> => ({
-		queryKey: keys.courses(term),
-		queryFn: ({queryKey: [_group, _courses, term], signal}) =>
-			coursesForTerm(term, {signal}),
-		staleTime: ONE_HOUR,
-	})
-
-	return useQueries({
-		queries: terms.map(query),
-	})
-}
-
-export function useCourseData(): UseQueryResult<CourseType[], unknown>[] {
 	let {data: terms = []} = useAvailableTerms()
 
 	let query = (
@@ -111,14 +77,6 @@ export function useDepartments(): UseQueryResult<string[]> {
 	return useQuery({
 		queryKey: keys.departments,
 		queryFn: ({signal}) => deptData({signal}),
-		staleTime: ONE_DAY,
-	})
-}
-
-export function useTimes(): UseQueryResult<string[]> {
-	return useQuery({
-		queryKey: keys.times,
-		queryFn: ({signal}) => timeData({signal}),
 		staleTime: ONE_DAY,
 	})
 }

--- a/source/views/sis/course-search/results.tsx
+++ b/source/views/sis/course-search/results.tsx
@@ -14,7 +14,7 @@ import {RouteProp, useNavigation, useRoute} from '@react-navigation/native'
 import {ChangeTextEvent, RootStackParamList} from '../../../navigation/types'
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
 import {useDebounce} from '@frogpond/use-debounce'
-import {ListSeparator, ListSectionHeader} from '@frogpond/lists'
+import {ListSeparator, ListSectionHeader, largeListProps} from '@frogpond/lists'
 import * as c from '@frogpond/colors'
 import {CourseRow} from './row'
 import memoize from 'lodash/memoize'
@@ -188,7 +188,7 @@ export const CourseSearchResultsView = (): JSX.Element => {
 				<ListSectionHeader title={parseTerm(title)} />
 			)}
 			sections={results}
-			windowSize={10}
+			{...largeListProps}
 		/>
 	)
 }

--- a/source/views/sis/course-search/results.tsx
+++ b/source/views/sis/course-search/results.tsx
@@ -72,11 +72,9 @@ const useSelectedFilter = (
 const useSelectedTerm = (filters: FilterType<CourseType>[]) => {
 	let termFilter = useSelectedFilter('term', filters)
 
-	if (termFilter) {
-		if (termFilter.enabled) {
-			let termFilterSpec = termFilter.spec as ListSpecType
-			return termFilterSpec.selected.map((spec) => Number(spec.title))
-		}
+	if (termFilter?.enabled) {
+		let termFilterSpec = termFilter.spec as ListSpecType
+		return termFilterSpec.selected.map((spec) => Number(spec.title))
 	}
 
 	return []
@@ -85,11 +83,9 @@ const useSelectedTerm = (filters: FilterType<CourseType>[]) => {
 const useSelecteLevel = (filters: FilterType<CourseType>[]) => {
 	let levelFilter = useSelectedFilter('level', filters)
 
-	if (levelFilter) {
-		if (levelFilter.enabled) {
-			let levelFilterSpec = levelFilter.spec as ListSpecType
-			return levelFilterSpec.selected.map((spec) => Number(spec.title))
-		}
+	if (levelFilter?.enabled) {
+		let levelFilterSpec = levelFilter.spec as ListSpecType
+		return levelFilterSpec.selected.map((spec) => Number(spec.title))
 	}
 
 	return []
@@ -98,11 +94,9 @@ const useSelecteLevel = (filters: FilterType<CourseType>[]) => {
 const useSelectedGE = (filters: FilterType<CourseType>[]) => {
 	let geFilter = useSelectedFilter('gereqs', filters)
 
-	if (geFilter) {
-		if (geFilter.enabled) {
-			let geFilterSpec = geFilter.spec as ListSpecType
-			return geFilterSpec.selected.map((spec) => spec.title)
-		}
+	if (geFilter?.enabled) {
+		let geFilterSpec = geFilter.spec as ListSpecType
+		return geFilterSpec.selected.map((spec) => spec.title)
 	}
 
 	return []

--- a/source/views/sis/course-search/results.tsx
+++ b/source/views/sis/course-search/results.tsx
@@ -80,7 +80,7 @@ const useSelectedTerm = (filters: FilterType<CourseType>[]) => {
 	return []
 }
 
-const useSelecteLevel = (filters: FilterType<CourseType>[]) => {
+const useSelectedLevel = (filters: FilterType<CourseType>[]) => {
 	let levelFilter = useSelectedFilter('level', filters)
 
 	if (levelFilter?.enabled) {
@@ -123,7 +123,7 @@ export const CourseSearchResultsView = (): JSX.Element => {
 	let delayedQuery = useDebounce(searchQuery, 500)
 
 	let selectedTerms = useSelectedTerm(filters)
-	let selectedLevels = useSelecteLevel(filters)
+	let selectedLevels = useSelectedLevel(filters)
 	let selectedGEs = useSelectedGE(filters)
 
 	let allCoursesByTerm = useCourseData(


### PR DESCRIPTION
Closes #6765 

Fixes incorrect results when filtering by term, level, and ge requirements

- Adds helper methods for filtering by the above criteria
- Adds more performant large list props to course search results list