### PR TITLE
bump ruby version to 3.1

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,7 +40,7 @@ jobs:
           cache: npm
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler-cache: true
       - name: Restore Gradle cache
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
@@ -84,7 +84,7 @@ jobs:
           cache: npm
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler-cache: true
       - run: sudo xcode-select -s /Applications/Xcode_15.2.app
       - run: git fetch --prune --unshallow

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ruby_version: '3.0'
+  ruby-version: '3.1'
   xcode_version: 'Xcode_15.2'
   java_version: '11'
   java_distribution: temurin
@@ -89,7 +89,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ env.ruby_version }}
+          ruby-version: ${{ env.ruby-version }}
           bundler-cache: true
 
   cache-cocoapods:
@@ -111,7 +111,7 @@ jobs:
         id: cocoapods-cache
         with:
           path: ios/Pods
-          key: ${{ runner.os }}-cocoapods-ruby@${{ env.ruby_version }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/Podfile', '**/Podfile.lock', 'package-lock.json', '.github/job.yml') }}
+          key: ${{ runner.os }}-cocoapods-ruby@${{ env.ruby-version }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/Podfile', '**/Podfile.lock', 'package-lock.json', '.github/job.yml') }}
 
       - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
@@ -123,7 +123,7 @@ jobs:
         env:
           BUNDLE_FROZEN: "true"
         with:
-          ruby-version: ${{ env.ruby_version }}
+          ruby-version: ${{ env.ruby-version }}
           bundler-cache: true
 
       - name: Restore node_modules cache
@@ -471,7 +471,7 @@ jobs:
         env:
           BUNDLE_FROZEN: "true"
         with:
-          ruby-version: ${{ env.ruby_version }}
+          ruby-version: ${{ env.ruby-version }}
           bundler-cache: true
 
       - name: Restore Cocoapods cache

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler-cache: true
 
       - run: sudo xcode-select -s /Applications/Xcode_15.2.app


### PR DESCRIPTION
Attempt to fix ruby issues. Something is up with cache bundler ruby step
> `activesupport-7.2.1` requires ruby version >= 3.1.0, which is incompatible with the current version, ruby 3.0.7p220

Tracking back to #7230 which may have introduced this issue when bumping `activesupport@7.1.3.2` to v7.2.1.