### PR TITLE
fix invisible cards in dark mode

### DIFF
--- a/source/views/reddit/post-row-card.tsx
+++ b/source/views/reddit/post-row-card.tsx
@@ -64,7 +64,7 @@ export function PostRowCard({post, onPress}: Props): React.ReactNode {
 
 const styles = StyleSheet.create({
 	card: {
-		backgroundColor: c.systemBackground,
+		backgroundColor: c.secondarySystemGroupedBackground,
 		borderRadius: 12,
 		marginHorizontal: 16,
 		overflow: 'hidden',

--- a/source/views/reddit/post-row-hero.tsx
+++ b/source/views/reddit/post-row-hero.tsx
@@ -73,7 +73,7 @@ export function PostRowHero({post, onPress}: Props): React.ReactNode {
 
 const styles = StyleSheet.create({
 	card: {
-		backgroundColor: c.systemBackground,
+		backgroundColor: c.secondarySystemGroupedBackground,
 		borderRadius: 16,
 		marginHorizontal: 16,
 		overflow: 'hidden',


### PR DESCRIPTION
## Problem

In card mode for the Reddit/Communities view, cards were invisible in dark mode. Both `systemBackground` (used by the cards) and `systemGroupedBackground` (used by the list background) resolve to black in dark mode, so cards blended into the background.

In light mode, cards were visible because `systemBackground` is white and `systemGroupedBackground` is light gray.

## Fix

Changed `post-row-card.tsx` and `post-row-hero.tsx` to use `secondarySystemGroupedBackground` — the correct iOS semantic color for cards on a grouped background:
- **Light mode:** white (same as before)
- **Dark mode:** elevated dark gray (now visible against the black background)

~|~
--|--
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-11 at 21 31 18" src="https://github.com/user-attachments/assets/47e67732-3ac1-4cb4-a489-e82d9abadf04" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-11 at 21 31 28" src="https://github.com/user-attachments/assets/161baf3e-3161-4b8f-b2e0-cdbbf463a0d7" />