### PR TITLE
Update renovate's concept of a react-native package

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,12 +15,11 @@
       "matchPackageNames": [
         "@types/react-native",
         "react-native",
-        "@react-native/metro-config",
-        "@react-native/eslint-config",
         "@types/react-test-renderer",
         "react-test-renderer",
         "@types/react",
-        "react"
+        "react",
+        "@react-native/*"
       ],
       "matchUpdateTypes": [
         "minor",

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,6 @@
       "matchPackageNames": [
         "@types/react-native",
         "react-native",
-        "metro-react-native-babel-preset",
         "@react-native/metro-config",
         "@react-native/eslint-config",
         "@types/react-test-renderer",


### PR DESCRIPTION
I saw https://github.com/StoDevX/AAO-React-Native/pull/7430 and realized that we needed to update this list. 

Also removed the old metro-rn-babel-preset package, as it was replaced by the one in https://github.com/StoDevX/AAO-React-Native/pull/7430