### PR TITLE
add dynamic color to Picker.Item labels

### DIFF
--- a/modules/filter/section-picker.tsx
+++ b/modules/filter/section-picker.tsx
@@ -20,6 +20,7 @@ export function PickerSection<T extends object>({
 	return (
 		<Section footer={caption} header={title.toUpperCase()}>
 			<Picker
+				itemStyle={styles.pickerItem}
 				onValueChange={(itemValue, itemIndex) => {
 					let pickedItem = spec.options[itemIndex]
 					onChange({...filter, spec: {...spec, selected: pickedItem}})


### PR DESCRIPTION
Although `Picker.Item` has a style property, it seems `Picker` has an [`itemStyle`](https://github.com/react-native-picker/picker#itemstyle) which applies to iOS labels.

We haven't used this picker in over a year so adding a style prop for dynamic text color was missed.

Dark | Light
--|--
<img width="384" alt="Screenshot 2023-10-16 at 4 22 02 PM" src="https://github.com/StoDevX/AAO-React-Native/assets/5240843/025872a3-eab0-47b3-8d2d-90e141bd4f0a"> | <img width="384" alt="Screenshot 2023-10-16 at 4 22 12 PM" src="https://github.com/StoDevX/AAO-React-Native/assets/5240843/4e436f2c-3dfa-4aef-a04f-87b9a02ff21e">
