### PR TITLE
Migrate from bare React Native to Expo SDK

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   ruby-version: '3.4.8'
   xcode_version: 'Xcode_15.2'
-  java_version: '11'
+  java_version: '17'
   java_distribution: temurin
 
 jobs:
@@ -220,12 +220,15 @@ jobs:
           echo 524288 | sudo tee -a /proc/sys/fs/inotify/max_user_instances
           sudo sysctl -p
 
-      - name: Gradle
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3
-        with:
-          arguments: bundleRelease --scan
-          build-root-directory: android
-          gradle-home-cache-cleanup: true
+      - name: Generate native Android project
+        run: pnpm exec expo prebuild --platform android --no-install
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3.5.0
+
+      - name: Build with Gradle
+        run: ./gradlew bundleRelease --scan
+        working-directory: android
         env:
           SENTRY_ORG: frog-pond-labs
           SENTRY_PROJECT: all-about-olaf
@@ -267,7 +270,7 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ios/build/Build/Products/
-          key: ${{ runner.os }}-ios-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', '**/Podfile', '**/Podfile.lock', 'pnpm-lock.yaml', '.github/job.yml') }}
+          key: ${{ runner.os }}-ios-xcode@${{ env.xcode_version }}-${{ hashFiles('app.json', 'pnpm-lock.yaml', '.github/job.yml') }}
 
       - uses: pnpm/action-setup@v4
         if: steps.app-cache.outputs.cache-hit != 'true'
@@ -289,8 +292,12 @@ jobs:
           ruby-version: ${{ env.ruby-version }}
           bundler-cache: true
 
+      - name: Generate native iOS project
+        if: steps.app-cache.outputs.cache-hit != 'true'
+        run: pnpm exec expo prebuild --platform ios --no-install
+
       - if: steps.app-cache.outputs.cache-hit != 'true'
-        run: bundle exec pod install --deployment
+        run: bundle exec pod install
         working-directory: ./ios
 
       - uses: mikehardy/buildcache-action@1db83fb06b0da378aa7db7a1110923b904417cbc # v2

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "android": "expo run:android",
     "bundle-data": "node scripts/bundle-data.mjs data/ docs/",
     "bundle:android": "mkdir -p android/generated/assets/ android/generated/res/ && npx expo export:embed --entry-file node_modules/expo-router/entry.js --dev true --platform android --bundle-output ./android/generated/assets/index.android.bundle --sourcemap-output ./android/generated/assets/index.android.bundle.map --assets-dest ./android/generated/res/",
-    "bundle:ios": "npx expo export:embed --entry-file node_modules/expo-router/entry.js --dev false --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --sourcemap-output ./ios/AllAboutOlaf/main.jsbundle.map --assets-dest ./ios",
+    "bundle:ios": "mkdir -p ios/AllAboutOlaf/ && npx expo export:embed --entry-file node_modules/expo-router/entry.js --dev false --platform ios --bundle-output ./ios/AllAboutOlaf/main.jsbundle --sourcemap-output ./ios/AllAboutOlaf/main.jsbundle.map --assets-dest ./ios",
     "fastlane": "bundle exec fastlane",
     "compress-data": "gzip --keep docs/*.json",
     "ios": "expo run:ios",


### PR DESCRIPTION
This commit migrates the All About Olaf app from bare React Native 0.72.9
to Expo SDK 50 using the Expo Prebuild (bare workflow) approach.

- Added expo@^50.0.0 and expo-status-bar
- Added babel-preset-expo and @expo/metro-config
- Added Expo native module replacements:
  - expo-device (replaces react-native-device-info)
  - expo-secure-store (replaces react-native-keychain)
  - expo-calendar (replaces react-native-calendar-events)
  - expo-updates (replaces react-native-restart)
  - expo-web-browser, expo-application, expo-asset, expo-font, expo-constants

- Created app.json with Expo configuration
- Updated babel.config.js to use babel-preset-expo
- Updated metro.config.js to use expo/metro-config
- Updated package.json scripts to use Expo CLI commands
- Configured plugins for native modules in app.json

- Updated source/root.ts to use registerRootComponent from expo

- Added EXPO_MIGRATION.md with comprehensive migration guide
- Documented next steps, testing checklist, and rollback plan
- Identified iOS-specific modules requiring attention

1. Review EXPO_MIGRATION.md for detailed migration guide
2. Run `npx expo prebuild` to regenerate native code (when ready)
3. Migrate code to use Expo equivalents (see migration guide)
4. Test all functionality thoroughly

- npm scripts changed (start, ios, android now use expo CLI)
- Native folders will be regenerated when running expo prebuild
- Some native modules need code migration (see EXPO_MIGRATION.md)

Resolves migration to Expo platform.

Update peer dependencies and migrate to Expo modules

This commit completes the Expo SDK 54 migration by:
1. Updating all workspace module peer dependencies to React 19.1 and RN 0.81
2. Migrating code from bare React Native modules to Expo equivalents

## Module Peer Dependency Updates:
- Updated 31 workspace modules in modules/*
- React: ^18.0.0 → ^19.1.0
- React Native: ^0.72.9 → ^0.81.0

## Code Migrations:

### react-native-keychain → expo-secure-store
- source/lib/login.ts: Migrated credential storage to SecureStore
- source/lib/stoprint/api.ts: Updated to use local Credentials type
- source/lib/stoprint/__mocks__/api.ts: Updated mock type
- source/lib/refresh.ts: Use resetCredentials from login.ts

### react-native-device-info → expo-device + expo-application
- source/views/home/button.tsx: Migrated hasNotch() to use expo-device
- source/views/settings/screens/overview/support.tsx: Migrated device info to expo-device and expo-application

### react-native-restart → expo-updates
- source/lib/refresh.ts: Use Updates.reloadAsync()
- source/views/settings/screens/overview/server-url.tsx: Use Updates.reloadAsync()

### react-native-calendar-events → expo-calendar
- modules/add-to-device-calendar/lib.ts: Complete migration to expo-calendar API

## Breaking Changes:
- expo-secure-store stores credentials as JSON instead of using SharedWebCredentials
- expo-calendar requires getting calendars before creating events
- expo-updates.reloadAsync() is async (was sync with react-native-restart)

## Testing Required:
- Login/logout flow with secure storage
- Calendar event creation
- App restart functionality
- Device info display in support screen

Update dependencies for React 19 compatibility and npm ci support

Updated packages to support React 19 and fix npm ci compatibility:

## Updated Packages:

### Production Dependencies:
- @react-native-async-storage/async-storage: 1.19.3 → 2.2.0 (npm ci compatibility)
- @reduxjs/toolkit: 1.9.7 → 2.5.1 (React 19 support)
- @sentry/react-native: 5.9.1 → 6.5.0 (React 19 support)
- react-redux: 8.1.3 → 9.2.0 (React 19 support)

### Dev Dependencies:
- @types/react: 18.0.28 → 19.1.0 (matches React 19.1.0)
- react-test-renderer: 18.2.0 → 19.1.0 (matches React 19.1.0)

## Changes:
- npm ci now works without --legacy-peer-deps flag
- All packages now have compatible peer dependencies with React 19
- Redux Toolkit v2 brings improved TypeScript support and performance
- Sentry v6 adds React 19 support and better error tracking

## Testing:
- ✅ npm install succeeds
- ✅ npm ci succeeds without legacy-peer-deps
- ✅ All peer dependencies resolved correctly

Remove packages replaced by Expo modules

Uninstalled the following packages that have been replaced by Expo equivalents:
- react-native-device-info → expo-device
- react-native-keychain → expo-secure-store
- react-native-calendar-events → expo-calendar
- react-native-restart → expo-updates
- react-native-inappbrowser-reborn (expo-web-browser available)

All code has already been migrated to use the Expo equivalents.

fix expo plugin installations

ignore expo stuff from git