### PR TITLE
fix android menu daypart picker item label color crash

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -374,7 +374,7 @@ PODS:
     - React-Core
   - RNCClipboard (1.11.1):
     - React-Core
-  - RNCPicker (2.4.10):
+  - RNCPicker (2.5.1):
     - React-Core
   - RNDateTimePicker (6.7.5):
     - React-Core
@@ -652,7 +652,7 @@ SPEC CHECKSUMS:
   RNCalendarEvents: 7e65eb4a94f53c1744d1e275f7fafcfaa619f7a3
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNCClipboard: 2834e1c4af68697089cdd455ee4a4cdd198fa7dd
-  RNCPicker: 0bc2f0a29abcca7b7ed44a2d036aac9ab6d25700
+  RNCPicker: 529d564911e93598cc399b56cc0769ce3675f8c8
   RNDateTimePicker: 65e1d202799460b286ff5e741d8baf54695e8abd
   RNDeviceInfo: 02ea8b23e2280fa18e00a06d7e62804d74028579
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39

--- a/modules/filter/section-picker.tsx
+++ b/modules/filter/section-picker.tsx
@@ -21,6 +21,7 @@ export function PickerSection<T extends object>({
 		<Section footer={caption} header={title.toUpperCase()}>
 			<Picker
 				itemStyle={styles.pickerItem}
+				mode="dropdown"
 				onValueChange={(itemValue, itemIndex) => {
 					let pickedItem = spec.options[itemIndex]
 					onChange({...filter, spec: {...spec, selected: pickedItem}})

--- a/modules/filter/section-picker.tsx
+++ b/modules/filter/section-picker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {StyleSheet} from 'react-native'
+import {Platform, StyleSheet} from 'react-native'
 import * as c from '@frogpond/colors'
 import type {PickerType} from './types'
 import {Section} from '@frogpond/tableview'
@@ -46,6 +46,10 @@ const styles = StyleSheet.create({
 		backgroundColor: c.secondarySystemBackground,
 	},
 	pickerItem: {
-		color: c.label,
+		...Platform.select({
+			ios: {
+				color: c.label,
+			},
+		}),
 	},
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@react-native-clipboard/clipboard": "1.11.1",
         "@react-native-community/datetimepicker": "6.7.5",
         "@react-native-community/netinfo": "9.3.10",
-        "@react-native-picker/picker": "2.4.10",
+        "@react-native-picker/picker": "2.5.1",
         "@react-navigation/bottom-tabs": "6.5.8",
         "@react-navigation/material-bottom-tabs": "6.2.16",
         "@react-navigation/material-top-tabs": "6.6.3",
@@ -5554,9 +5554,9 @@
       }
     },
     "node_modules/@react-native-picker/picker": {
-      "version": "2.4.10",
-      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.10.tgz",
-      "integrity": "sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.5.1.tgz",
+      "integrity": "sha512-/sADUfQsosMRYtrqqL3ZYZSECRygj0fXtpRLqxJfwuMEoqfvfn40756R6B1alzusVvDRZFI0ari0iQid56hA/Q==",
       "peerDependencies": {
         "react": ">=16",
         "react-native": ">=0.57"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@react-native-clipboard/clipboard": "1.11.1",
     "@react-native-community/datetimepicker": "6.7.5",
     "@react-native-community/netinfo": "9.3.10",
-    "@react-native-picker/picker": "2.4.10",
+    "@react-native-picker/picker": "2.5.1",
     "@react-navigation/bottom-tabs": "6.5.8",
     "@react-navigation/material-bottom-tabs": "6.2.16",
     "@react-navigation/material-top-tabs": "6.6.3",


### PR DESCRIPTION
- Fix color crashing the daypart picker in the menus view for Android (https://github.com/StoDevX/AAO-React-Native/pull/7095/commits/2328f206c2d6ab71eba777c85cd26073d43172af)
- Set `mode` of dropdown for Android to give an anchored and compact layout
- Update dependency `@react-native-picker/picker` to v2.5.1
- Closes #7040

Noting the dependency version change is not necessary, the fix is localized to style changes.

---

[Mode `dropdown` ](https://github.com/react-native-picker/picker#mode)

Adding this prop to Android compacts the layout and attaches the items to the dropdown instead of opening a centered detached dialog.

> On Android, specifies how to display the selection items when the user taps on the picker:
>
> 'dialog': Show a modal dialog. This is the default.
> 'dropdown': Shows a dropdown anchored to the picker view

Before | After 
--|--
<img width="335" alt="Screenshot 2023-10-26 at 10 42 57 AM" src="https://github.com/StoDevX/AAO-React-Native/assets/5240843/2819b790-390b-45e0-a7d8-7db6ff4229a1"> | <img width="335" alt="Screenshot 2023-10-26 at 11 36 37 AM" src="https://github.com/StoDevX/AAO-React-Native/assets/5240843/3ace9c6d-7989-401e-a6d3-e3c73326db77">

---

### Debugging notes

We haven't used this picker in over a year so any style or color changes here for **Android** dynamic text color specifically for this one picker component for this component until recently, as noted in #7088 for iOS.

This has been around for 9 months in development since https://github.com/StoDevX/AAO-React-Native/commit/143a1bcf3ed2f4c2e84da5b78d42f683c07ad853.

Changes in #7088 did not impact this and are still safe. [`itemStyle`](https://github.com/react-native-picker/picker#itemstyle) only applies to iOS.

1. `modules/filter/section-picker.tsx` has a text color set to `c.label`

2. `modules/colors/platform.ts` Android label color is PlatformColor `@android:color/primary_text_light`

    ```
    export const label = Platform.select({
    	ios: PlatformColor('label'),
      	android: PlatformColor('@android:color/primary_text_light'),
    	default: TEMP_ANDROID_FOREGROUND,
    })
    ```

Debugging, commenting out the style application to `<Picker.Item />` at least renders without issue on Android

```diff
<Picker.Item
	key={i}
	label={val.label}
-	style={styles.pickerItem}
	value={JSON.stringify(val)}
/>
```

So we can try to just apply the text color to iOS here.

```tsx
pickerItem: {
  ...Platform.select({
    ios: {
      color: c.label,
    },
  }),
},
```