### PR TITLE
Fix xcodebuild deprecation warning for manual target order

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -108,7 +108,7 @@ jobs:
             ios/AllAboutOlaf/main.jsbundle
             ios/AllAboutOlaf/main.jsbundle.map
             ios/assets/
-          key: ${{ runner.os }}-jsbundle-${{ hashFiles('.mise.toml', 'package.json', 'package-lock.json', '.github/job.yml', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
+          key: jsbundle-${{ hashFiles('.mise.toml', 'package.json', 'package-lock.json', '.github/job.yml', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
 
       - name: Bundle data
         if: steps.jsbundle-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -150,7 +150,7 @@ jobs:
         with:
           lookup-only: true
           path: ios/build/Build/Products/
-          key: ${{ runner.os }}-ios-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', '**/Podfile.lock', '.github/job.yml') }}
+          key: ${{ runner.os }}-ios-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', '**/Podfile.lock', 'ios/**', '.github/job.yml') }}
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         if: steps.app-cache.outputs.cache-hit != 'true'

--- a/ios/AllAboutOlaf.xcodeproj/xcshareddata/xcschemes/AllAboutOlaf.xcscheme
+++ b/ios/AllAboutOlaf.xcodeproj/xcshareddata/xcschemes/AllAboutOlaf.xcscheme
@@ -3,7 +3,7 @@
    LastUpgradeVersion = "1330"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry


### PR DESCRIPTION
## Summary

- Switch `parallelizeBuildables` from `NO` to `YES` in the Xcode scheme to use dependency order instead of manual target order
- Fixes the deprecation warning: *"Building targets in manual order is deprecated - choose Dependency Order in scheme settings instead"*
- hawken: expanded the scope of the hashed files for the app cache key to include all of `ios/**` - realized we needed this when the first workflow on this branch didn't build a new app!

https://claude.ai/code/session_015ZmtUbQRfjxE589ex1YEEF