### PR TITLE
add dynamic routes to the dev api route tool

### DIFF
--- a/source/views/settings/screens/api-test/api-test.tsx
+++ b/source/views/settings/screens/api-test/api-test.tsx
@@ -51,6 +51,10 @@ const styles = StyleSheet.create({
 		paddingTop: 20,
 		paddingBottom: 10,
 	},
+	headerLeftButton: {
+		fontWeight: '600',
+		color: c.link,
+	},
 })
 
 type DisplayMode = 'raw' | 'parsed'
@@ -85,10 +89,7 @@ export const APITestView = (): JSX.Element => {
 			onPress={() => setSearchPath('')}
 			style={commonStyles.button}
 		>
-			{/* eslint-disable-next-line react-native/no-inline-styles */}
-			<Text style={[commonStyles.text, {fontWeight: '600', color: c.link}]}>
-				Reset
-			</Text>
+			<Text style={[commonStyles.text, styles.headerLeftButton]}>Reset</Text>
 		</Touchable>
 	)
 

--- a/source/views/settings/screens/api-test/api-test.tsx
+++ b/source/views/settings/screens/api-test/api-test.tsx
@@ -4,10 +4,13 @@ import {Platform, StyleSheet, TextInput, Text, View} from 'react-native'
 import {client} from '@frogpond/api'
 import {useDebounce} from '@frogpond/use-debounce'
 import {useQuery} from '@tanstack/react-query'
-import {CellToggle} from '@frogpond/tableview/cells'
 import {HtmlContent} from '@frogpond/html-content'
 import {Icon} from '@frogpond/icon'
 import {CloseScreenButton} from '@frogpond/navigation-buttons'
+import {commonStyles} from '@frogpond/navigation-buttons/styles'
+import {LoadingView} from '@frogpond/notice'
+import {Touchable} from '@frogpond/touchable'
+import {CellToggle} from '@frogpond/tableview/cells'
 
 import {useNavigation} from '@react-navigation/native'
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
@@ -17,6 +20,7 @@ import {DebugView} from '../debug'
 import {syntaxHighlight} from './util/highlight'
 import {CSS_CODE_STYLES} from './util/highlight-styles'
 import {ChangeTextEvent} from '../../../../navigation/types'
+import {ServerRoutesListView} from './routes-list'
 
 const styles = StyleSheet.create({
 	container: {
@@ -57,7 +61,7 @@ export const APITestView = (): JSX.Element => {
 
 	let [displayMode, setDisplayMode] = React.useState<DisplayMode>('raw')
 
-	let {data, error} = useQuery({
+	let {data, isLoading, error} = useQuery({
 		queryKey: ['api-test', path],
 		queryFn: ({signal, queryKey: [_group, path]}) => {
 			if (!path) {
@@ -71,8 +75,26 @@ export const APITestView = (): JSX.Element => {
 
 	let navigation = useNavigation()
 
+	const HeaderLeftButton = () => (
+		<Touchable
+			accessibilityLabel="Reset"
+			accessibilityRole="button"
+			accessible={true}
+			borderless={true}
+			highlight={false}
+			onPress={() => setSearchPath('')}
+			style={commonStyles.button}
+		>
+			{/* eslint-disable-next-line react-native/no-inline-styles */}
+			<Text style={[commonStyles.text, {fontWeight: '600', color: c.link}]}>
+				Reset
+			</Text>
+		</Touchable>
+	)
+
 	React.useLayoutEffect(() => {
 		navigation.setOptions({
+			headerLeft: () => Platform.OS === 'ios' && <HeaderLeftButton />,
 			headerSearchBarOptions: {
 				autoCapitalize: 'none',
 				barTintColor: c.systemFill,
@@ -132,13 +154,15 @@ export const APITestView = (): JSX.Element => {
 			/>
 		) : !path ? (
 			<EmptySearch />
+		) : isLoading ? (
+			<LoadingView />
 		) : displayMode === 'raw' ? (
 			<JSONView />
 		) : (
 			<DebugView state={JSON.parse(data || '{}')} />
 		)
 
-	return (
+	const SearchResponseView = () => (
 		<View style={styles.container}>
 			<CellToggle
 				label="Parse as JSON"
@@ -148,6 +172,12 @@ export const APITestView = (): JSX.Element => {
 
 			{APIResponse}
 		</View>
+	)
+
+	return path.length ? (
+		<SearchResponseView />
+	) : (
+		<ServerRoutesListView setSearchPath={setSearchPath} />
 	)
 }
 

--- a/source/views/settings/screens/api-test/query.ts
+++ b/source/views/settings/screens/api-test/query.ts
@@ -1,0 +1,38 @@
+import {client} from '@frogpond/api'
+import {useQuery, UseQueryResult} from '@tanstack/react-query'
+import groupBy from 'lodash/groupBy'
+
+export const keys = {
+	all: ['routes'] as const,
+}
+
+export interface ServerRoute {
+	displayName: string
+	path: string
+	params: string[]
+}
+
+export function useServerRoutes(): UseQueryResult<
+	Array<{title: string; data: ServerRoute[]}>,
+	unknown
+> {
+	return useQuery({
+		queryKey: keys.all,
+		queryFn: async ({signal}) => {
+			let response = await client.get('routes', {signal}).json()
+			return response as ServerRoute[]
+		},
+		select: (routes) => {
+			let grouped = groupBy(routes, (r) => {
+				const parts = r.path.split('/').filter((v) => v)
+				return parts[0]
+			})
+			let groupedRoutes = Object.entries(grouped).map(([key, value]) => ({
+				title: key,
+				data: value,
+			}))
+
+			return groupedRoutes
+		},
+	})
+}

--- a/source/views/settings/screens/api-test/routes-list.tsx
+++ b/source/views/settings/screens/api-test/routes-list.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import {View, SectionList, SafeAreaView, StyleSheet} from 'react-native'
+
+import {ListRow, ListSectionHeader, ListSeparator, Title} from '@frogpond/lists'
+import {Column} from '@frogpond/layout'
+import {LoadingView, NoticeView} from '@frogpond/notice'
+import * as c from '@frogpond/colors'
+
+import {useServerRoutes} from './query'
+
+interface ServerRoutesListParams {
+	setSearchPath: React.Dispatch<React.SetStateAction<string>>
+}
+
+export const ServerRoutesListView = (
+	props: ServerRoutesListParams,
+): JSX.Element => {
+	let {
+		data: groupedRoutes = [],
+		error: routesError,
+		isLoading: isRoutesLoading,
+		isError: isRoutesError,
+		refetch: routesRefetch,
+	} = useServerRoutes()
+
+	return (
+		<View style={styles.serverRouteContainer}>
+			{isRoutesLoading ? (
+				<LoadingView />
+			) : isRoutesError && routesError instanceof Error ? (
+				<NoticeView
+					buttonText="Try Again"
+					onPress={routesRefetch}
+					text={`A problem occured while loading: ${routesError}`}
+				/>
+			) : !groupedRoutes ? (
+				<NoticeView text="No routes were found." />
+			) : (
+				<SectionList
+					ItemSeparatorComponent={ListSeparator}
+					contentInsetAdjustmentBehavior="automatic"
+					keyExtractor={(item, index) => `${item.path}-${index}`}
+					keyboardDismissMode="on-drag"
+					keyboardShouldPersistTaps="never"
+					onRefresh={routesRefetch}
+					refreshing={isRoutesLoading}
+					renderItem={({item}) => {
+						return (
+							<SafeAreaView>
+								<ListRow
+									fullWidth={false}
+									onPress={() => props.setSearchPath(item.displayName)}
+									style={styles.serverRouteRow}
+								>
+									<Column flex={1}>
+										<Title lines={1}>{item.displayName}</Title>
+									</Column>
+								</ListRow>
+							</SafeAreaView>
+						)
+					}}
+					renderSectionHeader={({section: {title}}) => (
+						<ListSectionHeader title={title} />
+					)}
+					sections={groupedRoutes}
+				/>
+			)}
+		</View>
+	)
+}
+
+const styles = StyleSheet.create({
+	serverRouteContainer: {
+		flex: 1,
+		backgroundColor: c.systemBackground,
+	},
+	serverRouteRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+	},
+})


### PR DESCRIPTION
Part of the [internal tooling effort](https://github.com/orgs/StoDevX/projects/5?pane=issue&itemId=18626786).

- This consumes [the list of v1 routes](https://github.com/frog-pond/ccc-server/pull/696) from the proxy server over at `/v1/routes`.
- Search still functions as before and will not filter this list to provide additional utility.
- Not every route will work when chosen due to parameters that needs passing but this is a step in the right direction for us to build out UI for filling that in if we would like to go in that direction.

~|~
--|--
<img src="https://github.com/StoDevX/AAO-React-Native/assets/5240843/b60132c1-43a5-4b50-ad6b-ed2e39d826f2" width=300 /> | <img src="https://github.com/StoDevX/AAO-React-Native/assets/5240843/71dd2eca-7c3b-494d-b6e4-4911c0be8f85" width=300 />


