### PR TITLE
Add renovate group for @react-native-vector-icons packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,13 @@
       ]
     },
     {
+      "description": "group all @react-native-vector-icons/* packages together",
+      "groupName": "@react-native-vector-icons/*",
+      "matchPackageNames": [
+        "@react-native-vector-icons/*"
+      ]
+    },
+    {
       "description": "group all patch-level updates into a single weekly PR",
       "matchUpdateTypes": [
         "patch"


### PR DESCRIPTION
as per the title.

Goal is to combine all three of these into one:

<img width="565" height="97" alt="image" src="https://github.com/user-attachments/assets/a3769ada-e545-4072-9447-abc8e63cccae" />
