### PR TITLE
pin gha digests to semver channels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
+	"helpers:pinGitHubActionDigestsToSemver",
     ":docker",
     ":maintainLockFilesWeekly",
     ":pinAllExceptPeerDependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-	"helpers:pinGitHubActionDigestsToSemver",
+    "helpers:pinGitHubActionDigestsToSemver",
     ":docker",
     ":maintainLockFilesWeekly",
     ":pinAllExceptPeerDependencies",


### PR DESCRIPTION
when renovate pins actions, by default it tracks the "major version" of the underlying repo. This should make it follow the three-part semver info, which should allow it to show diff info in update PRs.