### PR TITLE
Add Claude Code pre-commit hooks for lint, tsc, and formatting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreCommit": [
+      {
+        "command": "pnpm run pretty --check",
+        "description": "Check formatting with prettier"
+      },
+      {
+        "command": "pnpm run lint",
+        "description": "Run ESLint"
+      },
+      {
+        "command": "pnpm run typecheck",
+        "description": "Run TypeScript type checking"
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start": "expo start",
     "test": "jest",
     "validate-bus-data": "node scripts/validate-bus-schedules.mjs",
+    "typecheck": "tsc --noEmit",
     "validate-data": "node scripts/validate-data.mjs"
   },
   "prettier": {


### PR DESCRIPTION
Configure Claude Code `PreCommit` hooks in `.claude/settings.json` to run prettier check, ESLint, and TypeScript type checking before every commit. Add `typecheck` script to `package.json`.

## Changes
- **`.claude/settings.json`** — new file with `PreCommit` hooks for:
  - `pnpm run pretty --check` (formatting)
  - `pnpm run lint` (ESLint)
  - `pnpm run typecheck` (TypeScript)
- **`package.json`** — added `"typecheck": "tsc --noEmit"` script