### PR TITLE
ci: delete Podfile.lock before pod install

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -55,6 +55,12 @@ jobs:
 
       - run: mise x -- pod repo update
 
+      # Delete the existing Podfile.lock so `pod install` resolves from
+      # scratch instead of trying to update the existing lockfile. This
+      # avoids resolver failures when dependencies have drifted far enough
+      # that an in-place update can't find a consistent graph.
+      - run: rm -f ios/Podfile.lock
+
       - run: mise run pod:install --verbose
 
       - name: push-on-podfile-change


### PR DESCRIPTION
## Summary

Targets #7477. The `iOS Update Cocoapods` job on that PR is failing because `pod install` tries to update the existing `Podfile.lock` in place, and a major version bump of `react-native-screens` (3 → 4) drifts the dependency graph far enough that the resolver can't find a consistent update.

This PR removes `ios/Podfile.lock` before running `pod install` in `.github/workflows/cocoapods.yml`, forcing a fresh resolve. `scripts/push-on-podfile-change.sh` already handles the resulting diff (or lack of one) correctly — if the regenerated lockfile matches, the script exits without pushing; otherwise it commits the updated lockfile back to the PR branch.

## Test plan

- [ ] Merge this branch into `renovate/react-native-screens-4.x` (or wait for Renovate to rebase); confirm the `iOS Update Cocoapods` check succeeds and a fresh `Podfile.lock` is pushed.
- [ ] Confirm the downstream `Build for iOS` and `iOS Bundle` jobs pass on the regenerated lockfile.

https://claude.ai/code/session_01WFJLFiXgBqoQ1xeBmQ1CXQ