### PR TITLE
Group all patch-level dependency updates into a single weekly PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,6 +56,16 @@
         "@reduxjs/**",
         "react-redux"
       ]
+    },
+    {
+      "description": "group all patch-level updates into a single weekly PR",
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "groupName": "all patch updates",
+      "schedule": [
+        "before 9am on monday"
+      ]
     }
   ],
   "prConcurrentLimit": 4


### PR DESCRIPTION
Adds a Renovate packageRule that matches all patch updates, groups them
under "all patch updates", and schedules the PR for Monday mornings.

https://claude.ai/code/session_01BWe5k5HG9dSNnh3VfSzktV