### PR TITLE
Fix pods.sh to use mise-managed cocoapods directly

### DIFF
--- a/scripts/pods.sh
+++ b/scripts/pods.sh
@@ -14,7 +14,6 @@ if test "$(uname)" != "Darwin"; then
 	echo 'not on Darwin; using scripts/xcrun and scripts/xcodebuild shims so the react-native pod specs can run on Linux'
 fi
 
-bundle install
 cd ios || exit 1
 
 # if this script is invoked with a `--` argument, run the following command instead of `pod install`:
@@ -23,8 +22,8 @@ if test "$1" = "--"; then
 	exec "$@"
 fi
 
-if ! bundle exec pod install --deployment; then
+if ! pod install --deployment; then
 	STATUS=$?
-	echo 'try running "bundle exec pod install --repo-update"' 1>&2
+	echo 'try running "pod install --repo-update"' 1>&2
 	exit $STATUS
 fi


### PR DESCRIPTION
## Summary

- Removes `bundle install` and `bundle exec` from `scripts/pods.sh`, since cocoapods is now managed by mise (not Bundler)
- Fixes the "Build for iOS" CI failure where Bundler 4.0.10 intercepted the `pod` executable and refused to run it because cocoapods was no longer in the Gemfile

## Context

The `hawken/more-mise-less-bundler` branch moved cocoapods from Bundler to mise (`.mise.toml` has `cocoapods = "1.16.2"`), but `scripts/pods.sh` was not updated to match. Bundler's `Gem.replace_bin_path` intercepts the pod binary and raises:

```
can't find executable pod for gem cocoapods. cocoapods is not currently included in the bundle,
perhaps you meant to add it to your Gemfile?
```

This caused `pod install` to silently fail, which then caused the subsequent `xcodebuild` step to fail with a missing-dependencies build error.

Ref: https://github.com/StoDevX/AAO-React-Native/actions/runs/24215752719/job/70696332873

## Test plan

- [ ] CI "CocoaPods" job passes (runs `mise run pods` on Ubuntu)
- [ ] CI "Build for iOS" job passes (runs `mise run pods` then `detox build` on macOS)

https://claude.ai/code/session_01WEpeMmg6dAUjhXd4UDF4SH