### PR TITLE
add white background color to news row images

### DIFF
--- a/source/views/news/news-row.tsx
+++ b/source/views/news/news-row.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import {StyleSheet, Image, Alert} from 'react-native'
 import {Column, Row} from '@frogpond/layout'
+import * as c from '@frogpond/colors'
 import {ListRow, Detail, Title} from '@frogpond/lists'
 import type {StoryType} from './types'
 
@@ -49,6 +50,7 @@ export const NewsRow = (props: Props): JSX.Element => {
 
 const styles = StyleSheet.create({
 	image: {
+		backgroundColor: c.white,
 		borderRadius: 5,
 		marginRight: 15,
 		height: 70,


### PR DESCRIPTION
Improves consistency of the images rendered and reduces transparent artifacts.

Before  | After
--|--
![Simulator Screen Shot - iPhone 14 Pro - 2023-10-26 at 15 14 23](https://github.com/StoDevX/AAO-React-Native/assets/5240843/d1980df0-53fe-457f-8f92-a562509c18c8) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-26 at 15 14 01](https://github.com/StoDevX/AAO-React-Native/assets/5240843/2dd7bd21-08ba-46ff-9c67-4dfdcefc7577)
![Simulator Screen Shot - iPhone 14 Pro - 2023-10-26 at 15 15 03](https://github.com/StoDevX/AAO-React-Native/assets/5240843/f71c50da-a4c2-439f-82d7-ee76332fb675) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-10-26 at 15 14 57](https://github.com/StoDevX/AAO-React-Native/assets/5240843/6b6f63e5-d696-41e9-902d-5397ef7d4566)



