### PR TITLE
fix row spacings on home screen buttons and api-test list

### DIFF
--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import {Platform, StyleSheet, Text, View} from 'react-native'
-import {SafeAreaView} from 'react-native-safe-area-context'
 import {Entypo as Icon} from '@react-native-vector-icons/entypo'
 import type {ViewType} from '../views'
 import {Touchable} from '@frogpond/touchable'
@@ -17,21 +16,19 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 		view.foreground === 'light' ? styles.lightForeground : styles.darkForeground
 
 	return (
-		<SafeAreaView>
-			<Touchable
-				accessibilityLabel={view.title}
-				accessibilityRole="button"
-				accessible={true}
-				highlight={false}
-				onPress={onPress}
-				style={[styles.button, {backgroundColor: view.tint}]}
-			>
-				<View style={styles.contents}>
-					<Icon name={view.icon} size={32} style={[foreground, styles.icon]} />
-					<Text style={[foreground, styles.text]}>{view.title}</Text>
-				</View>
-			</Touchable>
-		</SafeAreaView>
+		<Touchable
+			accessibilityLabel={view.title}
+			accessibilityRole="button"
+			accessible={true}
+			highlight={false}
+			onPress={onPress}
+			style={[styles.button, {backgroundColor: view.tint}]}
+		>
+			<View style={styles.contents}>
+				<Icon name={view.icon} size={32} style={[foreground, styles.icon]} />
+				<Text style={[foreground, styles.text]}>{view.title}</Text>
+			</View>
+		</Touchable>
 	)
 }
 

--- a/source/views/settings/screens/api-test/list.tsx
+++ b/source/views/settings/screens/api-test/list.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 import {View, SectionList, StyleSheet} from 'react-native'
-import {SafeAreaView} from 'react-native-safe-area-context'
-
 import {ListRow, ListSectionHeader, ListSeparator, Title} from '@frogpond/lists'
 import {Column} from '@frogpond/layout'
 import {LoadingView, NoticeView} from '@frogpond/notice'
@@ -62,17 +60,15 @@ export const APITestView = (): React.ReactNode => {
 
 	const renderItem = React.useCallback(
 		(item: ServerRoute) => (
-			<SafeAreaView>
-				<ListRow
-					fullWidth={false}
-					onPress={() => navigation.navigate('APITestDetail', {query: item})}
-					style={styles.serverRouteRow}
-				>
-					<Column flex={1}>
-						<Title lines={1}>{item.displayName}</Title>
-					</Column>
-				</ListRow>
-			</SafeAreaView>
+			<ListRow
+				fullWidth={false}
+				onPress={() => navigation.navigate('APITestDetail', {query: item})}
+				style={styles.serverRouteRow}
+			>
+				<Column flex={1}>
+					<Title lines={1}>{item.displayName}</Title>
+				</Column>
+			</ListRow>
 		),
 		[navigation],
 	)


### PR DESCRIPTION
Fixes item spacing on screens by removing per-item `SafeAreaView` wrappers:

- `source/views/home/button.tsx` — Removed `SafeAreaView` around each `HomeScreenButton`
- `source/views/settings/screens/api-test/list.tsx` — Removed `SafeAreaView` around each `ListRow` in `renderItem`

`SafeAreaView` was adding safe area insets (notch/home indicator padding) to every individual item instead of just the screen container, causing the inflated vertical spacing. Parent containers already handle safe area at the screen level.

Before | After
---|---
<img  alt="Screenshot 2026-04-19 at 1 39 03 PM" src="https://github.com/user-attachments/assets/f79f0970-5202-4a50-916f-d06cbfd6fcb2" /> | <img  alt="Screenshot 2026-04-19 at 1 37 17 PM" src="https://github.com/user-attachments/assets/c051a5bd-7818-497f-a131-990cc455a91e" />
<img alt="Screenshot 2026-04-19 at 1 39 25 PM" src="https://github.com/user-attachments/assets/45958710-407b-4f5e-982a-66ac032fccbf" /> | <img alt="Screenshot 2026-04-19 at 1 37 06 PM" src="https://github.com/user-attachments/assets/09666c0d-5ce3-43e7-93fa-054da64626da" />

