### PR TITLE
fix: add contentInsetAdjustmentBehavior to FancyMenu SectionList

### DIFF
--- a/modules/food-menu/fancy-menu.tsx
+++ b/modules/food-menu/fancy-menu.tsx
@@ -170,6 +170,7 @@ export function FancyMenu(props: Props): React.ReactNode {
 			ListEmptyComponent={<NoticeView style={styles.message} text={message} />}
 			ListHeaderComponent={header}
 			contentContainerStyle={styles.contentContainer}
+			contentInsetAdjustmentBehavior="automatic"
 			extraData={filters}
 			keyExtractor={(item: MenuItemType) => item.id}
 			onRefresh={props.onRefresh}


### PR DESCRIPTION
The last row in the food menu was hidden behind the native bottom tab bar after `SafeAreaView` was removed. Adding `contentInsetAdjustmentBehavior=automatic` tells iOS to automatically adjust content insets for overlapping bars, matching the pattern used by 11 other lists in the codebase.

Before | After 
---|---
<img alt="Screenshot 2026-04-19 at 1 53 29 PM" src="https://github.com/user-attachments/assets/2ea35531-1f4a-4f14-b06b-4d358f42a16c" /> | <img alt="Screenshot 2026-04-19 at 1 52 54 PM" src="https://github.com/user-attachments/assets/63e295a9-0e47-4735-9027-ff1588fc65ed" />
