### PR TITLE
remove non displaying webcams

### DIFF
--- a/data/webcams/0-alumni-hall-west.yaml
+++ b/data/webcams/0-alumni-hall-west.yaml
@@ -1,7 +1,0 @@
-name: Alumni Hall West
-pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=alumniwest#fold
-streamUrl: https://cdn.stobcm.com/webcams/alumniwest.stream/master.m3u8
-thumbnail: alumniwest
-tagline: A view of the Ytterboe Hall and the wind turbine
-accentColor: [48, 63, 102]
-textColor: '#fff'

--- a/data/webcams/1-buntrock-plaza.yaml
+++ b/data/webcams/1-buntrock-plaza.yaml
@@ -1,7 +1,0 @@
-name: Buntrock Plaza
-pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=bcplaza#fold
-streamUrl: https://cdn.stobcm.com/webcams/bcplaza.stream/master.m3u8
-thumbnail: bcplaza
-tagline: Looking out to the plaza and campus green
-accentColor: [93, 114, 72]
-textColor: '#fff'

--- a/data/webcams/4-tomson-east-lantern.yaml
+++ b/data/webcams/4-tomson-east-lantern.yaml
@@ -1,7 +1,0 @@
-name: Tomson East Lantern
-pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=tomsoneast#fold
-streamUrl: https://cdn.stobcm.com/webcams/tomsoneast.stream/master.m3u8
-thumbnail: tomsoneast
-tagline: A view of the campus green and Wind Chime Memorial
-accentColor: [89, 84, 82]
-textColor: '#fff'

--- a/data/webcams/5-tomson-west-lantern.yaml
+++ b/data/webcams/5-tomson-west-lantern.yaml
@@ -1,7 +1,0 @@
-name: Tomson West Lantern
-pageUrl: https://www.stolaf.edu/multimedia/webcams/?cam=tomsonwest#fold
-streamUrl: https://cdn.stobcm.com/webcams/tomsonwest.stream/master.m3u8
-thumbnail: tomsonwest
-tagline: Looking out to Mellby Hall and the Theater Building
-accentColor: [110, 126, 91]
-textColor: '#fff'


### PR DESCRIPTION
Keeping the images unless we’d rather delete them. I could also see us adding visible props to this list but that would require an app update