### PR TITLE
Add Detox e2e coverage for app icon switching

### DIFF
--- a/e2e/module-app-icon.spec.ts
+++ b/e2e/module-app-icon.spec.ts
@@ -16,15 +16,11 @@ beforeEach(async () => {
 	await device.reloadReactNative()
 })
 
-// Make sure the icon is reset to default when the suite finishes so the next
-// test file doesn't inherit a changed icon.
+// Reinstall the app after this suite runs so the alternate icon (which iOS
+// persists across normal launches) can't leak into subsequent specs, even if
+// a test errored partway through without restoring the default.
 afterAll(async () => {
-	try {
-		await element(by.id('app-icon-cell-default')).tap()
-		await system.element(by.system.label('OK')).atIndex(0).tap()
-	} catch {
-		// Already the default icon, nothing to reset.
-	}
+	await device.launchApp({delete: true})
 })
 
 // Dismisses the iOS system alert that iOS raises whenever the alternate icon

--- a/e2e/module-app-icon.spec.ts
+++ b/e2e/module-app-icon.spec.ts
@@ -1,0 +1,61 @@
+import {afterAll, beforeAll, beforeEach, test} from '@jest/globals'
+import {by, device, element, expect, system} from 'detox'
+
+// launch the app once - do this per-test-file to grant only the permissions
+// needed for a given test
+//
+// `delete: true` gives us a clean install so the alternate icon starts at
+// the default. iOS persists the alternate icon name across normal app
+// launches, so we need a fresh install to guarantee a known starting state.
+beforeAll(async () => {
+	await device.launchApp({delete: true})
+})
+
+// in this file, only reload the rn stuff between tests
+beforeEach(async () => {
+	await device.reloadReactNative()
+})
+
+// Make sure the icon is reset to default when the suite finishes so the next
+// test file doesn't inherit a changed icon.
+afterAll(async () => {
+	try {
+		await element(by.id('app-icon-cell-default')).tap()
+		await system.element(by.system.label('OK')).atIndex(0).tap()
+	} catch {
+		// Already the default icon, nothing to reset.
+	}
+})
+
+// Dismisses the iOS system alert that iOS raises whenever the alternate icon
+// changes ("You have changed the icon to ..."). The alert is a system-owned
+// view, not something the app renders, so it has to be matched via Detox's
+// `system` facade.
+const dismissIconChangedAlert = async () => {
+	await system.element(by.system.label('OK')).atIndex(0).tap()
+}
+
+test('changes the app icon to Big Ole and back to Old Main', async () => {
+	await element(by.id('button-open-settings')).tap()
+
+	// The default icon should be selected on a fresh install.
+	await expect(element(by.id('app-icon-cell-default-selected'))).toBeVisible()
+	await expect(element(by.id('app-icon-cell-icon_type_windmill'))).toBeVisible()
+
+	// Switch to Big Ole.
+	await element(by.id('app-icon-cell-icon_type_windmill')).tap()
+	await dismissIconChangedAlert()
+
+	// Big Ole is now selected; Old Main is not.
+	await expect(
+		element(by.id('app-icon-cell-icon_type_windmill-selected')),
+	).toBeVisible()
+	await expect(element(by.id('app-icon-cell-default'))).toBeVisible()
+
+	// Switch back to the default (Old Main).
+	await element(by.id('app-icon-cell-default')).tap()
+	await dismissIconChangedAlert()
+
+	await expect(element(by.id('app-icon-cell-default-selected'))).toBeVisible()
+	await expect(element(by.id('app-icon-cell-icon_type_windmill'))).toBeVisible()
+})

--- a/source/views/settings/screens/change-icon.tsx
+++ b/source/views/settings/screens/change-icon.tsx
@@ -102,6 +102,7 @@ let IconCell = (props: IconCellProps) => {
 				/>
 			}
 			onPress={setIcon}
+			testID={`app-icon-cell-${icon.type}${isSelected ? '-selected' : ''}`}
 			title={icon.title}
 		/>
 	)


### PR DESCRIPTION
Targets #7473.

## Summary

Yes — icon switching _can_ be exercised end-to-end on the iOS simulator. `react-native-change-icon@5.0.0` calls the public `UIApplication.setAlternateIconName:completionHandler:` API, which is supported on the simulator but raises a non-suppressible system alert ("You have changed the icon to …"). Detox 20 can drive that alert through its `system` facade, so the flow is fully testable.

This PR adds that coverage on top of #7473.

## Changes

- **`source/views/settings/screens/change-icon.tsx`** — add a `testID` to each `IconCell` that encodes the selected state (e.g. `app-icon-cell-default-selected` vs `app-icon-cell-icon_type_windmill`). The Cell from `react-native-tableview-simple` already forwards `testID` onto the underlying `TouchableHighlight`, so no further plumbing is needed.
- **`e2e/module-app-icon.spec.ts`** — new Detox spec that:
  1. Launches with `{delete: true}` so the alternate icon starts from a known default (iOS persists `alternateIconName` across normal launches).
  2. Opens Settings and asserts Old Main is selected.
  3. Taps Big Ole, dismisses the iOS system alert via `system.element(by.system.label('OK')).atIndex(0).tap()`, and asserts Big Ole is now selected.
  4. Taps Old Main, dismisses the alert again, and asserts Old Main is back.
  5. `afterAll` resets the icon as a safety net so the simulator state doesn't leak to whichever spec runs next.

## Why `testID` and not the checkmark?

The checkmark accessory is a styled `View` inside `react-native-tableview-simple`, with no label or traits Detox can reliably match on. Encoding the selected state into the cell's `testID` is the smallest change that makes the selected-ness queryable.

## Verification

`mise run agent:pre-commit` — prettier, tsc, jest, and eslint all green (pre-existing warnings unchanged). Detox itself runs in CI on macOS; I can't drive the simulator from this environment, so the spec will get its first real exercise in that job.

## Test plan

- [ ] `mise run agent:pre-commit`
- [ ] Detox CI job runs `e2e/module-app-icon.spec.ts` on the iOS simulator and it passes
- [ ] Manual sanity check: Settings → APP ICON → tap Big Ole → dismiss alert → checkmark moves → tap Old Main → dismiss alert → checkmark returns

Sources:
- [iOS simulator supports alternate icons](https://github.com/skb1129/react-native-change-icon)
- [System alert cannot be disabled on iOS](https://github.com/skb1129/react-native-change-icon/discussions/48)

https://claude.ai/code/session_012CJLkr9hYs9qRFRgroyfMA