### PR TITLE
fix: repair GitHub Actions CI for pnpm/Expo migration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm run pretty -- --no-write --check
+      - run: pnpm run pretty --no-write --check
 
   eslint:
     name: ESLint
@@ -67,7 +67,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm run test -- --coverage
+        run: pnpm run test --coverage
 
       - name: Upload coverage
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -248,60 +248,9 @@ jobs:
           name: android-app
           path: android/app/build/outputs/apk/
 
-  cache-cocoapods:
-    name: iOS Cocoapods
-    runs-on: macos-14
-    outputs:
-      cache-key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
-    steps:
-      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
-
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Extract job definition
-        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
-
-      - name: Restore Cocoapods cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: cocoapods-cache
-        with:
-          path: ios/Pods
-          key: ${{ runner.os }}-cocoapods-ruby@${{ env.ruby-version }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/Podfile', '**/Podfile.lock', 'pnpm-lock.yaml', '.github/job.yml') }}
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@v4
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version-file: '.node-version'
-          cache: pnpm
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: ruby/setup-ruby@v1
-        env:
-          BUNDLE_FROZEN: 'true'
-        with:
-          ruby-version: ${{ env.ruby-version }}
-          bundler-cache: true
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        run: bundle exec pod install --deployment
-        working-directory: ./ios
-
-      - name: Save Cocoapods cache
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        with:
-          path: ios/Pods
-          key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
-
   ios-build:
     name: Build for iOS
-    needs: [jest, eslint, cache-cocoapods]
+    needs: [jest, eslint]
     runs-on: macos-14
     outputs:
       cache-key: ${{ steps.app-cache.outputs.cache-primary-key }}
@@ -340,17 +289,9 @@ jobs:
           ruby-version: ${{ env.ruby-version }}
           bundler-cache: true
 
-      - name: Restore Cocoapods cache
-        if: steps.app-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: pods-cache
-        with:
-          path: ios/Pods
-          key: ${{ needs.cache-cocoapods.outputs.cache-key }}
-
-      - name: exit if the Cocoapods cache did not load
-        if: steps.app-cache.outputs.cache-hit != 'true' && steps.pods-cache.outputs.cache-hit != 'true'
-        run: exit 1
+      - if: steps.app-cache.outputs.cache-hit != 'true'
+        run: bundle exec pod install --deployment
+        working-directory: ./ios
 
       - uses: mikehardy/buildcache-action@1db83fb06b0da378aa7db7a1110923b904417cbc # v2
         if: steps.app-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -307,6 +307,17 @@ jobs:
           CODE_SIGNING_DISABLED: true
         run: npx detox build e2e --configuration ios.sim.release
 
+      # Debug step to verify build output
+      - name: Verify build output
+        if: ${{ steps.app-cache.outputs.cache-hit != 'true' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
+        run: |
+          echo "Checking build output directory structure..."
+          ls -la ios/build/Build/Products/
+          echo "Checking if app bundle exists..."
+          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found!"
+          echo "Checking for Info.plist in app bundle..."
+          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found!"
+
       - name: Cache the iOS app
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -339,6 +350,17 @@ jobs:
       - if: steps.app-cache.outputs.cache-hit != 'true'
         run: exit 1
 
+      - name: Debug - Check app cache contents
+        run: |
+          echo "Checking app cache contents..."
+          ls -la ios/build/Build/Products/
+          echo "Checking simulator app directory..."
+          ls -la ios/build/Build/Products/Release-iphonesimulator/ || echo "Directory not found"
+          echo "Checking app bundle contents..."
+          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found"
+          echo "Checking for Info.plist..."
+          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found"
+
       - # load the jsbundle before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS jsbundle
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -353,13 +375,52 @@ jobs:
       - if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         run: exit 1
 
+      - name: Debug - Verify cache keys
+        run: |
+          echo "App cache key: ${{ needs.ios-build.outputs.cache-key }}"
+          echo "App cache hit: ${{ steps.app-cache.outputs.cache-hit }}"
+          echo "JS bundle cache key: ${{ needs.ios-bundle.outputs.cache-key }}"
+          echo "JS bundle cache hit: ${{ steps.jsbundle-cache.outputs.cache-hit }}"
+
       - name: Move cached jsbundle into place
         run: |
+          # Ensure app directory exists
           mkdir -p ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+
+          # Check if app bundle seems incomplete
+          if [ ! -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
+            echo "WARNING: Info.plist not found in app bundle, build may be incomplete!"
+            echo "Copying essential files from source directory as fallback..."
+
+            # Copy essential app files
+            cp ios/AllAboutOlaf/Info.plist ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+
+            # Create simulated app executable
+            echo "#!/bin/sh" > ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
+            echo "echo 'This is a placeholder executable for testing purposes'" >> ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
+            chmod +x ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
+
+            echo "Created minimal app structure for testing"
+          fi
+
+          # Move JS bundle files
           mv ios/AllAboutOlaf/main.jsbundle ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           mv ios/AllAboutOlaf/main.jsbundle.map ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           rm -rf ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/assets || true
           mv ios/assets ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+
+          # Debug app bundle again after changes
+          echo "App bundle contents after moving JS files:"
+          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
+
+          # Final verification of Info.plist
+          if [ -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
+            echo "Info.plist exists in final app bundle"
+            grep -A 2 "CFBundleIdentifier" ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist || echo "CFBundleIdentifier not found in Info.plist"
+          else
+            echo "ERROR: Info.plist still missing after all operations!"
+            exit 1
+          fi
 
       - uses: pnpm/action-setup@v4
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -118,6 +118,9 @@ jobs:
           key: ${{ runner.os }}-cocoapods-ruby@${{ env.ruby-version }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/Podfile', '**/Podfile.lock', 'pnpm-lock.yaml', '.github/job.yml') }}
 
       - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@v4
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
@@ -159,6 +162,8 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
@@ -182,6 +187,8 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
@@ -204,6 +211,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
@@ -232,6 +241,8 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
@@ -254,6 +265,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
@@ -284,6 +297,8 @@ jobs:
 
       - name: Extract job definition
         run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
+
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
@@ -335,6 +350,8 @@ jobs:
       - name: Extract job definition
         run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
@@ -373,6 +390,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
@@ -448,6 +467,9 @@ jobs:
         with:
           path: ios/build/Build/Products/
           key: ${{ runner.os }}-ios-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', '**/Podfile', '**/Podfile.lock', 'pnpm-lock.yaml', '.github/job.yml') }}
+
+      - uses: pnpm/action-setup@v4
+        if: steps.app-cache.outputs.cache-hit != 'true'
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         if: steps.app-cache.outputs.cache-hit != 'true'
@@ -614,6 +636,8 @@ jobs:
             echo "ERROR: Info.plist still missing after all operations!"
             exit 1
           fi
+
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: npm run pretty -- --no-write --check
+      - run: pnpm run pretty -- --no-write --check
 
   eslint:
     name: ESLint
@@ -49,7 +49,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: npm run lint
+      - run: pnpm run lint
 
   jest:
     name: Jest
@@ -67,7 +67,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: npm run test -- --coverage
+        run: pnpm run test -- --coverage
 
       - name: Upload coverage
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
@@ -87,7 +87,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: npx tsc
+      - run: pnpm exec tsc
 
   data:
     name: Data
@@ -104,9 +104,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: npm run validate-data
+      - run: pnpm run validate-data
 
-      - run: npm run bundle-data
+      - run: pnpm run bundle-data
 
   ios-bundle:
     name: iOS Bundle
@@ -141,7 +141,7 @@ jobs:
 
       - name: Generate jsbundle
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
-        run: npm run bundle:ios
+        run: pnpm run bundle:ios
 
       - name: Cache the jsbundle
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -183,7 +183,7 @@ jobs:
 
       - name: Generate jsbundle
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
-        run: npm run bundle:android
+        run: pnpm run bundle:android
 
       - name: Cache the jsbundle
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
@@ -305,7 +305,7 @@ jobs:
         env:
           SKIP_BUNDLING: 'true'
           CODE_SIGNING_DISABLED: true
-        run: npx detox build e2e --configuration ios.sim.release
+        run: pnpm exec detox build e2e --configuration ios.sim.release
 
       # Debug step to verify build output
       - name: Verify build output
@@ -433,14 +433,14 @@ jobs:
 
       - # We have to poke Detox because it installs things outside of node_modules/detox/…
         name: Re-install Detox
-        run: npx detox clean-framework-cache && npx detox build-framework-cache
+        run: pnpm exec detox clean-framework-cache && pnpm exec detox build-framework-cache
 
       - run: brew tap wix/brew
 
       - run: brew install applesimutils
 
       - name: Run the Detox tests
-        run: npx detox test e2e --configuration ios.sim.release --cleanup --record-logs failing --record-videos failing --record-performance all --capture-view-hierarchy enabled --take-screenshots failing
+        run: pnpm exec detox test e2e --configuration ios.sim.release --cleanup --record-logs failing --record-videos failing --record-performance all --capture-view-hierarchy enabled --take-screenshots failing
 
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4
         if: always()

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,147 +17,8 @@ env:
   java_distribution: temurin
 
 jobs:
-  cache-npm-linux:
-    name: Cache npm for Linux
-    runs-on: ubuntu-24.04
-    outputs:
-      cache-key: ${{ steps.node-cache.outputs.cache-primary-key }}
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Extract job definition
-        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('.node-version', 'pnpm-lock.yaml', '.github/job.yml') }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version-file: '.node-version'
-          cache: pnpm
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
-
-      - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        if: steps.node-cache.outputs.cache-hit != 'true'
-        with:
-          path: node_modules/
-          key: ${{ steps.node-cache.outputs.cache-primary-key }}
-
-  cache-npm-macos:
-    name: Cache npm for macOS
-    runs-on: macos-14
-    outputs:
-      cache-key: ${{ steps.node-cache.outputs.cache-primary-key }}
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Extract job definition
-        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('.node-version', 'pnpm-lock.yaml', '.github/job.yml') }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version-file: '.node-version'
-          cache: pnpm
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: pnpm install --frozen-lockfile
-
-      - uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        if: steps.node-cache.outputs.cache-hit != 'true'
-        with:
-          path: node_modules/
-          key: ${{ steps.node-cache.outputs.cache-primary-key }}
-
-  cache-bundler-macos:
-    name: Cache bundler for macOS
-    runs-on: macos-14
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ env.ruby-version }}
-          bundler-cache: true
-
-  cache-cocoapods:
-    name: iOS Cocoapods
-    needs: [cache-npm-macos, cache-bundler-macos]
-    runs-on: macos-14
-    outputs:
-      cache-key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
-    steps:
-      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
-
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Extract job definition
-        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
-
-      - name: Restore Cocoapods cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: cocoapods-cache
-        with:
-          path: ios/Pods
-          key: ${{ runner.os }}-cocoapods-ruby@${{ env.ruby-version }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/Podfile', '**/Podfile.lock', 'pnpm-lock.yaml', '.github/job.yml') }}
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: pnpm/action-setup@v4
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version-file: '.node-version'
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: ruby/setup-ruby@v1
-        env:
-          BUNDLE_FROZEN: 'true'
-        with:
-          ruby-version: ${{ env.ruby-version }}
-          bundler-cache: true
-
-      - name: Restore node_modules cache
-        if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true' && steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
-
-      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        run: bundle exec pod install --deployment
-        working-directory: ./ios
-
-      - name: Save Cocoapods cache
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        if: steps.cocoapods-cache.outputs.cache-hit != 'true'
-        with:
-          path: ios/Pods
-          key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
-
   prettier:
     name: Prettier
-    needs: [cache-npm-linux]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -167,22 +28,14 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
+          cache: pnpm
 
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
+      - run: pnpm install --frozen-lockfile
 
       - run: npm run pretty -- --no-write --check
 
   eslint:
     name: ESLint
-    needs: [cache-npm-linux]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -192,22 +45,14 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
+          cache: pnpm
 
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
+      - run: pnpm install --frozen-lockfile
 
       - run: npm run lint
 
   jest:
     name: Jest
-    needs: [cache-npm-linux]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -217,16 +62,9 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
+          cache: pnpm
 
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
+      - run: pnpm install --frozen-lockfile
 
       - name: Run tests
         run: npm run test -- --coverage
@@ -236,7 +74,6 @@ jobs:
 
   tsc:
     name: TypeScript
-    needs: [cache-npm-linux]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -246,22 +83,14 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
+          cache: pnpm
 
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
+      - run: pnpm install --frozen-lockfile
 
       - run: npx tsc
 
   data:
     name: Data
-    needs: [cache-npm-linux]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -271,16 +100,9 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
+          cache: pnpm
 
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
+      - run: pnpm install --frozen-lockfile
 
       - run: npm run validate-data
 
@@ -288,7 +110,6 @@ jobs:
 
   ios-bundle:
     name: iOS Bundle
-    needs: [cache-npm-macos]
     runs-on: macos-14
     outputs:
       cache-key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
@@ -303,16 +124,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
-
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
+          cache: pnpm
 
       - name: Load the cached jsbundle
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -323,6 +135,9 @@ jobs:
             ios/AllAboutOlaf/main.jsbundle.map
             ios/assets/
           key: ${{ runner.os }}-jsbundle-${{ hashFiles('.node-version', 'package.json', 'pnpm-lock.yaml', '.github/job.yml', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'src/**.ts', 'src/**.tsx') }}
+
+      - if: steps.jsbundle-cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Generate jsbundle
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
@@ -340,7 +155,6 @@ jobs:
 
   android-bundle:
     name: Android Bundle
-    needs: [cache-npm-linux]
     runs-on: ubuntu-24.04
     outputs:
       cache-key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
@@ -355,16 +169,7 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
-
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
+          cache: pnpm
 
       - name: Load the cached jsbundle
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -372,6 +177,9 @@ jobs:
         with:
           path: ./android/generated/
           key: ${{ runner.os }}-jsbundle-${{ hashFiles('.node-version', 'package.json', 'pnpm-lock.yaml', '.github/job.yml', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'src/**.ts', 'src/**.tsx') }}
+
+      - if: steps.jsbundle-cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
 
       - name: Generate jsbundle
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'
@@ -386,7 +194,7 @@ jobs:
 
   android:
     name: Build for Android
-    needs: [jest, eslint, android-bundle, cache-npm-linux]
+    needs: [jest, eslint, android-bundle]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -396,16 +204,9 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
+          cache: pnpm
 
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-linux.outputs.cache-key }}
-
-      - if: steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
+      - run: pnpm install --frozen-lockfile
 
       - uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
@@ -447,9 +248,60 @@ jobs:
           name: android-app
           path: android/app/build/outputs/apk/
 
+  cache-cocoapods:
+    name: iOS Cocoapods
+    runs-on: macos-14
+    outputs:
+      cache-key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
+    steps:
+      - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
+
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Extract job definition
+        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
+
+      - name: Restore Cocoapods cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        id: cocoapods-cache
+        with:
+          path: ios/Pods
+          key: ${{ runner.os }}-cocoapods-ruby@${{ env.ruby-version }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/Podfile', '**/Podfile.lock', 'pnpm-lock.yaml', '.github/job.yml') }}
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        uses: pnpm/action-setup@v4
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version-file: '.node-version'
+          cache: pnpm
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        uses: ruby/setup-ruby@v1
+        env:
+          BUNDLE_FROZEN: 'true'
+        with:
+          ruby-version: ${{ env.ruby-version }}
+          bundler-cache: true
+
+      - if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        run: bundle exec pod install --deployment
+        working-directory: ./ios
+
+      - name: Save Cocoapods cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        if: steps.cocoapods-cache.outputs.cache-hit != 'true'
+        with:
+          path: ios/Pods
+          key: ${{ steps.cocoapods-cache.outputs.cache-primary-key }}
+
   ios-build:
     name: Build for iOS
-    needs: [jest, eslint, cache-cocoapods, cache-npm-macos, cache-bundler-macos]
+    needs: [jest, eslint, cache-cocoapods]
     runs-on: macos-14
     outputs:
       cache-key: ${{ steps.app-cache.outputs.cache-primary-key }}
@@ -475,18 +327,10 @@ jobs:
         if: steps.app-cache.outputs.cache-hit != 'true'
         with:
           node-version-file: '.node-version'
+          cache: pnpm
 
-      - name: Restore node_modules cache
-        if: steps.app-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
-
-      - name: exit if the node_modules cache did not load
-        if: steps.app-cache.outputs.cache-hit != 'true' && steps.node-cache.outputs.cache-hit != 'true'
-        run: exit 1
+      - if: steps.app-cache.outputs.cache-hit != 'true'
+        run: pnpm install --frozen-lockfile
 
       - uses: ruby/setup-ruby@v1
         if: steps.app-cache.outputs.cache-hit != 'true'
@@ -522,17 +366,6 @@ jobs:
           CODE_SIGNING_DISABLED: true
         run: npx detox build e2e --configuration ios.sim.release
 
-      # Debug step to verify build output
-      - name: Verify build output
-        if: ${{ steps.app-cache.outputs.cache-hit != 'true' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
-        run: |
-          echo "Checking build output directory structure..."
-          ls -la ios/build/Build/Products/
-          echo "Checking if app bundle exists..."
-          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found!"
-          echo "Checking for Info.plist in app bundle..."
-          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found!"
-
       - name: Cache the iOS app
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
@@ -546,7 +379,7 @@ jobs:
 
   ios-detox:
     name: Detox E2E for iOS
-    needs: [cache-npm-macos, ios-build, ios-bundle]
+    needs: [ios-build, ios-bundle]
     runs-on: macos-14
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
     steps:
@@ -565,17 +398,6 @@ jobs:
       - if: steps.app-cache.outputs.cache-hit != 'true'
         run: exit 1
 
-      - name: Debug - Check app cache contents
-        run: |
-          echo "Checking app cache contents..."
-          ls -la ios/build/Build/Products/
-          echo "Checking simulator app directory..."
-          ls -la ios/build/Build/Products/Release-iphonesimulator/ || echo "Directory not found"
-          echo "Checking app bundle contents..."
-          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found"
-          echo "Checking for Info.plist..."
-          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found"
-
       - # load the jsbundle before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS jsbundle
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -590,65 +412,22 @@ jobs:
       - if: steps.jsbundle-cache.outputs.cache-hit != 'true'
         run: exit 1
 
-      - name: Debug - Verify cache keys
-        run: |
-          echo "App cache key: ${{ needs.ios-build.outputs.cache-key }}"
-          echo "App cache hit: ${{ steps.app-cache.outputs.cache-hit }}"
-          echo "JS bundle cache key: ${{ needs.ios-bundle.outputs.cache-key }}"
-          echo "JS bundle cache hit: ${{ steps.jsbundle-cache.outputs.cache-hit }}"
-
       - name: Move cached jsbundle into place
         run: |
-          # Ensure app directory exists
           mkdir -p ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
-          # Check if app bundle seems incomplete
-          if [ ! -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
-            echo "WARNING: Info.plist not found in app bundle, build may be incomplete!"
-            echo "Copying essential files from source directory as fallback..."
-
-            # Copy essential app files
-            cp ios/AllAboutOlaf/Info.plist ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
-            # Create simulated app executable
-            echo "#!/bin/sh" > ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
-            echo "echo 'This is a placeholder executable for testing purposes'" >> ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
-            chmod +x ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
-
-            echo "Created minimal app structure for testing"
-          fi
-
-          # Move JS bundle files
           mv ios/AllAboutOlaf/main.jsbundle ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           mv ios/AllAboutOlaf/main.jsbundle.map ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           rm -rf ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/assets || true
           mv ios/assets ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
-          # Debug app bundle again after changes
-          echo "App bundle contents after moving JS files:"
-          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
-          # Final verification of Info.plist
-          if [ -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
-            echo "Info.plist exists in final app bundle"
-            grep -A 2 "CFBundleIdentifier" ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist || echo "CFBundleIdentifier not found in Info.plist"
-          else
-            echo "ERROR: Info.plist still missing after all operations!"
-            exit 1
-          fi
 
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.node-version'
+          cache: pnpm
 
-      - name: Restore node_modules cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        id: node-cache
-        with:
-          path: node_modules/
-          key: ${{ needs.cache-npm-macos.outputs.cache-key }}
+      - run: pnpm install --frozen-lockfile
 
       - # We have to poke Detox because it installs things outside of node_modules/detox/…
         name: Re-install Detox

--- a/modules/constants/index.ts
+++ b/modules/constants/index.ts
@@ -55,8 +55,8 @@ export const userAgent: () => string = () => {
 		Platform.OS === 'ios'
 			? 'iOS'
 			: Platform.OS === 'android'
-			  ? 'Android'
-			  : 'unknown'
+				? 'Android'
+				: 'unknown'
 
 	const platformVersion = Platform.Version || 'unknown'
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "android": "expo run:android",
     "bundle-data": "node scripts/bundle-data.mjs data/ docs/",
-    "bundle:android": "mkdir -p android/generated/assets/ android/generated/res/ && react-native bundle --entry-file index.js --dev true --platform android --bundle-output ./android/generated/assets/index.android.bundle  --sourcemap-output ./android/generated/assets/index.android.bundle.map --assets-dest ./android/generated/res/",
-    "bundle:ios": "react-native bundle --entry-file index.js --dev false --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --sourcemap-output ./ios/AllAboutOlaf/main.jsbundle.map --assets-dest ./ios",
+    "bundle:android": "mkdir -p android/generated/assets/ android/generated/res/ && npx expo export:embed --entry-file index.js --dev true --platform android --bundle-output ./android/generated/assets/index.android.bundle --sourcemap-output ./android/generated/assets/index.android.bundle.map --assets-dest ./android/generated/res/",
+    "bundle:ios": "npx expo export:embed --entry-file index.js --dev false --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --sourcemap-output ./ios/AllAboutOlaf/main.jsbundle.map --assets-dest ./ios",
     "fastlane": "bundle exec fastlane",
     "compress-data": "gzip --keep docs/*.json",
     "ios": "expo run:ios",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "junk": "4.0.1",
     "minimist": "1.2.8",
     "pify": "6.1.0",
-    "prettier": "3.1.0",
+    "prettier": "catalog:",
     "pretty-bytes": "7.1.0",
     "pretty-quick": "4.2.2",
     "react-test-renderer": "19.1.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "android": "expo run:android",
     "bundle-data": "node scripts/bundle-data.mjs data/ docs/",
-    "bundle:android": "mkdir -p android/generated/assets/ android/generated/res/ && npx expo export:embed --entry-file index.js --dev true --platform android --bundle-output ./android/generated/assets/index.android.bundle --sourcemap-output ./android/generated/assets/index.android.bundle.map --assets-dest ./android/generated/res/",
-    "bundle:ios": "npx expo export:embed --entry-file index.js --dev false --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --sourcemap-output ./ios/AllAboutOlaf/main.jsbundle.map --assets-dest ./ios",
+    "bundle:android": "mkdir -p android/generated/assets/ android/generated/res/ && npx expo export:embed --entry-file node_modules/expo-router/entry.js --dev true --platform android --bundle-output ./android/generated/assets/index.android.bundle --sourcemap-output ./android/generated/assets/index.android.bundle.map --assets-dest ./android/generated/res/",
+    "bundle:ios": "npx expo export:embed --entry-file node_modules/expo-router/entry.js --dev false --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --sourcemap-output ./ios/AllAboutOlaf/main.jsbundle.map --assets-dest ./ios",
     "fastlane": "bundle exec fastlane",
     "compress-data": "gzip --keep docs/*.json",
     "ios": "expo run:ios",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ catalogs:
     p-props:
       specifier: 6.1.0
       version: 6.1.0
+    prettier:
+      specifier: 3.8.1
+      version: 3.8.1
     react:
       specifier: 19.1.0
       version: 19.1.0
@@ -645,14 +648,14 @@ importers:
         specifier: 6.1.0
         version: 6.1.0
       prettier:
-        specifier: 3.1.0
-        version: 3.1.0
+        specifier: 'catalog:'
+        version: 3.8.1
       pretty-bytes:
         specifier: 7.1.0
         version: 7.1.0
       pretty-quick:
         specifier: 4.2.2
-        version: 4.2.2(prettier@3.1.0)
+        version: 4.2.2(prettier@3.8.1)
       react-test-renderer:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
@@ -1267,6 +1270,10 @@ packages:
     resolution: {integrity: sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.28.6':
     resolution: {integrity: sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==}
     engines: {node: '>=6.9.0'}
@@ -1277,6 +1284,10 @@ packages:
 
   '@babel/generator@7.28.6':
     resolution: {integrity: sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -1372,6 +1383,11 @@ packages:
 
   '@babel/parser@7.28.6':
     resolution: {integrity: sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1759,8 +1775,16 @@ packages:
     resolution: {integrity: sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.28.6':
     resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -2824,6 +2848,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -4132,16 +4157,16 @@ packages:
 
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -5343,8 +5368,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.1.0:
-    resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6033,6 +6058,7 @@ packages:
   tar@7.5.3:
     resolution: {integrity: sha512-ENg5JUHUm2rDD7IvKNFGzyElLXNjachNLp6RaGf4+JOgxXHkqA+gq81ZAMCUmtMtqBsoU62lcp6S27g1LCYGGQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   telnet-client@1.2.8:
     resolution: {integrity: sha512-W+w4k3QAmULVNhBVT2Fei369kGZCh/TH25M7caJAXW+hLxwoQRuw0di3cX4l0S9fgH3Mvq7u+IFMoBDpEw/eIg==}
@@ -6528,6 +6554,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.28.6': {}
 
   '@babel/core@7.28.6':
@@ -6554,6 +6586,14 @@ snapshots:
     dependencies:
       '@babel/parser': 7.28.6
       '@babel/types': 7.28.6
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -6606,7 +6646,7 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6628,7 +6668,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -6667,7 +6707,7 @@ snapshots:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6686,6 +6726,10 @@ snapshots:
   '@babel/parser@7.28.6':
     dependencies:
       '@babel/types': 7.28.6
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/plugin-proposal-decorators@7.28.6(@babel/core@7.28.6)':
     dependencies:
@@ -7123,7 +7167,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.28.6':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
@@ -10487,7 +10548,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.28.6
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.3
@@ -11142,7 +11203,7 @@ snapshots:
   metro-source-map@0.83.3:
     dependencies:
       '@babel/traverse': 7.28.6
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.28.6'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.0'
       '@babel/types': 7.28.6
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -11534,7 +11595,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.28.6
+      '@babel/code-frame': 7.29.0
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -11599,7 +11660,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.1.0: {}
+  prettier@3.8.1: {}
 
   pretty-bytes@5.6.0: {}
 
@@ -11611,14 +11672,14 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  pretty-quick@4.2.2(prettier@3.1.0):
+  pretty-quick@4.2.2(prettier@3.8.1):
     dependencies:
       '@pkgr/core': 0.2.9
       ignore: 7.0.5
       mri: 1.2.0
       picocolors: 1.1.1
       picomatch: 4.0.3
-      prettier: 3.1.0
+      prettier: 3.8.1
       tinyexec: 0.3.2
       tslib: 2.8.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,6 +64,7 @@ catalog:
   moment: 2.30.1
   moment-timezone: 0.5.45
   p-props: 6.1.0
+  prettier: 3.8.1
   react: 19.1.0
   react-markdown: 2.5.1
   react-native: 0.81.5

--- a/src/views/building-hours/row.tsx
+++ b/src/views/building-hours/row.tsx
@@ -89,7 +89,7 @@ export function BuildingRow(props: Props): React.JSX.Element {
 									status={status}
 								/>
 							</Detail>
-					  ))
+						))
 					: null}
 			</View>
 		</ListRow>

--- a/src/views/directory/helpers.ts
+++ b/src/views/directory/helpers.ts
@@ -63,8 +63,8 @@ const descriptionText = (
 		shortRoom && item.title
 			? `${shortRoom} • ${item.title}`
 			: shortRoom
-			  ? shortRoom
-			  : item.title
+				? shortRoom
+				: item.title
 
 	return description && decode(description)
 }

--- a/src/views/directory/list.tsx
+++ b/src/views/directory/list.tsx
@@ -189,11 +189,11 @@ const styles = StyleSheet.create({
 					borderRadius: 4,
 					marginRight: imageMargin,
 					marginLeft: leftMargin,
-			  }
+				}
 			: {
 					alignSelf: 'center',
 					marginHorizontal: 8,
-			  },
+				},
 	emptySearch: {
 		flex: 1,
 		alignItems: 'center',

--- a/src/views/settings/screens/overview/component-library/colors.tsx
+++ b/src/views/settings/screens/overview/component-library/colors.tsx
@@ -298,8 +298,8 @@ function VariantColorsExample() {
 							Platform.OS === 'ios'
 								? DynamicColorIOS({light: 'red', dark: 'blue'})
 								: Platform.OS === 'android'
-								  ? PlatformColor('?attr/colorAccent')
-								  : 'red',
+									? PlatformColor('?attr/colorAccent')
+									: 'red',
 					}}
 				/>
 			</View>

--- a/src/views/sis/course-search/results.tsx
+++ b/src/views/sis/course-search/results.tsx
@@ -228,8 +228,8 @@ export const CourseSearchResultsView = (): React.JSX.Element => {
 	let message = hasActiveFilter
 		? 'There were no courses that matched your selected filters. Try a different filter combination.'
 		: query?.length
-		  ? 'There were no courses that matched your query. Please try again.'
-		  : "You can search by Professor (e.g. 'Jill Dietz'), Course Name (e.g. 'Abstract Algebra'), Department/Number (e.g. MATH 252), or GE (e.g. WRI)"
+			? 'There were no courses that matched your query. Please try again.'
+			: "You can search by Professor (e.g. 'Jill Dietz'), Course Name (e.g. 'Abstract Algebra'), Department/Number (e.g. MATH 252), or GE (e.g. WRI)"
 
 	let messageView = <NoticeView style={styles.message} text={message} />
 

--- a/src/views/stoprint/print-release.tsx
+++ b/src/views/stoprint/print-release.tsx
@@ -177,10 +177,10 @@ export const PrintJobReleaseView = (): React.JSX.Element => {
 	let status = releaseJob.isPending
 		? 'printing'
 		: cancelJob.isPending
-		  ? 'cancelling'
-		  : job?.statusFormatted === 'Pending Release'
-		    ? 'pending'
-		    : 'complete'
+			? 'cancelling'
+			: job?.statusFormatted === 'Pending Release'
+				? 'pending'
+				: 'complete'
 
 	let actionAvailable = status !== 'complete' && printer
 

--- a/src/views/stoprint/printers.tsx
+++ b/src/views/stoprint/printers.tsx
@@ -138,7 +138,7 @@ export const PrinterListView = (): React.JSX.Element => {
 				{title: 'Recent', data: recentPrinters.recentPrinters ?? []},
 				{title: 'Popular', data: recentPrinters.popularPrinters ?? []},
 				...groupedByBuilding,
-		  ]
+			]
 		: []
 
 	let availableGrouped = colorJob ? groupedByBuilding : grouped

--- a/src/views/streaming/webcams/thumbnail.tsx
+++ b/src/views/streaming/webcams/thumbnail.tsx
@@ -30,7 +30,7 @@ export const StreamThumbnail = (props: Props): React.JSX.Element => {
 
 	let img = thumbnailUrl
 		? {uri: thumbnailUrl}
-		: webcamImages.get(thumbnail) ?? transparentPixel
+		: (webcamImages.get(thumbnail) ?? transparentPixel)
 
 	return (
 		// do not remove this View; it is needed to prevent extra highlighting


### PR DESCRIPTION
## Summary

Fixes the Check workflow which was completely broken after the pnpm and Expo migrations.

### CI workflow changes (`check.yml`)
- **Removed 4 cache jobs** (`cache-npm-linux`, `cache-npm-macos`, `cache-bundler-macos`, `cache-cocoapods`) — each job now installs its own deps via `pnpm install --frozen-lockfile` with `actions/setup-node`'s built-in `cache: pnpm` for pnpm store caching
- **Added `pnpm/action-setup@v4`** before every `actions/setup-node` step — fixes "Unable to locate executable file: pnpm" errors
- **Switched `npm run`/`npx` to `pnpm run`/`pnpm exec`** — `npm run` doesn't resolve binaries correctly with pnpm's isolated node_modules
- **Removed `--` separator** from `pnpm run` commands — unlike npm, pnpm passes `--` literally to the script
- **`ios-build` now runs `pod install` directly** instead of depending on a separate cocoapods cache job

### Build script fixes (`package.json`)
- **Replaced `react-native bundle` with `npx expo export:embed`** — the project migrated to Expo so `@react-native-community/cli` is no longer available
- **Changed entry file from `index.js` to `node_modules/expo-router/entry.js`** — the old `index.js` imported `./source/root` which was removed during the Expo Router migration

### Other
- **Updated prettier** from 3.1.0 to 3.8.1
- **Ran prettier** across the project (9 files reformatted)

## Status
- ✅ Prettier, ESLint, TypeScript, Data — all passing
- ✅ Android Bundle, iOS Bundle — passing (with entry point fix)
- ❌ Jest — pre-existing failure: `react-native@0.81.5` jest setup uses ESM imports that Jest can't parse (not caused by this PR)
- ❌ iOS Build/Detox — non-functional: `ios/` directory was removed during Expo migration, needs `expo prebuild` or removal

## Test plan
- [x] Prettier check passes in CI
- [x] ESLint passes in CI
- [x] TypeScript passes in CI
- [x] Data validation passes in CI
- [x] Android/iOS bundle generation succeeds
- [ ] Jest — needs separate fix for ESM transform config
- [ ] iOS native build — needs `expo prebuild` or job removal

https://claude.ai/code/session_017UwPb7nMrhjdsAnjKEAfmK