### PR TITLE
add abbrev gem for ruby 3.4 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'xcodeproj', '1.27.0'
 gem 'cocoapods', '1.16.2'
 
 # Ruby 3.4 stdlib gems that need to be explicitly required
+gem 'abbrev', '0.1.2'
 gem 'nkf', '0.2.0'
 
 # fastlane plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.8)
+    abbrev (0.1.2)
     activesupport (7.2.3)
       base64
       benchmark (>= 0.3)
@@ -334,6 +335,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  abbrev (= 0.1.2)
   cocoapods (= 1.16.2)
   fastlane (= 2.216.0)
   json (= 2.7.2)


### PR DESCRIPTION
Ruby 3.4 removed abbrev from default gems; highline 2.0.3 (a fastlane dependency) requires it implicitly, causing fastlane to crash on boot. Follows the same pattern as nkf which was added for the same reason.