### PR TITLE
Add xcpretty formatting to build output in CI environments

### DIFF
--- a/detox.config.js
+++ b/detox.config.js
@@ -60,7 +60,13 @@ function generateBuildCommand(configuration) {
 		)
 	}
 
-	return baseCommand.join(' ')
+	let command = baseCommand.join(' ')
+
+	if (process.env.CI) {
+		command = `set -o pipefail && ${command} | xcpretty`
+	}
+
+	return command
 }
 
 /**


### PR DESCRIPTION
## Summary
Enhanced the build command generation to format Xcode build output using xcpretty when running in CI environments, improving log readability and making build failures easier to diagnose.

## Key Changes
- Modified `generateBuildCommand()` to conditionally append xcpretty formatting to the build command when `CI` environment variable is set
- Added `set -o pipefail` to ensure the command fails if the build fails (preventing xcpretty from masking build errors)
- The xcpretty formatter is only applied in CI environments, leaving local development builds unchanged

## Implementation Details
- The build command is now stored in a variable before being returned, allowing for conditional modifications
- Uses shell pipefail option to preserve exit codes through the pipe to xcpretty
- This change maintains backward compatibility for local development while improving CI log output formatting

https://claude.ai/code/session_01MdTJ2H8DUPxNSugyXfZk8H