### PR TITLE
Fix cache condition mismatch in iOS build CI job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -189,7 +189,7 @@ jobs:
           USE_CCACHE: '1'
 
       - name: Build UITest bundle
-        if: ${{ steps.app-cache.outputs.cache-hit != 'true' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
+        if: ${{ steps.app-cache.outputs.cache-matched-key == '' && !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
         env:
           SKIP_BUNDLING: 'true'
           CODE_SIGNING_DISABLED: 'true'


### PR DESCRIPTION
## Summary

- Fix condition mismatch on the "Build UITest bundle" step in the `ios-build` job that caused it to run even when dependencies were skipped due to a cache prefix match
- Change `cache-hit != 'true'` to `cache-matched-key == ''` for consistency with every other conditional step in the job

## Details

When a `restore-keys` prefix match occurs (e.g., a PR branch misses the exact cache key but matches master's cache because the file hashes are identical):

| Output | Exact match | Prefix match | No match |
|--------|------------|-------------|----------|
| `cache-hit` | `'true'` | `'false'` | `'false'` |
| `cache-matched-key` | primary key | restore key | `''` |

Steps 7–12 (mise, npm, ccache, cocoapods) gate on `cache-matched-key == ''`, so they are **skipped** on a prefix match. But the build step gated on `cache-hit != 'true'`, which evaluates to `true` on a prefix match — so xcodebuild **ran** without CocoaPods installed, failing with missing `.xcconfig` errors.

Observed on #7491.

## Test plan

- [ ] Confirm CI passes on this PR (no iOS-file changes, so the cache prefix match path is exercised)
- [ ] Verify a PR that changes iOS files still triggers a full rebuild when no exact cache match exists

https://claude.ai/code/session_01FkumjnZ3te8a6AfBSteybS