### PR TITLE
Fix CI Node installation and resolve App Store version issues

### DIFF
--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -1158,7 +1158,6 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Sentry/Sentry.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
 				"${PODS_ROOT}/../../node_modules/@react-native-vector-icons/entypo/fonts/Entypo.ttf",
 				"${PODS_ROOT}/../../node_modules/@react-native-vector-icons/ionicons/fonts/Ionicons.ttf",
 				"${PODS_ROOT}/../../node_modules/@react-native-vector-icons/material-design-icons/fonts/MaterialDesignIcons.ttf",
@@ -1175,7 +1174,6 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Sentry.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Entypo.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Ionicons.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialDesignIcons.ttf",
@@ -1405,6 +1403,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 2.8.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1439,6 +1438,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 2.8.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1487,7 +1487,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				CXX = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1518,10 +1518,7 @@
 					"$(inherited)",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -1564,7 +1561,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 16;
+				CURRENT_PROJECT_VERSION = 17;
 				CXX = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1587,10 +1584,7 @@
 					"$(inherited)",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -47,7 +47,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -64,7 +64,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSMinimumSystemVersion</key>

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -28,10 +28,9 @@ echo "node path: ${NODE_PATH}"
 # Add brew node's bin dir to PATH so npm is available for the rest of this script
 export PATH="${NODE_BREW_PREFIX}/bin:$PATH"
 
-# Install mise via curl (for task running: bundle-data, pod:install).
-# The curl installer puts mise at ~/.local/bin/mise — no Homebrew PATH dependence.
-curl https://mise.run | sh
-export PATH="$HOME/.local/bin:$PATH"
+# Install mise via Homebrew (for task running: bundle-data, pod:install).
+brew install mise
+export PATH="$(brew --prefix)/bin:$PATH"
 
 echo "mise version: $(mise --version)"
 

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -12,11 +12,29 @@ export SENTRY_PROJECT='all-about-olaf'
 # cd out of ios/ci_scripts into main project directory
 cd ../../
 
-# install mise and tools
-brew install mise
-mise install node
+# Install node via Homebrew. Homebrew is officially available on Xcode Cloud
+# and brew --prefix always returns an arch-aware absolute path, so we never
+# need to rely on PATH being configured correctly.
+brew install node@24
 
-# activate mise shims so node/npm are on PATH in non-interactive scripts
+NODE_BREW_PREFIX="$(brew --prefix node@24)"
+NODE_PATH="${NODE_BREW_PREFIX}/bin/node"
+
+# Confirm node works
+echo "node path: ${NODE_PATH}"
+"${NODE_PATH}" --version
+
+# Add brew node's bin dir to PATH so npm is available for the rest of this script
+export PATH="${NODE_BREW_PREFIX}/bin:$PATH"
+
+# Install mise via curl (for task running: bundle-data, pod:install).
+# The curl installer puts mise at ~/.local/bin/mise — no Homebrew PATH dependence.
+curl https://mise.run | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+echo "mise version: $(mise --version)"
+
+# Activate mise shims for ruby/cocoapods tools used in task runs
 eval "$(mise activate bash --shims)"
 
 # install node modules
@@ -28,18 +46,16 @@ mise run bundle-data
 # install pods
 mise run pod:install --deployment
 
-# Write ios/.xcode.env.local so Xcode Cloud's build environment can find mise-managed tools.
-# PATH changes in this script don't carry over into xcodebuild, so we resolve the
-# paths now and bake them in. NODE_BINARY is the surefire fix for React Native's
-# bundling phase; prepending the shims dir to PATH covers every other mise tool.
-NODE_PATH="$(mise which node)"
-# mise shims live at $MISE_DATA_DIR/shims (default: ~/.local/share/mise/shims)
-# per https://mise.jdx.dev/dev-tools/shims.html
-MISE_SHIMS="${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims"
+# Write ios/.xcode.env.local so Xcode Cloud's xcodebuild can find node.
+# PATH changes in this script don't carry over into xcodebuild build phases,
+# so we bake in the absolute brew-managed path now.
+echo "Writing ios/.xcode.env.local with NODE_BINARY=${NODE_PATH}"
 {
-  printf 'export PATH="%s:$PATH"\n' "${MISE_SHIMS}"
   printf 'export NODE_BINARY=%s\n' "${NODE_PATH}"
 } > ios/.xcode.env.local
+
+echo "Contents of ios/.xcode.env.local:"
+cat ios/.xcode.env.local
 
 # if/when we go to Expo
 # npx expo prebuild

--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -15,6 +15,7 @@ cd ../../
 # Install node via Homebrew. Homebrew is officially available on Xcode Cloud
 # and brew --prefix always returns an arch-aware absolute path, so we never
 # need to rely on PATH being configured correctly.
+# If this doesn't work, we'll have to fix pathing issues and hopefully mise shims.
 brew install node@24
 
 NODE_BREW_PREFIX="$(brew --prefix node@24)"

--- a/ios/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -exu
 echo "Running ci_pre_xcodebuild.sh"
 
 # Xcode Cloud sets CI_BUILD_NUMBER automatically (monotonically increasing per workflow).

--- a/ios/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/ci_scripts/ci_pre_xcodebuild.sh
@@ -7,6 +7,11 @@ echo "Running ci_pre_xcodebuild.sh"
 # VERSIONING_SYSTEM = "apple-generic" must be set in the project (it is).
 cd "$(dirname "$0")/.."
 
+if [[ -z "${CI_BUILD_NUMBER:-}" ]]; then
+	echo "CI_BUILD_NUMBER is not set. This script must run in Xcode Cloud or with CI_BUILD_NUMBER provided." >&2
+	exit 1
+fi
+
 agvtool new-version -all "$CI_BUILD_NUMBER"
 
 echo "Build number set to $CI_BUILD_NUMBER"

--- a/ios/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ios/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+echo "Running ci_pre_xcodebuild.sh"
+
+# Xcode Cloud sets CI_BUILD_NUMBER automatically (monotonically increasing per workflow).
+# agvtool requires running from the directory containing the .xcodeproj, and
+# VERSIONING_SYSTEM = "apple-generic" must be set in the project (it is).
+cd "$(dirname "$0")/.."
+
+agvtool new-version -all "$CI_BUILD_NUMBER"
+
+echo "Build number set to $CI_BUILD_NUMBER"


### PR DESCRIPTION
This pull request updates the iOS build system to improve version management, streamline CI scripts, and clean up project configuration. The most important changes are grouped below.

**Versioning Improvements:**
* The Xcode project (`project.pbxproj`) now sets `MARKETING_VERSION` to `2.8.0` and increments `CURRENT_PROJECT_VERSION` to `17`, ensuring consistent semantic and build versioning. 
* `Info.plist` now references `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` for its version fields, enabling automatic version updates from project settings.
* A new CI script, `ci_pre_xcodebuild.sh`, uses `agvtool` to set the build number from Xcode Cloud’s `CI_BUILD_NUMBER`, automating build versioning in CI.

**CI Script and Tooling Updates:**
* The `ci_post_clone.sh` script now installs Node.js via Homebrew (using `node@24`) for more reliable path handling in Xcode Cloud, instead of using `mise` for Node.
* The script writes the absolute path to the Node binary into `ios/.xcode.env.local` for use during Xcode build phases, ensuring React Native bundling works in CI. 

**Project Configuration Cleanup:**
* Removes the `glog_privacy.bundle` resource from build phases, cleaning up unused or unnecessary bundle references in `project.pbxproj`. 
* Simplifies linker flags (`OTHER_LDFLAGS`) entries in the Xcode project for both Debug and Release configurations. 