### PR TITLE
ci: run iOS bundle job on Ubuntu instead of macOS

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,7 +86,7 @@ jobs:
 
   ios-bundle:
     name: iOS Bundle
-    runs-on: macos-14
+    runs-on: ubuntu-24.04
     outputs:
       cache-key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
     steps:


### PR DESCRIPTION
## Summary

- Switch the `ios-bundle` CI job from `macos-14` to `ubuntu-24.04`
- The `react-native bundle` command (Metro bundler) is a pure JavaScript operation — it doesn't require Xcode or any macOS-native tooling
- The `--platform ios` flag only controls how Metro resolves platform-specific files (`.ios.js` vs `.js`), not the build environment

## Motivation

Ubuntu runners are cheaper and faster to provision than macOS runners. Since the iOS bundle job only runs Metro (a Node.js tool), there's no reason it needs macOS.

## What to verify

The CI run on this PR will tell us if the job succeeds on Ubuntu. Specifically:

1. **Does `react-native bundle --platform ios` work on Linux?** — It should, since Metro is pure JS
2. **Does the downstream `ios-detox` job correctly restore the cached jsbundle?** — The cache key changes from `macOS-jsbundle-...` to `Linux-jsbundle-...`, but `ios-detox` uses the exact key exported by `ios-bundle` via `needs.ios-bundle.outputs.cache-key`, so this should be transparent
3. **Are there any native module compilation issues?** — Unlikely since bundling doesn't compile native code, but worth confirming

## Test plan

- [ ] `ios-bundle` job passes on `ubuntu-24.04`
- [ ] `ios-detox` job successfully restores the jsbundle cache from the Ubuntu-built artifact
- [ ] E2E tests pass end-to-end

https://claude.ai/code/session_01Kz7C8ZV933AnHzAb6o8iAK