### PR TITLE
fix: add contentInsetAdjustmentBehavior and remove SafeAreaView wrappers

### DIFF
--- a/modules/event-list/event-detail-view.tsx
+++ b/modules/event-list/event-detail-view.tsx
@@ -36,7 +36,7 @@ export function EventDetail(): React.ReactNode {
 	let {event, poweredBy} = route.params
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<TableView>
 				<MaybeSection content={event.title.trim()} header="EVENT" />
 				<MaybeSection content={getTimes(event).trim()} header="TIME" />

--- a/modules/event-list/event-list.tsx
+++ b/modules/event-list/event-list.tsx
@@ -65,6 +65,7 @@ export function EventList(props: Props): React.ReactNode {
 			ItemSeparatorComponent={FullWidthSeparator}
 			ListEmptyComponent={<NoticeView text="No events." />}
 			contentContainerStyle={styles.contentContainer}
+			contentInsetAdjustmentBehavior="automatic"
 			keyExtractor={(item, index) => index.toString()}
 			onRefresh={props.onRefresh}
 			refreshing={props.refreshing}

--- a/modules/filter/section.tsx
+++ b/modules/filter/section.tsx
@@ -24,7 +24,7 @@ export function FilterSection<T extends object>({
 		}
 
 		return (
-			<ScrollView>
+			<ScrollView contentInsetAdjustmentBehavior="automatic">
 				<ListSection<T> filter={filter} onChange={onChange} />
 			</ScrollView>
 		)

--- a/modules/food-menu/food-item-detail.tsx
+++ b/modules/food-menu/food-item-detail.tsx
@@ -20,7 +20,7 @@ export const MenuItemDetailView = (): React.ReactNode => {
 	const {item, icons} = route.params
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<Text selectable={true} style={styles.title}>
 				{item.label}
 			</Text>

--- a/source/views/building-hours/detail/building.tsx
+++ b/source/views/building-hours/detail/building.tsx
@@ -37,7 +37,7 @@ export const BuildingDetail = React.memo((props: Props): React.ReactNode => {
 	let links = info.links || []
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			{headerImage ? (
 				<Image
 					accessibilityIgnoresInvertColors={true}

--- a/source/views/building-hours/list.tsx
+++ b/source/views/building-hours/list.tsx
@@ -57,6 +57,7 @@ export function BuildingHoursView(): React.ReactNode {
 				isLoading ? <LoadingView /> : <NoticeView text="No hours." />
 			}
 			contentContainerStyle={styles.container}
+			contentInsetAdjustmentBehavior="automatic"
 			keyExtractor={(item) => item.name}
 			onRefresh={refetch}
 			refreshing={isRefetching}

--- a/source/views/building-hours/report/editor.tsx
+++ b/source/views/building-hours/report/editor.tsx
@@ -71,7 +71,7 @@ export function BuildingHoursScheduleEditorView(): React.ReactNode {
 	}, [set])
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<TableView>
 				<Section footer={summary}>
 					<WeekToggles days={set.days} onChangeDays={onChangeDays} />

--- a/source/views/building-hours/report/overview.tsx
+++ b/source/views/building-hours/report/overview.tsx
@@ -126,7 +126,7 @@ export let BuildingHoursProblemReportView = (): React.ReactNode => {
 	let {schedule: schedules = [], name} = building
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<InfoHeader
 				message="If you could change what is incorrect and share it with us we&rsquo;d greatly appreciate it."
 				title="Thanks for spotting a problem!"

--- a/source/views/contacts/detail.tsx
+++ b/source/views/contacts/detail.tsx
@@ -70,7 +70,7 @@ export const ContactsDetailView = (): React.ReactNode => {
 			: null
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			{headerImage ? (
 				<Image resizeMode="cover" source={headerImage} style={styles.image} />
 			) : null}

--- a/source/views/contacts/list.tsx
+++ b/source/views/contacts/list.tsx
@@ -56,6 +56,7 @@ export let ContactsListView = (): React.ReactNode => {
 				isLoading ? <LoadingView /> : <NoticeView text="No results found." />
 			}
 			contentContainerStyle={styles.contentContainer}
+			contentInsetAdjustmentBehavior="automatic"
 			keyExtractor={(item) => item.title}
 			onRefresh={refetch}
 			refreshing={isRefetching}

--- a/source/views/dictionary/report/editor.tsx
+++ b/source/views/dictionary/report/editor.tsx
@@ -29,6 +29,7 @@ let DictionaryEditorView = (): React.ReactNode => {
 
 	return (
 		<ScrollView
+			contentInsetAdjustmentBehavior="automatic"
 			keyboardDismissMode="on-drag"
 			keyboardShouldPersistTaps="always"
 		>

--- a/source/views/directory/detail.tsx
+++ b/source/views/directory/detail.tsx
@@ -38,7 +38,7 @@ export function DirectoryDetailView(): React.ReactNode {
 	} = route.params.contact
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<Image
 				accessibilityIgnoresInvertColors={true}
 				resizeMode="cover"

--- a/source/views/directory/list.tsx
+++ b/source/views/directory/list.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {FlatList, Image, StyleSheet, Text, View} from 'react-native'
-import {SafeAreaView} from 'react-native-safe-area-context'
 import {Column} from '@frogpond/layout'
 import {Detail, ListRow, ListSeparator, Title} from '@frogpond/lists'
 import * as c from '@frogpond/colors'
@@ -134,15 +133,13 @@ type DirectoryItemRowProps = {
 
 function IosDirectoryItemRow({item, onPress}: DirectoryItemRowProps) {
 	return (
-		<SafeAreaView>
-			<ListRow fullWidth={true} onPress={onPress} style={styles.row}>
-				<Image source={{uri: item.thumbnail}} style={styles.image} />
-				<Column flex={1}>
-					<Title lines={1}>{item.displayName}</Title>
-					<Detail lines={1}>{item.description}</Detail>
-				</Column>
-			</ListRow>
-		</SafeAreaView>
+		<ListRow fullWidth={true} onPress={onPress} style={styles.row}>
+			<Image source={{uri: item.thumbnail}} style={styles.image} />
+			<Column flex={1}>
+				<Title lines={1}>{item.displayName}</Title>
+				<Detail lines={1}>{item.description}</Detail>
+			</Column>
+		</ListRow>
 	)
 }
 

--- a/source/views/home/index.tsx
+++ b/source/views/home/index.tsx
@@ -38,6 +38,7 @@ function HomePage(): React.ReactNode {
 	return (
 		<ScrollView
 			alwaysBounceHorizontal={false}
+			contentInsetAdjustmentBehavior="automatic"
 			showsHorizontalScrollIndicator={false}
 			showsVerticalScrollIndicator={false}
 			testID="screen-homescreen"

--- a/source/views/menus/carleton-menus.tsx
+++ b/source/views/menus/carleton-menus.tsx
@@ -50,7 +50,10 @@ export function CarletonCafeIndex(): React.ReactNode {
 	]
 
 	return (
-		<ScrollView style={styles.container}>
+		<ScrollView
+			contentInsetAdjustmentBehavior="automatic"
+			style={styles.container}
+		>
 			{carletonCafes.map((loc, i, collection) => (
 				<View key={i}>
 					<ListRow

--- a/source/views/news/news-list.tsx
+++ b/source/views/news/news-list.tsx
@@ -128,6 +128,7 @@ export const NewsList = (props: Props): React.ReactNode => {
 			}
 			ListHeaderComponent={header}
 			contentContainerStyle={styles.contentContainer}
+			contentInsetAdjustmentBehavior="automatic"
 			data={filterStories(entries, filters)}
 			keyExtractor={(item: StoryType) => item.title}
 			onRefresh={refetch}

--- a/source/views/settings/screens/debug/list.tsx
+++ b/source/views/settings/screens/debug/list.tsx
@@ -54,7 +54,7 @@ export const DebugView = (props: Props = {}): React.ReactNode => {
 
 export const DebugSimpleItem = ({item}: {item: unknown}): React.ReactNode => {
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<TableView style={styles.table}>
 				<Section
 					header={typeof item}
@@ -70,7 +70,7 @@ export const DebugSimpleItem = ({item}: {item: unknown}): React.ReactNode => {
 
 export const DebugToStringItem = ({item}: {item: unknown}): React.ReactNode => {
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<TableView style={styles.table}>
 				<Section
 					header={typeof item}
@@ -100,6 +100,7 @@ export const DebugArrayItem = ({item}: {item: unknown[]}): React.ReactNode => {
 		<FlatList
 			ItemSeparatorComponent={ListSeparator}
 			ListEmptyComponent={<NoticeView text="Nothing found." />}
+			contentInsetAdjustmentBehavior="automatic"
 			data={keyed}
 			renderItem={({item: debugItem}) => (
 				<DebugRow
@@ -129,6 +130,7 @@ export const DebugObjectItem = ({
 		<FlatList
 			ItemSeparatorComponent={ListSeparator}
 			ListEmptyComponent={<NoticeView text="Nothing found." />}
+			contentInsetAdjustmentBehavior="automatic"
 			data={keyed}
 			renderItem={({item: debugItem}) => (
 				<DebugRow

--- a/source/views/settings/screens/overview/component-library/base/library-wrapper.tsx
+++ b/source/views/settings/screens/overview/component-library/base/library-wrapper.tsx
@@ -13,7 +13,10 @@ interface RowProps {
 }
 
 export const LibraryWrapper = ({children}: WrapperProps): React.ReactNode => (
-	<ScrollView contentContainerStyle={styles.container}>
+	<ScrollView
+		contentContainerStyle={styles.container}
+		contentInsetAdjustmentBehavior="automatic"
+	>
 		<TableView>{children}</TableView>
 	</ScrollView>
 )

--- a/source/views/settings/screens/overview/component-library/faq-banners.tsx
+++ b/source/views/settings/screens/overview/component-library/faq-banners.tsx
@@ -9,7 +9,10 @@ import {FaqBanner} from '../../../../faqs'
 import {fallbackFaqs} from '../../../../faqs/local-faqs'
 
 export const FaqBannerLibrary = (): React.ReactNode => (
-	<ScrollView contentContainerStyle={styles.container}>
+	<ScrollView
+		contentContainerStyle={styles.container}
+		contentInsetAdjustmentBehavior="automatic"
+	>
 		{fallbackFaqs.map((banner) => (
 			<View key={banner.id} style={styles.example}>
 				<Text style={styles.exampleTitle}>

--- a/source/views/settings/screens/overview/index.tsx
+++ b/source/views/settings/screens/overview/index.tsx
@@ -29,6 +29,7 @@ const SettingsView = (): React.ReactNode => {
 	return (
 		<ScrollView
 			contentContainerStyle={styles.container}
+			contentInsetAdjustmentBehavior="automatic"
 			keyboardDismissMode="on-drag"
 			keyboardShouldPersistTaps="always"
 		>

--- a/source/views/sis/balances-acknowledgement.tsx
+++ b/source/views/sis/balances-acknowledgement.tsx
@@ -64,7 +64,10 @@ function Ack(props: AcknowledgementProps) {
 	let {title, children, onPositive} = props
 
 	return (
-		<ScrollView contentContainerStyle={styles.container}>
+		<ScrollView
+			contentContainerStyle={styles.container}
+			contentInsetAdjustmentBehavior="automatic"
+		>
 			<Card header={title}>
 				<>
 					{children}

--- a/source/views/sis/balances.tsx
+++ b/source/views/sis/balances.tsx
@@ -42,6 +42,7 @@ export const BalancesView = (): React.ReactNode => {
 	return (
 		<ScrollView
 			contentContainerStyle={styles.stage}
+			contentInsetAdjustmentBehavior="automatic"
 			refreshControl={refresh}
 			testID="balances-view"
 		>

--- a/source/views/sis/course-search/detail/index.tsx
+++ b/source/views/sis/course-search/detail/index.tsx
@@ -28,7 +28,11 @@ import {RootStackParamList} from '../../../../navigation/types'
 import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
 
 const Container = (props: ScrollViewProps) => (
-	<ScrollView {...props} style={[styles.container, props.style]} />
+	<ScrollView
+		{...props}
+		contentInsetAdjustmentBehavior="automatic"
+		style={[styles.container, props.style]}
+	/>
 )
 
 const Header = (props: TextProps) => (

--- a/source/views/sis/student-work/detail.tsx
+++ b/source/views/sis/student-work/detail.tsx
@@ -201,7 +201,7 @@ export const JobDetailView = (): React.ReactNode => {
 	let {job} = route.params
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<Title selectable={true}>{job.title}</Title>
 			<TableView>
 				<ContactInformation job={job} />

--- a/source/views/sis/student-work/index.tsx
+++ b/source/views/sis/student-work/index.tsx
@@ -51,6 +51,7 @@ const StudentWorkView = (): React.ReactNode => {
 				)
 			}
 			contentContainerStyle={styles.contentContainer}
+			contentInsetAdjustmentBehavior="automatic"
 			keyExtractor={(_item: JobType, index: number) => index.toString()}
 			onRefresh={refetch}
 			refreshing={isRefetching}

--- a/source/views/stoprint/components/error.tsx
+++ b/source/views/stoprint/components/error.tsx
@@ -18,6 +18,7 @@ export function StoPrintErrorView(props: Props): React.ReactNode {
 	return (
 		<ScrollView
 			contentContainerStyle={styles.content}
+			contentInsetAdjustmentBehavior="automatic"
 			refreshControl={
 				<RefreshControl
 					onRefresh={props.onRefresh}

--- a/source/views/stoprint/components/notice.tsx
+++ b/source/views/stoprint/components/notice.tsx
@@ -21,6 +21,7 @@ export const StoPrintNoticeView = (props: Props): React.ReactElement => {
 	return (
 		<ScrollView
 			contentContainerStyle={styles.content}
+			contentInsetAdjustmentBehavior="automatic"
 			refreshControl={
 				onRefresh && refreshing != null ? (
 					<RefreshControl onRefresh={onRefresh} refreshing={refreshing} />

--- a/source/views/stoprint/print-jobs.tsx
+++ b/source/views/stoprint/print-jobs.tsx
@@ -110,6 +110,7 @@ export const PrintJobsView = (): React.ReactNode => {
 	return (
 		<SectionList
 			ItemSeparatorComponent={ListSeparator}
+			contentInsetAdjustmentBehavior="automatic"
 			keyExtractor={(item) => item.id.toString()}
 			onRefresh={jobsRefetch}
 			refreshing={jobsRefetching}

--- a/source/views/stoprint/print-release.tsx
+++ b/source/views/stoprint/print-release.tsx
@@ -155,7 +155,7 @@ export const PrintJobReleaseView = (): React.ReactNode => {
 
 	if (loadingUsername) {
 		return (
-			<ScrollView>
+			<ScrollView contentInsetAdjustmentBehavior="automatic">
 				<LoadingView />
 			</ScrollView>
 		)
@@ -192,7 +192,7 @@ export const PrintJobReleaseView = (): React.ReactNode => {
 	let actionAvailable = status !== 'complete' && printer
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<Header>{job.documentName}</Header>
 			<TableView>
 				<JobInformation job={job} />

--- a/source/views/stoprint/printers.tsx
+++ b/source/views/stoprint/printers.tsx
@@ -150,6 +150,7 @@ export const PrinterListView = (): React.ReactNode => {
 	return (
 		<SectionList
 			ItemSeparatorComponent={ListSeparator}
+			contentInsetAdjustmentBehavior="automatic"
 			keyExtractor={(item: Printer) => item.printerName}
 			onRefresh={refetchAll}
 			refreshing={isRefetching}

--- a/source/views/streaming/radio/controller.tsx
+++ b/source/views/streaming/radio/controller.tsx
@@ -191,7 +191,10 @@ export function RadioControllerView(props: Props): React.ReactNode {
 	let logoWrapper = [styles.logoWrapper, sideways && landscape.logoWrapper]
 
 	return (
-		<ScrollView contentContainerStyle={root}>
+		<ScrollView
+			contentContainerStyle={root}
+			contentInsetAdjustmentBehavior="automatic"
+		>
 			<View style={logoWrapper}>
 				<Image resizeMode="contain" source={image} style={logo} />
 			</View>

--- a/source/views/streaming/streams/list.tsx
+++ b/source/views/streaming/streams/list.tsx
@@ -145,6 +145,7 @@ export const StreamListView = (): React.ReactNode => {
 			}
 			ListHeaderComponent={header}
 			contentContainerStyle={styles.contentContainer}
+			contentInsetAdjustmentBehavior="automatic"
 			keyExtractor={(item: StreamType) => item.eid}
 			onRefresh={refetch}
 			refreshing={isRefetching}

--- a/source/views/streaming/webcams/list.tsx
+++ b/source/views/streaming/webcams/list.tsx
@@ -38,6 +38,7 @@ export let WebcamsView = (): React.ReactNode => {
 	return (
 		<ScrollView
 			contentContainerStyle={styles.container}
+			contentInsetAdjustmentBehavior="automatic"
 			refreshControl={
 				<RefreshControl onRefresh={refetch} refreshing={isRefetching} />
 			}

--- a/source/views/student-orgs/detail.tsx
+++ b/source/views/student-orgs/detail.tsx
@@ -61,7 +61,7 @@ let StudentOrgsDetailView = (): React.ReactNode => {
 	} = route.params.org
 
 	return (
-		<ScrollView>
+		<ScrollView contentInsetAdjustmentBehavior="automatic">
 			<TableView>
 				<Text selectable={true} style={styles.name}>
 					{orgName}

--- a/source/views/transportation/bus/detail.tsx
+++ b/source/views/transportation/bus/detail.tsx
@@ -125,6 +125,7 @@ function BusStopDetailInternal(props: Props): React.ReactNode {
 			<FlatList
 				ListFooterComponent={<ListFooter title={BUS_FOOTER_MESSAGE} />}
 				ListHeaderComponent={headerElement}
+				contentInsetAdjustmentBehavior="automatic"
 				data={[emptyRowElement]}
 				keyExtractor={(item, index) => `${item.key}-${index}`}
 				renderItem={({item}) => item}
@@ -182,6 +183,7 @@ function BusStopDetailInternal(props: Props): React.ReactNode {
 			ItemSeparatorComponent={undefined}
 			ListFooterComponent={<ListFooter title={BUS_FOOTER_MESSAGE} />}
 			ListHeaderComponent={headerElement}
+			contentInsetAdjustmentBehavior="automatic"
 			data={timeRows}
 			keyExtractor={(item, index) => `${item.key}-${index}`}
 			renderItem={({item}) => item}

--- a/source/views/transportation/bus/line.tsx
+++ b/source/views/transportation/bus/line.tsx
@@ -235,6 +235,7 @@ export function BusLine(props: Props): React.ReactNode {
 			ListEmptyComponent={EMPTY_SCHEDULE_MESSAGE}
 			ListFooterComponent={footerElement}
 			ListHeaderComponent={headerElement}
+			contentInsetAdjustmentBehavior="automatic"
 			data={timetable}
 			keyExtractor={(item, index) => `${item.name}-${index}`}
 			renderItem={({item, index}) => (

--- a/source/views/transportation/other-modes/list.tsx
+++ b/source/views/transportation/other-modes/list.tsx
@@ -44,6 +44,7 @@ let OtherModesView = (): React.ReactNode => {
 				isLoading ? <LoadingView /> : <ListEmpty mode="bug" />
 			}
 			contentContainerStyle={styles.contentContainer}
+			contentInsetAdjustmentBehavior="automatic"
 			keyExtractor={(item) => item.name}
 			onRefresh={refetch}
 			refreshing={isRefetching}


### PR DESCRIPTION
Continues
#7565
#7564 

- Add contentInsetAdjustmentBehavior="automatic" to all SectionList, FlatList, and ScrollView components across the app for proper safe area inset handling.
- Remove per-item SafeAreaView wrapper from directory list rows that caused excessive vertical spacing.