### PR TITLE
fix(ci): fix xcode cloud ci_post_clone.sh failing to find npm

### DIFF
--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -1,4 +1,4 @@
-#!/bin.bash
+#!/bin/zsh
 set -ex
 echo "Running ci_post_clone.sh"
 
@@ -15,6 +15,9 @@ cd ../../
 # install mise and tools
 brew install mise
 mise install node
+
+# activate mise so node/npm are on PATH
+eval "$(mise activate zsh)"
 
 # install node modules
 npm ci


### PR DESCRIPTION
* fix shebang typo
* add mise activation after installing node so npm is on PATH
* make script executable to avoid fallback warning
