### PR TITLE
Add basic snapshot tests to `notice` module using react-test-renderer

### DIFF
--- a/modules/notice/__tests__/LoadingView.test.tsx
+++ b/modules/notice/__tests__/LoadingView.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import {describe, expect, test} from '@jest/globals'
+
+import TestRenderer from 'react-test-renderer'
+import {LoadingView} from '../loading'
+
+describe('LoadingView', () => {
+	test('it displays "Loading…" when no text is supplied', () => {
+		const tree = TestRenderer.create(<LoadingView />).toJSON()
+		expect(tree).toMatchSnapshot()
+	})
+
+	test('it displays text when text is supplied', () => {
+		const tree = TestRenderer.create(<LoadingView text="foo bar" />).toJSON()
+		expect(tree).toMatchSnapshot()
+	})
+})

--- a/modules/notice/__tests__/NoticeView.test.tsx
+++ b/modules/notice/__tests__/NoticeView.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import {StyleSheet} from 'react-native'
+import {describe, expect, it} from '@jest/globals'
+
+import TestRenderer from 'react-test-renderer'
+import {NoticeView} from '../notice'
+
+describe('NoticeView', () => {
+	describe('when given no text to display', () => {
+		it('displays "Notice!" as its text', () => {
+			const tree = TestRenderer.create(<NoticeView />).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+	})
+
+	describe('when given text to display', () => {
+		it('displays the text', () => {
+			const tree = TestRenderer.create(<NoticeView text="foo bar" />).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+	})
+
+	describe('when given view style overrides', () => {
+		it('applies view style overrides', () => {
+			const styleOverride = StyleSheet.create({
+				view: {
+					padding: 31,
+				},
+			})
+			const tree = TestRenderer.create(
+				<NoticeView style={styleOverride.view} text="foo bar" />,
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+	})
+
+	describe('when instructed to display a spinner', () => {
+		it('displays a spinner', () => {
+			const tree = TestRenderer.create(
+				<NoticeView spinner={true} text="foo bar" />,
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+	})
+
+	describe('when header text is given', () => {
+		it('displays the header text', () => {
+			const tree = TestRenderer.create(
+				<NoticeView header="blammo" text="foo bar" />,
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+	})
+
+	describe('when buttonText is given', () => {
+		it('displays a button with the buttonText in its title', () => {
+			const tree = TestRenderer.create(
+				<NoticeView buttonText="button text" text="foo bar" />,
+			).toJSON()
+			expect(tree).toMatchSnapshot()
+		})
+	})
+})

--- a/modules/notice/__tests__/__snapshots__/LoadingView.test.tsx.snap
+++ b/modules/notice/__tests__/__snapshots__/LoadingView.test.tsx.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LoadingView it displays "Loading…" when no text is supplied 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": {
+          "semantic": [
+            "systemBackground",
+          ],
+        },
+        "flex": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 30,
+      },
+      undefined,
+    ]
+  }
+>
+  <ActivityIndicator
+    style={
+      {
+        "alignItems": "center",
+        "justifyContent": "center",
+        "padding": 8,
+      }
+    }
+  />
+  <Text
+    selectable={true}
+    style={
+      [
+        {
+          "color": {
+            "semantic": [
+              "label",
+            ],
+          },
+          "textAlign": "center",
+        },
+        undefined,
+      ]
+    }
+  >
+    Loading…
+  </Text>
+</View>
+`;
+
+exports[`LoadingView it displays text when text is supplied 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": {
+          "semantic": [
+            "systemBackground",
+          ],
+        },
+        "flex": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 30,
+      },
+      undefined,
+    ]
+  }
+>
+  <ActivityIndicator
+    style={
+      {
+        "alignItems": "center",
+        "justifyContent": "center",
+        "padding": 8,
+      }
+    }
+  />
+  <Text
+    selectable={true}
+    style={
+      [
+        {
+          "color": {
+            "semantic": [
+              "label",
+            ],
+          },
+          "textAlign": "center",
+        },
+        undefined,
+      ]
+    }
+  >
+    foo bar
+  </Text>
+</View>
+`;

--- a/modules/notice/__tests__/__snapshots__/NoticeView.test.tsx.snap
+++ b/modules/notice/__tests__/__snapshots__/NoticeView.test.tsx.snap
@@ -1,0 +1,363 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoticeView when buttonText is given displays a button with the buttonText in its title 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": {
+          "semantic": [
+            "systemBackground",
+          ],
+        },
+        "flex": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 30,
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    selectable={true}
+    style={
+      [
+        {
+          "color": {
+            "semantic": [
+              "label",
+            ],
+          },
+          "textAlign": "center",
+        },
+        undefined,
+      ]
+    }
+  >
+    foo bar
+  </Text>
+  <View
+    accessibilityRole="button"
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": undefined,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "alignSelf": "center",
+        "backgroundColor": {
+          "semantic": [
+            "tertiarySystemFill",
+          ],
+        },
+        "borderRadius": 6,
+        "marginVertical": 10,
+        "opacity": 1,
+        "overflow": "hidden",
+        "paddingHorizontal": 20,
+        "paddingVertical": 10,
+      }
+    }
+  >
+    <Text
+      style={
+        [
+          {
+            "color": "#007aff",
+            "fontSize": 17,
+            "fontWeight": "500",
+            "textAlign": "center",
+          },
+          null,
+          [
+            {
+              "backgroundColor": "transparent",
+              "color": "#FFFFFF",
+              "fontFamily": "System",
+              "fontSize": 16,
+              "fontWeight": "400",
+              "letterSpacing": -0.32,
+              "lineHeight": 21,
+            },
+            {
+              "color": {
+                "semantic": [
+                  "label",
+                ],
+              },
+            },
+            null,
+          ],
+          null,
+        ]
+      }
+    >
+      button text
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`NoticeView when given no text to display displays "Notice!" as its text 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": {
+          "semantic": [
+            "systemBackground",
+          ],
+        },
+        "flex": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 30,
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    selectable={true}
+    style={
+      [
+        {
+          "color": {
+            "semantic": [
+              "label",
+            ],
+          },
+          "textAlign": "center",
+        },
+        undefined,
+      ]
+    }
+  >
+    Notice!
+  </Text>
+</View>
+`;
+
+exports[`NoticeView when given text to display displays the text 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": {
+          "semantic": [
+            "systemBackground",
+          ],
+        },
+        "flex": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 30,
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    selectable={true}
+    style={
+      [
+        {
+          "color": {
+            "semantic": [
+              "label",
+            ],
+          },
+          "textAlign": "center",
+        },
+        undefined,
+      ]
+    }
+  >
+    foo bar
+  </Text>
+</View>
+`;
+
+exports[`NoticeView when given view style overrides applies view style overrides 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": {
+          "semantic": [
+            "systemBackground",
+          ],
+        },
+        "flex": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 30,
+      },
+      {
+        "padding": 31,
+      },
+    ]
+  }
+>
+  <Text
+    selectable={true}
+    style={
+      [
+        {
+          "color": {
+            "semantic": [
+              "label",
+            ],
+          },
+          "textAlign": "center",
+        },
+        undefined,
+      ]
+    }
+  >
+    foo bar
+  </Text>
+</View>
+`;
+
+exports[`NoticeView when header text is given displays the header text 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": {
+          "semantic": [
+            "systemBackground",
+          ],
+        },
+        "flex": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 30,
+      },
+      undefined,
+    ]
+  }
+>
+  <Text
+    selectable={true}
+    style={
+      [
+        {
+          "marginBottom": 4,
+          "marginTop": 8,
+        },
+        [
+          {
+            "backgroundColor": "transparent",
+            "color": {
+              "semantic": [
+                "label",
+              ],
+            },
+            "fontFamily": "System",
+            "fontSize": 20,
+            "fontWeight": "600",
+            "letterSpacing": 0.75,
+            "lineHeight": 25,
+          },
+          undefined,
+        ],
+      ]
+    }
+  >
+    blammo
+  </Text>
+  <Text
+    selectable={true}
+    style={
+      [
+        {
+          "color": {
+            "semantic": [
+              "label",
+            ],
+          },
+          "textAlign": "center",
+        },
+        undefined,
+      ]
+    }
+  >
+    foo bar
+  </Text>
+</View>
+`;
+
+exports[`NoticeView when instructed to display a spinner displays a spinner 1`] = `
+<View
+  style={
+    [
+      {
+        "alignItems": "center",
+        "backgroundColor": {
+          "semantic": [
+            "systemBackground",
+          ],
+        },
+        "flex": 1,
+        "justifyContent": "center",
+        "paddingHorizontal": 30,
+      },
+      undefined,
+    ]
+  }
+>
+  <ActivityIndicator
+    style={
+      {
+        "alignItems": "center",
+        "justifyContent": "center",
+        "padding": 8,
+      }
+    }
+  />
+  <Text
+    selectable={true}
+    style={
+      [
+        {
+          "color": {
+            "semantic": [
+              "label",
+            ],
+          },
+          "textAlign": "center",
+        },
+        undefined,
+      ]
+    }
+  >
+    foo bar
+  </Text>
+</View>
+`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,7 @@
         "prettier": "3.1.0",
         "pretty-bytes": "6.1.0",
         "pretty-quick": "3.1.3",
+        "react-test-renderer": "18.2.0",
         "string-natural-compare": "3.0.1",
         "strip-ansi": "7.0.1",
         "ts-jest": "29.1.1",
@@ -17468,7 +17469,6 @@
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
       "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "react-is": "^18.2.0",
         "react-shallow-renderer": "^16.15.0",
@@ -17482,8 +17482,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "prettier": "3.1.0",
     "pretty-bytes": "6.1.0",
     "pretty-quick": "3.1.3",
+    "react-test-renderer": "18.2.0",
     "string-natural-compare": "3.0.1",
     "strip-ansi": "7.0.1",
     "ts-jest": "29.1.1",


### PR DESCRIPTION
I was a bit surprised to see `react-test-renderer` not in the tree despite appearing in our package-lock. Why not use it if we have to download it anyhow?

For now, I'm just using snapshot tests, so any change to colors or external components will result in changes to the snapshots that must be manually reviewed.

A perhaps more useful set of tests would involve actually checking children of the root nodes.