### PR TITLE
Restore menu daypart picker

### DIFF
--- a/modules/food-menu/fancy-menu.tsx
+++ b/modules/food-menu/fancy-menu.tsx
@@ -127,8 +127,8 @@ export function FancyMenu(props: Props): JSX.Element {
 	// reset the filters when the data changes
 	useEffect(() => {
 		let foodItemsArray = Object.values(foodItems)
-		setFilters(buildFilters(foodItemsArray, menuCorIcons, [meal]))
-	}, [foodItems, menuCorIcons, meal])
+		setFilters(buildFilters(foodItemsArray, menuCorIcons, meals, now))
+	}, [foodItems, menuCorIcons, meals, now])
 
 	// re-group the food when the data changes
 	useEffect(() => {


### PR DESCRIPTION
This restores the menu daypart picker that allows a user to switch between different meal times (breakfast, brunch, lunch, dinner) into the filter builder.

Additionally, passing in `now` into the filter builder gets closest-mealtime selection working with this filter.

We have all of this functionality in the shipping apps so it seems like it would be good that this is restored.