### PR TITLE
remove react-native-calendar-events dependency

### DIFF
--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -84,8 +84,6 @@
 			</dict>
 		</dict>
 	</dict>
-	<key>NSCalendarsUsageDescription</key>
-	<string>We use your calendar to add events to your calendar so that you remember what you wanted to attend.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Entypo.ttf</string>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1663,8 +1663,6 @@ PODS:
     - React-logger
     - React-perflogger
     - React-utils (= 0.76.9)
-  - RNCalendarEvents (2.2.0):
-    - React
   - RNCClipboard (1.16.3):
     - React-Core
   - RNCPicker (2.11.4):
@@ -1968,7 +1966,6 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - RNCalendarEvents (from `../node_modules/react-native-calendar-events`)
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - "RNDateTimePicker (from `../node_modules/@react-native-community/datetimepicker`)"
@@ -2144,8 +2141,6 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
-  RNCalendarEvents:
-    :path: "../node_modules/react-native-calendar-events"
   RNCClipboard:
     :path: "../node_modules/@react-native-clipboard/clipboard"
   RNCPicker:
@@ -2248,7 +2243,6 @@ SPEC CHECKSUMS:
   React-utils: ed818f19ab445000d6b5c4efa9d462449326cc9f
   ReactCodegen: f853a20cc9125c5521c8766b4b49375fec20648b
   ReactCommon: 300d8d9c5cb1a6cd79a67cf5d8f91e4d477195f9
-  RNCalendarEvents: f90f73666b6bcbb3cc8a491ffbb5e48c0db3de37
   RNCClipboard: f6679d470d0da2bce2a37b0af7b9e0bf369ecda5
   RNCPicker: 7de564dce1f90b53e386a24001aafc3578233dfe
   RNDateTimePicker: a4679e6488003e5fb68502b50ffb1b74b8b31ca0

--- a/modules/add-to-device-calendar/add-to-calendar.ts
+++ b/modules/add-to-device-calendar/add-to-calendar.ts
@@ -54,8 +54,10 @@ export class AddToCalendar extends React.Component<Props, State> {
 
 		const result = await addToCalendar(event)
 
-		if (result) {
+		if (result === 'saved') {
 			this.setState(() => ({message: MESSAGES.success, disabled: true}))
+		} else if (result === 'cancelled') {
+			this.setState(() => ({message: '', disabled: false}))
 		} else {
 			this.setState(() => ({message: MESSAGES.error, disabled: false}))
 		}

--- a/modules/add-to-device-calendar/lib.ts
+++ b/modules/add-to-device-calendar/lib.ts
@@ -3,11 +3,8 @@ import {encode as base64Encode} from 'base-64'
 import {Share} from 'react-native'
 import type {EventType} from '@frogpond/event-type'
 
-function pad(n: number): string {
-	return String(n).padStart(2, '0')
-}
-
 function formatICSDate(date: Date): string {
+	let pad = (n: number) => String(n).padStart(2, '0')
 	return (
 		date.getUTCFullYear().toString() +
 		pad(date.getUTCMonth() + 1) +

--- a/modules/add-to-device-calendar/lib.ts
+++ b/modules/add-to-device-calendar/lib.ts
@@ -1,75 +1,73 @@
 import * as Sentry from '@sentry/react-native'
+import {encode as base64Encode} from 'base-64'
+import {Share} from 'react-native'
 import type {EventType} from '@frogpond/event-type'
-import RNCalendarEvents from 'react-native-calendar-events'
-import {Alert, Linking, Platform} from 'react-native'
 
-export async function addToCalendar(event: EventType): Promise<boolean> {
+function pad(n: number): string {
+	return String(n).padStart(2, '0')
+}
+
+function formatICSDate(date: Date): string {
+	return (
+		date.getUTCFullYear().toString() +
+		pad(date.getUTCMonth() + 1) +
+		pad(date.getUTCDate()) +
+		'T' +
+		pad(date.getUTCHours()) +
+		pad(date.getUTCMinutes()) +
+		pad(date.getUTCSeconds()) +
+		'Z'
+	)
+}
+
+function escapeICSText(text: string): string {
+	return text
+		.replace(/\\/gu, '\\\\')
+		.replace(/;/gu, '\\;')
+		.replace(/,/gu, '\\,')
+		.replace(/\r?\n/gu, '\\n')
+}
+
+export function buildICS(event: EventType): string {
+	let uid = `aao-${Date.now()}-${Math.random().toString(36).slice(2)}@stolaf.edu`
+	let lines = [
+		'BEGIN:VCALENDAR',
+		'VERSION:2.0',
+		'PRODID:-//St. Olaf College//All About Olaf//EN',
+		'CALSCALE:GREGORIAN',
+		'METHOD:PUBLISH',
+		'BEGIN:VEVENT',
+		`UID:${uid}`,
+		`DTSTAMP:${formatICSDate(new Date())}`,
+		`DTSTART:${formatICSDate(event.startTime.toDate())}`,
+		`DTEND:${formatICSDate(event.endTime.toDate())}`,
+		`SUMMARY:${escapeICSText(event.title)}`,
+		`DESCRIPTION:${escapeICSText(event.description)}`,
+		`LOCATION:${escapeICSText(event.location)}`,
+		'END:VEVENT',
+		'END:VCALENDAR',
+	]
+	return lines.join('\r\n')
+}
+
+export type AddToCalendarResult = 'saved' | 'cancelled' | 'error'
+
+export async function addToCalendar(
+	event: EventType,
+): Promise<AddToCalendarResult> {
 	try {
-		const authCode = await RNCalendarEvents.checkPermissions(false)
+		let ics = buildICS(event)
+		let dataUrl = `data:text/calendar;base64,${base64Encode(ics)}`
 
-		const authStatus =
-			authCode === 'authorized' ? true : await requestCalendarAccess()
+		let result = await Share.share({
+			url: dataUrl,
+			title: event.title,
+		})
 
-		if (!authStatus) {
-			return false
-		}
-
-		return await saveEventToCalendar(event)
+		return result.action === Share.sharedAction ? 'saved' : 'cancelled'
 	} catch (error) {
 		Sentry.captureException(error)
 		console.error(error)
-		return false
+		return 'error'
 	}
-}
-
-async function saveEventToCalendar(event: EventType): Promise<boolean> {
-	try {
-		await RNCalendarEvents.saveEvent(event.title, {
-			location: event.location,
-			startDate: event.startTime.toISOString(),
-			endDate: event.endTime.toISOString(),
-			description: event.description,
-			notes: event.description,
-		})
-
-		return true
-	} catch (err) {
-		Sentry.captureException(err)
-		console.error(err)
-		return false
-	}
-}
-
-function promptSettings(): Alert | void {
-	if (Platform.OS === 'ios') {
-		// Note: remember to change this text in the iOS plist, too.
-		return Alert.alert(
-			'"All About Olaf" Would Like to Access Your Calendar',
-			`We use your calendar to add events to your calendar so that you remember
-       what you wanted to attend.`,
-			[
-				{
-					text: "Don't Allow",
-					onPress: () => console.log('cancel pressed'),
-					style: 'cancel',
-				},
-				{text: 'Settings', onPress: () => Linking.openURL('app-settings:')},
-			],
-		)
-	}
-}
-
-async function requestCalendarAccess(): Promise<boolean> {
-	let status = null
-	try {
-		status = await RNCalendarEvents.requestPermissions(false)
-	} catch (_err) {
-		return false
-	}
-
-	if (status !== 'authorized') {
-		return promptSettings() === undefined
-	}
-
-	return true
 }

--- a/modules/add-to-device-calendar/lib.ts
+++ b/modules/add-to-device-calendar/lib.ts
@@ -28,8 +28,14 @@ function escapeICSText(text: string): string {
 		.replace(/\r?\n/gu, '\\n')
 }
 
+let uidCounter = 0
+
 export function buildICS(event: EventType): string {
-	let uid = `aao-${Date.now()}-${Math.random().toString(36).slice(2)}@stolaf.edu`
+	// UID just needs to be unique per-calendar-object per RFC 5545 — it's a
+	// dedupe hint, not a secret — so a timestamp plus a monotonic counter is
+	// sufficient.
+	uidCounter += 1
+	let uid = `aao-${Date.now()}-${uidCounter}@stolaf.edu`
 	let lines = [
 		'BEGIN:VCALENDAR',
 		'VERSION:2.0',

--- a/modules/add-to-device-calendar/lib.ts
+++ b/modules/add-to-device-calendar/lib.ts
@@ -4,15 +4,14 @@ import {Share} from 'react-native'
 import type {EventType} from '@frogpond/event-type'
 
 function formatICSDate(date: Date): string {
-	let pad = (n: number) => String(n).padStart(2, '0')
 	return (
 		date.getUTCFullYear().toString() +
-		pad(date.getUTCMonth() + 1) +
-		pad(date.getUTCDate()) +
+		String(date.getUTCMonth() + 1).padStart(2, '0') +
+		String(date.getUTCDate()).padStart(2, '0') +
 		'T' +
-		pad(date.getUTCHours()) +
-		pad(date.getUTCMinutes()) +
-		pad(date.getUTCSeconds()) +
+		String(date.getUTCHours()).padStart(2, '0') +
+		String(date.getUTCMinutes()).padStart(2, '0') +
+		String(date.getUTCSeconds()).padStart(2, '0') +
 		'Z'
 	)
 }

--- a/modules/add-to-device-calendar/package.json
+++ b/modules/add-to-device-calendar/package.json
@@ -9,10 +9,10 @@
     "test": "jest"
   },
   "peerDependencies": {
+    "base-64": "^1.0.0",
     "delay": "^7.0.0",
     "react": "^18.0.0",
-    "react-native": "^0.76.0",
-    "react-native-calendar-events": "^2.2.0"
+    "react-native": "^0.76.0"
   },
   "dependencies": {
     "@frogpond/event-type": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "react-markdown": "2.5.1",
         "react-native": "0.76.9",
         "react-native-button": "3.1.0",
-        "react-native-calendar-events": "2.2.0",
         "react-native-change-icon": "5.0.0",
         "react-native-device-info": "11.1.0",
         "react-native-gesture-handler": "2.31.0",
@@ -139,10 +138,10 @@
         "@frogpond/event-type": "^1.0.0"
       },
       "peerDependencies": {
+        "base-64": "^1.0.0",
         "delay": "^7.0.0",
         "react": "^18.0.0",
-        "react-native": "^0.76.0",
-        "react-native-calendar-events": "^2.2.0"
+        "react-native": "^0.76.0"
       }
     },
     "modules/api": {
@@ -16582,15 +16581,6 @@
       },
       "peerDependencies": {
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-calendar-events": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-calendar-events/-/react-native-calendar-events-2.2.0.tgz",
-      "integrity": "sha512-tNUbhT6Ief0JM4OQzQAaz1ri0+MCcAoHptBcEXCz2g7q3A05pg62PR2Dio4F9t2fCAD7Y2+QggdY1ycAsF3Tsg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react-native": ">=0.60.0"
       }
     },
     "node_modules/react-native-change-icon": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "react-markdown": "2.5.1",
     "react-native": "0.76.9",
     "react-native-button": "3.1.0",
-    "react-native-calendar-events": "2.2.0",
     "react-native-change-icon": "5.0.0",
     "react-native-device-info": "11.1.0",
     "react-native-gesture-handler": "2.31.0",


### PR DESCRIPTION
## Summary

Replaces the abandoned `react-native-calendar-events` native module with a JS-only "Add to Calendar" flow, per #7471.

- `addToCalendar` now builds an `.ics` (VCALENDAR/VEVENT) document in memory, base64-encodes it, and hands it to `Share.share({url: 'data:text/calendar;base64,…'})`. iOS offers Calendar in the share sheet, which imports the event — same pattern our web "add to calendar" links use.
- The native calendar permission prompt and `NSCalendarsUsageDescription` plist entry are gone since we no longer touch `EKEventStore` directly.
- `addToCalendar` now returns `'saved' | 'cancelled' | 'error'` so a user cancel no longer shows "Error. Try again?".

Closes #7471.

## Files changed

- `modules/add-to-device-calendar/lib.ts` — rewritten; builds + shares `.ics`
- `modules/add-to-device-calendar/add-to-calendar.ts` — handle cancelled vs errored
- `modules/add-to-device-calendar/package.json` — drop `react-native-calendar-events` peer dep, add `base-64`
- `package.json`, `package-lock.json` — remove `react-native-calendar-events`
- `ios/Podfile.lock` — remove RNCalendarEvents entries
- `ios/AllAboutOlaf/Info.plist` — remove `NSCalendarsUsageDescription`

## Test plan

- [x] `mise run agent:pre-commit` — Prettier, ESLint, `tsc`, and Jest all pass (197 passed / 3 skipped / 36 suites)
- [ ] Regenerate `Podfile.lock` on macOS via `pod install` — I edited it by hand since `pod` isn't available on this Linux host. Confirm the iOS build links cleanly.
- [ ] Manual QA on device: open an event detail view, tap **Add to calendar**, verify the iOS share sheet appears with a `.ics`/Calendar option, and that picking Calendar prompts to add the event with the correct title/time/location/description.
- [ ] Verify cancelling the share sheet leaves the button in its original state (no error message).

https://claude.ai/code/session_01PFExvF2jbZ3PiEmsfXdkv5