### PR TITLE
Remove period after full month name in menu filter toolbar

### DIFF
--- a/modules/food-menu/filter-menu-toolbar.tsx
+++ b/modules/food-menu/filter-menu-toolbar.tsx
@@ -47,7 +47,7 @@ export function FilterMenuToolbar<T extends object>({
 		<>
 			<Toolbar>
 				<View style={[styles.toolbarSection, styles.today]}>
-					<Text style={styles.toolbarText}>{date.format('MMM. Do')}</Text>
+					<Text style={styles.toolbarText}>{date.format('MMM Do')}</Text>
 					{title ? <Text style={styles.toolbarText}> — {title}</Text> : null}
 				</View>
 				{mealFilter && multipleMeals ? (


### PR DESCRIPTION
Corrects a display bug in the client that says "May. 4" instead of "May 4"
