### PR TITLE
Add refetch functionality to course search filters

### DIFF
--- a/source/views/sis/course-search/lib/build-filters.ts
+++ b/source/views/sis/course-search/lib/build-filters.ts
@@ -7,30 +7,40 @@ export function useFilters(): {
 	isLoading: boolean
 	data: FilterType<CourseType>[]
 	error: null | Error
+	refetch: () => void
 } {
 	let {
 		data: terms = [],
 		error: termError,
 		isLoading: termsLoading,
+		refetch: refetchTerms,
 	} = useAvailableTerms()
 
 	let {
 		data: geReqs = [],
 		error: geReqError,
 		isLoading: geReqsLoading,
+		refetch: refetchGeReqs,
 	} = useGeReqs()
 
 	let {
 		data: departments = [],
 		error: departmentsError,
 		isLoading: deptsLoading,
+		refetch: refetchDepts,
 	} = useDepartments()
+
+	let refetch = () => {
+		void refetchTerms()
+		void refetchGeReqs()
+		void refetchDepts()
+	}
 
 	let isLoading = termsLoading || geReqsLoading || deptsLoading
 	let error = termError || geReqError || departmentsError
 
 	if (error) {
-		return {data: [], error, isLoading}
+		return {data: [], error, isLoading, refetch}
 	}
 
 	let allTerms = terms
@@ -152,5 +162,5 @@ export function useFilters(): {
 		} as ToggleType<CourseType>,
 	]
 
-	return {data: response, error: null, isLoading}
+	return {data: response, error: null, isLoading, refetch}
 }

--- a/source/views/sis/course-search/search.tsx
+++ b/source/views/sis/course-search/search.tsx
@@ -102,7 +102,7 @@ export const CourseSearchView = (): JSX.Element => {
 			<NoticeView
 				buttonText="Try Again"
 				onPress={refetch}
-				text={`A problem occured while loading: ${error}`}
+				text={`A problem occurred while loading: ${error}`}
 			/>
 		)
 	}

--- a/source/views/sis/course-search/search.tsx
+++ b/source/views/sis/course-search/search.tsx
@@ -32,7 +32,7 @@ const RightButton: React.FC<{onPress: () => void}> = ({onPress}) => (
 export const CourseSearchView = (): JSX.Element => {
 	let navigation = useNavigation()
 
-	let {data: basicFilters = [], isLoading, error} = useFilters()
+	let {data: basicFilters = [], isLoading, error, refetch} = useFilters()
 
 	let recentFilters = useAppSelector(selectRecentFilters)
 	let recentSearches = useAppSelector(selectRecentSearches)
@@ -101,7 +101,7 @@ export const CourseSearchView = (): JSX.Element => {
 		return (
 			<NoticeView
 				buttonText="Try Again"
-				// onPress={refetch}  // TODO: implement refetch here
+				onPress={refetch}
 				text={`A problem occured while loading: ${error}`}
 			/>
 		)


### PR DESCRIPTION
## Summary
This PR implements the refetch functionality for the course search filters, allowing users to retry loading filters when an error occurs.

## Key Changes
- **build-filters.ts**: 
  - Added `refetch` function to the `useFilters()` return type
  - Extracted `refetch` functions from each filter hook (`refetchTerms`, `refetchGeReqs`, `refetchDepts`)
  - Created a composite `refetch()` function that calls all three refetch functions
  - Updated both error and success return statements to include the `refetch` function

- **search.tsx**:
  - Destructured the `refetch` function from `useFilters()` hook
  - Connected the `refetch` function to the error state's "Try Again" button by replacing the TODO comment with the actual `onPress={refetch}` handler

## Implementation Details
The refetch implementation follows a composition pattern where individual refetch functions from each data source (terms, GE requirements, departments) are combined into a single refetch function that refreshes all filters simultaneously. This ensures consistent state across all filter categories when the user attempts to recover from an error.

https://claude.ai/code/session_01AQJJsev8yTFyNUcvXZVePJ