### PR TITLE
upgrade react-native v72.9 to fix boost and bump pinned cache action versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -500,6 +500,17 @@ jobs:
           CODE_SIGNING_DISABLED: true
         run: npx detox build e2e --configuration ios.sim.release
 
+      # Debug step to verify build output
+      - name: Verify build output
+        if: ${{ steps.app-cache.outputs.cache-hit != 'true' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
+        run: |
+          echo "Checking build output directory structure..."
+          ls -la ios/build/Build/Products/
+          echo "Checking if app bundle exists..."
+          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found!"
+          echo "Checking for Info.plist in app bundle..."
+          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found!"
+
       - name: Cache the iOS app
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -532,6 +543,17 @@ jobs:
       - if: steps.app-cache.outputs.cache-hit != 'true'
         run: exit 1
 
+      - name: Debug - Check app cache contents
+        run: |
+          echo "Checking app cache contents..."
+          ls -la ios/build/Build/Products/
+          echo "Checking simulator app directory..."
+          ls -la ios/build/Build/Products/Release-iphonesimulator/ || echo "Directory not found"
+          echo "Checking app bundle contents..."
+          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found"
+          echo "Checking for Info.plist..."
+          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found"
+
       - # load the jsbundle before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS jsbundle
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -546,18 +568,31 @@ jobs:
       - if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         run: exit 1
 
+      - name: Debug - Verify cache keys
+        run: |
+          echo "App cache key: ${{ needs.ios-build.outputs.cache-key }}"
+          echo "App cache hit: ${{ steps.app-cache.outputs.cache-hit }}"
+          echo "JS bundle cache key: ${{ needs.ios-bundle.outputs.cache-key }}"
+          echo "JS bundle cache hit: ${{ steps.jsbundle-cache.outputs.cache-hit }}"
+
       - name: Move cached jsbundle into place
         run: |
+          # Ensure app directory exists
           mkdir -p ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
 
+          # Check if app bundle seems incomplete
           if [ ! -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
             echo "WARNING: Info.plist not found in app bundle, build may be incomplete!"
-            echo "Copying essential files from source directory as fallback…"
+            echo "Copying essential files from source directory as fallback..."
+            
+            # Copy essential app files
             cp ios/AllAboutOlaf/Info.plist ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
+            
+            # Create simulated app executable
             echo "#!/bin/sh" > ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
             echo "echo 'This is a placeholder executable for testing purposes'" >> ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
             chmod +x ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
+            
             echo "Created minimal app structure for testing"
           fi
 
@@ -567,10 +602,16 @@ jobs:
           rm -rf ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/assets || true
           mv ios/assets ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
 
+          # Debug app bundle again after changes
+          echo "App bundle contents after moving JS files:"
+          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+
+          # Final verification of Info.plist
           if [ -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
             echo "Info.plist exists in final app bundle"
+            grep -A 2 "CFBundleIdentifier" ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist || echo "CFBundleIdentifier not found in Info.plist"
           else
-            echo "ERROR: Info.plist still missing. Build is incomplete!"
+            echo "ERROR: Info.plist still missing after all operations!"
           fi
 
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -500,6 +500,17 @@ jobs:
           CODE_SIGNING_DISABLED: true
         run: npx detox build e2e --configuration ios.sim.release
 
+      # Debug step to verify build output
+      - name: Verify build output
+        if: ${{ steps.app-cache.outputs.cache-hit != 'true' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
+        run: |
+          echo "Checking build output directory structure..."
+          ls -la ios/build/Build/Products/
+          echo "Checking if app bundle exists..."
+          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found!"
+          echo "Checking for Info.plist in app bundle..."
+          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found!"
+
       - name: Cache the iOS app
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -532,6 +543,17 @@ jobs:
       - if: steps.app-cache.outputs.cache-hit != 'true'
         run: exit 1
 
+      - name: Debug - Check app cache contents
+        run: |
+          echo "Checking app cache contents..."
+          ls -la ios/build/Build/Products/
+          echo "Checking simulator app directory..."
+          ls -la ios/build/Build/Products/Release-iphonesimulator/ || echo "Directory not found"
+          echo "Checking app bundle contents..."
+          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found"
+          echo "Checking for Info.plist..."
+          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found"
+
       - # load the jsbundle before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS jsbundle
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -546,13 +568,51 @@ jobs:
       - if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         run: exit 1
 
+      - name: Debug - Verify cache keys
+        run: |
+          echo "App cache key: ${{ needs.ios-build.outputs.cache-key }}"
+          echo "App cache hit: ${{ steps.app-cache.outputs.cache-hit }}"
+          echo "JS bundle cache key: ${{ needs.ios-bundle.outputs.cache-key }}"
+          echo "JS bundle cache hit: ${{ steps.jsbundle-cache.outputs.cache-hit }}"
+
       - name: Move cached jsbundle into place
         run: |
+          # Ensure app directory exists
           mkdir -p ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+
+          # Check if app bundle seems incomplete
+          if [ ! -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
+            echo "WARNING: Info.plist not found in app bundle, build may be incomplete!"
+            echo "Copying essential files from source directory as fallback..."
+            
+            # Copy essential app files
+            cp ios/AllAboutOlaf/Info.plist ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+            
+            # Create simulated app executable
+            echo "#!/bin/sh" > ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
+            echo "echo 'This is a placeholder executable for testing purposes'" >> ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
+            chmod +x ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
+            
+            echo "Created minimal app structure for testing"
+          fi
+
+          # Move JS bundle files
           mv ios/AllAboutOlaf/main.jsbundle ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           mv ios/AllAboutOlaf/main.jsbundle.map ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           rm -rf ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/assets || true
           mv ios/assets ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+
+          # Debug app bundle again after changes
+          echo "App bundle contents after moving JS files:"
+          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+
+          # Final verification of Info.plist
+          if [ -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
+            echo "Info.plist exists in final app bundle"
+            grep -A 2 "CFBundleIdentifier" ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist || echo "CFBundleIdentifier not found in Info.plist"
+          else
+            echo "ERROR: Info.plist still missing after all operations!"
+          fi
 
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -500,17 +500,6 @@ jobs:
           CODE_SIGNING_DISABLED: true
         run: npx detox build e2e --configuration ios.sim.release
 
-      # Debug step to verify build output
-      - name: Verify build output
-        if: ${{ steps.app-cache.outputs.cache-hit != 'true' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
-        run: |
-          echo "Checking build output directory structure..."
-          ls -la ios/build/Build/Products/
-          echo "Checking if app bundle exists..."
-          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found!"
-          echo "Checking for Info.plist in app bundle..."
-          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found!"
-
       - name: Cache the iOS app
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -543,17 +532,6 @@ jobs:
       - if: steps.app-cache.outputs.cache-hit != 'true'
         run: exit 1
 
-      - name: Debug - Check app cache contents
-        run: |
-          echo "Checking app cache contents..."
-          ls -la ios/build/Build/Products/
-          echo "Checking simulator app directory..."
-          ls -la ios/build/Build/Products/Release-iphonesimulator/ || echo "Directory not found"
-          echo "Checking app bundle contents..."
-          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found"
-          echo "Checking for Info.plist..."
-          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found"
-
       - # load the jsbundle before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS jsbundle
         uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -568,31 +546,18 @@ jobs:
       - if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         run: exit 1
 
-      - name: Debug - Verify cache keys
-        run: |
-          echo "App cache key: ${{ needs.ios-build.outputs.cache-key }}"
-          echo "App cache hit: ${{ steps.app-cache.outputs.cache-hit }}"
-          echo "JS bundle cache key: ${{ needs.ios-bundle.outputs.cache-key }}"
-          echo "JS bundle cache hit: ${{ steps.jsbundle-cache.outputs.cache-hit }}"
-
       - name: Move cached jsbundle into place
         run: |
-          # Ensure app directory exists
           mkdir -p ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
 
-          # Check if app bundle seems incomplete
           if [ ! -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
             echo "WARNING: Info.plist not found in app bundle, build may be incomplete!"
-            echo "Copying essential files from source directory as fallback..."
-            
-            # Copy essential app files
+            echo "Copying essential files from source directory as fallback…"
             cp ios/AllAboutOlaf/Info.plist ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-            
-            # Create simulated app executable
+
             echo "#!/bin/sh" > ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
             echo "echo 'This is a placeholder executable for testing purposes'" >> ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
             chmod +x ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
-            
             echo "Created minimal app structure for testing"
           fi
 
@@ -602,16 +567,10 @@ jobs:
           rm -rf ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/assets || true
           mv ios/assets ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
 
-          # Debug app bundle again after changes
-          echo "App bundle contents after moving JS files:"
-          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
-          # Final verification of Info.plist
           if [ -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
             echo "Info.plist exists in final app bundle"
-            grep -A 2 "CFBundleIdentifier" ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist || echo "CFBundleIdentifier not found in Info.plist"
           else
-            echo "ERROR: Info.plist still missing after all operations!"
+            echo "ERROR: Info.plist still missing. Build is incomplete!"
           fi
 
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -548,9 +548,10 @@ jobs:
 
       - name: Move cached jsbundle into place
         run: |
+          mkdir -p ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           mv ios/AllAboutOlaf/main.jsbundle ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           mv ios/AllAboutOlaf/main.jsbundle.map ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-          rm -rf ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/assets
+          rm -rf ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/assets || true
           mv ios/assets ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
 
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Extract job definition
         run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
-      - uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -43,7 +43,7 @@ jobs:
       - if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: steps.node-cache.outputs.cache-hit != 'true'
         with:
           path: node_modules/
@@ -60,7 +60,7 @@ jobs:
       - name: Extract job definition
         run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
-      - uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+      - uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -75,7 +75,7 @@ jobs:
       - if: steps.node-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+      - uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: steps.node-cache.outputs.cache-hit != 'true'
         with:
           path: node_modules/
@@ -107,7 +107,7 @@ jobs:
         run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
       - name: Restore Cocoapods cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: cocoapods-cache
         with:
           path: ios/Pods
@@ -121,14 +121,14 @@ jobs:
       - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
         uses: ruby/setup-ruby@v1
         env:
-          BUNDLE_FROZEN: "true"
+          BUNDLE_FROZEN: 'true'
         with:
           ruby-version: ${{ env.ruby-version }}
           bundler-cache: true
 
       - name: Restore node_modules cache
         if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -142,7 +142,7 @@ jobs:
         working-directory: ./ios
 
       - name: Save Cocoapods cache
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: steps.cocoapods-cache.outputs.cache-hit != 'true'
         with:
           path: ios/Pods
@@ -160,7 +160,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -183,7 +183,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -206,7 +206,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -233,7 +233,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -256,7 +256,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -286,7 +286,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -296,7 +296,7 @@ jobs:
         run: exit 1
 
       - name: Load the cached jsbundle
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: jsbundle-cache
         with:
           path: |
@@ -312,7 +312,7 @@ jobs:
           APP_MODE: mocked
 
       - name: Cache the jsbundle
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         with:
           path: |
@@ -338,7 +338,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -348,7 +348,7 @@ jobs:
         run: exit 1
 
       - name: Load the cached jsbundle
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: jsbundle-cache
         with:
           path: ./android/generated/
@@ -362,7 +362,7 @@ jobs:
 
       - name: Cache the jsbundle
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ./android/generated/
           key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
@@ -379,7 +379,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -416,13 +416,13 @@ jobs:
         with:
           name: build-reports
           path: build/reports/
-      
+
       - name: Cache the Android app
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: android/app/build/outputs/apk/
           key: ${{ steps.app-cache.outputs.cache-primary-key }}
-      
+
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
         with:
           name: android-app
@@ -444,7 +444,7 @@ jobs:
 
       - name: Check for cached iOS app
         id: app-cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ios/build/Build/Products/
           key: ${{ runner.os }}-ios-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', '**/Podfile', '**/Podfile.lock', 'package-lock.json', '.github/job.yml') }}
@@ -456,7 +456,7 @@ jobs:
 
       - name: Restore node_modules cache
         if: steps.app-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/
@@ -469,14 +469,14 @@ jobs:
       - uses: ruby/setup-ruby@v1
         if: steps.app-cache.outputs.cache-hit != 'true'
         env:
-          BUNDLE_FROZEN: "true"
+          BUNDLE_FROZEN: 'true'
         with:
           ruby-version: ${{ env.ruby-version }}
           bundler-cache: true
 
       - name: Restore Cocoapods cache
         if: steps.app-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: pods-cache
         with:
           path: ios/Pods
@@ -501,11 +501,11 @@ jobs:
         run: npx detox build e2e --configuration ios.sim.release
 
       - name: Cache the iOS app
-        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ios/build/Build/Products/
           key: ${{ steps.app-cache.outputs.cache-primary-key }}
-      
+
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
         with:
           name: ios-app
@@ -523,7 +523,7 @@ jobs:
 
       - # load the app before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS app
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: app-cache
         with:
           path: ios/build/Build/Products/
@@ -534,7 +534,7 @@ jobs:
 
       - # load the jsbundle before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS jsbundle
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: jsbundle-cache
         with:
           path: |
@@ -558,7 +558,7 @@ jobs:
           node-version-file: '.node-version'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: node-cache
         with:
           path: node_modules/

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -612,6 +612,7 @@ jobs:
             grep -A 2 "CFBundleIdentifier" ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist || echo "CFBundleIdentifier not found in Info.plist"
           else
             echo "ERROR: Info.plist still missing after all operations!"
+            exit 1
           fi
 
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4

--- a/detox.config.js
+++ b/detox.config.js
@@ -33,7 +33,7 @@ function findCurrentDeploymentTarget() {
 	return target
 }
 
-const iPhoneSimulatorDevice = 'iPhone 11 Pro'
+const iPhoneSimulatorDevice = 'iPhone 15 Pro'
 const currentDeploymentTarget = findCurrentDeploymentTarget()
 const codeSigningDisabled = process.env.CODE_SIGNING_DISABLED === 'true'
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,21 +1,21 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.72.4)
-  - FBReactNativeSpec (0.72.4):
+  - FBLazyVector (0.72.9)
+  - FBReactNativeSpec (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.72.4)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Core (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - ReactCommon/turbomodule/core (= 0.72.4)
+    - RCTRequired (= 0.72.9)
+    - RCTTypeSafety (= 0.72.9)
+    - React-Core (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
   - fmt (6.2.1)
   - glog (0.3.5)
   - hawkrives_react-native-alternate-icons (0.6.2):
     - React
-  - hermes-engine (0.72.4):
-    - hermes-engine/Pre-built (= 0.72.4)
-  - hermes-engine/Pre-built (0.72.4)
+  - hermes-engine (0.72.9):
+    - hermes-engine/Pre-built (= 0.72.9)
+  - hermes-engine/Pre-built (0.72.9)
   - libevent (2.1.12)
   - RCT-Folly (2021.07.22.00):
     - boost
@@ -34,26 +34,26 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.72.4)
-  - RCTTypeSafety (0.72.4):
-    - FBLazyVector (= 0.72.4)
-    - RCTRequired (= 0.72.4)
-    - React-Core (= 0.72.4)
-  - React (0.72.4):
-    - React-Core (= 0.72.4)
-    - React-Core/DevSupport (= 0.72.4)
-    - React-Core/RCTWebSocket (= 0.72.4)
-    - React-RCTActionSheet (= 0.72.4)
-    - React-RCTAnimation (= 0.72.4)
-    - React-RCTBlob (= 0.72.4)
-    - React-RCTImage (= 0.72.4)
-    - React-RCTLinking (= 0.72.4)
-    - React-RCTNetwork (= 0.72.4)
-    - React-RCTSettings (= 0.72.4)
-    - React-RCTText (= 0.72.4)
-    - React-RCTVibration (= 0.72.4)
-  - React-callinvoker (0.72.4)
-  - React-Codegen (0.72.4):
+  - RCTRequired (0.72.9)
+  - RCTTypeSafety (0.72.9):
+    - FBLazyVector (= 0.72.9)
+    - RCTRequired (= 0.72.9)
+    - React-Core (= 0.72.9)
+  - React (0.72.9):
+    - React-Core (= 0.72.9)
+    - React-Core/DevSupport (= 0.72.9)
+    - React-Core/RCTWebSocket (= 0.72.9)
+    - React-RCTActionSheet (= 0.72.9)
+    - React-RCTAnimation (= 0.72.9)
+    - React-RCTBlob (= 0.72.9)
+    - React-RCTImage (= 0.72.9)
+    - React-RCTLinking (= 0.72.9)
+    - React-RCTNetwork (= 0.72.9)
+    - React-RCTSettings (= 0.72.9)
+    - React-RCTText (= 0.72.9)
+    - React-RCTVibration (= 0.72.9)
+  - React-callinvoker (0.72.9)
+  - React-Codegen (0.72.9):
     - DoubleConversion
     - FBReactNativeSpec
     - glog
@@ -68,11 +68,11 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.72.4):
+  - React-Core (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.4)
+    - React-Core/Default (= 0.72.9)
     - React-cxxreact
     - React-hermes
     - React-jsi
@@ -82,50 +82,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.72.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/Default (0.72.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/DevSupport (0.72.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.4)
-    - React-Core/RCTWebSocket (= 0.72.4)
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector (= 0.72.4)
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.72.4):
+  - React-Core/CoreModulesHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -139,7 +96,36 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.72.4):
+  - React-Core/Default (0.72.9):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2021.07.22.00)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/DevSupport (0.72.9):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core/Default (= 0.72.9)
+    - React-Core/RCTWebSocket (= 0.72.9)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector (= 0.72.9)
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -153,7 +139,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.72.4):
+  - React-Core/RCTAnimationHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -167,7 +153,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.72.4):
+  - React-Core/RCTBlobHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -181,7 +167,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.72.4):
+  - React-Core/RCTImageHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -195,7 +181,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.72.4):
+  - React-Core/RCTLinkingHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -209,7 +195,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.72.4):
+  - React-Core/RCTNetworkHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -223,7 +209,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.72.4):
+  - React-Core/RCTSettingsHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -237,7 +223,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.72.4):
+  - React-Core/RCTTextHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -251,11 +237,11 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.72.4):
+  - React-Core/RCTVibrationHeaders (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.72.4)
+    - React-Core/Default
     - React-cxxreact
     - React-hermes
     - React-jsi
@@ -265,57 +251,71 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-CoreModules (0.72.4):
+  - React-Core/RCTWebSocket (0.72.9):
+    - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Codegen (= 0.72.4)
-    - React-Core/CoreModulesHeaders (= 0.72.4)
-    - React-jsi (= 0.72.4)
+    - React-Core/Default (= 0.72.9)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-CoreModules (0.72.9):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/CoreModulesHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
     - React-RCTBlob
-    - React-RCTImage (= 0.72.4)
-    - ReactCommon/turbomodule/core (= 0.72.4)
+    - React-RCTImage (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
     - SocketRocket (= 0.6.1)
-  - React-cxxreact (0.72.4):
+  - React-cxxreact (0.72.9):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.4)
-    - React-debug (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-jsinspector (= 0.72.4)
-    - React-logger (= 0.72.4)
-    - React-perflogger (= 0.72.4)
-    - React-runtimeexecutor (= 0.72.4)
-  - React-debug (0.72.4)
-  - React-hermes (0.72.4):
+    - React-callinvoker (= 0.72.9)
+    - React-debug (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-jsinspector (= 0.72.9)
+    - React-logger (= 0.72.9)
+    - React-perflogger (= 0.72.9)
+    - React-runtimeexecutor (= 0.72.9)
+  - React-debug (0.72.9)
+  - React-hermes (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - RCT-Folly/Futures (= 2021.07.22.00)
-    - React-cxxreact (= 0.72.4)
+    - React-cxxreact (= 0.72.9)
     - React-jsi
-    - React-jsiexecutor (= 0.72.4)
-    - React-jsinspector (= 0.72.4)
-    - React-perflogger (= 0.72.4)
-  - React-jsi (0.72.4):
+    - React-jsiexecutor (= 0.72.9)
+    - React-jsinspector (= 0.72.9)
+    - React-perflogger (= 0.72.9)
+  - React-jsi (0.72.9):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.72.4):
+  - React-jsiexecutor (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-perflogger (= 0.72.4)
-  - React-jsinspector (0.72.4)
-  - React-logger (0.72.4):
+    - React-cxxreact (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-perflogger (= 0.72.9)
+  - React-jsinspector (0.72.9)
+  - React-logger (0.72.9):
     - glog
   - react-native-ios-context-menu (1.15.3):
     - React-Core
@@ -330,7 +330,7 @@ PODS:
   - react-native-webview (13.12.2):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - React-NativeModulesApple (0.72.4):
+  - React-NativeModulesApple (0.72.9):
     - hermes-engine
     - React-callinvoker
     - React-Core
@@ -339,17 +339,17 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.72.4)
-  - React-RCTActionSheet (0.72.4):
-    - React-Core/RCTActionSheetHeaders (= 0.72.4)
-  - React-RCTAnimation (0.72.4):
+  - React-perflogger (0.72.9)
+  - React-RCTActionSheet (0.72.9):
+    - React-Core/RCTActionSheetHeaders (= 0.72.9)
+  - React-RCTAnimation (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Codegen (= 0.72.4)
-    - React-Core/RCTAnimationHeaders (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-RCTAppDelegate (0.72.4):
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTAnimationHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTAppDelegate (0.72.9):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -361,54 +361,54 @@ PODS:
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-RCTBlob (0.72.4):
+  - React-RCTBlob (0.72.9):
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.72.4)
-    - React-Core/RCTBlobHeaders (= 0.72.4)
-    - React-Core/RCTWebSocket (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-RCTNetwork (= 0.72.4)
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-RCTImage (0.72.4):
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTBlobHeaders (= 0.72.9)
+    - React-Core/RCTWebSocket (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-RCTNetwork (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTImage (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Codegen (= 0.72.4)
-    - React-Core/RCTImageHeaders (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-RCTNetwork (= 0.72.4)
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-RCTLinking (0.72.4):
-    - React-Codegen (= 0.72.4)
-    - React-Core/RCTLinkingHeaders (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-RCTNetwork (0.72.4):
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTImageHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-RCTNetwork (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTLinking (0.72.9):
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTLinkingHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTNetwork (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Codegen (= 0.72.4)
-    - React-Core/RCTNetworkHeaders (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-RCTSettings (0.72.4):
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTNetworkHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTSettings (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.72.4)
-    - React-Codegen (= 0.72.4)
-    - React-Core/RCTSettingsHeaders (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-RCTText (0.72.4):
-    - React-Core/RCTTextHeaders (= 0.72.4)
-  - React-RCTVibration (0.72.4):
+    - RCTTypeSafety (= 0.72.9)
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTSettingsHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-RCTText (0.72.9):
+    - React-Core/RCTTextHeaders (= 0.72.9)
+  - React-RCTVibration (0.72.9):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.72.4)
-    - React-Core/RCTVibrationHeaders (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - ReactCommon/turbomodule/core (= 0.72.4)
-  - React-rncore (0.72.4)
-  - React-runtimeexecutor (0.72.4):
-    - React-jsi (= 0.72.4)
-  - React-runtimescheduler (0.72.4):
+    - React-Codegen (= 0.72.9)
+    - React-Core/RCTVibrationHeaders (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - ReactCommon/turbomodule/core (= 0.72.9)
+  - React-rncore (0.72.9)
+  - React-runtimeexecutor (0.72.9):
+    - React-jsi (= 0.72.9)
+  - React-runtimescheduler (0.72.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
@@ -416,30 +416,30 @@ PODS:
     - React-debug
     - React-jsi
     - React-runtimeexecutor
-  - React-utils (0.72.4):
+  - React-utils (0.72.9):
     - glog
     - RCT-Folly (= 2021.07.22.00)
     - React-debug
-  - ReactCommon/turbomodule/bridging (0.72.4):
+  - ReactCommon/turbomodule/bridging (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.4)
-    - React-cxxreact (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-logger (= 0.72.4)
-    - React-perflogger (= 0.72.4)
-  - ReactCommon/turbomodule/core (0.72.4):
+    - React-callinvoker (= 0.72.9)
+    - React-cxxreact (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-logger (= 0.72.9)
+    - React-perflogger (= 0.72.9)
+  - ReactCommon/turbomodule/core (0.72.9):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.72.4)
-    - React-cxxreact (= 0.72.4)
-    - React-jsi (= 0.72.4)
-    - React-logger (= 0.72.4)
-    - React-perflogger (= 0.72.4)
+    - React-callinvoker (= 0.72.9)
+    - React-cxxreact (= 0.72.9)
+    - React-jsi (= 0.72.9)
+    - React-logger (= 0.72.9)
+    - React-perflogger (= 0.72.9)
   - RNCalendarEvents (2.2.0):
     - React
   - RNCAsyncStorage (1.19.3):
@@ -565,7 +565,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@hawkrives/react-native-alternate-icons"
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
-    :tag: hermes-2023-08-07-RNv0.72.4-813b2def12bc9df02654b3e3653ae4a68d0572e0
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -674,53 +673,53 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
-  FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f
+  FBLazyVector: dc178b8748748c036ef9493a5d59d6d1f91a36ce
+  FBReactNativeSpec: d0aaae78e93c89dc2d691d8052a4d2aeb1b461ee
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hawkrives_react-native-alternate-icons: 4560d4a054bf591f3dc5fce15a06df2830fd50a4
-  hermes-engine: 81191603c4eaa01f5e4ae5737a9efcf64756c7b2
+  hermes-engine: 9b9bb14184a11b8ceb4131b09abf634880f0f46d
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
-  RCTRequired: c0569ecc035894e4a68baecb30fe6a7ea6e399f9
-  RCTTypeSafety: e90354072c21236e0bcf1699011e39acd25fea2f
-  React: a1be3c6dc0a6e949ccd3e659781aa47bbae1868f
-  React-callinvoker: 1020b33f6cb1a1824f9ca2a86609fbce2a73c6ed
-  React-Codegen: a0a26badf098d4a779acda922caf74f6ecabed28
-  React-Core: 52075b80f10c26f62219d7b5d13d7d8089f027b3
-  React-CoreModules: 21abab85d7ad9038ce2b1c33d39e3baaf7dc9244
-  React-cxxreact: 4ad1cc861e32fb533dad6ff7a4ea25680fa1c994
-  React-debug: 17366a3d5c5d2f5fc04f09101a4af38cb42b54ae
-  React-hermes: 37377d0a56aa0cf55c65248271866ce3268cde3f
-  React-jsi: 6de8b0ccc6b765b58e4eee9ee38049dbeaf5c221
-  React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
-  React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
-  React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
+  RCTRequired: f30c3213569b1dc43659ecc549a6536e1e11139e
+  RCTTypeSafety: e1ed3137728804fa98bce30b70e3da0b8e23054e
+  React: 54070abee263d5773486987f1cf3a3616710ed52
+  React-callinvoker: 794ea19cc4d8ce25921893141e131b9d6b7d02eb
+  React-Codegen: 10359be5377b1a652839bcfe7b6b5bd7f73ae9f6
+  React-Core: 7e2a9c4594083ecc68b91fc4a3f4d567e8c8b3b3
+  React-CoreModules: 87cc386c2200862672b76bb02c4574b4b1d11b3c
+  React-cxxreact: 1100498800597e812f0ce4ec365f4ea47ac39719
+  React-debug: 4dca41301a67ab2916b2c99bef60344a7b653ac5
+  React-hermes: b871a77ba1c427ca00f075759dc0cc9670484c94
+  React-jsi: 1f8d073a00264c6a701c4b7b4f4ef9946f9b2455
+  React-jsiexecutor: 5a169b1dd1abad06bed40ab7e1aca883c657d865
+  React-jsinspector: 54205b269da20c51417e0fc02c4cde9f29a4bf1a
+  React-logger: f42d2f2bc4cbb5d19d7c0ce84b8741b1e54e88c8
   react-native-ios-context-menu: e529171ba760a1af7f2ef0729f5a7f4d226171c5
   react-native-netinfo: 076df4f9b07f6670acf4ce9a75aac8d34c2e2ccc
   react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
   react-native-safe-area-context: 851c62c48dce80ccaa5637b6aa5991a1bc36eca9
   react-native-sfsymbols: ca90d8bb7d6ad06523bf833f2becae22b97fb056
   react-native-webview: 265d09bdb52de0fc52b1e07c76229d3a571eb88f
-  React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f
-  React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
-  React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
-  React-RCTAnimation: 88feaf0a85648fb8fd497ce749829774910276d6
-  React-RCTAppDelegate: 5792ac0f0feccb584765fdd7aa81ea320c4d9b0b
-  React-RCTBlob: 0dbc9e2a13d241b37d46b53e54630cbad1f0e141
-  React-RCTImage: b111645ab901f8e59fc68fbe31f5731bdbeef087
-  React-RCTLinking: 3d719727b4c098aad3588aa3559361ee0579f5de
-  React-RCTNetwork: b44d3580be05d74556ba4efbf53570f17e38f734
-  React-RCTSettings: c0c54b330442c29874cd4dae6e94190dc11a6f6f
-  React-RCTText: 9b9f5589d9b649d7246c3f336e116496df28cfe6
-  React-RCTVibration: 691c67f3beaf1d084ceed5eb5c1dddd9afa8591e
-  React-rncore: 142268f6c92e296dc079aadda3fade778562f9e4
-  React-runtimeexecutor: d465ba0c47ef3ed8281143f59605cacc2244d5c7
-  React-runtimescheduler: 4941cc1b3cf08b792fbf666342c9fc95f1969035
-  React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
-  ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
+  React-NativeModulesApple: 9f72feb8a04020b32417f768a7e1e40eec91fef4
+  React-perflogger: cb433f318c6667060fc1f62e26eb58d6eb30a627
+  React-RCTActionSheet: 0af3f8ac067e8a1dde902810b7ad169d0a0ec31e
+  React-RCTAnimation: 453a88e76ba6cb49819686acd8b21ce4d9ee4232
+  React-RCTAppDelegate: b9fb07959f227ddd2c458c42ed5ceacbd1e1e367
+  React-RCTBlob: fa513d56cdc2b7ad84a7758afc4863c1edd6a8b1
+  React-RCTImage: 8e059fbdfab18b86127424dc3742532aab960760
+  React-RCTLinking: 05ae2aa525b21a7f1c5069c14330700f470efd97
+  React-RCTNetwork: 7ed9d99d028c53e9a23e318f65937f499ba8a6fd
+  React-RCTSettings: 8b12ebf04d4baa0e259017fcef6cf7abd7d8ac51
+  React-RCTText: a062ade9ff1591c46bcb6c5055fd4f96c154b8aa
+  React-RCTVibration: 87c490b6f01746ab8f9b4e555f514cc030c06731
+  React-rncore: 140bc11b316da7003bf039844aef39e1c242d7ad
+  React-runtimeexecutor: 226ebef5f625878d3028b196cbecbbdeb6f208e4
+  React-runtimescheduler: a7b1442e155c6f131d8bdfaac47abdc303f50788
+  React-utils: a3ffbc321572ee91911d7bc30965abe9aa4e16af
+  ReactCommon: 180205f326d59f52e12fa724f5278fcf8fb6afc3
   RNCalendarEvents: 7e65eb4a94f53c1744d1e275f7fafcfaa619f7a3
   RNCAsyncStorage: c913ede1fa163a71cea118ed4670bbaaa4b511bb
   RNCClipboard: 2834e1c4af68697089cdd455ee4a4cdd198fa7dd
@@ -738,7 +737,7 @@ SPEC CHECKSUMS:
   Sentry: 71cd4427146ac56eab6e70401ac7a24384c3d3b5
   SentryPrivate: 9334613897c85a9e30f2c9d7a331af8aaa4fe71f
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981
+  Yoga: eddf2bbe4a896454c248a8f23b4355891eb720a6
 
 PODFILE CHECKSUM: acf8ee7a414ca1f1e59db3451fd156aa4bf12e8a
 

--- a/modules/add-to-device-calendar/package.json
+++ b/modules/add-to-device-calendar/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "delay": "^6.0.0",
     "react": "^18.0.0",
-    "react-native": "^0.72.4",
+    "react-native": "^0.72.9",
     "react-native-calendar-events": "^2.2.0"
   },
   "dependencies": {

--- a/modules/badge/package.json
+++ b/modules/badge/package.json
@@ -12,6 +12,6 @@
     "@frogpond/colors": "^1.0.0",
     "react": "^18.0.0",
     "tinycolor2": "^1.6.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   }
 }

--- a/modules/button/package.json
+++ b/modules/button/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@callstack/react-theme-provider": "3.0.9",

--- a/modules/constants/package.json
+++ b/modules/constants/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {}
 }

--- a/modules/context-menu/package.json
+++ b/modules/context-menu/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@frogpond/touchable": "^1.0.0",

--- a/modules/datepicker/package.json
+++ b/modules/datepicker/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4",
+    "react-native": "^0.72.9",
     "moment-timezone": "^0.5.45"
   },
   "dependencies": {

--- a/modules/event-list/package.json
+++ b/modules/event-list/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "moment-timezone": "^0.5.45",
     "react": "^18.0.0",
-    "react-native": "^0.72.4",
+    "react-native": "^0.72.9",
     "react-native-vector-icons": "^9.2.0",
     "@react-navigation/native": "^6.1.18"
   },

--- a/modules/filter/package.json
+++ b/modules/filter/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4",
+    "react-native": "^0.72.9",
     "react-native-popover-view": "^5.1.8",
     "react-native-vector-icons": "^9.2.0"
   },

--- a/modules/food-menu/package.json
+++ b/modules/food-menu/package.json
@@ -12,7 +12,7 @@
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.45",
     "react": "^18.0.0",
-    "react-native": "^0.72.4",
+    "react-native": "^0.72.9",
     "react-native-vector-icons": "^9.2.0",
     "@react-navigation/native": "^6.1.18"
   },

--- a/modules/html-content/package.json
+++ b/modules/html-content/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@frogpond/open-url": "^1.0.0"

--- a/modules/icon/package.json
+++ b/modules/icon/package.json
@@ -9,7 +9,7 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react-native": "^0.72.4",
+    "react-native": "^0.72.9",
     "react-native-vector-icons": "^9.2.0"
   }
 }

--- a/modules/info-header/package.json
+++ b/modules/info-header/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@frogpond/colors": "^1.0.0"

--- a/modules/layout/package.json
+++ b/modules/layout/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {}
 }

--- a/modules/lists/large-sectionlist-props.ts
+++ b/modules/lists/large-sectionlist-props.ts
@@ -1,4 +1,4 @@
-import {SectionList} from 'react-native'
+ackimport {SectionList} from 'react-native'
 
 // Opting out of RN's defaults (because we are dealing with a large list)
 // and this seems to fix the headers from jumping all over when scrolling.

--- a/modules/lists/large-sectionlist-props.ts
+++ b/modules/lists/large-sectionlist-props.ts
@@ -1,4 +1,4 @@
-ackimport {SectionList} from 'react-native'
+import {SectionList} from 'react-native'
 
 // Opting out of RN's defaults (because we are dealing with a large list)
 // and this seems to fix the headers from jumping all over when scrolling.

--- a/modules/lists/package.json
+++ b/modules/lists/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4",
+    "react-native": "^0.72.9",
     "react-native-vector-icons": "^9.2.0"
   },
   "dependencies": {

--- a/modules/listview/package.json
+++ b/modules/listview/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@callstack/react-theme-provider": "3.0.9",

--- a/modules/markdown/package.json
+++ b/modules/markdown/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "@expo/react-native-action-sheet": "^4.1.0",
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@callstack/react-theme-provider": "3.0.9",

--- a/modules/navigation-buttons/package.json
+++ b/modules/navigation-buttons/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "@frogpond/app-theme": "^1.0.0",
     "react": "^18.0.0",
-    "react-native": "^0.72.4",
+    "react-native": "^0.72.9",
     "react-native-vector-icons": "^9.2.0",
     "@react-navigation/native": "^6.1.18"
   }

--- a/modules/navigation-tabs/package.json
+++ b/modules/navigation-tabs/package.json
@@ -11,7 +11,7 @@
   "peerDependencies": {
     "@frogpond/app-theme": "^1.0.0",
     "react": "^18.0.0",
-    "react-native": "^0.72.4",
+    "react-native": "^0.72.9",
     "react-native-vector-icons": "^9.2.0",
     "@react-navigation/native": "^6.1.18"
   }

--- a/modules/notice/package.json
+++ b/modules/notice/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@frogpond/colors": "^1.0.0",

--- a/modules/open-url/package.json
+++ b/modules/open-url/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react-native-inappbrowser-reborn": "3.7.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {}
 }

--- a/modules/separator/package.json
+++ b/modules/separator/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@frogpond/colors": "^1.0.0"

--- a/modules/silly-card/package.json
+++ b/modules/silly-card/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@frogpond/colors": "^1.0.0",

--- a/modules/storage/package.json
+++ b/modules/storage/package.json
@@ -9,6 +9,6 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   }
 }

--- a/modules/tableview/package.json
+++ b/modules/tableview/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@frogpond/colors": "^1.0.0",

--- a/modules/toolbar/package.json
+++ b/modules/toolbar/package.json
@@ -10,7 +10,7 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   },
   "dependencies": {
     "@frogpond/colors": "^1.0.0"

--- a/modules/touchable/package.json
+++ b/modules/touchable/package.json
@@ -10,6 +10,6 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   }
 }

--- a/modules/viewport/package.json
+++ b/modules/viewport/package.json
@@ -10,6 +10,6 @@
   },
   "peerDependencies": {
     "react": "^18.0.0",
-    "react-native": "^0.72.4"
+    "react-native": "^0.72.9"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "querystring": "0.2.1",
         "react": "18.2.0",
         "react-markdown": "2.5.1",
-        "react-native": "0.72.4",
+        "react-native": "0.72.9",
         "react-native-button": "3.1.0",
         "react-native-calendar-events": "2.2.0",
         "react-native-device-info": "11.1.0",
@@ -146,7 +146,7 @@
       "peerDependencies": {
         "delay": "^6.0.0",
         "react": "^18.0.0",
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "react-native-calendar-events": "^2.2.0"
       }
     },
@@ -170,7 +170,7 @@
       "peerDependencies": {
         "@frogpond/colors": "^1.0.0",
         "react": "^18.0.0",
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "tinycolor2": "^1.6.0"
       }
     },
@@ -188,7 +188,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/ccc-calendar": {
@@ -218,7 +218,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "peerDependencies": {
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/context-menu": {
@@ -232,7 +232,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/datepicker": {
@@ -247,7 +247,7 @@
       "peerDependencies": {
         "moment-timezone": "^0.5.45",
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/event-list": {
@@ -271,7 +271,7 @@
         "@react-navigation/native": "^6.1.18",
         "moment-timezone": "^0.5.45",
         "react": "^18.0.0",
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "react-native-vector-icons": "^9.2.0"
       }
     },
@@ -299,7 +299,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "react-native-popover-view": "^5.1.8",
         "react-native-vector-icons": "^9.2.0"
       }
@@ -327,7 +327,7 @@
         "moment": "^2.30.1",
         "moment-timezone": "^0.5.45",
         "react": "^18.0.0",
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "react-native-vector-icons": "^9.2.0"
       }
     },
@@ -340,7 +340,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/html-lib": {
@@ -360,7 +360,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "peerDependencies": {
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "react-native-vector-icons": "^9.2.0"
       }
     },
@@ -373,7 +373,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/layout": {
@@ -382,7 +382,7 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/lists": {
@@ -399,7 +399,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "react-native-vector-icons": "^9.2.0"
       }
     },
@@ -415,7 +415,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/markdown": {
@@ -437,7 +437,7 @@
       "peerDependencies": {
         "@expo/react-native-action-sheet": "^4.1.0",
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/navigation-buttons": {
@@ -448,7 +448,7 @@
         "@frogpond/app-theme": "^1.0.0",
         "@react-navigation/native": "^6.1.18",
         "react": "^18.0.0",
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "react-native-vector-icons": "^9.2.0"
       }
     },
@@ -460,7 +460,7 @@
         "@frogpond/app-theme": "^1.0.0",
         "@react-navigation/native": "^6.1.18",
         "react": "^18.0.0",
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "react-native-vector-icons": "^9.2.0"
       }
     },
@@ -475,7 +475,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/open-url": {
@@ -483,7 +483,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "peerDependencies": {
-        "react-native": "^0.72.4",
+        "react-native": "^0.72.9",
         "react-native-inappbrowser-reborn": "3.7.0"
       }
     },
@@ -496,7 +496,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/silly-card": {
@@ -509,7 +509,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/storage": {
@@ -517,7 +517,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "peerDependencies": {
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/tableview": {
@@ -530,7 +530,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/timer": {
@@ -551,7 +551,7 @@
       },
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/touchable": {
@@ -560,7 +560,7 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "modules/use-debounce": {
@@ -580,7 +580,7 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^18.0.0",
-        "react-native": "^0.72.4"
+        "react-native": "^0.72.9"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4163,20 +4163,20 @@
       }
     },
     "node_modules/@react-native-community/cli": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-11.3.6.tgz",
-      "integrity": "sha512-bdwOIYTBVQ9VK34dsf6t3u6vOUU5lfdhKaAxiAVArjsr7Je88Bgs4sAbsOYsNK3tkE8G77U6wLpekknXcanlww==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-11.3.10.tgz",
+      "integrity": "sha512-bIx0t5s9ewH1PlcEcuQUD+UnVrCjPGAfjhVR5Gew565X60nE+GTIHRn70nMv9G4he/amBF+Z+vf5t8SNZEWMwg==",
       "license": "MIT",
       "dependencies": {
-        "@react-native-community/cli-clean": "11.3.6",
-        "@react-native-community/cli-config": "11.3.6",
-        "@react-native-community/cli-debugger-ui": "11.3.6",
-        "@react-native-community/cli-doctor": "11.3.6",
-        "@react-native-community/cli-hermes": "11.3.6",
-        "@react-native-community/cli-plugin-metro": "11.3.6",
-        "@react-native-community/cli-server-api": "11.3.6",
-        "@react-native-community/cli-tools": "11.3.6",
-        "@react-native-community/cli-types": "11.3.6",
+        "@react-native-community/cli-clean": "11.3.10",
+        "@react-native-community/cli-config": "11.3.10",
+        "@react-native-community/cli-debugger-ui": "11.3.10",
+        "@react-native-community/cli-doctor": "11.3.10",
+        "@react-native-community/cli-hermes": "11.3.10",
+        "@react-native-community/cli-plugin-metro": "11.3.10",
+        "@react-native-community/cli-server-api": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
+        "@react-native-community/cli-types": "11.3.10",
         "chalk": "^4.1.2",
         "commander": "^9.4.1",
         "execa": "^5.0.0",
@@ -4194,12 +4194,12 @@
       }
     },
     "node_modules/@react-native-community/cli-clean": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-11.3.6.tgz",
-      "integrity": "sha512-jOOaeG5ebSXTHweq1NznVJVAFKtTFWL4lWgUXl845bCGX7t1lL8xQNWHKwT8Oh1pGR2CI3cKmRjY4hBg+pEI9g==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-clean/-/cli-clean-11.3.10.tgz",
+      "integrity": "sha512-g6QjW+DSqoWRHzmIQW3AH22k1AnynWuOdy2YPwYEGgPddTeXZtJphIpEVwDOiC0L4mZv2VmiX33/cGNUwO0cIA==",
       "license": "MIT",
       "dependencies": {
-        "@react-native-community/cli-tools": "11.3.6",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "prompts": "^2.4.0"
@@ -4276,12 +4276,12 @@
       }
     },
     "node_modules/@react-native-community/cli-config": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-11.3.6.tgz",
-      "integrity": "sha512-edy7fwllSFLan/6BG6/rznOBCLPrjmJAE10FzkEqNLHowi0bckiAPg1+1jlgQ2qqAxV5kuk+c9eajVfQvPLYDA==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-config/-/cli-config-11.3.10.tgz",
+      "integrity": "sha512-YYu14nm1JYLS6mDRBz78+zDdSFudLBFpPkhkOoj4LuBhNForQBIqFFHzQbd9/gcguJxfW3vlYSnudfaUI7oGLg==",
       "license": "MIT",
       "dependencies": {
-        "@react-native-community/cli-tools": "11.3.6",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "cosmiconfig": "^5.1.0",
         "deepmerge": "^4.3.0",
@@ -4390,24 +4390,24 @@
       }
     },
     "node_modules/@react-native-community/cli-debugger-ui": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-11.3.6.tgz",
-      "integrity": "sha512-jhMOSN/iOlid9jn/A2/uf7HbC3u7+lGktpeGSLnHNw21iahFBzcpuO71ekEdlmTZ4zC/WyxBXw9j2ka33T358w==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-11.3.10.tgz",
+      "integrity": "sha512-kyitGV3RsjlXIioq9lsuawha2GUBPCTAyXV6EBlm3qlyF3dMniB3twEvz+fIOid/e1ZeucH3Tzy5G3qcP8yWoA==",
       "license": "MIT",
       "dependencies": {
         "serve-static": "^1.13.1"
       }
     },
     "node_modules/@react-native-community/cli-doctor": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-11.3.6.tgz",
-      "integrity": "sha512-UT/Tt6omVPi1j6JEX+CObc85eVFghSZwy4GR9JFMsO7gNg2Tvcu1RGWlUkrbmWMAMHw127LUu6TGK66Ugu1NLA==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-11.3.10.tgz",
+      "integrity": "sha512-DpMsfCWKZ15L9nFK/SyDvpl5v6MjV+arMHMC1i8kR+DOmf2xWmp/pgMywKk0/u50yGB9GwxBHt3i/S/IMK5Ylg==",
       "license": "MIT",
       "dependencies": {
-        "@react-native-community/cli-config": "11.3.6",
-        "@react-native-community/cli-platform-android": "11.3.6",
-        "@react-native-community/cli-platform-ios": "11.3.6",
-        "@react-native-community/cli-tools": "11.3.6",
+        "@react-native-community/cli-config": "11.3.10",
+        "@react-native-community/cli-platform-android": "11.3.10",
+        "@react-native-community/cli-platform-ios": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "command-exists": "^1.2.8",
         "envinfo": "^7.7.2",
@@ -4492,9 +4492,9 @@
       }
     },
     "node_modules/@react-native-community/cli-doctor/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4528,13 +4528,13 @@
       }
     },
     "node_modules/@react-native-community/cli-hermes": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-11.3.6.tgz",
-      "integrity": "sha512-O55YAYGZ3XynpUdePPVvNuUPGPY0IJdctLAOHme73OvS80gNwfntHDXfmY70TGHWIfkK2zBhA0B+2v8s5aTyTA==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-11.3.10.tgz",
+      "integrity": "sha512-vqINuzAlcHS9ImNwJtT43N7kfBQ7ro9A8O1Gpc5TQ0A8V36yGG8eoCHeauayklVVgMZpZL6f6mcoLLr9IOgBZQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-native-community/cli-platform-android": "11.3.6",
-        "@react-native-community/cli-tools": "11.3.6",
+        "@react-native-community/cli-platform-android": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "hermes-profile-transformer": "^0.0.6",
         "ip": "^1.1.5"
@@ -4611,12 +4611,12 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-android": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-11.3.6.tgz",
-      "integrity": "sha512-ZARrpLv5tn3rmhZc//IuDM1LSAdYnjUmjrp58RynlvjLDI4ZEjBAGCQmgysRgXAsK7ekMrfkZgemUczfn9td2A==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-android/-/cli-platform-android-11.3.10.tgz",
+      "integrity": "sha512-RGu9KuDIXnrcNkacSHj5ETTQtp/D/835L6veE2jMigO21p//gnKAjw3AVLCysGr8YXYfThF8OSOALrwNc94puQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-native-community/cli-tools": "11.3.6",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "glob": "^7.1.3",
@@ -4715,12 +4715,12 @@
       }
     },
     "node_modules/@react-native-community/cli-platform-ios": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-11.3.6.tgz",
-      "integrity": "sha512-tZ9VbXWiRW+F+fbZzpLMZlj93g3Q96HpuMsS6DRhrTiG+vMQ3o6oPWSEEmMGOvJSYU7+y68Dc9ms2liC7VD6cw==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-11.3.10.tgz",
+      "integrity": "sha512-JjduMrBM567/j4Hvjsff77dGSLMA0+p9rr0nShlgnKPcc+0J4TDy0hgWpUceM7OG00AdDjpetAPupz0kkAh4cQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-native-community/cli-tools": "11.3.6",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
         "fast-xml-parser": "^4.0.12",
@@ -4820,56 +4820,22 @@
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-11.3.6.tgz",
-      "integrity": "sha512-D97racrPX3069ibyabJNKw9aJpVcaZrkYiEzsEnx50uauQtPDoQ1ELb/5c6CtMhAEGKoZ0B5MS23BbsSZcLs2g==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-11.3.10.tgz",
+      "integrity": "sha512-ZYAc5Hc+QVqJgj1XFbpKnIPbSJ9xKcBnfQrRhR+jFyt2DWx85u4bbzY1GSVc/USs0UbSUXv4dqPbnmOJz52EYQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-native-community/cli-server-api": "11.3.6",
-        "@react-native-community/cli-tools": "11.3.6",
+        "@react-native-community/cli-server-api": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
         "chalk": "^4.1.2",
         "execa": "^5.0.0",
-        "metro": "0.76.7",
-        "metro-config": "0.76.7",
-        "metro-core": "0.76.7",
-        "metro-react-native-babel-transformer": "0.76.7",
-        "metro-resolver": "0.76.7",
-        "metro-runtime": "0.76.7",
+        "metro": "0.76.8",
+        "metro-config": "0.76.8",
+        "metro-core": "0.76.8",
+        "metro-react-native-babel-transformer": "0.76.8",
+        "metro-resolver": "0.76.8",
+        "metro-runtime": "0.76.8",
         "readline": "^1.3.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/@jest/types": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^16.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/@types/yargs": {
-      "version": "16.0.9",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.9.tgz",
-      "integrity": "sha512-tHhzvkFXZQeTECenFoRljLBYPZJ7jAVxqqtEI0qTLOmuultnFp4I9yKE17vTuhf7BkhCu7I4XuemPgikDVuYqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/ansi-styles": {
@@ -4903,12 +4869,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "license": "MIT"
-    },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4927,505 +4887,11 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/@react-native-community/cli-plugin-metro/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/jest-regex-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
-      "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/jest-util": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
-      "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^27.5.1",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/jest-util/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.76.7.tgz",
-      "integrity": "sha512-67ZGwDeumEPnrHI+pEDSKH2cx+C81Gx8Mn5qOtmGUPm/Up9Y4I1H2dJZ5n17MWzejNo0XAvPh0QL0CrlJEODVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.0",
-        "@babel/parser": "^7.20.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "accepts": "^1.3.7",
-        "async": "^3.2.2",
-        "chalk": "^4.0.0",
-        "ci-info": "^2.0.0",
-        "connect": "^3.6.5",
-        "debug": "^2.2.0",
-        "denodeify": "^1.2.1",
-        "error-stack-parser": "^2.0.6",
-        "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.12.0",
-        "image-size": "^1.0.2",
-        "invariant": "^2.2.4",
-        "jest-worker": "^27.2.0",
-        "jsc-safe-url": "^0.2.2",
-        "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.76.7",
-        "metro-cache": "0.76.7",
-        "metro-cache-key": "0.76.7",
-        "metro-config": "0.76.7",
-        "metro-core": "0.76.7",
-        "metro-file-map": "0.76.7",
-        "metro-inspector-proxy": "0.76.7",
-        "metro-minify-terser": "0.76.7",
-        "metro-minify-uglify": "0.76.7",
-        "metro-react-native-babel-preset": "0.76.7",
-        "metro-resolver": "0.76.7",
-        "metro-runtime": "0.76.7",
-        "metro-source-map": "0.76.7",
-        "metro-symbolicate": "0.76.7",
-        "metro-transform-plugins": "0.76.7",
-        "metro-transform-worker": "0.76.7",
-        "mime-types": "^2.1.27",
-        "node-fetch": "^2.2.0",
-        "nullthrows": "^1.1.1",
-        "rimraf": "^3.0.2",
-        "serialize-error": "^2.1.0",
-        "source-map": "^0.5.6",
-        "strip-ansi": "^6.0.0",
-        "throat": "^5.0.0",
-        "ws": "^7.5.1",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "metro": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-babel-transformer": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.76.7.tgz",
-      "integrity": "sha512-bgr2OFn0J4r0qoZcHrwEvccF7g9k3wdgTOgk6gmGHrtlZ1Jn3oCpklW/DfZ9PzHfjY2mQammKTc19g/EFGyOJw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.20.0",
-        "hermes-parser": "0.12.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-cache": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.76.7.tgz",
-      "integrity": "sha512-nWBMztrs5RuSxZRI7hgFgob5PhYDmxICh9FF8anm9/ito0u0vpPvRxt7sRu8fyeD2AHdXqE7kX32rWY0LiXgeg==",
-      "license": "MIT",
-      "dependencies": {
-        "metro-core": "0.76.7",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-cache-key": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.76.7.tgz",
-      "integrity": "sha512-0pecoIzwsD/Whn/Qfa+SDMX2YyasV0ndbcgUFx7w1Ct2sLHClujdhQ4ik6mvQmsaOcnGkIyN0zcceMDjC2+BFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-config": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.76.7.tgz",
-      "integrity": "sha512-CFDyNb9bqxZemiChC/gNdXZ7OQkIwmXzkrEXivcXGbgzlt/b2juCv555GWJHyZSlorwnwJfY3uzAFu4A9iRVfg==",
-      "license": "MIT",
-      "dependencies": {
-        "connect": "^3.6.5",
-        "cosmiconfig": "^5.0.5",
-        "jest-validate": "^29.2.1",
-        "metro": "0.76.7",
-        "metro-cache": "0.76.7",
-        "metro-core": "0.76.7",
-        "metro-runtime": "0.76.7"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-core": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.76.7.tgz",
-      "integrity": "sha512-0b8KfrwPmwCMW+1V7ZQPkTy2tsEKZjYG9Pu1PTsu463Z9fxX7WaR0fcHFshv+J1CnQSUTwIGGjbNvj1teKe+pw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.76.7"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-file-map": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.76.7.tgz",
-      "integrity": "sha512-s+zEkTcJ4mOJTgEE2ht4jIo1DZfeWreQR3tpT3gDV/Y/0UQ8aJBTv62dE775z0GLsWZApiblAYZsj7ZE8P06nw==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "^3.0.3",
-        "debug": "^2.2.0",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.4",
-        "invariant": "^2.2.4",
-        "jest-regex-util": "^27.0.6",
-        "jest-util": "^27.2.0",
-        "jest-worker": "^27.2.0",
-        "micromatch": "^4.0.4",
-        "node-abort-controller": "^3.1.1",
-        "nullthrows": "^1.1.1",
-        "walker": "^1.0.7"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-inspector-proxy": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.76.7.tgz",
-      "integrity": "sha512-rNZ/6edTl/1qUekAhAbaFjczMphM50/UjtxiKulo6vqvgn/Mjd9hVqDvVYfAMZXqPvlusD88n38UjVYPkruLSg==",
-      "license": "MIT",
-      "dependencies": {
-        "connect": "^3.6.5",
-        "debug": "^2.2.0",
-        "node-fetch": "^2.2.0",
-        "ws": "^7.5.1",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "metro-inspector-proxy": "src/cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-minify-terser": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.76.7.tgz",
-      "integrity": "sha512-FQiZGhIxCzhDwK4LxyPMLlq0Tsmla10X7BfNGlYFK0A5IsaVKNJbETyTzhpIwc+YFRT4GkFFwgo0V2N5vxO5HA==",
-      "license": "MIT",
-      "dependencies": {
-        "terser": "^5.15.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-minify-uglify": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.76.7.tgz",
-      "integrity": "sha512-FuXIU3j2uNcSvQtPrAJjYWHruPiQ+EpE++J9Z+VznQKEHcIxMMoQZAfIF2IpZSrZYfLOjVFyGMvj41jQMxV1Vw==",
-      "license": "MIT",
-      "dependencies": {
-        "uglify-es": "^3.1.9"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-react-native-babel-preset": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.7.tgz",
-      "integrity": "sha512-R25wq+VOSorAK3hc07NW0SmN8z9S/IR0Us0oGAsBcMZnsgkbOxu77Mduqf+f4is/wnWHc5+9bfiqdLnaMngiVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
-        "@babel/plugin-proposal-class-properties": "^7.18.0",
-        "@babel/plugin-proposal-export-default-from": "^7.0.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.0",
-        "@babel/plugin-proposal-numeric-separator": "^7.0.0",
-        "@babel/plugin-proposal-object-rest-spread": "^7.20.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.20.0",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-        "@babel/plugin-syntax-export-default-from": "^7.0.0",
-        "@babel/plugin-syntax-flow": "^7.18.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.0.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.0.0",
-        "@babel/plugin-transform-arrow-functions": "^7.0.0",
-        "@babel/plugin-transform-async-to-generator": "^7.20.0",
-        "@babel/plugin-transform-block-scoping": "^7.0.0",
-        "@babel/plugin-transform-classes": "^7.0.0",
-        "@babel/plugin-transform-computed-properties": "^7.0.0",
-        "@babel/plugin-transform-destructuring": "^7.20.0",
-        "@babel/plugin-transform-flow-strip-types": "^7.20.0",
-        "@babel/plugin-transform-function-name": "^7.0.0",
-        "@babel/plugin-transform-literals": "^7.0.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.0.0",
-        "@babel/plugin-transform-parameters": "^7.0.0",
-        "@babel/plugin-transform-react-display-name": "^7.0.0",
-        "@babel/plugin-transform-react-jsx": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.0.0",
-        "@babel/plugin-transform-react-jsx-source": "^7.0.0",
-        "@babel/plugin-transform-runtime": "^7.0.0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
-        "@babel/plugin-transform-spread": "^7.0.0",
-        "@babel/plugin-transform-sticky-regex": "^7.0.0",
-        "@babel/plugin-transform-typescript": "^7.5.0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "react-refresh": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-react-native-babel-transformer": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.76.7.tgz",
-      "integrity": "sha512-W6lW3J7y/05ph3c2p3KKJNhH0IdyxdOCbQ5it7aM2MAl0SM4wgKjaV6EYv9b3rHklpV6K3qMH37UKVcjMooWiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.20.0",
-        "babel-preset-fbjs": "^3.4.0",
-        "hermes-parser": "0.12.0",
-        "metro-react-native-babel-preset": "0.76.7",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-resolver": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.76.7.tgz",
-      "integrity": "sha512-pC0Wgq29HHIHrwz23xxiNgylhI8Rq1V01kQaJ9Kz11zWrIdlrH0ZdnJ7GC6qA0ErROG+cXmJ0rJb8/SW1Zp2IA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-runtime": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.76.7.tgz",
-      "integrity": "sha512-MuWHubQHymUWBpZLwuKZQgA/qbb35WnDAKPo83rk7JRLIFPvzXSvFaC18voPuzJBt1V98lKQIonh6MiC9gd8Ug==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react-refresh": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-source-map": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.76.7.tgz",
-      "integrity": "sha512-Prhx7PeRV1LuogT0Kn5VjCuFu9fVD68eefntdWabrksmNY6mXK8pRqzvNJOhTojh6nek+RxBzZeD6MIOOyXS6w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "invariant": "^2.2.4",
-        "metro-symbolicate": "0.76.7",
-        "nullthrows": "^1.1.1",
-        "ob1": "0.76.7",
-        "source-map": "^0.5.6",
-        "vlq": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-symbolicate": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.76.7.tgz",
-      "integrity": "sha512-p0zWEME5qLSL1bJb93iq+zt5fz3sfVn9xFYzca1TJIpY5MommEaS64Va87lp56O0sfEIvh4307Oaf/ZzRjuLiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "metro-source-map": "0.76.7",
-        "nullthrows": "^1.1.1",
-        "source-map": "^0.5.6",
-        "through2": "^2.0.1",
-        "vlq": "^1.0.0"
-      },
-      "bin": {
-        "metro-symbolicate": "src/index.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-transform-plugins": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.76.7.tgz",
-      "integrity": "sha512-iSmnjVApbdivjuzb88Orb0JHvcEt5veVyFAzxiS5h0QB+zV79w6JCSqZlHCrbNOkOKBED//LqtKbFVakxllnNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.20.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/metro-transform-worker": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.76.7.tgz",
-      "integrity": "sha512-cGvELqFMVk9XTC15CMVzrCzcO6sO1lURfcbgjuuPdzaWuD11eEyocvkTX0DPiRjsvgAmicz4XYxVzgYl3MykDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.0",
-        "@babel/parser": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "babel-preset-fbjs": "^3.4.0",
-        "metro": "0.76.7",
-        "metro-babel-transformer": "0.76.7",
-        "metro-cache": "0.76.7",
-        "metro-cache-key": "0.76.7",
-        "metro-source-map": "0.76.7",
-        "metro-transform-plugins": "0.76.7",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/ob1": {
-      "version": "0.76.7",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.76.7.tgz",
-      "integrity": "sha512-BQdRtxxoUNfSoZxqeBGOyuT9nEYSn18xZHwGMb0mMVpn2NBcYbnyKY4BK2LIHRgw33CBGlUmE+KMaNvyTpLLtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@react-native-community/cli-plugin-metro/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -5443,13 +4909,13 @@
       }
     },
     "node_modules/@react-native-community/cli-server-api": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-11.3.6.tgz",
-      "integrity": "sha512-8GUKodPnURGtJ9JKg8yOHIRtWepPciI3ssXVw5jik7+dZ43yN8P5BqCoDaq8e1H1yRer27iiOfT7XVnwk8Dueg==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-server-api/-/cli-server-api-11.3.10.tgz",
+      "integrity": "sha512-WEwHWIpqx3gA6Da+lrmq8+z78E1XbxxjBlvHAXevhjJj42N4SO417eZiiUVrFzEFVVJSUee9n9aRa0kUR+0/2w==",
       "license": "MIT",
       "dependencies": {
-        "@react-native-community/cli-debugger-ui": "11.3.6",
-        "@react-native-community/cli-tools": "11.3.6",
+        "@react-native-community/cli-debugger-ui": "11.3.10",
+        "@react-native-community/cli-tools": "11.3.10",
         "compression": "^1.7.1",
         "connect": "^3.6.5",
         "errorhandler": "^1.5.1",
@@ -5585,9 +5051,9 @@
       }
     },
     "node_modules/@react-native-community/cli-tools": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-11.3.6.tgz",
-      "integrity": "sha512-JpmUTcDwAGiTzLsfMlIAYpCMSJ9w2Qlf7PU7mZIRyEu61UzEawyw83DkqfbzDPBuRwRnaeN44JX2CP/yTO3ThQ==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-tools/-/cli-tools-11.3.10.tgz",
+      "integrity": "sha512-4kCuCwVcGagSrNg9vxMNVhynwpByuC/J5UnKGEet3HuqmoDhQW15m18fJXiehA8J+u9WBvHduefy9nZxO0C06Q==",
       "license": "MIT",
       "dependencies": {
         "appdirsjs": "^1.2.4",
@@ -5706,9 +5172,9 @@
       }
     },
     "node_modules/@react-native-community/cli-tools/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5730,9 +5196,9 @@
       }
     },
     "node_modules/@react-native-community/cli-types": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-11.3.6.tgz",
-      "integrity": "sha512-6DxjrMKx5x68N/tCJYVYRKAtlRHbtUVBZrnAvkxbRWFD9v4vhNgsPM0RQm8i2vRugeksnao5mbnRGpS6c0awCw==",
+      "version": "11.3.10",
+      "resolved": "https://registry.npmjs.org/@react-native-community/cli-types/-/cli-types-11.3.10.tgz",
+      "integrity": "sha512-0FHK/JE7bTn0x1y8Lk5m3RISDHIBQqWLltO2Mf7YQ6cAeKs8iNOJOeKaHJEY+ohjsOyCziw+XSC4cY57dQrwNA==",
       "license": "MIT",
       "dependencies": {
         "joi": "^17.2.1"
@@ -5820,9 +5286,9 @@
       }
     },
     "node_modules/@react-native-community/cli/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8320,9 +7786,9 @@
       }
     },
     "node_modules/bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8739,17 +8205,17 @@
       }
     },
     "node_modules/compression": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
-      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
+      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.5",
-        "bytes": "3.0.0",
-        "compressible": "~2.0.16",
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
         "debug": "2.6.9",
+        "negotiator": "~0.6.4",
         "on-headers": "~1.0.2",
-        "safe-buffer": "5.1.2",
+        "safe-buffer": "5.2.1",
         "vary": "~1.1.2"
       },
       "engines": {
@@ -8769,6 +8235,35 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -9290,14 +8785,14 @@
       }
     },
     "node_modules/deprecated-react-native-prop-types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-4.1.0.tgz",
-      "integrity": "sha512-WfepZHmRbbdTvhcolb8aOKEvQdcmTMn5tKLbqbXmkBvjFjRVWAYqsXk/DBsV8TZxws8SdGHLuHaJrHSQUPRdfw==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-4.2.3.tgz",
+      "integrity": "sha512-2rLTiMKidIFFYpIVM69UnQKngLqQfL6I11Ch8wGSBftS18FUXda+o2we2950X+1dmbgps28niI3qwyH4eX3Z1g==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/normalize-colors": "*",
-        "invariant": "*",
-        "prop-types": "*"
+        "@react-native/normalize-colors": "<0.73.0",
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1"
       }
     },
     "node_modules/destroy": {
@@ -11006,22 +10501,18 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.0.tgz",
-      "integrity": "sha512-/PlTQCI96+fZMAOLMZK4CWG1ItCbfZ/0jx7UIJFChPNrx7tcEgerUgWbeieCM9MfHInUDyK8DWYZ+YrywDJuTg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -15334,7 +14825,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro/-/metro-0.76.8.tgz",
       "integrity": "sha512-oQA3gLzrrYv3qKtuWArMgHPbHu8odZOD9AoavrqSFllkPgOtmkBvNNDLCELqv5SjBfqjISNffypg+5UGG3y0pg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -15397,7 +14887,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.76.8.tgz",
       "integrity": "sha512-Hh6PW34Ug/nShlBGxkwQJSgPGAzSJ9FwQXhUImkzdsDgVu6zj5bx258J8cJVSandjNoQ8nbaHK6CaHlnbZKbyA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
@@ -15412,7 +14901,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.76.8.tgz",
       "integrity": "sha512-QBJSJIVNH7Hc/Yo6br/U/qQDUpiUdRgZ2ZBJmvAbmAKp2XDzsapnMwK/3BGj8JNWJF7OLrqrYHsRsukSbUBpvQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "metro-core": "0.76.8",
@@ -15426,7 +14914,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.76.8.tgz",
       "integrity": "sha512-buKQ5xentPig9G6T37Ww/R/bC+/V1MA5xU/D8zjnhlelsrPG6w6LtHUS61ID3zZcMZqYaELWk5UIadIdDsaaLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -15436,7 +14923,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.76.8.tgz",
       "integrity": "sha512-SL1lfKB0qGHALcAk2zBqVgQZpazDYvYFGwCK1ikz0S6Y/CM2i2/HwuZN31kpX6z3mqjv/6KvlzaKoTb1otuSAA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
@@ -15455,7 +14941,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.76.8.tgz",
       "integrity": "sha512-sl2QLFI3d1b1XUUGxwzw/KbaXXU/bvFYrSKz6Sg19AdYGWFyzsgZ1VISRIDf+HWm4R/TJXluhWMEkEtZuqi3qA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash.throttle": "^4.1.1",
@@ -15469,7 +14954,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.76.8.tgz",
       "integrity": "sha512-A/xP1YNEVwO1SUV9/YYo6/Y1MmzhL4ZnVgcJC3VmHp/BYVOXVStzgVbWv2wILe56IIMkfXU+jpXrGKKYhFyHVw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.0.3",
@@ -15496,7 +14980,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
       "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -15513,7 +14996,6 @@
       "version": "16.0.9",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.9.tgz",
       "integrity": "sha512-tHhzvkFXZQeTECenFoRljLBYPZJ7jAVxqqtEI0qTLOmuultnFp4I9yKE17vTuhf7BkhCu7I4XuemPgikDVuYqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -15523,7 +15005,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -15539,7 +15020,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -15556,7 +15036,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -15569,14 +15048,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/metro-file-map/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -15586,7 +15063,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15596,7 +15072,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
       "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -15606,7 +15081,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
       "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^27.5.1",
@@ -15624,7 +15098,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -15639,7 +15112,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15655,14 +15127,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/metro-file-map/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -15675,7 +15145,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-inspector-proxy/-/metro-inspector-proxy-0.76.8.tgz",
       "integrity": "sha512-Us5o5UEd4Smgn1+TfHX4LvVPoWVo9VsVMn4Ldbk0g5CQx3Gu0ygc/ei2AKPGTwsOZmKxJeACj7yMH2kgxQP/iw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
@@ -15695,7 +15164,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -15705,14 +15173,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/metro-minify-terser": {
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.76.8.tgz",
       "integrity": "sha512-Orbvg18qXHCrSj1KbaeSDVYRy/gkro2PC7Fy2tDSH1c9RB4aH8tuMOIXnKJE+1SXxBtjWmQ5Yirwkth2DyyEZA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "terser": "^5.15.0"
@@ -15725,7 +15191,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-minify-uglify/-/metro-minify-uglify-0.76.8.tgz",
       "integrity": "sha512-6l8/bEvtVaTSuhG1FqS0+Mc8lZ3Bl4RI8SeRIifVLC21eeSDp4CEBUWSGjpFyUDfi6R5dXzYaFnSgMNyfxADiQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "uglify-es": "^3.1.9"
@@ -15738,7 +15203,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.8.tgz",
       "integrity": "sha512-Ptza08GgqzxEdK8apYsjTx2S8WDUlS2ilBlu9DR1CUcHmg4g3kOkFylZroogVAUKtpYQNYwAvdsjmrSdDNtiAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
@@ -15792,7 +15256,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.76.8.tgz",
       "integrity": "sha512-3h+LfS1WG1PAzhq8QF0kfXjxuXetbY/lgz8vYMQhgrMMp17WM1DNJD0gjx8tOGYbpbBC1qesJ45KMS4o5TA73A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
@@ -15812,7 +15275,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.76.8.tgz",
       "integrity": "sha512-KccOqc10vrzS7ZhG2NSnL2dh3uVydarB7nOhjreQ7C4zyWuiW9XpLC4h47KtGQv3Rnv/NDLJYeDqaJ4/+140HQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -15892,7 +15354,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.76.8.tgz",
       "integrity": "sha512-PlkGTQNqS51Bx4vuufSQCdSn2R2rt7korzngo+b5GCkeX5pjinPjnO2kNhQ8l+5bO0iUD/WZ9nsM2PGGKIkWFA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
@@ -15909,7 +15370,6 @@
       "version": "0.76.8",
       "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.76.8.tgz",
       "integrity": "sha512-mE1fxVAnJKmwwJyDtThildxxos9+DGs9+vTrx2ktSFMEVTtXS/bIv2W6hux1pqivqAfyJpTeACXHk5u2DgGvIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
@@ -15933,7 +15393,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15943,7 +15402,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -15959,7 +15417,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -15976,14 +15433,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/metro/node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -15996,14 +15451,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/metro/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -16013,7 +15466,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16023,7 +15475,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -16038,7 +15489,6 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -16054,14 +15504,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/metro/node_modules/serialize-error": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -16071,7 +15519,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -16081,7 +15528,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16094,7 +15540,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -17474,25 +16919,26 @@
       }
     },
     "node_modules/react-native": {
-      "version": "0.72.4",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.72.4.tgz",
-      "integrity": "sha512-+vrObi0wZR+NeqL09KihAAdVlQ9IdplwznJWtYrjnQ4UbCW6rkzZJebRsugwUneSOKNFaHFEo1uKU89HsgtYBg==",
+      "version": "0.72.9",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.72.9.tgz",
+      "integrity": "sha512-20rcKaX73zy1qw3yEQIc1rIvvulkxrhOlAO/A1O7GzZc6l8RdzayjV3jgyM3gIHdLco6+qC6Pmi1QcguMyWuyQ==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.2.1",
-        "@react-native-community/cli": "11.3.6",
-        "@react-native-community/cli-platform-android": "11.3.6",
-        "@react-native-community/cli-platform-ios": "11.3.6",
+        "@react-native-community/cli": "11.3.10",
+        "@react-native-community/cli-platform-android": "11.3.10",
+        "@react-native-community/cli-platform-ios": "11.3.10",
         "@react-native/assets-registry": "^0.72.0",
-        "@react-native/codegen": "^0.72.6",
+        "@react-native/codegen": "^0.72.8",
         "@react-native/gradle-plugin": "^0.72.11",
         "@react-native/js-polyfills": "^0.72.1",
         "@react-native/normalize-colors": "^0.72.0",
         "@react-native/virtualized-lists": "^0.72.8",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
+        "ansi-regex": "^5.0.0",
         "base64-js": "^1.1.2",
-        "deprecated-react-native-prop-types": "4.1.0",
+        "deprecated-react-native-prop-types": "^4.2.3",
         "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.5",
         "invariant": "^2.2.4",
@@ -19265,15 +18711,22 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/sudo-prompt": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
       "integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT"
     },
     "node_modules/supports-color": {
@@ -20416,9 +19869,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "querystring": "0.2.1",
     "react": "18.2.0",
     "react-markdown": "2.5.1",
-    "react-native": "0.72.4",
+    "react-native": "0.72.9",
     "react-native-button": "3.1.0",
     "react-native-calendar-events": "2.2.0",
     "react-native-device-info": "11.1.0",

--- a/source/views/building-hours/lib/__tests__/__snapshots__/get-detailed-building-status.test.ts.snap
+++ b/source/views/building-hours/lib/__tests__/__snapshots__/get-detailed-building-status.test.ts.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`checks a list of schedules to see if any are open 1`] = `
-[
-  {
-    "isActive": true,
-    "label": "Hours",
-    "status": "10:30 AM — 2:00 AM",
-  },
-]
-`;
-
 exports[`handles multiple internal schedules for the same timeframe 1`] = `
 [
   {
@@ -41,16 +31,6 @@ exports[`handles multiple named schedules for the same timeframe 1`] = `
     "isActive": true,
     "label": "Hours2",
     "status": "1:00 PM — 3:00 PM",
-  },
-]
-`;
-
-exports[`returns a list of [isOpen, scheduleName, verboseStatus] tuples 1`] = `
-[
-  {
-    "isActive": true,
-    "label": "Hours",
-    "status": "10:30 AM — 2:00 AM",
   },
 ]
 `;

--- a/source/views/building-hours/lib/__tests__/get-detailed-building-status.test.ts
+++ b/source/views/building-hours/lib/__tests__/get-detailed-building-status.test.ts
@@ -4,6 +4,8 @@ import {plainMoment} from './moment.helper'
 import {BuildingType} from '../../types'
 
 it('returns a list of [isOpen, scheduleName, verboseStatus] tuples', () => {
+	jest.useFakeTimers().setSystemTime(new Date('2018-06-23T13:00:00Z').getTime())
+
 	let m = plainMoment('06-23-2018 1:00pm', 'MM-DD-YYYY h:mma')
 	let building: BuildingType = {
 		name: 'building',
@@ -28,11 +30,14 @@ it('returns a list of [isOpen, scheduleName, verboseStatus] tuples', () => {
 	expect(typeof actual[0].isActive).toBe('boolean')
 	expect(typeof actual[0].label).toBe('string')
 	expect(typeof actual[0].status).toBe('string')
+	expect(actual[0].status).toBe('10:30 AM — 2:00 AM')
 
-	expect(actual).toMatchSnapshot()
+	jest.useRealTimers()
 })
 
 it('checks a list of schedules to see if any are open', () => {
+	jest.useFakeTimers().setSystemTime(new Date('2018-06-23T13:00:00Z').getTime())
+
 	let m = plainMoment('06-23-2018 1:00pm', 'MM-DD-YYYY h:mma')
 	let building: BuildingType = {
 		name: 'building',
@@ -51,9 +56,10 @@ it('checks a list of schedules to see if any are open', () => {
 	}
 
 	let actual = getDetailedBuildingStatus(building, m)
-	expect(actual).toMatchSnapshot()
-
+	expect(actual[0].status).toBe('10:30 AM — 2:00 AM')
 	expect(actual[0].isActive).toBe(true)
+
+	jest.useRealTimers()
 })
 
 it('handles multiple internal schedules for the same timeframe', () => {


### PR DESCRIPTION
- [x] First, cache actions for save/restore required being bumped to 4.2.0 in a footnote of the sunset warning if you're on pinned hashes. It's beyond me why they didn't keep in lockstep with the 4.0 bump for non-pinned. See this link for more info. https://github.com/actions/cache/tree/v4.2.0?tab=readme-ov-file#whats-new

    > If you are using pinned SHAs, please use the SHAs of versions v4.2.0 or v3.4.0

- [x] Second, our boost checksum broke by an upstream issue which react native maintainers said we could avoid patching by upgrading to `react-native@72.9`. See this link https://github.com/facebook/react-native/issues/42180 for more info.

- [x]  Third, closes #1835 with our DST woes with `useFakeTimers`/`useRealTimers` for the building hours tests that span past midnight

- [x] Fourth, fix CI/CD breakage with upping to iPhone 15 Pro as a detox target, and extra logging and fallback cases in iOS build got us thru detox, but seems flaky and not consistent that we're able to land in the fallback sometimes but not others. Caching?