### PR TITLE
guard against registering the sentry nav container in dev

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -22,6 +22,7 @@ import {NavigationContainer} from '@react-navigation/native'
 
 import {RootStack} from './navigation'
 import {LoadingView} from '@frogpond/notice'
+import {IS_PRODUCTION} from '@frogpond/constants'
 import {StatusBar, useColorScheme} from 'react-native'
 
 export default function App(): JSX.Element {
@@ -30,6 +31,15 @@ export default function App(): JSX.Element {
 	const scheme = useColorScheme()
 	const theme = scheme === 'dark' ? CombinedDarkTheme : CombinedLightTheme
 	const statusBarStyle = scheme === 'dark' ? 'light-content' : 'dark-content'
+
+	const registerContainer = () => {
+		if (!IS_PRODUCTION) {
+			return
+		}
+
+		// Register the navigation container with the instrumentation
+		sentryInit.routingInstrumentation.registerNavigationContainer(navigationRef)
+	}
 
 	return (
 		<ReduxProvider store={store}>
@@ -43,15 +53,7 @@ export default function App(): JSX.Element {
 				>
 					<PaperProvider theme={theme}>
 						<ActionSheetProvider>
-							<NavigationContainer
-								onReady={() => {
-									// Register the navigation container with the instrumentation
-									sentryInit.routingInstrumentation.registerNavigationContainer(
-										navigationRef,
-									)
-								}}
-								theme={theme}
-							>
+							<NavigationContainer onReady={registerContainer} theme={theme}>
 								<StatusBar barStyle={statusBarStyle} />
 								<RootStack />
 							</NavigationContainer>


### PR DESCRIPTION
To keep implementation consistent with our routing instrumentation wrapper, we can guard against calling this with an environment check. If we want to use those logs to trace something in the future, we can remove this check while debugging.