### PR TITLE
Fix post-submit nav guard and address review feedback

### DIFF
--- a/source/views/building-hours/report/overview.tsx
+++ b/source/views/building-hours/report/overview.tsx
@@ -36,16 +36,19 @@ function useBuildingEditor(
 	navigation: NativeStackNavigationProp<RootStackParamList>,
 ) {
 	let [building, dispatch] = React.useReducer(buildingReducer, initialBuilding)
+	let [submitted, setSubmitted] = React.useState(false)
 
 	let initialBuildingJson = React.useMemo(
 		() => JSON.stringify(initialBuilding),
 		[initialBuilding],
 	)
 
-	let hasUnsavedChanges = React.useMemo(
+	let hasDiff = React.useMemo(
 		() => JSON.stringify(building) !== initialBuildingJson,
 		[building, initialBuildingJson],
 	)
+
+	let hasUnsavedChanges = hasDiff && !submitted
 
 	/**
 	 * checking for unsaved edits
@@ -102,6 +105,7 @@ function useBuildingEditor(
 
 	let submit = React.useCallback((): void => {
 		console.log(JSON.stringify(building))
+		setSubmitted(true)
 		submitReport(initialBuilding, building)
 	}, [building, initialBuilding])
 


### PR DESCRIPTION
## Summary

- **Fix post-submit nav guard**: Add `submitted` boolean so users aren't prompted to discard after pressing "Submit Report" — `hasUnsavedChanges` is now `hasDiff && !submitted`
- **JSON.stringify dirty check**: Correct undo semantics (reverting all edits = no prompt), cheaper than YAML
- **Extract `building-reducer.ts`**: Decouples reducer tests from UI dependencies
- **Exhaustive default throws**: Prevents state corruption at runtime
- **Consistent action naming**: `SET_BUILDING_NAME`, `UPDATE_SCHEDULE`, `ADD_HOURS`, `SET_HOURS`, `DELETE_HOURS`
- **`UPDATE_SCHEDULE` partial merge**: Fixes stale closure risk in `editTitle`/`editNotes`/`toggleChapel`
- **Remove dead `EDIT_SCHEDULE` action** and PR-note comments

## Test plan

- [x] 8 reducer unit tests pass
- [x] ESLint clean
- [x] Prettier clean
- [x] TypeScript compiles

https://claude.ai/code/session_01731GAJqdifZKLpBVBMHrFW