### PR TITLE
feat(sentry): enable Sentry.wrap, appLoaded, and Hermes profiling

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -65,20 +65,23 @@ function ErrorFallback({
 	)
 }
 
-export default function App(): JSX.Element {
+function App(): JSX.Element {
 	// Create a ref for the navigation container
 	const navigationRef = React.useRef()
 	const scheme = useColorScheme()
 	const theme = scheme === 'dark' ? CombinedDarkTheme : CombinedLightTheme
 	const statusBarStyle = scheme === 'dark' ? 'light-content' : 'dark-content'
 
-	const registerContainer = () => {
+	const onNavigationReady = () => {
 		if (!IS_PRODUCTION) {
 			return
 		}
 
 		// Register the navigation container with the integration
 		sentryInit.navigationIntegration.registerNavigationContainer(navigationRef)
+
+		// Signal to Sentry that the app has finished starting up
+		Sentry.appLoaded()
 	}
 
 	return (
@@ -94,7 +97,7 @@ export default function App(): JSX.Element {
 					>
 						<PaperProvider theme={theme}>
 							<ActionSheetProvider>
-								<NavigationContainer onReady={registerContainer} theme={theme}>
+								<NavigationContainer onReady={onNavigationReady} theme={theme}>
 									<StatusBar barStyle={statusBarStyle} />
 									<RootStack />
 								</NavigationContainer>
@@ -106,3 +109,7 @@ export default function App(): JSX.Element {
 		</Sentry.ErrorBoundary>
 	)
 }
+
+// Wrap the App with Sentry to enable touch-event breadcrumbs and
+// time-to-initial-display timing.
+export default Sentry.wrap(App)

--- a/source/init/sentry.ts
+++ b/source/init/sentry.ts
@@ -14,10 +14,11 @@ function install() {
 		dsn: SENTRY_DSN,
 
 		tracesSampleRate: 0.2,
+		profilesSampleRate: 0.1,
 
 		tracePropagationTargets: ['localhost', 'frogpond.tech', /^\//u],
 
-		integrations: [navigationIntegration],
+		integrations: [navigationIntegration, Sentry.hermesProfilingIntegration()],
 	})
 }
 


### PR DESCRIPTION
Follow-up to #7464. Picks up three low-risk v8 features:

- **`Sentry.wrap(App)`** — enables Sentry's `TouchEventBoundary` (taps captured as breadcrumbs) and time-to-initial-display timing for the root view.
- **`Sentry.appLoaded()`** — called from `NavigationContainer.onReady` so Sentry has an explicit signal for when startup is finished (new in `@sentry/react-native` 8.7.0).
- **`hermesProfilingIntegration`** — attaches JS CPU profiles to a 10% sample of transactions. RN 0.76 uses Hermes by default so this is a drop-in.

### Why this is stacked on the v8 upgrade branch

All three APIs require `@sentry/react-native` v8, so this PR targets `renovate/sentry-react-native-8.x` as its base. Once #7464 merges to master this will automatically re-target master.

### Test plan

- [x] `mise run tsc` passes
- [x] `mise run lint` passes
- [x] `mise run pretty:check` passes
- [x] `mise run test` passes (36 suites, 197 passing)
- [ ] Smoke test in TestFlight: confirm tap breadcrumbs appear on an intentional error, and that a transaction event includes a profile attachment.