### PR TITLE
chore: remove remaining Detox references

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -36,8 +36,6 @@ jobs:
       - run: git fetch --prune --unshallow
       - run: npm ci
       - run: mise run pod:install --deployment
-      - run: brew tap wix/brew
-      - run: brew install applesimutils
       - run: bundle exec fastlane ios ci-run
         env:
           FASTLANE_PASSWORD: ${{ secrets.FASTLANE_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,5 @@ fastlane/play-private-key.json
 /.bundle/
 /vendor/bundle/
 
-# detox artifacts folder
-/artifacts
-
 # generated logs files in CI
 /logs

--- a/Brewfile
+++ b/Brewfile
@@ -1,8 +1,3 @@
 brew 'node'
 brew 'ruby'
 brew 'watchman'
-
-# Additional packages for Detox
-# Note: applesimutils is optional if you don't plan on doing any iOS Detox runs.
-tap 'wix/brew'
-brew 'applesimutils'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ These patterns are especially important in this codebase:
 - Mock native modules and external APIs
 - Descriptive test names; group with `describe` blocks
 - `beforeEach`/`afterEach` for setup/cleanup
+- **XCUITest debugging:** iOS UI tests live in `ios/AllAboutOlafUITests/` and run as sharded CI jobs. When a test fails, two artifacts are uploaded per shard: `uitest-attachments-{shard}` (screenshots extracted via `xcrun xcresulttool export attachments`) and `uitest-results-{shard}.xcresult` (the full XCResult bundle). Start with the attachments for a quick look; open the `.xcresult` bundle in Xcode (or query via `xcrun xcresulttool get --format json --path uitest-results.xcresult`) for full logs, traces, and per-test activity.
 
 ## Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,6 @@ These patterns are especially important in this codebase:
 - Mock native modules and external APIs
 - Descriptive test names; group with `describe` blocks
 - `beforeEach`/`afterEach` for setup/cleanup
-- **Detox E2E debugging:** When a Detox test fails on CI, download the `detox-ios-{shard}` artifact and look at the `testFnFailure.png` screenshot first — it shows the simulator screen at the moment of failure and is far more informative than the error message alone. Detox also records `test.mp4` (for failing tests), `device.log`, and `detox.log` in the same artifact directory.
 
 ## Development Commands
 

--- a/scripts/should-skip-build
+++ b/scripts/should-skip-build
@@ -17,7 +17,7 @@ def hash_diff(old_hash, new_hash, path)
 	(new_hash.dig(*path).to_a - old_hash.dig(*path).to_a).to_h
 end
 
-NPM_DEP_NAME_REGEXP = /detox|react|jsc/.freeze
+NPM_DEP_NAME_REGEXP = /react|jsc/.freeze
 def npm_native_package_changed?(source, target)
 	old_package = JSON.parse(sh("git show '#{source}:package.json'"))
 	new_package = JSON.parse(sh("git show '#{target}:package.json'"))
@@ -31,7 +31,6 @@ end
 
 BASE_GLOBS = [
               '.circleci/**',
-              'e2e/**',
               'fastlane/**',
               'scripts/**',
               'Gemfile.lock',


### PR DESCRIPTION
## Summary

Detox is no longer used for E2E testing (replaced by XCUITest in `ios/AllAboutOlafUITests/`), but a handful of stale references remained. This PR cleans them up:

- **`.gitignore`** — drop the `/artifacts` entry (Detox output folder)
- **`Brewfile`** — drop `applesimutils` and the `wix/brew` tap
- **`CLAUDE.md`** — drop the "Detox E2E debugging" bullet (it referenced artifacts that are no longer produced)
- **`scripts/should-skip-build`** — drop `detox` from `NPM_DEP_NAME_REGEXP` and drop `e2e/**` from `BASE_GLOBS` (the `e2e/` directory no longer exists)
- **`.github/workflows/build-and-deploy.yml`** — drop the `brew tap wix/brew` + `brew install applesimutils` steps

`CHANGELOG.md` still mentions Detox twice — left intact as historical record.

## Test plan

- [x] `mise run agent:pre-commit` passes (prettier, tsc, jest, eslint)
- [ ] CI green on this PR
- [ ] Confirm no downstream script relies on the `/artifacts` path or the `e2e/**` glob

https://claude.ai/code/session_01BHKjzwDs55rnakRBZ3gL2f