### PR TITLE
feat(sentry): enable on-error mobile session replay

### DIFF
--- a/source/init/sentry.ts
+++ b/source/init/sentry.ts
@@ -17,7 +17,21 @@ function install() {
 
 		tracePropagationTargets: ['localhost', 'frogpond.tech', /^\//u],
 
-		integrations: [navigationIntegration],
+		// Session replay is opt-in per-error only; no blanket session recording.
+		replaysSessionSampleRate: 0,
+		replaysOnErrorSampleRate: 0.1,
+
+		integrations: [
+			navigationIntegration,
+			// All masking options default to `true` — text, images, and vector
+			// graphics are blurred in recordings. We pass the defaults
+			// explicitly so this choice is visible at the call site.
+			Sentry.mobileReplayIntegration({
+				maskAllText: true,
+				maskAllImages: true,
+				maskAllVectors: true,
+			}),
+		],
 	})
 }
 


### PR DESCRIPTION
Follow-up to #7464. Enables Sentry's mobile session replay on errors only, with aggressive masking.

## What

Adds `mobileReplayIntegration`. When an error is captured, Sentry uploads a short video of the frames leading up to it — useful for reproducing UI-state-dependent bugs that don't surface from the stack trace alone.

## Privacy / bandwidth posture

This is the reason this PR is separated out from #7497 and #7498.

- `replaysSessionSampleRate: 0` — **no** blanket session recording. A replay is only produced if an error happens.
- `replaysOnErrorSampleRate: 0.1` — 10% of error-containing sessions are recorded. Easy to tune up once we have a feel for volume and signal.
- `maskAllText: true`, `maskAllImages: true`, `maskAllVectors: true` — every text node, image, and SVG is blurred in the recording. These match the library defaults but are spelled out so the privacy choice is visible at the call site.

## Verification before merging

Because replay ships screen recordings of real users, please don't merge without a manual pass on TestFlight:

- [ ] Trigger the debug "Send Exception" in Settings → Developer → Sentry event.
- [ ] Open the resulting replay in the Sentry UI.
- [ ] Confirm no text, image, or avatar renders through unmasked. In particular eyeball:
  - Directory / contact list cells
  - Dining menu items
  - Course catalog search results
  - Any screen showing a logged-in user's name or email

If anything leaks, we have two escape hatches:
- Per-element masking: wrap the view in `<Sentry.Mask>`.
- Per-screen opt-out: drop the screen class into `excludedViewClasses` on iOS.

## Why stacked on the v8 branch

`mobileReplayIntegration` only exists in `@sentry/react-native` v8+, so this PR targets `renovate/sentry-react-native-8.x`. Will auto-retarget master once #7464 merges.

## Test plan

- [x] `mise run tsc` passes
- [x] `mise run lint` passes
- [x] `mise run pretty:check` passes
- [x] `mise run test` passes (36 suites, 197 passing)
- [ ] Manual masking check on TestFlight (see above).