### PR TITLE
Update dependency react-native-reanimated to v3.18.2

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1667,7 +1667,7 @@ PODS:
     - React-Core
   - RNKeychain (8.2.0):
     - React-Core
-  - RNReanimated (3.17.5):
+  - RNReanimated (3.18.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1689,10 +1689,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.17.5)
-    - RNReanimated/worklets (= 3.17.5)
+    - RNReanimated/reanimated (= 3.18.2)
+    - RNReanimated/worklets (= 3.18.2)
     - Yoga
-  - RNReanimated/reanimated (3.17.5):
+  - RNReanimated/reanimated (3.18.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1714,9 +1714,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.17.5)
+    - RNReanimated/reanimated/apple (= 3.18.2)
     - Yoga
-  - RNReanimated/reanimated/apple (3.17.5):
+  - RNReanimated/reanimated/apple (3.18.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1739,7 +1739,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.17.5):
+  - RNReanimated/worklets (3.18.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1761,9 +1761,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.17.5)
+    - RNReanimated/worklets/apple (= 3.18.2)
     - Yoga
-  - RNReanimated/worklets/apple (3.17.5):
+  - RNReanimated/worklets/apple (3.18.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2191,7 +2191,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: b1c06808f2eaf5c568e006ab3f34813d959ca1c8
   RNInAppBrowser: 904d24dc75e8e6c6c98a3160329192608946f9df
   RNKeychain: bbe2f6d5cc008920324acb49ef86ccc03d3b38e4
-  RNReanimated: 9a9be32b5f0f613fa593dee04d1c992aafb85399
+  RNReanimated: 0c3a7040d5a646729fef882e82144b9bf64120fd
   RNScreens: f8a7e3cbee7eaac5613eecd89ecf719fdf8abfc5
   RNSearchBar: feb1a3829c44d6ae1b96dc1397062b2fbfb95825
   RNSentry: 6aff72ada7ba9a8ec9937c9e9273e368cd0ab2ec

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "react-native-network-logger": "2.0.1",
         "react-native-paper": "5.15.0",
         "react-native-popover-view": "5.1.9",
-        "react-native-reanimated": "3.17.5",
+        "react-native-reanimated": "3.18.2",
         "react-native-restart": "0.0.27",
         "react-native-safe-area-context": "4.14.1",
         "react-native-screens": "4.13.1",
@@ -13866,9 +13866,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
-      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.18.2.tgz",
+      "integrity": "sha512-Hc8UleWN0KS8t4p5BzyaIwzJd+u4GC1DaYJDyustNu/rc7OW+0/xiJkwFZkA4Ivy/yPTWDPvLkSO/G1vXwG5Bw==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-native-network-logger": "2.0.1",
     "react-native-paper": "5.15.0",
     "react-native-popover-view": "5.1.9",
-    "react-native-reanimated": "3.17.5",
+    "react-native-reanimated": "3.18.2",
     "react-native-restart": "0.0.27",
     "react-native-safe-area-context": "4.14.1",
     "react-native-screens": "4.13.1",


### PR DESCRIPTION
Supersedes #7503.

Renovate proposed bumping `react-native-reanimated` from `3.17.5` to `3.19.5`, but per the [Reanimated compatibility matrix](https://docs.swmansion.com/react-native-reanimated/docs/3.x/guides/compatibility), the `3.19` line drops support for React Native 0.76. We're still on RN 0.76.9, so this PR bumps to `3.18.2` — the latest release on the `3.18` line, which continues to support RN 0.76.

## Test plan
- [x] `mise run agent:pre-commit` (prettier, eslint, tsc, jest) passes
- [ ] iOS build succeeds
- [ ] Smoke test any screens that rely on Reanimated (animated transitions, gestures)