### PR TITLE
fix: resolve all 32 failing jest test suites

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,10 @@
       {
         "command": "pnpm run typecheck",
         "description": "Run TypeScript type checking"
+      },
+      {
+        "command": "pnpm test",
+        "description": "Run jest tests"
       }
     ]
   }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	presets: ['babel-preset-expo'],
+	env: {
+		production: {
+			plugins: ['transform-remove-console'],
+		},
+	},
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,7 +17,7 @@ const config: Config = {
 	],
 	setupFiles: ['./scripts/jest-setup.js'],
 	transformIgnorePatterns: [
-		'node_modules/(?!(jest-)?react-native|@react-native|@frogpond|glamorous-native|react-navigation)',
+		'node_modules/(?!(?:\\.pnpm/.+/node_modules/)?(react-native|@react-native|@frogpond|@react-navigation|@expo|expo|react-native-|@reduxjs|immer|redux|react-redux))',
 	],
 	reporters: [['github-actions', {silent: false}], 'summary'],
 }

--- a/modules/notice/__tests__/LoadingView.test.tsx
+++ b/modules/notice/__tests__/LoadingView.test.tsx
@@ -1,17 +1,23 @@
 import React from 'react'
 import {describe, expect, test} from '@jest/globals'
 
-import TestRenderer from 'react-test-renderer'
+import TestRenderer, {act} from 'react-test-renderer'
 import {LoadingView} from '../loading'
 
 describe('LoadingView', () => {
-	test('it displays "Loading…" when no text is supplied', () => {
-		const tree = TestRenderer.create(<LoadingView />).toJSON()
-		expect(tree).toMatchSnapshot()
+	test('it displays "Loading…" when no text is supplied', async () => {
+		let tree: TestRenderer.ReactTestRenderer
+		await act(() => {
+			tree = TestRenderer.create(<LoadingView />)
+		})
+		expect(tree!.toJSON()).toMatchSnapshot()
 	})
 
-	test('it displays text when text is supplied', () => {
-		const tree = TestRenderer.create(<LoadingView text="foo bar" />).toJSON()
-		expect(tree).toMatchSnapshot()
+	test('it displays text when text is supplied', async () => {
+		let tree: TestRenderer.ReactTestRenderer
+		await act(() => {
+			tree = TestRenderer.create(<LoadingView text="foo bar" />)
+		})
+		expect(tree!.toJSON()).toMatchSnapshot()
 	})
 })

--- a/modules/notice/__tests__/NoticeView.test.tsx
+++ b/modules/notice/__tests__/NoticeView.test.tsx
@@ -2,62 +2,80 @@ import React from 'react'
 import {StyleSheet} from 'react-native'
 import {describe, expect, it} from '@jest/globals'
 
-import TestRenderer from 'react-test-renderer'
+import TestRenderer, {act} from 'react-test-renderer'
 import {NoticeView} from '../notice'
 
 describe('NoticeView', () => {
 	describe('when given no text to display', () => {
-		it('displays "Notice!" as its text', () => {
-			const tree = TestRenderer.create(<NoticeView />).toJSON()
-			expect(tree).toMatchSnapshot()
+		it('displays "Notice!" as its text', async () => {
+			let tree: TestRenderer.ReactTestRenderer
+			await act(() => {
+				tree = TestRenderer.create(<NoticeView />)
+			})
+			expect(tree!.toJSON()).toMatchSnapshot()
 		})
 	})
 
 	describe('when given text to display', () => {
-		it('displays the text', () => {
-			const tree = TestRenderer.create(<NoticeView text="foo bar" />).toJSON()
-			expect(tree).toMatchSnapshot()
+		it('displays the text', async () => {
+			let tree: TestRenderer.ReactTestRenderer
+			await act(() => {
+				tree = TestRenderer.create(<NoticeView text="foo bar" />)
+			})
+			expect(tree!.toJSON()).toMatchSnapshot()
 		})
 	})
 
 	describe('when given view style overrides', () => {
-		it('applies view style overrides', () => {
+		it('applies view style overrides', async () => {
 			const styleOverride = StyleSheet.create({
 				view: {
 					padding: 31,
 				},
 			})
-			const tree = TestRenderer.create(
-				<NoticeView style={styleOverride.view} text="foo bar" />,
-			).toJSON()
-			expect(tree).toMatchSnapshot()
+			let tree: TestRenderer.ReactTestRenderer
+			await act(() => {
+				tree = TestRenderer.create(
+					<NoticeView style={styleOverride.view} text="foo bar" />,
+				)
+			})
+			expect(tree!.toJSON()).toMatchSnapshot()
 		})
 	})
 
 	describe('when instructed to display a spinner', () => {
-		it('displays a spinner', () => {
-			const tree = TestRenderer.create(
-				<NoticeView spinner={true} text="foo bar" />,
-			).toJSON()
-			expect(tree).toMatchSnapshot()
+		it('displays a spinner', async () => {
+			let tree: TestRenderer.ReactTestRenderer
+			await act(() => {
+				tree = TestRenderer.create(
+					<NoticeView spinner={true} text="foo bar" />,
+				)
+			})
+			expect(tree!.toJSON()).toMatchSnapshot()
 		})
 	})
 
 	describe('when header text is given', () => {
-		it('displays the header text', () => {
-			const tree = TestRenderer.create(
-				<NoticeView header="blammo" text="foo bar" />,
-			).toJSON()
-			expect(tree).toMatchSnapshot()
+		it('displays the header text', async () => {
+			let tree: TestRenderer.ReactTestRenderer
+			await act(() => {
+				tree = TestRenderer.create(
+					<NoticeView header="blammo" text="foo bar" />,
+				)
+			})
+			expect(tree!.toJSON()).toMatchSnapshot()
 		})
 	})
 
 	describe('when buttonText is given', () => {
-		it('displays a button with the buttonText in its title', () => {
-			const tree = TestRenderer.create(
-				<NoticeView buttonText="button text" text="foo bar" />,
-			).toJSON()
-			expect(tree).toMatchSnapshot()
+		it('displays a button with the buttonText in its title', async () => {
+			let tree: TestRenderer.ReactTestRenderer
+			await act(() => {
+				tree = TestRenderer.create(
+					<NoticeView buttonText="button text" text="foo bar" />,
+				)
+			})
+			expect(tree!.toJSON()).toMatchSnapshot()
 		})
 	})
 })

--- a/modules/notice/__tests__/NoticeView.test.tsx
+++ b/modules/notice/__tests__/NoticeView.test.tsx
@@ -47,9 +47,7 @@ describe('NoticeView', () => {
 		it('displays a spinner', async () => {
 			let tree: TestRenderer.ReactTestRenderer
 			await act(() => {
-				tree = TestRenderer.create(
-					<NoticeView spinner={true} text="foo bar" />,
-				)
+				tree = TestRenderer.create(<NoticeView spinner={true} text="foo bar" />)
 			})
 			expect(tree!.toJSON()).toMatchSnapshot()
 		})

--- a/scripts/jest-setup.js
+++ b/scripts/jest-setup.js
@@ -3,3 +3,12 @@ import {setTimezone} from '@frogpond/constants'
 
 setTimezone('America/Chicago')
 jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter')
+jest.mock('@react-native-clipboard/clipboard', () => ({
+	getString: jest.fn(() => Promise.resolve('')),
+	setString: jest.fn(),
+	__esModule: true,
+	default: {
+		getString: jest.fn(() => Promise.resolve('')),
+		setString: jest.fn(),
+	},
+}))


### PR DESCRIPTION
## Summary
- Restore `babel.config.js` that was accidentally deleted in a prior WIP commit — without it, `babel-jest` has no configuration and cannot transform any JS/TS files
- Fix `transformIgnorePatterns` in `jest.config.ts` for pnpm compatibility (pnpm nests packages under `node_modules/.pnpm/`, which the old regex didn't account for)
- Add `@react-native-clipboard/clipboard` mock to `scripts/jest-setup.js` (native TurboModule unavailable in Jest)
- Wrap `react-test-renderer.create()` calls in `act()` for React 19 compatibility in notice component tests

## Test plan
- [x] `npx jest --no-cache` — all 32 test suites pass (179 tests pass, 3 skipped, 45 snapshots match)

https://claude.ai/code/session_01QV5XThGgCHXk1sqHz9duXG