### PR TITLE
update boost podfile.lock checksum

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Extract job definition
         run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
-      - uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -43,7 +43,7 @@ jobs:
       - if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: steps.node-cache.outputs.cache-hit != 'true'
         with:
           path: node_modules/
@@ -60,7 +60,7 @@ jobs:
       - name: Extract job definition
         run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
-      - uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -75,7 +75,7 @@ jobs:
       - if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: steps.node-cache.outputs.cache-hit != 'true'
         with:
           path: node_modules/
@@ -107,7 +107,7 @@ jobs:
         run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
       - name: Restore Cocoapods cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: cocoapods-cache
         with:
           path: ios/Pods
@@ -121,14 +121,14 @@ jobs:
       - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
         uses: ruby/setup-ruby@v1
         env:
-          BUNDLE_FROZEN: "true"
+          BUNDLE_FROZEN: 'true'
         with:
           ruby-version: ${{ env.ruby-version }}
           bundler-cache: true
 
       - name: Restore node_modules cache
         if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -142,7 +142,7 @@ jobs:
         working-directory: ./ios
 
       - name: Save Cocoapods cache
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: steps.cocoapods-cache.outputs.cache-hit != 'true'
         with:
           path: ios/Pods
@@ -160,7 +160,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -183,7 +183,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -206,7 +206,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -233,7 +233,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -256,7 +256,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -286,7 +286,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -296,7 +296,7 @@ jobs:
         run: exit 1
 
       - name: Load the cached jsbundle
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: jsbundle-cache
         with:
           path: |
@@ -312,7 +312,7 @@ jobs:
           APP_MODE: mocked
 
       - name: Cache the jsbundle
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         with:
           path: |
@@ -338,7 +338,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -348,7 +348,7 @@ jobs:
         run: exit 1
 
       - name: Load the cached jsbundle
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: jsbundle-cache
         with:
           path: ./android/generated/
@@ -362,7 +362,7 @@ jobs:
 
       - name: Cache the jsbundle
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ./android/generated/
           key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
@@ -379,7 +379,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -416,13 +416,13 @@ jobs:
         with:
           name: build-reports
           path: build/reports/
-      
+
       - name: Cache the Android app
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: android/app/build/outputs/apk/
           key: ${{ steps.app-cache.outputs.cache-primary-key }}
-      
+
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
         with:
           name: android-app
@@ -444,7 +444,7 @@ jobs:
 
       - name: Check for cached iOS app
         id: app-cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ios/build/Build/Products/
           key: ${{ runner.os }}-ios-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', '**/Podfile', '**/Podfile.lock', 'package-lock.json', '.github/job.yml') }}
@@ -456,7 +456,7 @@ jobs:
 
       - name: Restore node_modules cache
         if: steps.app-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -469,14 +469,14 @@ jobs:
       - uses: ruby/setup-ruby@v1
         if: steps.app-cache.outputs.cache-hit != 'true'
         env:
-          BUNDLE_FROZEN: "true"
+          BUNDLE_FROZEN: 'true'
         with:
           ruby-version: ${{ env.ruby-version }}
           bundler-cache: true
 
       - name: Restore Cocoapods cache
         if: steps.app-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: pods-cache
         with:
           path: ios/Pods
@@ -501,11 +501,11 @@ jobs:
         run: npx detox build e2e --configuration ios.sim.release
 
       - name: Cache the iOS app
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ios/build/Build/Products/
           key: ${{ steps.app-cache.outputs.cache-primary-key }}
-      
+
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
         with:
           name: ios-app
@@ -523,7 +523,7 @@ jobs:
 
       - # load the app before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS app
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: app-cache
         with:
           path: ios/build/Build/Products/
@@ -534,7 +534,7 @@ jobs:
 
       - # load the jsbundle before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS jsbundle
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: jsbundle-cache
         with:
           path: |
@@ -558,7 +558,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/

--- a/contrib/0001-rn.patch
+++ b/contrib/0001-rn.patch
@@ -11,3 +11,17 @@ index c209bec..228fb92 100644
    withTheme: <Props extends { theme: Theme }, C>(
      WrappedComponent: React.ComponentType<Props> & C
    ) => React.ComponentType<
+
+diff --git node_modules/react-native/third-party-podspecs/boost.podspec node_modules/react-native/third-party-podspecs/boost.podspec
+index 3d9331c..bbbb738 100644
+--- node_modules/react-native/third-party-podspecs/boost.podspec
++++ node_modules/react-native/third-party-podspecs/boost.podspec
+@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
+   spec.homepage = 'http://www.boost.org'
+   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+   spec.authors = 'Rene Rivera'
+-  spec.source = { :http => 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2',
++  spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',
+                   :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
+ 
+   # Pinning to the same version as React.podspec.

--- a/contrib/0001-rn.patch
+++ b/contrib/0001-rn.patch
@@ -25,3 +25,11 @@ index 3d9331c..bbbb738 100644
                    :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
  
    # Pinning to the same version as React.podspec.
+
+diff --git ios/Podfile.lock ios/Podfile.lock
+index abc123..def456 100644
+--- ios/Podfile.lock
++++ ios/Podfile.lock
+@@ -676,1 +676,1 @@
+-  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
++  boost: 57d2868c099736d80fcd648bf211b4431e51a558

--- a/contrib/0001-rn.patch
+++ b/contrib/0001-rn.patch
@@ -25,11 +25,3 @@ index 3d9331c..bbbb738 100644
                    :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
  
    # Pinning to the same version as React.podspec.
-
-diff --git ios/Podfile.lock ios/Podfile.lock
-index abc123..def456 100644
---- ios/Podfile.lock
-+++ ios/Podfile.lock
-@@ -676,1 +676,1 @@
--  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
-+  boost: 57d2868c099736d80fcd648bf211b4431e51a558

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -674,7 +674,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f


### PR DESCRIPTION
First, cache actions for save/restore required being bumped to 4.2.0 in a footnote of the sunset warning if you're on pinned hashes. It's beyond me why they didn't keep in lockstep with the 4.0 bump for non-pinned. See this link for more info. https://github.com/actions/cache/tree/v4.2.0?tab=readme-ov-file#whats-new

> If you are using pinned SHAs, please use the SHAs of versions v4.2.0 or v3.4.0

Second, our `boost` checksum does not match and this is caused by an upstream issue which react native maintainers said to apply a patch-package to the spec source for react-native's boost. This moved it away from jfrog and to boost.io. Then the checksum should match.  See this link https://github.com/facebook/react-native/issues/42180 for more info.