### PR TITLE
Address code review feedback on building hours editor

### DIFF
--- a/source/views/building-hours/report/__tests__/building-reducer.test.ts
+++ b/source/views/building-hours/report/__tests__/building-reducer.test.ts
@@ -1,5 +1,4 @@
-import {buildingReducer} from '../building-reducer'
-import type {BuildingAction} from '../building-reducer'
+import {buildingReducer, type BuildingAction} from '../building-reducer'
 import type {BuildingType} from '../../types'
 
 const baseBuilding: BuildingType = {

--- a/source/views/building-hours/report/__tests__/building-reducer.test.ts
+++ b/source/views/building-hours/report/__tests__/building-reducer.test.ts
@@ -1,4 +1,5 @@
-import {buildingReducer, BuildingAction} from '../overview'
+import {buildingReducer} from '../building-reducer'
+import type {BuildingAction} from '../building-reducer'
 import type {BuildingType} from '../../types'
 
 const baseBuilding: BuildingType = {

--- a/source/views/building-hours/report/building-reducer.ts
+++ b/source/views/building-hours/report/building-reducer.ts
@@ -1,0 +1,96 @@
+import type {
+	BuildingType,
+	NamedBuildingScheduleType,
+	SingleBuildingScheduleType,
+} from '../types'
+import {blankSchedule} from '../lib'
+
+export type BuildingAction =
+	| {type: 'SET_BUILDING_NAME'; name: string}
+	| {type: 'ADD_SCHEDULE'}
+	| {
+			type: 'UPDATE_SCHEDULE'
+			scheduleIndex: number
+			data: Partial<NamedBuildingScheduleType>
+	  }
+	| {type: 'DELETE_SCHEDULE'; scheduleIndex: number}
+	| {type: 'ADD_HOURS'; scheduleIndex: number}
+	| {
+			type: 'SET_HOURS'
+			scheduleIndex: number
+			setIndex: number
+			data: SingleBuildingScheduleType
+	  }
+	| {type: 'DELETE_HOURS'; scheduleIndex: number; setIndex: number}
+
+export function buildingReducer(
+	state: BuildingType,
+	action: BuildingAction,
+): BuildingType {
+	switch (action.type) {
+		case 'SET_BUILDING_NAME':
+			return {...state, name: action.name}
+
+		case 'ADD_SCHEDULE':
+			return {
+				...state,
+				schedule: [
+					...state.schedule,
+					{title: 'Hours', hours: [blankSchedule()]},
+				],
+			}
+
+		case 'UPDATE_SCHEDULE': {
+			let schedules = [...state.schedule]
+			schedules[action.scheduleIndex] = {
+				...schedules[action.scheduleIndex],
+				...action.data,
+			}
+			return {...state, schedule: schedules}
+		}
+
+		case 'DELETE_SCHEDULE': {
+			let schedules = [...state.schedule]
+			schedules.splice(action.scheduleIndex, 1)
+			return {...state, schedule: schedules}
+		}
+
+		case 'ADD_HOURS': {
+			let schedules = [...state.schedule]
+			schedules[action.scheduleIndex] = {
+				...schedules[action.scheduleIndex],
+				hours: [...schedules[action.scheduleIndex].hours, blankSchedule()],
+			}
+			return {...state, schedule: schedules}
+		}
+
+		case 'SET_HOURS': {
+			let schedules = [...state.schedule]
+			let hours = [...schedules[action.scheduleIndex].hours]
+			hours[action.setIndex] = action.data
+			schedules[action.scheduleIndex] = {
+				...schedules[action.scheduleIndex],
+				hours,
+			}
+			return {...state, schedule: schedules}
+		}
+
+		case 'DELETE_HOURS': {
+			let schedules = [...state.schedule]
+			let hours = [...schedules[action.scheduleIndex].hours]
+			hours.splice(action.setIndex, 1)
+			schedules[action.scheduleIndex] = {
+				...schedules[action.scheduleIndex],
+				hours,
+			}
+			return {...state, schedule: schedules}
+		}
+
+		default: {
+			let _exhaustive: never = action
+			throw new Error(
+				`Unhandled building action: ${JSON.stringify(_exhaustive)}`,
+			)
+		}
+	}
+}

--- a/source/views/building-hours/report/overview.tsx
+++ b/source/views/building-hours/report/overview.tsx
@@ -223,7 +223,9 @@ export let BuildingHoursProblemReportView = (): JSX.Element => {
 			<TableView>
 				<Section header="NAME">
 					<TitleCell
-						onChange={(newName) => dispatch({type: 'SET_BUILDING_NAME', name: newName})}
+						onChange={(newName) =>
+							dispatch({type: 'SET_BUILDING_NAME', name: newName})
+						}
 						text={name || ''}
 					/>
 				</Section>

--- a/source/views/building-hours/report/overview.tsx
+++ b/source/views/building-hours/report/overview.tsx
@@ -20,8 +20,10 @@ import type {
 	NamedBuildingScheduleType,
 	SingleBuildingScheduleType,
 } from '../types'
-import {summarizeDays, formatBuildingTimes, blankSchedule} from '../lib'
+import {summarizeDays, formatBuildingTimes} from '../lib'
 import {submitReport} from './submit'
+import {buildingReducer} from './building-reducer'
+import type {BuildingAction} from './building-reducer'
 import {
 	NativeStackNavigationOptions,
 	NativeStackNavigationProp,
@@ -30,112 +32,21 @@ import {RouteProp, useNavigation, useRoute} from '@react-navigation/native'
 import {CloseScreenButton} from '@frogpond/navigation-buttons'
 import {RootStackParamList} from '../../../navigation/types'
 
-export type BuildingAction =
-	| {type: 'SET_BUILDING_NAME'; name: string}
-	| {type: 'ADD_SCHEDULE'}
-	| {
-			type: 'UPDATE_SCHEDULE'
-			scheduleIndex: number
-			data: Partial<NamedBuildingScheduleType>
-	  }
-	| {type: 'DELETE_SCHEDULE'; scheduleIndex: number}
-	| {type: 'ADD_HOURS'; scheduleIndex: number}
-	| {
-			type: 'SET_HOURS'
-			scheduleIndex: number
-			setIndex: number
-			data: SingleBuildingScheduleType
-	  }
-	| {type: 'DELETE_HOURS'; scheduleIndex: number; setIndex: number}
-
-export function buildingReducer(
-	state: BuildingType,
-	action: BuildingAction,
-): BuildingType {
-	switch (action.type) {
-		case 'SET_BUILDING_NAME':
-			return {...state, name: action.name}
-
-		case 'ADD_SCHEDULE':
-			return {
-				...state,
-				schedule: [
-					...state.schedule,
-					{title: 'Hours', hours: [blankSchedule()]},
-				],
-			}
-
-		case 'UPDATE_SCHEDULE': {
-			let schedules = [...state.schedule]
-			schedules[action.scheduleIndex] = {
-				...schedules[action.scheduleIndex],
-				...action.data,
-			}
-			return {...state, schedule: schedules}
-		}
-
-		case 'DELETE_SCHEDULE': {
-			let schedules = [...state.schedule]
-			schedules.splice(action.scheduleIndex, 1)
-			return {...state, schedule: schedules}
-		}
-
-		case 'ADD_HOURS': {
-			let schedules = [...state.schedule]
-			schedules[action.scheduleIndex] = {
-				...schedules[action.scheduleIndex],
-				hours: [...schedules[action.scheduleIndex].hours, blankSchedule()],
-			}
-			return {...state, schedule: schedules}
-		}
-
-		case 'SET_HOURS': {
-			let schedules = [...state.schedule]
-			let hours = [...schedules[action.scheduleIndex].hours]
-			hours[action.setIndex] = action.data
-			schedules[action.scheduleIndex] = {
-				...schedules[action.scheduleIndex],
-				hours,
-			}
-			return {...state, schedule: schedules}
-		}
-
-		case 'DELETE_HOURS': {
-			let schedules = [...state.schedule]
-			let hours = [...schedules[action.scheduleIndex].hours]
-			hours.splice(action.setIndex, 1)
-			schedules[action.scheduleIndex] = {
-				...schedules[action.scheduleIndex],
-				hours,
-			}
-			return {...state, schedule: schedules}
-		}
-
-		default: {
-			let _exhaustive: never = action
-			return _exhaustive
-		}
-	}
-}
-
 function useBuildingEditor(
 	initialBuilding: BuildingType,
 	navigation: NativeStackNavigationProp<RootStackParamList>,
 ) {
 	let [building, dispatch] = React.useReducer(buildingReducer, initialBuilding)
 
-	let [isDirty, setIsDirty] = React.useState(false)
-	let [submitted, setSubmitted] = React.useState(false)
-
-	let wrappedDispatch: typeof dispatch = React.useCallback(
-		(action) => {
-			setIsDirty(true)
-			dispatch(action)
-		},
-		[dispatch],
+	let initialBuildingJson = React.useMemo(
+		() => JSON.stringify(initialBuilding),
+		[initialBuilding],
 	)
 
-	let hasUnsavedChanges = isDirty && !submitted
+	let hasUnsavedChanges = React.useMemo(
+		() => JSON.stringify(building) !== initialBuildingJson,
+		[building, initialBuildingJson],
+	)
 
 	/**
 	 * checking for unsaved edits
@@ -174,30 +85,28 @@ function useBuildingEditor(
 			navigation.navigate('BuildingHoursScheduleEditor', {
 				set: set,
 				onEditSet: (editedData: SingleBuildingScheduleType) =>
-					wrappedDispatch({
+					dispatch({
 						type: 'SET_HOURS',
 						scheduleIndex: scheduleIdx,
 						setIndex: setIdx,
 						data: editedData,
 					}),
 				onDeleteSet: () =>
-					wrappedDispatch({
+					dispatch({
 						type: 'DELETE_HOURS',
 						scheduleIndex: scheduleIdx,
 						setIndex: setIdx,
 					}),
 			}),
-		[navigation, wrappedDispatch],
+		[navigation],
 	)
 
 	let submit = React.useCallback((): void => {
 		console.log(JSON.stringify(building))
-		setSubmitted(true)
-		setIsDirty(false)
 		submitReport(initialBuilding, building)
 	}, [building, initialBuilding])
 
-	return {building, dispatch: wrappedDispatch, openEditor, submit}
+	return {building, dispatch, openEditor, submit}
 }
 
 export let BuildingHoursProblemReportView = (): JSX.Element => {

--- a/source/views/building-hours/report/overview.tsx
+++ b/source/views/building-hours/report/overview.tsx
@@ -22,8 +22,7 @@ import type {
 } from '../types'
 import {summarizeDays, formatBuildingTimes} from '../lib'
 import {submitReport} from './submit'
-import {buildingReducer} from './building-reducer'
-import type {BuildingAction} from './building-reducer'
+import {buildingReducer, type BuildingAction} from './building-reducer'
 import {
 	NativeStackNavigationOptions,
 	NativeStackNavigationProp,


### PR DESCRIPTION
## Summary

Addresses code review feedback from #7371.

- **Fix submit not resetting dirty state**: Replace `isDirty`/`submitted` flags with `JSON.stringify` comparison for correct undo semantics — users who revert all edits won't be prompted
- **Fix stale closure risk**: Add `UPDATE_SCHEDULE` (partial merge) action so `editTitle`/`editNotes`/`toggleChapel` no longer spread a potentially-stale `schedule` prop
- **Consistent action naming**: `SET_BUILDING_NAME`, `ADD_SCHEDULE`, `UPDATE_SCHEDULE`, `DELETE_SCHEDULE`, `ADD_HOURS`, `SET_HOURS`, `DELETE_HOURS` — removed dead `EDIT_SCHEDULE` action
- **Exhaustive default throws**: Reducer default case throws instead of returning the action value, preventing state corruption
- **Extract reducer module**: `buildingReducer` and `BuildingAction` moved to `building-reducer.ts` to decouple tests from UI dependencies
- **Remove PR-note comments**: Cleaned up "Simplification N" comments
- **Fix prettier**: Fixed formatting in `copilot-setup-steps.yml`

## Test plan

- [x] All 8 reducer unit tests pass
- [x] ESLint clean
- [x] Prettier clean (full repo)
- [x] TypeScript compiles (only pre-existing unrelated error)

https://claude.ai/code/session_01731GAJqdifZKLpBVBMHrFW