### PR TITLE
fix: add Buffer polyfill for Hermes to fix entities v7 crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
+import './source/polyfills/buffer'
 import 'text-encoding-polyfill'
 import './source/root'

--- a/source/polyfills/buffer.js
+++ b/source/polyfills/buffer.js
@@ -1,0 +1,9 @@
+// Hermes does not provide a global Buffer. Some packages (e.g. entities ≥ v7,
+// used by htmlparser2 ≥ v10) reference Buffer at module-load time as a fallback
+// for base64 decoding when atob is unavailable. This polyfill must be imported
+// before any such package is loaded.
+import {Buffer} from 'buffer'
+
+if (typeof globalThis.Buffer === 'undefined') {
+	globalThis.Buffer = Buffer
+}


### PR DESCRIPTION
## Summary

- The htmlparser2 v10.x upgrade (PR #7412) pulled in `entities` v7.0.1, which decodes base64-encoded HTML entity tables at **module load time**
- The `decodeBase64()` fallback chain references `Buffer.from` when `atob` is unavailable, but Hermes doesn't provide a global `Buffer`, causing a `ReferenceError` crash
- The crash path is: Streaming Media view → `streams/row.tsx` → `@frogpond/html-lib` → `htmlparser2` → `entities` → `decode-data-html.js` (module init) → 💥
- Adds a global `Buffer` polyfill (using the existing `buffer` v6.0.3 dependency) as the first import in `index.js`, before any code that transitively loads `entities`

## Test plan

- [ ] Detox streaming tests pass (all 5 tests in `streaming.spec.ts` that were previously crashing)
- [ ] Basic smoke tests continue to pass
- [ ] Verify no regression on other views that use `@frogpond/html-lib` (e.g. dining menus)

https://claude.ai/code/session_014wb8vyGx1MDVEZnyckbtjn