### PR TITLE
discover local ccc-server via mDNS on the Server URL screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,17 @@ mise run tsc    # Type check
 mise run pods   # Install cocoapods, even on Linux
 ```
 
+### Local Server Discovery
+
+In dev mode (debug builds, or with the dev-mode override enabled in Settings), the Settings → Server URL screen will automatically discover a `ccc-server` instance running on the same network via mDNS. Discovered servers appear as tappable cells; tapping one fills the URL field.
+
+To use this:
+1. Start `ccc-server` with mDNS advertisement enabled: `mise run stolaf-college:mdns` (in the `ccc-server` repo)
+2. Run a debug build of the app on a device on the same network
+3. Navigate to Settings → Server URL — the server will appear automatically
+
+The feature uses `react-native-zeroconf` (native pod). If the pod hasn't been linked yet (`mise run pods`), discovery is silently skipped — the screen won't crash.
+
 ## Agent Workflow
 
 **Session startup:** Always run `mise run agent:setup` at the start of every session. This installs dependencies and bundles data files.

--- a/ios/AllAboutOlaf.xcodeproj/project.pbxproj
+++ b/ios/AllAboutOlaf.xcodeproj/project.pbxproj
@@ -1158,6 +1158,7 @@
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/Sentry/Sentry.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
 				"${PODS_ROOT}/../../node_modules/@react-native-vector-icons/entypo/fonts/Entypo.ttf",
 				"${PODS_ROOT}/../../node_modules/@react-native-vector-icons/ionicons/fonts/Ionicons.ttf",
 				"${PODS_ROOT}/../../node_modules/@react-native-vector-icons/material-design-icons/fonts/MaterialDesignIcons.ttf",
@@ -1174,6 +1175,7 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Sentry.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Entypo.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Ionicons.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MaterialDesignIcons.ttf",
@@ -1518,7 +1520,10 @@
 					"$(inherited)",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
@@ -1584,7 +1589,10 @@
 					"$(inherited)",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/ios/AllAboutOlaf/Info.plist
+++ b/ios/AllAboutOlaf/Info.plist
@@ -84,6 +84,12 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_ccc-server._tcp.</string>
+	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Used in development mode to discover a local ccc-server instance on the same network.</string>
 	<key>RCTNewArchEnabled</key>
 	<false/>
 	<key>UIAppFonts</key>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1983,6 +1983,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - react-native-zeroconf (0.14.0):
+    - React-Core
   - React-NativeModulesApple (0.81.5):
     - boost
     - DoubleConversion
@@ -2854,6 +2856,7 @@ DEPENDENCIES:
   - "react-native-vector-icons-ionicons (from `../node_modules/@react-native-vector-icons/ionicons`)"
   - "react-native-vector-icons-material-design-icons (from `../node_modules/@react-native-vector-icons/material-design-icons`)"
   - react-native-webview (from `../node_modules/react-native-webview`)
+  - react-native-zeroconf (from `../node_modules/react-native-zeroconf`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -3023,6 +3026,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-vector-icons/material-design-icons"
   react-native-webview:
     :path: "../node_modules/react-native-webview"
+  react-native-zeroconf:
+    :path: "../node_modules/react-native-zeroconf"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-oscompat:
@@ -3112,7 +3117,7 @@ SPEC CHECKSUMS:
   ComputableLayout: c50faffac4ed9f8f05b0ce5e6f3a60df1f6042c8
   ContextMenuAuxiliaryPreview: 20be0be795b783b68f8792732eed4bed9f202c1c
   DGSwiftUtilities: 567f8d5ee618f0b7afb185b17aa45ff356315a0f
-  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   EXConstants: fce59a631a06c4151602843667f7cfe35f81e271
   Expo: 78ceda23ec2990e8ec94980be4fce1aea9ffcdd5
   ExpoAsset: f867e55ceb428aab99e1e8c082b5aee7c159ea18
@@ -3124,7 +3129,7 @@ SPEC CHECKSUMS:
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 5beb8028d5a2e75dd9634917f23e23d3a061d2aa
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897
@@ -3168,6 +3173,7 @@ SPEC CHECKSUMS:
   react-native-vector-icons-ionicons: 040a326f94703859486b26b05a1173f2fe3821c1
   react-native-vector-icons-material-design-icons: d281715d786e8668a211c021ba2f3b9368af2f4f
   react-native-webview: 39dc5eb2f6e31fbad4e3dcd4b61c73e294976e3c
+  react-native-zeroconf: eb2e5584308f20f5fc3eb0cea2ceafbbd345b48b
   React-NativeModulesApple: ebf2ce72b35870036900d6498b33724386540a71
   React-oscompat: eb0626e8ba1a2c61673c991bf9dc21834898475d
   React-perflogger: 509e1f9a3ee28df71b0a66de806ac515ce951246

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3117,7 +3117,7 @@ SPEC CHECKSUMS:
   ComputableLayout: c50faffac4ed9f8f05b0ce5e6f3a60df1f6042c8
   ContextMenuAuxiliaryPreview: 20be0be795b783b68f8792732eed4bed9f202c1c
   DGSwiftUtilities: 567f8d5ee618f0b7afb185b17aa45ff356315a0f
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   EXConstants: fce59a631a06c4151602843667f7cfe35f81e271
   Expo: 78ceda23ec2990e8ec94980be4fce1aea9ffcdd5
   ExpoAsset: f867e55ceb428aab99e1e8c082b5aee7c159ea18
@@ -3129,7 +3129,7 @@ SPEC CHECKSUMS:
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 5beb8028d5a2e75dd9634917f23e23d3a061d2aa
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 9f4dfe93326146a1c99eb535b1cb0b857a3cd172
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 5eb1d2eeff5fb91151e8a8eef45b6c7658b6c897

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "react-native-typography": "1.4.1",
         "react-native-url-polyfill": "3.0.0",
         "react-native-webview": "13.16.1",
+        "react-native-zeroconf": "0.14.0",
         "react-redux": "9.2.0",
         "redux-persist": "6.0.0",
         "semver": "7.7.4",
@@ -15399,6 +15400,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-zeroconf": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-native-zeroconf/-/react-native-zeroconf-0.14.0.tgz",
+      "integrity": "sha512-TqjORroaVZrBYLzk3YtviQy8lUl/iiMacknxixRYlmGaqgsv4LJXIYafpnvPa3y2SC4/qu2mvF8D1/VTTxylgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60"
       }
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react-native-typography": "1.4.1",
     "react-native-url-polyfill": "3.0.0",
     "react-native-webview": "13.16.1",
+    "react-native-zeroconf": "0.14.0",
     "react-redux": "9.2.0",
     "redux-persist": "6.0.0",
     "semver": "7.7.4",

--- a/source/views/settings/screens/overview/__tests__/use-server-discovery.test.ts
+++ b/source/views/settings/screens/overview/__tests__/use-server-discovery.test.ts
@@ -1,0 +1,114 @@
+import {renderHook, act} from '@testing-library/react-native'
+import {NativeModules} from 'react-native'
+import {useServerDiscovery} from '../use-server-discovery'
+
+const mockUseIsDevMode = jest.fn(() => true)
+
+jest.mock('../../../../../lib/use-is-dev-mode', () => ({
+	useIsDevMode: () => mockUseIsDevMode(),
+}))
+
+type Service = {
+	name: string
+	host: string
+	port: number
+	addresses?: string[]
+	txt?: Record<string, string>
+}
+
+const handlers: {
+	resolved?: (...args: unknown[]) => void
+	remove?: (...args: unknown[]) => void
+} = {}
+
+const mockScan = jest.fn()
+const mockStop = jest.fn()
+const mockRemoveDeviceListeners = jest.fn()
+const mockRemoveAllListeners = jest.fn()
+
+jest.mock('react-native-zeroconf', () =>
+	jest.fn().mockImplementation(() => ({
+		on: (
+			event: 'resolved' | 'remove',
+			callback: (...args: unknown[]) => void,
+		) => {
+			if (event === 'resolved') {
+				handlers.resolved = callback
+				return
+			}
+
+			handlers.remove = callback
+		},
+		scan: mockScan,
+		stop: mockStop,
+		removeDeviceListeners: mockRemoveDeviceListeners,
+		removeAllListeners: mockRemoveAllListeners,
+	})),
+)
+
+describe('useServerDiscovery', () => {
+	beforeEach(() => {
+		mockUseIsDevMode.mockReturnValue(true)
+		NativeModules['RNZeroconf'] = {}
+		Object.keys(handlers).forEach(
+			(key) => delete handlers[key as keyof typeof handlers],
+		)
+		jest.clearAllMocks()
+	})
+
+	it('builds discovered server URLs from address and default /v1/ path', () => {
+		let {result} = renderHook(() => useServerDiscovery())
+
+		act(() => {
+			handlers.resolved?.({
+				name: 'Gecko',
+				host: 'Gecko.local.',
+				port: 3000,
+				addresses: ['192.168.0.10'],
+				txt: {path: ''},
+			} as Service)
+		})
+
+		expect(result.current).toEqual([
+			{name: 'Gecko', url: 'http://192.168.0.10:3000/v1/'},
+		])
+	})
+
+	it('removes only the matching discovered server', () => {
+		let {result} = renderHook(() => useServerDiscovery())
+
+		act(() => {
+			handlers.resolved?.({
+				name: 'Gecko',
+				host: 'Gecko.local.',
+				port: 3000,
+				addresses: ['192.168.0.10'],
+			} as Service)
+			handlers.resolved?.({
+				name: 'Otter',
+				host: 'Otter.local.',
+				port: 3000,
+				addresses: ['192.168.0.11'],
+			} as Service)
+		})
+
+		act(() => {
+			handlers.remove?.('Gecko')
+		})
+
+		expect(result.current).toEqual([
+			{name: 'Otter', url: 'http://192.168.0.11:3000/v1/'},
+		])
+	})
+
+	it('cleans up listeners on unmount', () => {
+		let {unmount} = renderHook(() => useServerDiscovery())
+
+		unmount()
+
+		expect(mockRemoveAllListeners).toHaveBeenCalledWith('resolved')
+		expect(mockRemoveAllListeners).toHaveBeenCalledWith('remove')
+		expect(mockStop).toHaveBeenCalledTimes(1)
+		expect(mockRemoveDeviceListeners).toHaveBeenCalledTimes(1)
+	})
+})

--- a/source/views/settings/screens/overview/server-url.tsx
+++ b/source/views/settings/screens/overview/server-url.tsx
@@ -1,18 +1,27 @@
 import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import {Section} from '@frogpond/tableview'
-import {CellTextField, ButtonCell} from '@frogpond/tableview/cells'
+import {
+	CellTextField,
+	ButtonCell,
+	PushButtonCell,
+} from '@frogpond/tableview/cells'
 import restart from 'react-native-restart-newarch'
 import * as storage from '../../../../lib/storage'
 import {DEFAULT_URL} from '../../../../lib/constants'
 import {useMutation, useQuery} from '@tanstack/react-query'
 import {serverUrlOptions} from './query'
+import {useIsDevMode} from '../../../../lib/use-is-dev-mode'
+import {useServerDiscovery} from './use-server-discovery'
 
 export const ServerUrlSection = (): React.ReactElement => {
 	const [serverAddress, setServerAddress] = React.useState('')
 
 	let serverUrlQuery = useQuery(serverUrlOptions)
 	let {isLoading} = serverUrlQuery
+
+	const isDevMode = useIsDevMode()
+	const discoveredServers = useServerDiscovery()
 
 	React.useEffect(() => {
 		if (serverUrlQuery.data !== undefined) {
@@ -32,29 +41,42 @@ export const ServerUrlSection = (): React.ReactElement => {
 	const isValid = isUrlValid || serverAddress.length === 0
 
 	return (
-		<Section
-			footer="Empty means we will use the default URL."
-			header="SERVER URL"
-		>
-			{isLoading ? (
-				<CellTextField editable={false} placeholder="Loading…" value="" />
-			) : (
-				<>
-					<CellTextField
-						onChangeText={setServerAddress}
-						onSubmitEditing={reload}
-						placeholder={DEFAULT_URL}
-						value={serverAddress}
-					/>
-					<ButtonCell
-						disabled={!isValid}
-						onPress={reload}
-						textStyle={styles.buttonCell}
-						title={!isValid ? 'Invalid URL!' : 'Save'}
-					/>
-				</>
+		<>
+			<Section
+				footer="Empty means we will use the default URL."
+				header="SERVER URL"
+			>
+				{isLoading ? (
+					<CellTextField editable={false} placeholder="Loading…" value="" />
+				) : (
+					<>
+						<CellTextField
+							onChangeText={setServerAddress}
+							onSubmitEditing={reload}
+							placeholder={DEFAULT_URL}
+							value={serverAddress}
+						/>
+						<ButtonCell
+							disabled={!isValid}
+							onPress={reload}
+							textStyle={styles.buttonCell}
+							title={!isValid ? 'Invalid URL!' : 'Save'}
+						/>
+					</>
+				)}
+			</Section>
+			{isDevMode && discoveredServers.length > 0 && (
+				<Section footer="Tap a server to use it." header="LOCAL SERVERS">
+					{discoveredServers.map((server) => (
+						<PushButtonCell
+							key={server.url}
+							onPress={() => setServerAddress(server.url)}
+							title={server.url}
+						/>
+					))}
+				</Section>
 			)}
-		</Section>
+		</>
 	)
 }
 

--- a/source/views/settings/screens/overview/server-url.tsx
+++ b/source/views/settings/screens/overview/server-url.tsx
@@ -11,7 +11,6 @@ import * as storage from '../../../../lib/storage'
 import {DEFAULT_URL} from '../../../../lib/constants'
 import {useMutation, useQuery} from '@tanstack/react-query'
 import {serverUrlOptions} from './query'
-import {useIsDevMode} from '../../../../lib/use-is-dev-mode'
 import {useServerDiscovery} from './use-server-discovery'
 
 export const ServerUrlSection = (): React.ReactElement => {
@@ -20,7 +19,6 @@ export const ServerUrlSection = (): React.ReactElement => {
 	let serverUrlQuery = useQuery(serverUrlOptions)
 	let {isLoading} = serverUrlQuery
 
-	const isDevMode = useIsDevMode()
 	const discoveredServers = useServerDiscovery()
 
 	React.useEffect(() => {
@@ -65,7 +63,7 @@ export const ServerUrlSection = (): React.ReactElement => {
 					</>
 				)}
 			</Section>
-			{isDevMode && discoveredServers.length > 0 && (
+			{discoveredServers.length > 0 && (
 				<Section footer="Tap a server to use it." header="LOCAL SERVERS">
 					{discoveredServers.map((server) => (
 						<PushButtonCell

--- a/source/views/settings/screens/overview/use-server-discovery.ts
+++ b/source/views/settings/screens/overview/use-server-discovery.ts
@@ -8,6 +8,22 @@ type DiscoveredServer = {
 	url: string
 }
 
+type ResolvedService = {
+	name: string
+	host: string
+	port: number
+	addresses?: string[]
+	txt?: Record<string, string>
+}
+
+const formatHost = ({
+	addresses,
+	host,
+}: Pick<ResolvedService, 'addresses' | 'host'>) => {
+	const rawHost = addresses?.[0] || host.replace(/\.$/u, '')
+	return rawHost.includes(':') ? `[${rawHost}]` : rawHost
+}
+
 export const useServerDiscovery = (): DiscoveredServer[] => {
 	const isDevMode = useIsDevMode()
 	const [servers, setServers] = React.useState<DiscoveredServer[]>([])
@@ -25,14 +41,9 @@ export const useServerDiscovery = (): DiscoveredServer[] => {
 
 		const zeroconf = new Zeroconf()
 
-		const onResolved = (service: {
-			name: string
-			host: string
-			port: number
-			txt?: Record<string, string>
-		}) => {
-			const path = service.txt?.path ?? '/v1/'
-			const url = `http://${service.host}:${service.port}${path}`
+		const onResolved = (service: ResolvedService) => {
+			const path = service.txt?.path || '/v1/'
+			const url = `http://${formatHost(service)}:${service.port}${path}`
 			setServers((prev) => {
 				const already = prev.some((s) => s.url === url)
 				if (already) return prev
@@ -40,8 +51,8 @@ export const useServerDiscovery = (): DiscoveredServer[] => {
 			})
 		}
 
-		const onRemove = (_name: string) => {
-			setServers([])
+		const onRemove = (name: string) => {
+			setServers((prev) => prev.filter((server) => server.name !== name))
 		}
 
 		zeroconf.on('resolved', onResolved)
@@ -49,6 +60,8 @@ export const useServerDiscovery = (): DiscoveredServer[] => {
 		zeroconf.scan('ccc-server', 'tcp', 'local.')
 
 		return () => {
+			zeroconf.removeAllListeners('resolved')
+			zeroconf.removeAllListeners('remove')
 			zeroconf.stop()
 			zeroconf.removeDeviceListeners()
 		}

--- a/source/views/settings/screens/overview/use-server-discovery.ts
+++ b/source/views/settings/screens/overview/use-server-discovery.ts
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import Zeroconf from 'react-native-zeroconf'
+import {NativeModules} from 'react-native'
+import {useIsDevMode} from '../../../../lib/use-is-dev-mode'
+
+type DiscoveredServer = {
+	name: string
+	url: string
+}
+
+export const useServerDiscovery = (): DiscoveredServer[] => {
+	const isDevMode = useIsDevMode()
+	const [servers, setServers] = React.useState<DiscoveredServer[]>([])
+
+	React.useEffect(() => {
+		if (!isDevMode) {
+			return
+		}
+
+		// The native module is only available after `pod install` links the pod.
+		// Degrade gracefully if it hasn't been linked yet.
+		if (!NativeModules['RNZeroconf']) {
+			return
+		}
+
+		const zeroconf = new Zeroconf()
+
+		const onResolved = (service: {
+			name: string
+			host: string
+			port: number
+			txt?: Record<string, string>
+		}) => {
+			const path = service.txt?.path ?? '/v1/'
+			const url = `http://${service.host}:${service.port}${path}`
+			setServers((prev) => {
+				const already = prev.some((s) => s.url === url)
+				if (already) return prev
+				return [...prev, {name: service.name, url}]
+			})
+		}
+
+		const onRemove = (_name: string) => {
+			setServers([])
+		}
+
+		zeroconf.on('resolved', onResolved)
+		zeroconf.on('remove', onRemove)
+		zeroconf.scan('ccc-server', 'tcp', 'local.')
+
+		return () => {
+			zeroconf.stop()
+			zeroconf.removeDeviceListeners()
+		}
+	}, [isDevMode])
+
+	return servers
+}

--- a/types/react-native-zeroconf.d.ts
+++ b/types/react-native-zeroconf.d.ts
@@ -1,0 +1,37 @@
+declare module 'react-native-zeroconf' {
+	import {EventEmitter} from 'events'
+
+	export type ZeroconfService = {
+		name: string
+		fullName: string
+		host: string
+		port: number
+		addresses: string[]
+		txt: Record<string, string>
+	}
+
+	export default class Zeroconf extends EventEmitter {
+		scan(type?: string, protocol?: string, domain?: string): void
+		stop(): void
+		getServices(): Record<string, ZeroconfService>
+		addDeviceListeners(): void
+		removeDeviceListeners(): void
+		publishService(
+			type: string,
+			protocol: string,
+			domain: string,
+			name: string,
+			port: number,
+			txt?: Record<string, string>,
+		): void
+		unpublishService(name: string): void
+
+		on(event: 'resolved', listener: (service: ZeroconfService) => void): this
+		on(event: 'found', listener: (name: string) => void): this
+		on(event: 'remove', listener: (name: string) => void): this
+		on(event: 'start', listener: () => void): this
+		on(event: 'stop', listener: () => void): this
+		on(event: 'error', listener: (error: Error) => void): this
+		on(event: 'update', listener: () => void): this
+	}
+}


### PR DESCRIPTION
## Summary

In dev mode, the Settings → Server URL screen now scans for a `_ccc-server._tcp` mDNS service on the local network and presents any discovered servers as tappable cells. Tapping fills the URL field; the user still presses Save to apply and restart.

Companion PR: https://github.com/frog-pond/ccc-server/pull/1066

## How it works

A new `useServerDiscovery` hook wraps `react-native-zeroconf` and:
- Returns empty immediately if not in dev mode — zero cost for production users
- Guards against the native module being null (before `pod install`) so the screen doesn't crash
- Scans for `_ccc-server._tcp` services on mount, stops on unmount

The `ServerUrlSection` renders a **LOCAL SERVERS** section (dev mode only, hidden until at least one server is found) with `PushButtonCell` rows.

## Setup

```sh
# package install, podfile install, pods linkage
...

# Start ccc-server with mDNS advertisement
mise run stolaf-college:mdns  # in the ccc-server repo

# Run a debug build on a device on the same network
# Navigate to Settings → Server URL
```

<img width="306" height="215" alt="Screenshot 2026-05-09 at 1 04 21 PM" src="https://github.com/user-attachments/assets/a21c21d3-fe43-45e1-9d56-17daa3766a86" />


## Changes
- `source/views/settings/screens/overview/use-server-discovery.ts` — new hook
- `source/views/settings/screens/overview/server-url.tsx` — LOCAL SERVERS section
- `types/react-native-zeroconf.d.ts` — type declaration for untyped package
- `ios/AllAboutOlaf/Info.plist` — `NSBonjourServices` + `NSLocalNetworkUsageDescription` (required by iOS 14+)
- `CLAUDE.md` — documents the local discovery workflow