### PR TITLE
ci: restructure caches and cleanup in check workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '17 8 * * *'
 
+env:
+  MISE_RUBY_COMPILE: 'false'
+
 jobs:
   js:
     name: JavaScript Checks

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -5,10 +5,13 @@ on:
   pull_request:
     types:
       - closed
+  delete:
   workflow_dispatch:
   push:
     branches:
       - master
+  schedule:
+    - cron: '0 */6 * * *'
 
 jobs:
   cleanup:
@@ -25,7 +28,16 @@ jobs:
             gh cache delete --all --succeed-on-no-caches --ref "$ref"
           done
 
+      - name: Clean up caches for the just-deleted branch
+        if: github.event_name == 'delete' && github.event.ref_type == 'branch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DELETED_REF: refs/heads/${{ github.event.ref }}
+        run: |
+          gh cache delete --all --succeed-on-no-caches --ref "$DELETED_REF"
+
       - name: Delete PR caches for all branches without open PRs
+        if: github.event_name != 'delete'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -39,17 +51,17 @@ jobs:
               esac
             done
 
-      # - name: Delete caches for readonly-queue refs that have finished
-      #   if: github.event_name == 'push'
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     gh cache list --limit 500 --json 'ref' -q '.[].ref' \
-      #       | sed -n 's|refs/pull/\([0-9]*\)/merge|\1|p' \
-      #       | sort -un \
-      #       | while read pr; do
-      #         state="$(gh pr view "$pr" --json state -q .state 2>/dev/null)"
-      #         case "$state" in MERGED|CLOSED)
-      #           gh cache delete --all --succeed-on-no-caches --ref "refs/pull/$pr/merge";;
-      #         esac
-      #       done
+      - name: Delete caches for merge-queue refs whose refs have gone away
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh cache list --limit 500 --json 'ref' -q '.[].ref' \
+            | grep '^refs/heads/gh-readonly-queue/' \
+            | sort -u \
+            | while read ref; do
+              branch="${ref#refs/heads/}"
+              if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${branch}" >/dev/null 2>&1; then
+                gh cache delete --all --succeed-on-no-caches --ref "$ref"
+              fi
+            done

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Clean up caches for the just-closed branch
-        if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && github.ref != 'master'
+        if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && github.ref_name != 'master'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -130,7 +130,13 @@ jobs:
     outputs:
       cache-key: ${{ steps.app-cache.outputs.cache-matched-key || steps.app-cache.outputs.cache-primary-key }}
     steps:
+      - name: List available Xcode versions
+        run: ls -d /Applications/Xcode*.app
+
       - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
+
+      - name: List available iOS simulators
+        run: xcrun simctl list devices iOS
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,8 @@ concurrency:
 
 env:
   xcode_version: 'Xcode_16.4'
+  cache_epoch: '1'
+  MISE_RUBY_COMPILE: 'false'
 
 jobs:
   hk:
@@ -77,20 +79,18 @@ jobs:
 
   ios-bundle:
     name: iOS Bundle
+    needs: [jest, eslint]
     runs-on: ubuntu-24.04
     outputs:
-      cache-key: ${{ steps.jsbundle-cache.outputs.cache-primary-key }}
+      cache-key: ${{ steps.jsbundle-cache.outputs.cache-matched-key || steps.jsbundle-cache.outputs.cache-primary-key }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Extract job definition
-        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - run: npm ci
 
-      - name: Load the cached jsbundle
+      - name: Restore cached jsbundle
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: jsbundle-cache
         with:
@@ -99,21 +99,23 @@ jobs:
             ios/AllAboutOlaf/main.jsbundle
             ios/AllAboutOlaf/main.jsbundle.map
             ios/assets/
-          key: jsbundle-${{ hashFiles('.mise.toml', 'package.json', 'package-lock.json', '.github/job.yml', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
+          key: jsbundle/e=${{ env.cache_epoch }}/host=ubuntu@24.04/target=ios/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('.mise.toml', 'package.json', 'package-lock.json', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
+          restore-keys: |
+            jsbundle/e=${{ env.cache_epoch }}/host=ubuntu@24.04/target=ios/ref=master/hash=${{ hashFiles('.mise.toml', 'package.json', 'package-lock.json', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
 
       - name: Bundle data
-        if: steps.jsbundle-cache.outputs.cache-hit != 'true'
+        if: steps.jsbundle-cache.outputs.cache-matched-key == ''
         run: mise run bundle-data
 
       - name: Generate jsbundle
-        if: steps.jsbundle-cache.outputs.cache-hit != 'true'
+        if: steps.jsbundle-cache.outputs.cache-matched-key == ''
         run: mise run bundle:ios
         env:
           APP_MODE: mocked
 
-      - name: Cache the jsbundle
+      - name: Save jsbundle to cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        if: steps.jsbundle-cache.outputs.cache-hit != 'true'
+        if: steps.jsbundle-cache.outputs.cache-matched-key == ''
         with:
           path: |
             ios/AllAboutOlaf/main.jsbundle
@@ -126,20 +128,11 @@ jobs:
     needs: [jest, eslint]
     runs-on: macos-15
     outputs:
-      cache-key: ${{ steps.app-cache.outputs.cache-primary-key }}
+      cache-key: ${{ steps.app-cache.outputs.cache-matched-key || steps.app-cache.outputs.cache-primary-key }}
     steps:
-      - name: List available Xcode versions
-        run: ls -d /Applications/Xcode*.app
-
       - run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
 
-      - name: List available iOS simulators
-        run: xcrun simctl list devices iOS
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Extract job definition
-        run: yq '.jobs.${{ github.job }}' .github/workflows/check.yml > .github/job.yml
 
       - name: Check for cached iOS app
         id: app-cache
@@ -147,52 +140,44 @@ jobs:
         with:
           lookup-only: true
           path: ios/build/Build/Products/
-          key: ${{ runner.os }}-ios-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', 'ios/Podfile', '**/Podfile.lock', 'ios/AllAboutOlaf/**', '.github/job.yml') }}
+          key: ios-app/e=${{ env.cache_epoch }}/host=macOS@15/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('**/project.pbxproj', 'ios/Podfile', '**/Podfile.lock', 'ios/AllAboutOlaf/**') }}
+          restore-keys: |
+            ios-app/e=${{ env.cache_epoch }}/host=macOS@15/target=ios/xcode=${{ env.xcode_version }}/ref=master/hash=${{ hashFiles('**/project.pbxproj', 'ios/Podfile', '**/Podfile.lock', 'ios/AllAboutOlaf/**') }}
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        if: steps.app-cache.outputs.cache-hit != 'true'
+        if: steps.app-cache.outputs.cache-matched-key == ''
 
       - name: Install npm dependencies
-        if: steps.app-cache.outputs.cache-hit != 'true'
+        if: steps.app-cache.outputs.cache-matched-key == ''
         run: npm ci
 
       - name: Install ccache
-        if: steps.app-cache.outputs.cache-hit != 'true'
+        if: steps.app-cache.outputs.cache-matched-key == ''
         run: brew install ccache
 
-      - name: Restore ccache
-        if: steps.app-cache.outputs.cache-hit != 'true'
+      - name: Restore/save ccache
+        if: steps.app-cache.outputs.cache-matched-key == ''
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/Library/Caches/ccache
-          key: ccache-${{ runner.os }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', 'ios/Podfile', '**/Podfile.lock', 'ios/AllAboutOlaf/**', '.github/job.yml') }}
+          key: ccache/e=${{ env.cache_epoch }}/host=macOS@15/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('**/project.pbxproj', 'ios/Podfile', '**/Podfile.lock', 'ios/AllAboutOlaf/**') }}
           restore-keys: |
-            ccache-${{ runner.os }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', 'ios/Podfile', '**/Podfile.lock', 'ios/AllAboutOlaf/**', '.github/job.yml') }}
+            ccache/e=${{ env.cache_epoch }}/host=macOS@15/target=ios/xcode=${{ env.xcode_version }}/ref=master/hash=${{ hashFiles('**/project.pbxproj', 'ios/Podfile', '**/Podfile.lock', 'ios/AllAboutOlaf/**') }}
 
       - name: Configure ccache
-        if: steps.app-cache.outputs.cache-hit != 'true'
+        if: steps.app-cache.outputs.cache-matched-key == ''
         run: |
           ccache --set-config=max_size=2G
           ccache --zero-stats
 
-      - name: Restore CocoaPods cache
-        id: pods-cache
-        if: steps.app-cache.outputs.cache-hit != 'true'
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ios/Pods
-          key: pods-${{ runner.os }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', 'ios/Podfile', '**/Podfile.lock', 'ios/AllAboutOlaf/**', '.github/job.yml') }}
-          restore-keys: |
-            pods-${{ runner.os }}-xcode@${{ env.xcode_version }}-${{ hashFiles('**/project.pbxproj', 'ios/Podfile', '**/Podfile.lock', 'ios/AllAboutOlaf/**', '.github/job.yml') }}
-
       - name: Install CocoaPods
-        if: steps.app-cache.outputs.cache-hit != 'true' && steps.pods-cache.outputs.cache-hit != 'true'
+        if: steps.app-cache.outputs.cache-matched-key == ''
         run: mise run pod:install --deployment
         env:
           USE_CCACHE: '1'
 
       - name: Build the iOS app
-        if: ${{ steps.app-cache.outputs.cache-hit != 'true' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
+        if: ${{ steps.app-cache.outputs.cache-matched-key == '' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
         env:
           SKIP_BUNDLING: 'true'
           CODE_SIGNING_DISABLED: 'true'
@@ -200,27 +185,18 @@ jobs:
         run: npx detox build e2e --configuration ios.sim.release
 
       - name: Show ccache stats
-        if: steps.app-cache.outputs.cache-hit != 'true'
+        if: steps.app-cache.outputs.cache-matched-key == ''
         run: ccache --show-stats
 
-      # Debug step to verify build output
-      - name: Verify build output
-        if: ${{ steps.app-cache.outputs.cache-hit != 'true' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
-        run: |
-          echo "Checking build output directory structure..."
-          ls -la ios/build/Build/Products/
-          echo "Checking if app bundle exists..."
-          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found!"
-          echo "Checking for Info.plist in app bundle..."
-          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found!"
-
-      - name: Cache the iOS app
+      - name: Save iOS app to cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        if: steps.app-cache.outputs.cache-matched-key == ''
         with:
           path: ios/build/Build/Products/
           key: ${{ steps.app-cache.outputs.cache-primary-key }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: steps.app-cache.outputs.cache-matched-key == ''
         with:
           name: ios-app
           path: ios/build/Build/Products/
@@ -248,17 +224,6 @@ jobs:
           path: ios/build/Build/Products/
           key: ${{ needs.ios-build.outputs.cache-key }}
 
-      - name: Debug - Check app cache contents
-        run: |
-          echo "Checking app cache contents..."
-          ls -la ios/build/Build/Products/
-          echo "Checking simulator app directory..."
-          ls -la ios/build/Build/Products/Release-iphonesimulator/ || echo "Directory not found"
-          echo "Checking app bundle contents..."
-          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/ || echo "App bundle not found"
-          echo "Checking for Info.plist..."
-          cat ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist | head -10 || echo "Info.plist not found"
-
       - # load the jsbundle before reinstalling detox, so that the package-lock cannot change
         name: Load the cached iOS jsbundle
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -273,43 +238,10 @@ jobs:
 
       - name: Move cached jsbundle into place
         run: |
-          # Ensure app directory exists
-          mkdir -p ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
-          # Check if app bundle seems incomplete
-          if [ ! -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
-            echo "WARNING: Info.plist not found in app bundle, build may be incomplete!"
-            echo "Copying essential files from source directory as fallback..."
-
-            # Copy essential app files
-            cp ios/AllAboutOlaf/Info.plist ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
-            # Create simulated app executable
-            echo "#!/bin/sh" > ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
-            echo "echo 'This is a placeholder executable for testing purposes'" >> ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
-            chmod +x ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/AllAboutOlaf
-
-            echo "Created minimal app structure for testing"
-          fi
-
-          # Move JS bundle files
           mv ios/AllAboutOlaf/main.jsbundle ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           mv ios/AllAboutOlaf/main.jsbundle.map ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
           rm -rf ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/assets || true
           mv ios/assets ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
-          # Debug app bundle again after changes
-          echo "App bundle contents after moving JS files:"
-          ls -la ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/
-
-          # Final verification of Info.plist
-          if [ -f ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist ]; then
-            echo "Info.plist exists in final app bundle"
-            grep -A 2 "CFBundleIdentifier" ios/build/Build/Products/Release-iphonesimulator/AllAboutOlaf.app/Info.plist || echo "CFBundleIdentifier not found in Info.plist"
-          else
-            echo "ERROR: Info.plist still missing after all operations!"
-            exit 1
-          fi
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
@@ -323,12 +255,6 @@ jobs:
         run: |
           brew tap wix/brew
           brew install applesimutils
-
-      - name: List available simulators
-        run: xcrun simctl list devices iOS
-
-      - name: List available device types
-        run: xcrun simctl list devicetypes
 
       - name: Discover the Detox device
         id: detox-device

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,10 +86,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-
-      - run: npm ci
-
       - name: Restore cached jsbundle
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         id: jsbundle-cache
@@ -102,6 +98,13 @@ jobs:
           key: jsbundle/e=${{ env.cache_epoch }}/host=ubuntu@24.04/target=ios/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('.mise.toml', 'package.json', 'package-lock.json', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
           restore-keys: |
             jsbundle/e=${{ env.cache_epoch }}/host=ubuntu@24.04/target=ios/ref=master/hash=${{ hashFiles('.mise.toml', 'package.json', 'package-lock.json', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**.ts', 'modules/**.tsx', 'source/**.ts', 'source/**.tsx') }}
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        if: steps.jsbundle-cache.outputs.cache-matched-key == ''
+
+      - name: Install npm dependencies
+        if: steps.jsbundle-cache.outputs.cache-matched-key == ''
+        run: npm ci
 
       - name: Bundle data
         if: steps.jsbundle-cache.outputs.cache-matched-key == ''
@@ -196,13 +199,13 @@ jobs:
 
       - name: Save iOS app to cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        if: steps.app-cache.outputs.cache-matched-key == ''
+        if: ${{ steps.app-cache.outputs.cache-matched-key == '' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
         with:
           path: ios/build/Build/Products/
           key: ${{ steps.app-cache.outputs.cache-primary-key }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: steps.app-cache.outputs.cache-matched-key == ''
+        if: ${{ steps.app-cache.outputs.cache-matched-key == '' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-detox') }}
         with:
           name: ios-app
           path: ios/build/Build/Products/

--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -12,6 +12,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  MISE_RUBY_COMPILE: 'false'
+
 jobs:
   ios-podfile-update:
     # Adapted from https://gist.github.com/A-Tokyo/0d811e818513fc4d3272335d2847d748

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - .github/workflows/copilot-setup-steps.yml
 
+env:
+  MISE_RUBY_COMPILE: 'false'
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -3,6 +3,9 @@ name: Validate/Deploy Data
 on:
   push: {branches: [master]}
 
+env:
+  MISE_RUBY_COMPILE: 'false'
+
 jobs:
   validate-then-deploy:
     name: Validate, then deploy data


### PR DESCRIPTION
## Summary

Restructures the caches in `check.yml` to read from master as a fallback while writing only to branch-scoped keys, removes the CocoaPods cache, and extends `cache-cleanup.yml` to handle branch deletion and stale merge-queue caches. Also sets `MISE_RUBY_COMPILE=false` on every workflow so mise fetches prebuilt Ruby instead of compiling from source.

### `check.yml`

- **New cache key shape** for `jsbundle`, `ios-app`, and `ccache`:
  ```
  {kind}/e={epoch}/host={os}@{ver}/target=ios/xcode={ver}/ref={ref}/hash={hash}
  ```
  `host`/`xcode` segments are omitted where they don't apply (the jsbundle skips `xcode`).
- **Master fallback via `restore-keys`.** PRs read from their own branch-scoped cache first, then fall back to an exact-shape master key. Build/save steps now gate on `cache-matched-key == ''` (instead of `cache-hit != 'true'`), so a master-fallback hit skips rebuild *and* skips re-saving the same bytes under a branch-scoped key.
- **`cache_epoch` env var.** Bump it in one place to invalidate all three caches at once for version-bumps that can't be reflected in `hashFiles`.
- **CocoaPods cache removed.** The iOS app cache already covers it.
- **`.github/job.yml` yq extraction removed** from `ios-bundle` and `ios-build`. Workflow-level invalidations go through `cache_epoch` now.
- **Debug noise removed:** the "Verify build output" block, the "Debug - Check app cache contents" block, the Info.plist placeholder-executable fallback in `ios-detox`, and the final Info.plist verification. The `ls /Applications/Xcode*.app` and `xcrun simctl list devices iOS` steps are kept in `ios-build` — runners periodically shift Xcode versions and simulator types out from under us, so the log output is worth the noise.
- **`ios-bundle` now `needs: [jest, eslint]`** to match `ios-build`.
- **`ios-bundle`** runs its cache lookup *before* `mise-action`/`npm ci`, so a cache hit skips the toolchain install entirely.
- **`ios-build`'s cache save and artifact upload** are now gated on both cache miss *and* absence of the `ci/skip-detox` label, matching the build step. Previously a `ci/skip-detox` run would have tried to save an empty `Products/` directory.

### `cache-cleanup.yml`

- Added `on: delete:` trigger + a step that wipes caches scoped to the deleted branch.
- Added `schedule: '0 */6 * * *'` as a backstop.
- New step that lists `refs/heads/gh-readonly-queue/*` cache refs, checks each against `gh api .../git/ref/heads/...`, and deletes caches whose refs no longer exist. Runs on push-to-master, cron, and manual dispatch.
- Fixed a latent bug in the `pull_request: closed` / `workflow_dispatch` cleanup: the guard used `github.ref != 'master'`, but `github.ref` is `refs/heads/master` on master, so the guard was always true and a manual dispatch on master would have deleted master-scoped caches. Switched to `github.ref_name`.

### Other workflows

- Added workflow-level `env: MISE_RUBY_COMPILE: 'false'` to `build-and-deploy.yml`, `deploy-data.yml`, `cocoapods.yml`, and `copilot-setup-steps.yml`.

## Test plan

- [x] `mise run agent:pre-commit` passes locally (prettier, tsc, jest 197 pass / 3 skipped, eslint 0 errors)
- [x] All six workflow YAML files parse as valid YAML
- [x] CI runs green on this branch
- [ ] First cache save produces a branch-scoped key in the new `{kind}/e=…/host=…/ref=…/hash=…` shape (verifiable via `gh cache list`)
- [ ] A second run on the same branch hits the branch-scoped cache exactly (`cache-matched-key == cache-primary-key`), skipping build *and* save
- [ ] A run on a fresh branch falls back to master via `restore-keys` (`cache-matched-key != ''` and `!= cache-primary-key`), skipping build and skipping the save-under-branch-key step
- [ ] Bumping `cache_epoch` in a follow-up test invalidates all three caches at once
- [ ] Branch deletion on a test branch triggers `cache-cleanup.yml` and removes its caches
- [ ] Merge-queue cache sweep removes caches for `gh-readonly-queue/*` refs that have been cleaned up