### PR TITLE
Reddit in-app link navigation

### DIFF
--- a/source/views/reddit/comment-row.tsx
+++ b/source/views/reddit/comment-row.tsx
@@ -19,6 +19,7 @@ type Props = {
 	isOP?: boolean
 	isCollapsed?: boolean
 	onPress?: () => void
+	onLinkPress?: (url: string) => void
 	testID?: string
 }
 
@@ -28,6 +29,7 @@ export function CommentRow({
 	isOP = false,
 	isCollapsed = false,
 	onPress,
+	onLinkPress,
 	testID,
 }: Props): React.ReactNode {
 	const color = DEPTH_COLORS[depth % DEPTH_COLORS.length]
@@ -78,7 +80,7 @@ export function CommentRow({
 						seg.type === 'link' ? (
 							<Text
 								key={i}
-								onPress={() => openUrl(seg.url)}
+								onPress={() => (onLinkPress ?? openUrl)(seg.url)}
 								style={styles.link}
 							>
 								{seg.text}

--- a/source/views/reddit/post-detail.tsx
+++ b/source/views/reddit/post-detail.tsx
@@ -167,9 +167,7 @@ export function PostDetailView(): React.ReactNode {
 		return []
 	})()
 
-	const isCrosspost =
-		postType === 'crosspost' ||
-		(bodySegments.length === 0 && !thumbnail && !linkUrl)
+	const isCrosspost = postType === 'crosspost' || crosspostParent != null
 
 	const toggleCollapse = React.useCallback((id: string) => {
 		setCollapsedIds((prev) => {
@@ -281,13 +279,9 @@ export function PostDetailView(): React.ReactNode {
 								: 'View linked post on Reddit'
 						}
 						accessibilityRole="link"
-						onPress={() => {
-							const raw = crosspostParent?.permalink ?? postUrl
-							const url = raw.startsWith('/')
-								? `https://www.reddit.com${raw}`
-								: raw
-							handleLinkPress(url)
-						}}
+						onPress={() =>
+							handleLinkPress(crosspostParent?.permalink ?? postUrl)
+						}
 						style={styles.crosspostCard}
 					>
 						<View style={styles.crosspostIconRow}>

--- a/source/views/reddit/post-detail.tsx
+++ b/source/views/reddit/post-detail.tsx
@@ -29,6 +29,7 @@ import type {
 	RedditPostDetailParams,
 } from './types'
 import {formatCommentCount} from './utils/format-count'
+import {useRedditLinkHandler} from './useRedditLinkHandler'
 
 type RouteType = RouteProp<
 	{RedditPostDetail: RedditPostDetailParams},
@@ -91,6 +92,8 @@ export function PostDetailView(): React.ReactNode {
 	const [fullscreenIndex, setFullscreenIndex] = React.useState<number | null>(
 		null,
 	)
+
+	const handleLinkPress = useRedditLinkHandler()
 
 	const {
 		data: comments = [],
@@ -238,7 +241,7 @@ export function PostDetailView(): React.ReactNode {
 							seg.type === 'link' ? (
 								<Text
 									key={i}
-									onPress={() => openUrl(seg.url)}
+									onPress={() => handleLinkPress(seg.url)}
 									style={styles.link}
 								>
 									{seg.text}
@@ -255,7 +258,7 @@ export function PostDetailView(): React.ReactNode {
 					<Pressable
 						accessibilityLabel={`Open link: ${linkDomain ?? linkUrl}`}
 						accessibilityRole="link"
-						onPress={() => openUrl(linkUrl)}
+						onPress={() => handleLinkPress(linkUrl)}
 						style={styles.linkCard}
 					>
 						<Icon name="globe-outline" style={styles.linkCardIcon} />
@@ -278,7 +281,13 @@ export function PostDetailView(): React.ReactNode {
 								: 'View linked post on Reddit'
 						}
 						accessibilityRole="link"
-						onPress={() => openUrl(crosspostParent?.permalink ?? postUrl)}
+						onPress={() => {
+							const raw = crosspostParent?.permalink ?? postUrl
+							const url = raw.startsWith('/')
+								? `https://www.reddit.com${raw}`
+								: raw
+							handleLinkPress(url)
+						}}
 						style={styles.crosspostCard}
 					>
 						<View style={styles.crosspostIconRow}>
@@ -396,6 +405,7 @@ export function PostDetailView(): React.ReactNode {
 					depth={item.depth}
 					isCollapsed={collapsedIds.has(item.comment.id)}
 					isOP={item.comment.author === postAuthor}
+					onLinkPress={handleLinkPress}
 					onPress={
 						item.comment.replies.length > 0
 							? () => toggleCollapse(item.comment.id)

--- a/source/views/reddit/reddit-api.ts
+++ b/source/views/reddit/reddit-api.ts
@@ -240,6 +240,23 @@ export async function fetchRedditPosts(
 	return parseRedditPostsJson(json)
 }
 
+export async function fetchRedditPost(
+	postUrl: string,
+	signal?: AbortSignal,
+): Promise<RedditPostType | null> {
+	const parsed = new URL(postUrl)
+	const jsonPath = parsed.pathname.replace(/\/$/u, '') + '.json'
+	const url = `https://www.reddit.com${jsonPath}?raw_json=1`
+	const res = await fetch(url, {signal, headers: {'User-Agent': USER_AGENT}})
+	if (!res.ok) throw new Error(`Reddit post fetch failed: ${res.status}`)
+	const json = await res.json()
+	if (!Array.isArray(json) || json.length < 1) return null
+	const postListing = json[0] as RawRedditListing
+	const child = postListing?.data?.children?.[0]
+	if (!child) return null
+	return parsePost(child.kind, child.data)
+}
+
 export async function fetchRedditComments(
 	postUrl: string,
 	signal?: AbortSignal,

--- a/source/views/reddit/useRedditLinkHandler.ts
+++ b/source/views/reddit/useRedditLinkHandler.ts
@@ -1,0 +1,75 @@
+import * as React from 'react'
+import {useNavigation} from '@react-navigation/native'
+import type {NativeStackNavigationProp} from '@react-navigation/native-stack'
+import {openUrl} from '@frogpond/open-url'
+import type {RootStackParamList} from '../../navigation/types'
+import {fetchRedditPost} from './reddit-api'
+
+/**
+ * Matches Reddit post URLs across www, old, and bare reddit.com domains.
+ * Extracts the subreddit name for use as the communityName.
+ */
+function parseRedditPostUrl(
+	url: string,
+): {postUrl: string; subreddit: string} | null {
+	try {
+		const parsed = new URL(url)
+		if (!/(^|\.)reddit\.com$/u.test(parsed.hostname)) return null
+		const match = /^\/r\/([^/]+)\/comments\/[^/]+/u.exec(parsed.pathname)
+		if (!match) return null
+		return {
+			postUrl: `https://www.reddit.com${parsed.pathname}`,
+			subreddit: match[1],
+		}
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Returns a link-press handler for use in Reddit post body and comments.
+ * If the URL is a Reddit post, fetches the post data and pushes a new
+ * PostDetailView onto the stack. Otherwise falls back to openUrl.
+ */
+export function useRedditLinkHandler(): (url: string) => Promise<void> {
+	const navigation =
+		useNavigation<NativeStackNavigationProp<RootStackParamList>>()
+
+	return React.useCallback(
+		async (url: string) => {
+			const redditMatch = parseRedditPostUrl(url)
+			if (!redditMatch) {
+				openUrl(url)
+				return
+			}
+
+			try {
+				const post = await fetchRedditPost(redditMatch.postUrl)
+				if (!post) {
+					openUrl(url)
+					return
+				}
+				navigation.push('RedditPostDetail', {
+					postUrl: post.permalink,
+					title: post.title,
+					author: post.author,
+					publishedAt: post.publishedAt,
+					contentHtml: post.contentHtml,
+					thumbnail: post.thumbnail,
+					communityName: `r/${redditMatch.subreddit}`,
+					postAuthor: post.author,
+					postType: post.postType,
+					imageUrl: post.imageUrl,
+					images: post.images,
+					linkUrl: post.linkUrl,
+					linkDomain: post.linkDomain,
+					crosspostParent: post.crosspostParent,
+					pollData: post.pollData,
+				})
+			} catch {
+				openUrl(url)
+			}
+		},
+		[navigation],
+	)
+}


### PR DESCRIPTION
Adds Reddit-link-aware navigation throughout the community/reddit feature.

When any link is tapped — in post body text, comments, link cards, or crosspost cards — the app checks if it's a Reddit post URL. If so, it fetches the post data and pushes a new PostDetailView onto the stack rather than opening a browser.

## What's covered

- **Post body links** — inline text links in self-posts
- **Comment links** — links anywhere in comment threads (chained navigation works via `navigation.push`)
- **Link cards** — for link-type posts, the link card goes through the handler (handles the rare case of a reddit.com link being the target)
- **Crosspost cards** — tapping the crosspost card now pushes a full PostDetailView for the original post, rather than opening the browser. Reddit's permalink is relative so it is expanded to an absolute URL before being passed to the handler.

## Implementation

- `useRedditLinkHandler` — hook that detects Reddit post URLs, fetches post data, and pushes the screen. Falls back to `openUrl` for non-Reddit links or fetch failures.
- `fetchRedditPost` — new API function that reuses the existing `.json` endpoint pattern from `fetchRedditComments`.
- `CommentRow` — accepts optional `onLinkPress` prop, falls back to `openUrl` when not provided.
- Circular dependency between `post-detail.tsx` and `useRedditLinkHandler.ts` was avoided by using the navigation key string literal (TypeScript still validates it against `RootStackParamList`).