### PR TITLE
Fix building hours showing closed when open past 1am

### DIFF
--- a/source/views/building-hours/lib/__tests__/parse-hours.test.ts
+++ b/source/views/building-hours/lib/__tests__/parse-hours.test.ts
@@ -78,6 +78,32 @@ describe('handles weird times', () => {
 
 		expect(now.isBetween(open, close)).toBe(true)
 	})
+
+	it('reports open at 2:30am for a building open until 3am', () => {
+		let time = '2018-11-11T02:30:00'
+		let now = plainMoment(time, 'YYYY-MM-DD[T]HH:mm:ss')
+		let input: SingleBuildingScheduleType = {
+			days: [],
+			from: '10:00pm',
+			to: '3:00am',
+		}
+		let {open, close} = parseHours(input, now)
+
+		expect(now.isBetween(open, close)).toBe(true)
+	})
+
+	it('reports closed at 4am after a 3am close', () => {
+		let time = '2018-11-11T04:00:00'
+		let now = plainMoment(time, 'YYYY-MM-DD[T]HH:mm:ss')
+		let input: SingleBuildingScheduleType = {
+			days: [],
+			from: '10:00pm',
+			to: '3:00am',
+		}
+		let {open, close} = parseHours(input, now)
+
+		expect(now.isBetween(open, close)).toBe(false)
+	})
 })
 
 xdescribe('checks a list of schedules to see if any are open', () => {

--- a/source/views/building-hours/lib/parse-hours.ts
+++ b/source/views/building-hours/lib/parse-hours.ts
@@ -7,27 +7,41 @@ import {TIME_FORMAT} from './constants'
 
 type HourPairType = {open: Moment; close: Moment}
 
-// TODO: Do "dayOfYear" handling better so that we don't need to handle wrapping at
-// the 6 month mark. (See #3375 for why this function changed.)
+// Anchor a "h:mma" time string onto the calendar day of `base`, keeping
+// `base`'s timezone/date and only replacing the time-of-day.
+function setTimeOnDay(base: Moment, time: string): Moment {
+	let parsed = moment.tz(time, TIME_FORMAT, true, timezone())
+	return base.clone().set({
+		hour: parsed.hour(),
+		minute: parsed.minute(),
+		second: 0,
+		millisecond: 0,
+	})
+}
+
 export function parseHours(
-	{from: fromTime, to: toTime}: SingleBuildingScheduleType,
+	schedule: SingleBuildingScheduleType,
 	m: Moment,
 ): HourPairType {
-	let dayOfYear = m.dayOfYear()
+	let {from: fromTime, to: toTime} = schedule
 
-	// if the moment is before 3am
-	if (m.hour() < 2) {
-		dayOfYear -= 1
-	}
-
-	let open = moment.tz(fromTime, TIME_FORMAT, true, timezone())
-	open.year(m.year()).month(m.month()).date(m.date()).dayOfYear(dayOfYear)
-
-	let close = moment.tz(toTime, TIME_FORMAT, true, timezone())
-	close.year(m.year()).month(m.month()).date(m.date()).dayOfYear(dayOfYear)
-
+	// Build the window that *starts* on m's own calendar day. If the close
+	// time is at or before the open time, the schedule runs past midnight, so
+	// the close belongs to the next day.
+	let open = setTimeOnDay(m, fromTime)
+	let close = setTimeOnDay(m, toTime)
 	if (close.isBefore(open)) {
 		close.add(1, 'day')
+	}
+
+	// A schedule that started *yesterday* can still be running now (e.g. a
+	// 10:00pm–3:00am window, checked at 2:30am). Prefer that window when m
+	// actually falls inside it. This replaces the old hard-coded "before 2am"
+	// day shift, so any past-midnight close time is handled correctly.
+	let prevOpen = open.clone().subtract(1, 'day')
+	let prevClose = close.clone().subtract(1, 'day')
+	if (m.isBetween(prevOpen, prevClose, 'minute', '[)')) {
+		return {open: prevOpen, close: prevClose}
 	}
 
 	return {open, close}


### PR DESCRIPTION
## Problem

`parseHours` used a hard-coded `if (m.hour() < 2)` heuristic to decide which calendar day a schedule belonged to. That only worked for close times at or before 2am. A building open until, say, **3am** was reported **closed** when checked between 2:00am and its close time, because the current moment was never shifted back into the previous night's window.

## Fix

Replace the magic-hour heuristic in `source/views/building-hours/lib/parse-hours.ts`:

- Build the schedule window anchored to the **current** calendar day (adding a day to the close time when the schedule runs past midnight).
- When the schedule crosses midnight, also test the window that **started the previous day**, and return whichever window actually contains the current moment.

This handles any past-midnight close time, not just those before 2am. As a bonus it removes the `dayOfYear` arithmetic that needed the #3375 six-month-wrap workaround.

The single `{open, close}` return contract is unchanged, so the other consumers (`is-schedule-really-open`, `format-times`, `get-schedule-status`, `chapel`) keep working — and they're covered by the existing suites.

## Tests

Added two regression cases to `parse-hours.test.ts` (TDD, RED first):

- A `10:00pm–3:00am` building checked at **2:30am** → reports **open** (failed before the fix).
- The same building checked at **4:00am** → reports **closed** (guard against over-reporting open).

### Verification
- All 10 building-hours suites pass (84 passed, 3 pre-existing `xdescribe` skips).
- Full project gate green: Prettier clean, `tsc` ✓, ESLint ✓, Jest 233 passed / 3 skipped across 41 suites.

https://claude.ai/code/session_01UkpHRLWxm5u5Fv3k7NWvH4