### PR TITLE
Rebuild the home screen tiles to look like Shortcuts' tiles

### DIFF
--- a/modules/colors/__tests__/display-p3.test.ts
+++ b/modules/colors/__tests__/display-p3.test.ts
@@ -48,6 +48,26 @@ describe('displayP3', () => {
 		expect(g).toBeGreaterThan(b)
 	})
 
+	test('matches the extended sRGB coordinates of the P3 primaries', () => {
+		// The failure this guards against is handing P3 coordinates straight to an
+		// extended sRGB initializer without converting them. Greys and the whole
+		// neutral axis are identical in both spaces, so that mistake looks correct
+		// until a saturated colour goes through it -- hence primaries here, and a
+		// grey below to prove the neutral axis is *also* right.
+		let primaries: [string, [number, number, number]][] = [
+			['#ff0000', [1.0931, -0.2267, -0.1501]],
+			['#00ff00', [-0.5116, 1.0183, -0.3107]],
+			['#0000ff', [0.0, 0.0, 1.042]],
+			['#808080', [0.5019, 0.5019, 0.5019]],
+		]
+		for (let [hex, expected] of primaries) {
+			let got = displayP3(hex)
+			for (let channel of [0, 1, 2]) {
+				expect(got[channel]).toBeCloseTo(expected[channel], 2)
+			}
+		}
+	})
+
 	test('accepts three- and six-digit hex alike', () => {
 		expect(displayP3('#fff')).toEqual(displayP3('#ffffff'))
 	})

--- a/modules/colors/__tests__/display-p3.test.ts
+++ b/modules/colors/__tests__/display-p3.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {displayP3Components as displayP3} from '../display-p3'
+
+describe('displayP3', () => {
+	test('leaves the achromatic ends alone', () => {
+		// White and black sit at the same place in every RGB space sharing a white
+		// point, so they must survive the conversion. The published matrices carry
+		// seven digits, so the round trip lands a rounding error either side of
+		// the exact value rather than on it.
+		let white = displayP3('#ffffff')
+		let black = displayP3('#000000')
+		for (let channel of [0, 1, 2]) {
+			expect(white[channel]).toBeCloseTo(1, 6)
+			expect(black[channel]).toBeCloseTo(0, 6)
+		}
+	})
+
+	test('leaves neutral greys neutral', () => {
+		let [r, g, b] = displayP3('#808080')
+		expect(g).toBeCloseTo(r, 4)
+		expect(b).toBeCloseTo(r, 4)
+	})
+
+	test('carries alpha through unchanged', () => {
+		expect(displayP3('#ffffff', 0.79)[3]).toBe(0.79)
+	})
+
+	test('reaches outside the sRGB gamut for saturated colours', () => {
+		// P3's primaries are further out than sRGB's, so a saturated P3 green has
+		// no sRGB equivalent and has to be expressed with a component below zero.
+		// Clamping here would be the bug this conversion exists to avoid.
+		let [red] = displayP3('#00ff00')
+		expect(red).toBeLessThan(0)
+	})
+
+	test('desaturates, rather than shifting, a colour sRGB can represent', () => {
+		// A mid-saturation P3 colour maps inside sRGB, and reads as a less
+		// saturated version of the same hue -- the whole reason the cards looked
+		// oversaturated when P3 samples were passed off as sRGB.
+		let [r, g, b] = displayP3('#7fe07e')
+		for (let c of [r, g, b]) {
+			expect(c).toBeGreaterThan(0)
+			expect(c).toBeLessThan(1)
+		}
+		// green stays the dominant channel
+		expect(g).toBeGreaterThan(r)
+		expect(g).toBeGreaterThan(b)
+	})
+
+	test('accepts three- and six-digit hex alike', () => {
+		expect(displayP3('#fff')).toEqual(displayP3('#ffffff'))
+	})
+
+	test('rejects a string that is not a hex colour', () => {
+		expect(() => displayP3('rebeccapurple')).toThrow(/hex/iu)
+	})
+})

--- a/modules/colors/__tests__/display-p3.test.ts
+++ b/modules/colors/__tests__/display-p3.test.ts
@@ -2,14 +2,17 @@ import {describe, expect, test} from '@jest/globals'
 
 import {displayP3Components as displayP3} from '../display-p3'
 
+const WHITE = 'color(display-p3 1 1 1)'
+const BLACK = 'color(display-p3 0 0 0)'
+
 describe('displayP3', () => {
 	test('leaves the achromatic ends alone', () => {
 		// White and black sit at the same place in every RGB space sharing a white
 		// point, so they must survive the conversion. The published matrices carry
 		// seven digits, so the round trip lands a rounding error either side of
 		// the exact value rather than on it.
-		let white = displayP3('#ffffff')
-		let black = displayP3('#000000')
+		let white = displayP3(WHITE)
+		let black = displayP3(BLACK)
 		for (let channel of [0, 1, 2]) {
 			expect(white[channel]).toBeCloseTo(1, 6)
 			expect(black[channel]).toBeCloseTo(0, 6)
@@ -17,35 +20,9 @@ describe('displayP3', () => {
 	})
 
 	test('leaves neutral greys neutral', () => {
-		let [r, g, b] = displayP3('#808080')
+		let [r, g, b] = displayP3('color(display-p3 0.5 0.5 0.5)')
 		expect(g).toBeCloseTo(r, 4)
 		expect(b).toBeCloseTo(r, 4)
-	})
-
-	test('carries alpha through unchanged', () => {
-		expect(displayP3('#ffffff', 0.79)[3]).toBe(0.79)
-	})
-
-	test('reaches outside the sRGB gamut for saturated colours', () => {
-		// P3's primaries are further out than sRGB's, so a saturated P3 green has
-		// no sRGB equivalent and has to be expressed with a component below zero.
-		// Clamping here would be the bug this conversion exists to avoid.
-		let [red] = displayP3('#00ff00')
-		expect(red).toBeLessThan(0)
-	})
-
-	test('desaturates, rather than shifting, a colour sRGB can represent', () => {
-		// A mid-saturation P3 colour maps inside sRGB, and reads as a less
-		// saturated version of the same hue -- the whole reason the cards looked
-		// oversaturated when P3 samples were passed off as sRGB.
-		let [r, g, b] = displayP3('#7fe07e')
-		for (let c of [r, g, b]) {
-			expect(c).toBeGreaterThan(0)
-			expect(c).toBeLessThan(1)
-		}
-		// green stays the dominant channel
-		expect(g).toBeGreaterThan(r)
-		expect(g).toBeGreaterThan(b)
 	})
 
 	test('matches the extended sRGB coordinates of the P3 primaries', () => {
@@ -53,26 +30,62 @@ describe('displayP3', () => {
 		// extended sRGB initializer without converting them. Greys and the whole
 		// neutral axis are identical in both spaces, so that mistake looks correct
 		// until a saturated colour goes through it -- hence primaries here, and a
-		// grey below to prove the neutral axis is *also* right.
+		// grey above to prove the neutral axis is *also* right.
 		let primaries: [string, [number, number, number]][] = [
-			['#ff0000', [1.0931, -0.2267, -0.1501]],
-			['#00ff00', [-0.5116, 1.0183, -0.3107]],
-			['#0000ff', [0.0, 0.0, 1.042]],
-			['#808080', [0.5019, 0.5019, 0.5019]],
+			['color(display-p3 1 0 0)', [1.0931, -0.2267, -0.1501]],
+			['color(display-p3 0 1 0)', [-0.5116, 1.0183, -0.3107]],
+			['color(display-p3 0 0 1)', [0.0, 0.0, 1.042]],
 		]
-		for (let [hex, expected] of primaries) {
-			let got = displayP3(hex)
+		for (let [css, expected] of primaries) {
+			let got = displayP3(css)
 			for (let channel of [0, 1, 2]) {
 				expect(got[channel]).toBeCloseTo(expected[channel], 2)
 			}
 		}
 	})
 
-	test('accepts three- and six-digit hex alike', () => {
-		expect(displayP3('#fff')).toEqual(displayP3('#ffffff'))
+	test('reaches outside the sRGB gamut for saturated colours', () => {
+		// P3's primaries are further out than sRGB's, so a saturated P3 green has
+		// no sRGB equivalent and has to be expressed with a component below zero.
+		// Clamping here would be the bug this conversion exists to avoid.
+		expect(displayP3('color(display-p3 0 1 0)')[0]).toBeLessThan(0)
 	})
 
-	test('rejects a string that is not a hex colour', () => {
-		expect(() => displayP3('rebeccapurple')).toThrow(/hex/iu)
+	describe('parsing', () => {
+		test('reads the alpha after the slash', () => {
+			expect(displayP3(`color(display-p3 1 1 1 / 0.79)`)[3]).toBe(0.79)
+			expect(displayP3(`color(display-p3 1 1 1 / 50%)`)[3]).toBe(0.5)
+		})
+
+		test('defaults alpha to opaque', () => {
+			expect(displayP3(WHITE)[3]).toBe(1)
+		})
+
+		test('accepts percentages for the components', () => {
+			expect(displayP3('color(display-p3 100% 0% 0%)')).toEqual(
+				displayP3('color(display-p3 1 0 0)'),
+			)
+		})
+
+		test('is insensitive to case and extra whitespace', () => {
+			expect(displayP3('COLOR( Display-P3   1  1   1 )')).toEqual(
+				displayP3(WHITE),
+			)
+		})
+
+		test('rejects a bare hex colour', () => {
+			// The whole point of the syntax: a P3 value must not be mistakable for
+			// an sRGB hex, because passing one where the other is expected is a
+			// silent wrong-colour bug rather than a loud failure.
+			expect(() => displayP3('#ed7c85')).toThrow(/display-p3/iu)
+		})
+
+		test('rejects another colour space', () => {
+			expect(() => displayP3('color(srgb 1 0 0)')).toThrow(/display-p3/iu)
+		})
+
+		test('rejects a component count it cannot use', () => {
+			expect(() => displayP3('color(display-p3 1 0)')).toThrow(/display-p3/iu)
+		})
 	})
 })

--- a/modules/colors/__tests__/display-p3.test.ts
+++ b/modules/colors/__tests__/display-p3.test.ts
@@ -90,11 +90,11 @@ describe('displayP3', () => {
 		})
 
 		test('rejects pathological whitespace without stalling', () => {
-			// The first parser matched with a regular expression permissive enough
-			// to attribute one run of spaces to several parts of itself, which
-			// backtracks polynomially on input that never matches. Parsing has to
-			// stay linear in the length of the string, so this rejects promptly
-			// rather than eventually.
+			// Parsing has to stay linear in the length of the string. A regular
+			// expression permissive enough to allow whitespace anywhere can
+			// attribute one run of spaces to several parts of itself and backtrack
+			// polynomially, so this asserts the rejection is prompt rather than
+			// merely eventual.
 			let hostile = `color(display-p3 ${' '.repeat(50_000)}`
 			let started = Date.now()
 			expect(() => displayP3(hostile)).toThrow()

--- a/modules/colors/__tests__/display-p3.test.ts
+++ b/modules/colors/__tests__/display-p3.test.ts
@@ -84,6 +84,18 @@ describe('displayP3', () => {
 			expect(() => displayP3('color(srgb 1 0 0)')).toThrow(/display-p3/iu)
 		})
 
+		test('rejects pathological whitespace without stalling', () => {
+			// The first parser matched with a regular expression permissive enough
+			// to attribute one run of spaces to several parts of itself, which
+			// backtracks polynomially on input that never matches. Parsing has to
+			// stay linear in the length of the string, so this rejects promptly
+			// rather than eventually.
+			let hostile = `color(display-p3 ${' '.repeat(50_000)}`
+			let started = Date.now()
+			expect(() => displayP3(hostile)).toThrow()
+			expect(Date.now() - started).toBeLessThan(1000)
+		})
+
 		test('rejects a component count it cannot use', () => {
 			expect(() => displayP3('color(display-p3 1 0)')).toThrow(/display-p3/iu)
 		})

--- a/modules/colors/__tests__/display-p3.test.ts
+++ b/modules/colors/__tests__/display-p3.test.ts
@@ -57,6 +57,11 @@ describe('displayP3', () => {
 			expect(displayP3(`color(display-p3 1 1 1 / 50%)`)[3]).toBe(0.5)
 		})
 
+		test('lets an override replace the alpha in the string', () => {
+			expect(displayP3(`color(display-p3 1 1 1 / 0.79)`, 0.4)[3]).toBe(0.4)
+			expect(displayP3(WHITE, 0.4)[3]).toBe(0.4)
+		})
+
 		test('defaults alpha to opaque', () => {
 			expect(displayP3(WHITE)[3]).toBe(1)
 		})

--- a/modules/colors/__tests__/gradients.test.ts
+++ b/modules/colors/__tests__/gradients.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from '@jest/globals'
 
+import {displayP3} from '../display-p3'
 import * as gradients from '../gradients'
 
 const EXPECTED_NAMES = [
@@ -26,13 +27,17 @@ describe('gradients', () => {
 		expect(exportedNames.sort()).toEqual([...EXPECTED_NAMES].sort())
 	})
 
-	test('every gradient is a [left, right] pair of hex colors', () => {
+	test('every gradient is an [inner, outer] pair of Display P3 colors', () => {
 		for (let name of EXPECTED_NAMES) {
 			let value = (gradients as Record<string, unknown>)[name]
 			expect(Array.isArray(value)).toBe(true)
 			expect((value as string[]).length).toBe(2)
 			for (let color of value as string[]) {
-				expect(color).toMatch(/^#[0-9a-f]{6}$/iu)
+				// Parsing it is a stronger check than matching a shape: these have to
+				// survive the conversion that actually renders them, and a hex value
+				// that slipped in would be rejected rather than quietly treated as
+				// sRGB.
+				expect(() => displayP3(color)).not.toThrow()
 			}
 		}
 	})

--- a/modules/colors/__tests__/gradients.test.ts
+++ b/modules/colors/__tests__/gradients.test.ts
@@ -26,7 +26,7 @@ describe('gradients', () => {
 		expect(exportedNames.sort()).toEqual([...EXPECTED_NAMES].sort())
 	})
 
-	test('every gradient is a [top, bottom] pair of hex colors', () => {
+	test('every gradient is a [left, right] pair of hex colors', () => {
 		for (let name of EXPECTED_NAMES) {
 			let value = (gradients as Record<string, unknown>)[name]
 			expect(Array.isArray(value)).toBe(true)

--- a/modules/colors/__tests__/gradients.test.ts
+++ b/modules/colors/__tests__/gradients.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, test} from '@jest/globals'
+
+import * as gradients from '../gradients'
+
+const EXPECTED_NAMES = [
+	'redGradient',
+	'orangeGradient',
+	'goldGradient',
+	'yellowGradient',
+	'greenGradient',
+	'mintGradient',
+	'lightBlueGradient',
+	'blueGradient',
+	'indigoGradient',
+	'purpleGradient',
+	'violetGradient',
+	'pinkGradient',
+	'grayGradient',
+	'sageGradient',
+	'tanGradient',
+]
+
+describe('gradients', () => {
+	test('exports exactly the 15 named gradients', () => {
+		let exportedNames = Object.keys(gradients).filter((k) => k !== 'Gradient')
+		expect(exportedNames.sort()).toEqual([...EXPECTED_NAMES].sort())
+	})
+
+	test('every gradient is a [top, bottom] pair of hex colors', () => {
+		for (let name of EXPECTED_NAMES) {
+			let value = (gradients as Record<string, unknown>)[name]
+			expect(Array.isArray(value)).toBe(true)
+			expect((value as string[]).length).toBe(2)
+			for (let color of value as string[]) {
+				expect(color).toMatch(/^#[0-9a-f]{6}$/iu)
+			}
+		}
+	})
+})

--- a/modules/colors/display-p3.ts
+++ b/modules/colors/display-p3.ts
@@ -127,8 +127,17 @@ export type ExtendedSrgbComponents = [number, number, number, number]
 /// Converts a `color(display-p3 ...)` colour into the components that reproduce
 /// it. Values outside 0...1 are expected and must not be clamped:
 /// they are what carries a colour sRGB cannot otherwise reach.
-export function displayP3Components(css: string): ExtendedSrgbComponents {
-	let [p3, alpha] = parseDisplayP3(css)
+///
+/// `alphaOverride` replaces whatever alpha the string carries. It exists for
+/// colours that are derived from another rather than authored -- a card's
+/// shadow is its own gradient at a fraction of its opacity -- where writing the
+/// alpha into the literal would mean duplicating the colour to vary it.
+export function displayP3Components(
+	css: string,
+	alphaOverride?: number,
+): ExtendedSrgbComponents {
+	let [p3, parsedAlpha] = parseDisplayP3(css)
+	let alpha = alphaOverride ?? parsedAlpha
 	let linearP3 = p3.map(toLinear) as Triple
 	let [red, green, blue] = apply(XYZ_TO_SRGB, apply(P3_TO_XYZ, linearP3)).map(
 		fromLinear,
@@ -142,6 +151,6 @@ export function displayP3Components(css: string): ExtendedSrgbComponents {
 /// its *parser* accepts; the array form goes to the same place but is missing
 /// from the type. The cast is the one place that gap is papered over, rather
 /// than at each of the call sites.
-export function displayP3(css: string): ColorValue {
-	return displayP3Components(css) as unknown as ColorValue
+export function displayP3(css: string, alphaOverride?: number): ColorValue {
+	return displayP3Components(css, alphaOverride) as unknown as ColorValue
 }

--- a/modules/colors/display-p3.ts
+++ b/modules/colors/display-p3.ts
@@ -75,33 +75,50 @@ function fromLinear(value: number): number {
 /// It is also the syntax React Native's own wide-gamut proposal uses, so if
 /// that ever lands on the JS side these values can be passed straight through
 /// and the conversion below deleted.
-const P3_PATTERN =
-	/^color\(\s*display-p3\s+(?<components>[^/)]+?)\s*(?:\/\s*(?<alpha>[^\s)]+)\s*)?\)$/iu
+const FUNCTION_NAME = 'color'
+const COLOUR_SPACE = 'display-p3'
 
 function component(text: string): number {
 	let value = text.endsWith('%')
 		? Number(text.slice(0, -1)) / 100
 		: Number(text)
-	if (Number.isNaN(value)) {
+	if (Number.isNaN(value) || text === '') {
 		throw new Error(`"${text}" is not a number or percentage`)
 	}
 	return value
 }
 
 function parseDisplayP3(css: string): [Triple, number] {
-	let match = P3_PATTERN.exec(css.trim())
-	if (!match?.groups) {
+	let reject = (): never => {
 		throw new Error(`"${css}" is not a color(display-p3 ...) colour`)
 	}
-	let parts = match.groups['components'].split(/\s+/u)
+
+	// Split on delimiters rather than matching with a regular expression. An
+	// expression general enough to allow whitespace anywhere ends up able to
+	// attribute the same run of spaces to more than one part of itself, which
+	// backtracks badly on input that never matches -- CodeQL flags it as a
+	// polynomial ReDoS, and it is one. Scanning is linear and says what it means.
+	let text = css.trim()
+	let open = text.indexOf('(')
+	if (open === -1 || !text.endsWith(')')) reject()
+	if (text.slice(0, open).trim().toLowerCase() !== FUNCTION_NAME) reject()
+
+	let body = text.slice(open + 1, -1).trim()
+	let space = body.search(/\s/u)
+	if (space === -1) reject()
+	if (body.slice(0, space).toLowerCase() !== COLOUR_SPACE) reject()
+
+	let [components, alpha, ...rest] = body.slice(space).split('/')
+	if (rest.length > 0) reject()
+
+	let parts = components.trim().split(/\s+/u)
 	if (parts.length !== 3) {
 		throw new Error(
-			`color(display-p3 ...) takes three components, got ${parts.length}`,
+			`color(${COLOUR_SPACE} ...) takes three components, got ${parts.length}`,
 		)
 	}
 	let [red, green, blue] = parts.map(component) as Triple
-	let alpha = match.groups['alpha'] ? component(match.groups['alpha']) : 1
-	return [[red, green, blue], alpha]
+	return [[red, green, blue], alpha === undefined ? 1 : component(alpha.trim())]
 }
 
 /// The components of a Display P3 colour, expressed in extended sRGB.

--- a/modules/colors/display-p3.ts
+++ b/modules/colors/display-p3.ts
@@ -1,0 +1,104 @@
+import type {ColorValue} from 'react-native'
+
+/// Colours reach SwiftUI through `UIColor(red:green:blue:alpha:)`, which since
+/// iOS 10 is *extended* sRGB: components outside 0...1 are legal and address
+/// colours beyond sRGB's gamut. That is the only way to name a Display P3
+/// colour from here. Expo's colour parser has no P3 syntax -- hex, rgb(), hsl()
+/// and hwb() all land in that same initializer with their components clamped
+/// into sRGB -- but a colour given as an array of numbers is passed through
+/// unclamped, so components can go where a string cannot.
+///
+/// This matters because the card gradients were sampled from screenshots that
+/// are themselves Display P3. Passing those raw values back as sRGB hex renders
+/// a visibly more saturated colour than the one that was measured: sampled
+/// #7fe07e came back off a device as #95dc87.
+
+/// sRGB and Display P3 share a white point (D65) and a transfer function, and
+/// differ only in their primaries, so converting between them is one matrix
+/// applied in linear light. These are the RGB-to-XYZ matrices for each.
+type Matrix = readonly [
+	readonly [number, number, number],
+	readonly [number, number, number],
+	readonly [number, number, number],
+]
+type Triple = [number, number, number]
+
+const P3_TO_XYZ: Matrix = [
+	[0.4865709, 0.2656677, 0.1982173],
+	[0.2289746, 0.6917385, 0.0792869],
+	[0.0, 0.0451134, 1.0439444],
+]
+const XYZ_TO_SRGB: Matrix = [
+	[3.2409699, -1.5373832, -0.4986108],
+	[-0.9692436, 1.8759675, 0.0415551],
+	[0.0556301, -0.203977, 1.0569715],
+]
+
+function apply(matrix: Matrix, [x, y, z]: Triple): Triple {
+	return [
+		matrix[0][0] * x + matrix[0][1] * y + matrix[0][2] * z,
+		matrix[1][0] * x + matrix[1][1] * y + matrix[1][2] * z,
+		matrix[2][0] * x + matrix[2][1] * y + matrix[2][2] * z,
+	]
+}
+
+/// The sRGB transfer function, and its inverse, extended through zero by
+/// mirroring. Extended sRGB is defined that way, and a P3 colour outside the
+/// sRGB gamut lands on the negative side of it.
+function toLinear(value: number): number {
+	let magnitude = Math.abs(value)
+	let linear =
+		magnitude <= 0.04045
+			? magnitude / 12.92
+			: ((magnitude + 0.055) / 1.055) ** 2.4
+	return Math.sign(value) * linear
+}
+
+function fromLinear(value: number): number {
+	let magnitude = Math.abs(value)
+	let encoded =
+		magnitude <= 0.0031308
+			? magnitude * 12.92
+			: 1.055 * magnitude ** (1 / 2.4) - 0.055
+	return Math.sign(value) * encoded
+}
+
+function parseHex(hex: string): Triple {
+	let digits = hex.replace(/^#/u, '')
+	if (digits.length === 3) {
+		digits = [...digits].map((digit) => digit + digit).join('')
+	}
+	if (!/^[0-9a-f]{6}$/iu.test(digits)) {
+		throw new Error(`"${hex}" is not a six-digit hex colour`)
+	}
+	let channel = (index: number): number =>
+		parseInt(digits.slice(index * 2, index * 2 + 2), 16) / 255
+	return [channel(0), channel(1), channel(2)]
+}
+
+/// The components of a Display P3 colour, expressed in extended sRGB.
+export type ExtendedSrgbComponents = [number, number, number, number]
+
+/// Converts a hex colour *measured in Display P3* into the components that
+/// reproduce it. Values outside 0...1 are expected and must not be clamped:
+/// they are what carries a colour sRGB cannot otherwise reach.
+export function displayP3Components(
+	hex: string,
+	alpha = 1,
+): ExtendedSrgbComponents {
+	let linearP3 = parseHex(hex).map(toLinear) as Triple
+	let [red, green, blue] = apply(XYZ_TO_SRGB, apply(P3_TO_XYZ, linearP3)).map(
+		fromLinear,
+	) as Triple
+	return [red, green, blue, alpha]
+}
+
+/// The same thing, typed for the props that take a colour.
+///
+/// @expo/ui types a colour as `string | ColorValue | NamedColor`, which is what
+/// its *parser* accepts; the array form goes to the same place but is missing
+/// from the type. The cast is the one place that gap is papered over, rather
+/// than at each of the call sites.
+export function displayP3(hex: string, alpha = 1): ColorValue {
+	return displayP3Components(hex, alpha) as unknown as ColorValue
+}

--- a/modules/colors/display-p3.ts
+++ b/modules/colors/display-p3.ts
@@ -94,10 +94,10 @@ function parseDisplayP3(css: string): [Triple, number] {
 	}
 
 	// Split on delimiters rather than matching with a regular expression. An
-	// expression general enough to allow whitespace anywhere ends up able to
-	// attribute the same run of spaces to more than one part of itself, which
-	// backtracks badly on input that never matches -- CodeQL flags it as a
-	// polynomial ReDoS, and it is one. Scanning is linear and says what it means.
+	// expression general enough to allow whitespace anywhere can attribute one
+	// run of spaces to several parts of itself, and backtracks polynomially on
+	// input that never matches: a ReDoS, and reachable, since this is exported.
+	// Scanning is linear in the length of the string.
 	let text = css.trim()
 	let open = text.indexOf('(')
 	if (open === -1 || !text.endsWith(')')) reject()

--- a/modules/colors/display-p3.ts
+++ b/modules/colors/display-p3.ts
@@ -63,30 +63,56 @@ function fromLinear(value: number): number {
 	return Math.sign(value) * encoded
 }
 
-function parseHex(hex: string): Triple {
-	let digits = hex.replace(/^#/u, '')
-	if (digits.length === 3) {
-		digits = [...digits].map((digit) => digit + digit).join('')
+/// Reads the CSS Color 4 `color(display-p3 r g b)` form, with an optional
+/// `/ alpha`. Components are 0...1 numbers or percentages.
+///
+/// Colours are written this way rather than as hex so that a P3 value cannot be
+/// mistaken for an sRGB one. They are different colours that would otherwise
+/// look identical in source, and passing one where the other is expected is a
+/// silently-wrong render rather than an error. React Native's own parser
+/// rejects this syntax, so the mistake fails loudly there too.
+///
+/// It is also the syntax React Native's own wide-gamut proposal uses, so if
+/// that ever lands on the JS side these values can be passed straight through
+/// and the conversion below deleted.
+const P3_PATTERN =
+	/^color\(\s*display-p3\s+(?<components>[^/)]+?)\s*(?:\/\s*(?<alpha>[^\s)]+)\s*)?\)$/iu
+
+function component(text: string): number {
+	let value = text.endsWith('%')
+		? Number(text.slice(0, -1)) / 100
+		: Number(text)
+	if (Number.isNaN(value)) {
+		throw new Error(`"${text}" is not a number or percentage`)
 	}
-	if (!/^[0-9a-f]{6}$/iu.test(digits)) {
-		throw new Error(`"${hex}" is not a six-digit hex colour`)
+	return value
+}
+
+function parseDisplayP3(css: string): [Triple, number] {
+	let match = P3_PATTERN.exec(css.trim())
+	if (!match?.groups) {
+		throw new Error(`"${css}" is not a color(display-p3 ...) colour`)
 	}
-	let channel = (index: number): number =>
-		parseInt(digits.slice(index * 2, index * 2 + 2), 16) / 255
-	return [channel(0), channel(1), channel(2)]
+	let parts = match.groups['components'].split(/\s+/u)
+	if (parts.length !== 3) {
+		throw new Error(
+			`color(display-p3 ...) takes three components, got ${parts.length}`,
+		)
+	}
+	let [red, green, blue] = parts.map(component) as Triple
+	let alpha = match.groups['alpha'] ? component(match.groups['alpha']) : 1
+	return [[red, green, blue], alpha]
 }
 
 /// The components of a Display P3 colour, expressed in extended sRGB.
 export type ExtendedSrgbComponents = [number, number, number, number]
 
-/// Converts a hex colour *measured in Display P3* into the components that
-/// reproduce it. Values outside 0...1 are expected and must not be clamped:
+/// Converts a `color(display-p3 ...)` colour into the components that reproduce
+/// it. Values outside 0...1 are expected and must not be clamped:
 /// they are what carries a colour sRGB cannot otherwise reach.
-export function displayP3Components(
-	hex: string,
-	alpha = 1,
-): ExtendedSrgbComponents {
-	let linearP3 = parseHex(hex).map(toLinear) as Triple
+export function displayP3Components(css: string): ExtendedSrgbComponents {
+	let [p3, alpha] = parseDisplayP3(css)
+	let linearP3 = p3.map(toLinear) as Triple
 	let [red, green, blue] = apply(XYZ_TO_SRGB, apply(P3_TO_XYZ, linearP3)).map(
 		fromLinear,
 	) as Triple
@@ -99,6 +125,6 @@ export function displayP3Components(
 /// its *parser* accepts; the array form goes to the same place but is missing
 /// from the type. The cast is the one place that gap is papered over, rather
 /// than at each of the call sites.
-export function displayP3(hex: string, alpha = 1): ColorValue {
-	return displayP3Components(hex, alpha) as unknown as ColorValue
+export function displayP3(css: string): ColorValue {
+	return displayP3Components(css) as unknown as ColorValue
 }

--- a/modules/colors/gradients.ts
+++ b/modules/colors/gradients.ts
@@ -11,12 +11,17 @@ export type Gradient = [string, string]
 // The outer stop of every colour is the bottom edge of that colour's swatch in
 // the Shortcuts colour picker: measured against eight real cards, the two agree
 // to within 3/255, so the picker gives a consistent reading for all fifteen.
-// The inner stop can only be read off a real card, and the captures cover
-// eleven of the fifteen. The remaining four are derived from the relationship
-// fitted to those eleven -- hue held, saturation x0.889, value moved 0.453 of
-// the way to 1.0 -- which reproduces the measured inners to within 19/255 on
-// the worst channel. Measured beats derived wherever both exist, hence the
-// mixture below.
+// The inner stop can only be read off a real card, and there is now a capture of
+// all fifteen.
+//
+// Four of them (orange, gold, sage, tan) come from JPEGs rather than PNGs. Their
+// outer stops still come from the picker, and their inner stops were derived by
+// applying each card's own measured outer-to-inner transform to that exact
+// outer, so the compression's colour shift largely cancels rather than being
+// baked in. Orange needed one more step: its capture is shifted enough that the
+// outer read 24/255 off the picker and the saturation ratio came out at 0.974,
+// outside the 0.78-0.94 the other fourteen span, so it takes the fitted ratio
+// and keeps only its own (unremarkable) value term.
 //
 // Health, not Shortcuts, is the reference for the card's *shape*: see button.tsx
 // for the padding and icon metrics that keep the cards at Health's compact
@@ -24,10 +29,10 @@ export type Gradient = [string, string]
 
 // measured: Directory
 export const redGradient: Gradient = ['#ed7c85', '#e66369']
-// derived
-export const orangeGradient: Gradient = ['#f5957a', '#ed8467']
-// derived
-export const goldGradient: Gradient = ['#f4b46e', '#eba65a']
+// measured: Important Contacts
+export const orangeGradient: Gradient = ['#f9977c', '#ed8467']
+// measured: Important Contacts
+export const goldGradient: Gradient = ['#f8bb77', '#eba65a']
 // measured: SIS, Save To Reader
 export const yellowGradient: Gradient = ['#f8d94f', '#f0bd42']
 // measured: Menus, Code Remotely
@@ -48,7 +53,7 @@ export const violetGradient: Gradient = ['#ca93f6', '#ac76dc']
 export const pinkGradient: Gradient = ['#f1a6ed', '#e58bcd']
 // measured: Credit Cards
 export const grayGradient: Gradient = ['#9fa7b2', '#828a95']
-// derived
-export const sageGradient: Gradient = ['#b5cdb7', '#8ea490']
-// derived
-export const tanGradient: Gradient = ['#cdb394', '#a38c70']
+// measured: Campus Dictionary
+export const sageGradient: Gradient = ['#acc2ae', '#8ea490']
+// measured: Map
+export const tanGradient: Gradient = ['#c3ac90', '#a38c70']

--- a/modules/colors/gradients.ts
+++ b/modules/colors/gradients.ts
@@ -4,15 +4,18 @@
 /// top/bottom or left/right pair.
 ///
 /// Both are Display P3, which is the space the screenshots they were sampled
-/// from are in and the space Shortcuts draws them in. They are *not* sRGB hex
-/// and must not be handed to anything that will read them as such: pass them
-/// through `displayP3` first. See display-p3.ts.
+/// from are in and the space Shortcuts draws them in, and both are written in
+/// the CSS Color 4 syntax that says so. Writing them as hex would make a P3
+/// value indistinguishable in source from an sRGB one, and passing one where
+/// the other is expected renders the wrong colour without erroring. Pass them
+/// through `displayP3` to get something a view can take. See display-p3.ts.
 export type Gradient = [string, string]
 
 // MARK: gradients
 //
-// Sampled from the Shortcuts cards themselves, on an iPhone 14 Pro. Every value
-// below is Display P3 -- see the note on Gradient.
+// Sampled from the Shortcuts cards themselves, on an iPhone 14 Pro. The
+// components are eighth-bit readings off those screenshots, written as
+// fractions -- so 0.9294 is 237/255, not a value measured to four places.
 //
 // The outer stop of every colour is the bottom edge of that colour's swatch in
 // the Shortcuts colour picker: measured against eight real cards, the two agree
@@ -35,32 +38,77 @@ export type Gradient = [string, string]
 // height.
 
 // measured: Directory
-export const redGradient: Gradient = ['#ed7c85', '#e66369']
+export const redGradient: Gradient = [
+	'color(display-p3 0.9294 0.4863 0.5216)',
+	'color(display-p3 0.902 0.3882 0.4118)',
+]
 // measured: Important Contacts
-export const orangeGradient: Gradient = ['#f1a083', '#ed8467']
+export const orangeGradient: Gradient = [
+	'color(display-p3 0.9451 0.6275 0.5137)',
+	'color(display-p3 0.9294 0.5176 0.4039)',
+]
 // measured: Important Contacts
-export const goldGradient: Gradient = ['#f8bb77', '#eba65a']
+export const goldGradient: Gradient = [
+	'color(display-p3 0.9725 0.7333 0.4667)',
+	'color(display-p3 0.9216 0.651 0.3529)',
+]
 // measured: SIS, Save To Reader
-export const yellowGradient: Gradient = ['#f8d94f', '#f0bd42']
+export const yellowGradient: Gradient = [
+	'color(display-p3 0.9725 0.851 0.3098)',
+	'color(display-p3 0.9412 0.7412 0.2588)',
+]
 // measured: Menus, Code Remotely
-export const greenGradient: Gradient = ['#7fe07e', '#67c263']
+export const greenGradient: Gradient = [
+	'color(display-p3 0.498 0.8784 0.4941)',
+	'color(display-p3 0.4039 0.7608 0.3882)',
+]
 // measured: Repeat with Each, GIF to MP4
-export const mintGradient: Gradient = ['#6ae6c7', '#5bc8a9']
+export const mintGradient: Gradient = [
+	'color(display-p3 0.4157 0.902 0.7804)',
+	'color(display-p3 0.3569 0.7843 0.6627)',
+]
 // measured: Streaming Media
-export const lightBlueGradient: Gradient = ['#5dcbf9', '#4eadf0']
+export const lightBlueGradient: Gradient = [
+	'color(display-p3 0.3647 0.7961 0.9765)',
+	'color(display-p3 0.3059 0.6784 0.9412)',
+]
 // measured: Hours
-export const blueGradient: Gradient = ['#539ef7', '#3c81f5']
+export const blueGradient: Gradient = [
+	'color(display-p3 0.3255 0.6196 0.9686)',
+	'color(display-p3 0.2353 0.5059 0.9608)',
+]
 // measured: Map
-export const indigoGradient: Gradient = ['#6079d6', '#445db8']
+export const indigoGradient: Gradient = [
+	'color(display-p3 0.3765 0.4745 0.8392)',
+	'color(display-p3 0.2667 0.3647 0.7216)',
+]
 // measured: News, Copy Article
-export const purpleGradient: Gradient = ['#966bd6', '#7950b7']
+export const purpleGradient: Gradient = [
+	'color(display-p3 0.5882 0.4196 0.8392)',
+	'color(display-p3 0.4745 0.3137 0.7176)',
+]
 // measured: Encode Media
-export const violetGradient: Gradient = ['#ca93f6', '#ac76dc']
+export const violetGradient: Gradient = [
+	'color(display-p3 0.7922 0.5765 0.9647)',
+	'color(display-p3 0.6745 0.4627 0.8627)',
+]
 // measured: Calendar
-export const pinkGradient: Gradient = ['#f1a6ed', '#e58bcd']
+export const pinkGradient: Gradient = [
+	'color(display-p3 0.9451 0.651 0.9294)',
+	'color(display-p3 0.898 0.5451 0.8039)',
+]
 // measured: Credit Cards
-export const grayGradient: Gradient = ['#9fa7b2', '#828a95']
+export const grayGradient: Gradient = [
+	'color(display-p3 0.6235 0.6549 0.698)',
+	'color(display-p3 0.5098 0.5412 0.5843)',
+]
 // measured: Campus Dictionary
-export const sageGradient: Gradient = ['#acc2ae', '#8ea490']
+export const sageGradient: Gradient = [
+	'color(display-p3 0.6745 0.7608 0.6824)',
+	'color(display-p3 0.5569 0.6431 0.5647)',
+]
 // measured: Map
-export const tanGradient: Gradient = ['#c1aa8e', '#a38c70']
+export const tanGradient: Gradient = [
+	'color(display-p3 0.7569 0.6667 0.5569)',
+	'color(display-p3 0.6392 0.549 0.4392)',
+]

--- a/modules/colors/gradients.ts
+++ b/modules/colors/gradients.ts
@@ -18,101 +18,92 @@ export type Gradient = [string, string]
 // fractions -- so 0.9294 is 237/255, not a value measured to four places.
 //
 // The outer stop of every colour is the bottom edge of that colour's swatch in
-// the Shortcuts colour picker: measured against eight real cards, the two agree
-// to within 3/255, so the picker gives a consistent reading for all fifteen.
-// The inner stop can only be read off a real card, and there is now a capture of
-// all fifteen.
+// the Shortcuts colour picker, which agrees with a real card to within 3/255.
+// The inner stop can only be read off a card, so each names the shortcut it was
+// read from -- one shortcut carried several colours across the captures, so it
+// is named more than once.
 //
-// Every inner stop is now read off a lossless capture. Four of them were
-// derived from JPEGs first, by applying each card's own measured
-// outer-to-inner transform to the picker's outer so the compression's colour
-// shift would cancel rather than being baked in, and re-measuring them since
-// says how well that worked: sage came back identical and tan within 2/255,
-// while orange and gold each moved by 9. The two that moved were the two whose
-// captures were shifted enough to throw their saturation ratios out of the
-// range the others span -- which is the signal to distrust a reading, if this
-// ever has to be done from a JPEG again.
-//
-// The card named against each colour is whichever shortcut happened to be that
-// colour when it was captured, and is there to say where the reading came from
-// rather than to describe the app. One of them was recoloured between captures,
-// so it is named more than once.
+// A colour sampled from a lossy capture cannot be trusted directly, but the
+// ratio between its two stops largely can: applying a card's own outer-to-inner
+// transform to the picker's exact outer cancels most of the shift. The signal
+// that a capture is too far gone for even that is a saturation ratio outside
+// the 0.78-0.94 the fifteen span.
 //
 // Health, not Shortcuts, is the reference for the card's *shape*: see button.tsx
 // for the padding and icon metrics that keep the cards at Health's compact
 // height.
 
-// measured: Directory
+// read from Directory
 export const redGradient: Gradient = [
 	'color(display-p3 0.9294 0.4863 0.5216)',
 	'color(display-p3 0.902 0.3882 0.4118)',
 ]
-// measured: Important Contacts
+// read from Important Contacts
 export const orangeGradient: Gradient = [
 	'color(display-p3 0.9451 0.6275 0.5137)',
 	'color(display-p3 0.9294 0.5176 0.4039)',
 ]
-// measured: Map
+// read from Map
 export const goldGradient: Gradient = [
 	'color(display-p3 0.9608 0.7686 0.451)',
 	'color(display-p3 0.9216 0.651 0.3529)',
 ]
-// measured: SIS, Save To Reader
+// read from SIS, Save To Reader
 export const yellowGradient: Gradient = [
 	'color(display-p3 0.9725 0.851 0.3098)',
 	'color(display-p3 0.9412 0.7412 0.2588)',
 ]
-// measured: Menus, Code Remotely
+// read from Menus, Code Remotely
 export const greenGradient: Gradient = [
 	'color(display-p3 0.498 0.8784 0.4941)',
 	'color(display-p3 0.4039 0.7608 0.3882)',
 ]
-// measured: Repeat with Each, GIF to MP4
+// read from Repeat with Each, GIF to MP4
 export const mintGradient: Gradient = [
 	'color(display-p3 0.4157 0.902 0.7804)',
 	'color(display-p3 0.3569 0.7843 0.6627)',
 ]
-// measured: Streaming Media
+// read from Streaming Media
 export const lightBlueGradient: Gradient = [
 	'color(display-p3 0.3647 0.7961 0.9765)',
 	'color(display-p3 0.3059 0.6784 0.9412)',
 ]
-// measured: Hours
+// read from Hours
 export const blueGradient: Gradient = [
 	'color(display-p3 0.3255 0.6196 0.9686)',
 	'color(display-p3 0.2353 0.5059 0.9608)',
 ]
-// measured: Map
+// read from Map
 export const indigoGradient: Gradient = [
 	'color(display-p3 0.3765 0.4745 0.8392)',
 	'color(display-p3 0.2667 0.3647 0.7216)',
 ]
-// measured: News, Copy Article
+// read from News, Copy Article
 export const purpleGradient: Gradient = [
 	'color(display-p3 0.5882 0.4196 0.8392)',
 	'color(display-p3 0.4745 0.3137 0.7176)',
 ]
-// measured: Encode Media
+// read from Encode Media
 export const violetGradient: Gradient = [
 	'color(display-p3 0.7922 0.5765 0.9647)',
 	'color(display-p3 0.6745 0.4627 0.8627)',
 ]
-// measured: Calendar
+// read from Calendar
 export const pinkGradient: Gradient = [
 	'color(display-p3 0.9451 0.651 0.9294)',
 	'color(display-p3 0.898 0.5451 0.8039)',
 ]
-// measured: Credit Cards
+// read from Credit Cards
 export const grayGradient: Gradient = [
 	'color(display-p3 0.6235 0.6549 0.698)',
 	'color(display-p3 0.5098 0.5412 0.5843)',
 ]
-// measured: Campus Dictionary
+// read from Campus Dictionary
 export const sageGradient: Gradient = [
 	'color(display-p3 0.6745 0.7608 0.6824)',
 	'color(display-p3 0.5569 0.6431 0.5647)',
 ]
-// measured: Map
+// read from Map
 export const tanGradient: Gradient = [
 	'color(display-p3 0.7569 0.6667 0.5569)',
 	'color(display-p3 0.6392 0.549 0.4392)',

--- a/modules/colors/gradients.ts
+++ b/modules/colors/gradients.ts
@@ -23,15 +23,20 @@ export type Gradient = [string, string]
 // The inner stop can only be read off a real card, and there is now a capture of
 // all fifteen.
 //
-// Gold is the one colour whose only capture is a JPEG. Its outer stop still
-// comes from the picker, and its inner was derived by applying that card's own
-// measured outer-to-inner transform to the exact outer, so the compression's
-// colour shift largely cancels rather than being baked in. Orange, sage and tan
-// were read the same way at first and have since been re-measured from a
-// lossless capture: sage came back identical and tan within 2/255, which is the
-// best evidence available that the technique holds. Orange moved by 9 -- its
-// JPEG was shifted enough to throw the saturation ratio out of family -- so the
-// direct reading replaces it.
+// Every inner stop is now read off a lossless capture. Four of them were
+// derived from JPEGs first, by applying each card's own measured
+// outer-to-inner transform to the picker's outer so the compression's colour
+// shift would cancel rather than being baked in, and re-measuring them since
+// says how well that worked: sage came back identical and tan within 2/255,
+// while orange and gold each moved by 9. The two that moved were the two whose
+// captures were shifted enough to throw their saturation ratios out of the
+// range the others span -- which is the signal to distrust a reading, if this
+// ever has to be done from a JPEG again.
+//
+// The card named against each colour is whichever shortcut happened to be that
+// colour when it was captured, and is there to say where the reading came from
+// rather than to describe the app. One of them was recoloured between captures,
+// so it is named more than once.
 //
 // Health, not Shortcuts, is the reference for the card's *shape*: see button.tsx
 // for the padding and icon metrics that keep the cards at Health's compact
@@ -47,9 +52,9 @@ export const orangeGradient: Gradient = [
 	'color(display-p3 0.9451 0.6275 0.5137)',
 	'color(display-p3 0.9294 0.5176 0.4039)',
 ]
-// measured: Important Contacts
+// measured: Map
 export const goldGradient: Gradient = [
-	'color(display-p3 0.9725 0.7333 0.4667)',
+	'color(display-p3 0.9608 0.7686 0.451)',
 	'color(display-p3 0.9216 0.651 0.3529)',
 ]
 // measured: SIS, Save To Reader

--- a/modules/colors/gradients.ts
+++ b/modules/colors/gradients.ts
@@ -19,9 +19,8 @@ export type Gradient = [string, string]
 //
 // The outer stop of every colour is the bottom edge of that colour's swatch in
 // the Shortcuts colour picker, which agrees with a real card to within 3/255.
-// The inner stop can only be read off a card, so each names the shortcut it was
-// read from -- one shortcut carried several colours across the captures, so it
-// is named more than once.
+// The inner stop can only be read off a card, at the top edge's centre where
+// the radial starts.
 //
 // A colour sampled from a lossy capture cannot be trusted directly, but the
 // ratio between its two stops largely can: applying a card's own outer-to-inner
@@ -33,77 +32,62 @@ export type Gradient = [string, string]
 // for the padding and icon metrics that keep the cards at Health's compact
 // height.
 
-// read from Directory
 export const redGradient: Gradient = [
 	'color(display-p3 0.9294 0.4863 0.5216)',
 	'color(display-p3 0.902 0.3882 0.4118)',
 ]
-// read from Important Contacts
 export const orangeGradient: Gradient = [
 	'color(display-p3 0.9451 0.6275 0.5137)',
 	'color(display-p3 0.9294 0.5176 0.4039)',
 ]
-// read from Map
 export const goldGradient: Gradient = [
 	'color(display-p3 0.9608 0.7686 0.451)',
 	'color(display-p3 0.9216 0.651 0.3529)',
 ]
-// read from SIS, Save To Reader
 export const yellowGradient: Gradient = [
 	'color(display-p3 0.9725 0.851 0.3098)',
 	'color(display-p3 0.9412 0.7412 0.2588)',
 ]
-// read from Menus, Code Remotely
 export const greenGradient: Gradient = [
 	'color(display-p3 0.498 0.8784 0.4941)',
 	'color(display-p3 0.4039 0.7608 0.3882)',
 ]
-// read from Repeat with Each, GIF to MP4
 export const mintGradient: Gradient = [
 	'color(display-p3 0.4157 0.902 0.7804)',
 	'color(display-p3 0.3569 0.7843 0.6627)',
 ]
-// read from Streaming Media
 export const lightBlueGradient: Gradient = [
 	'color(display-p3 0.3647 0.7961 0.9765)',
 	'color(display-p3 0.3059 0.6784 0.9412)',
 ]
-// read from Hours
 export const blueGradient: Gradient = [
 	'color(display-p3 0.3255 0.6196 0.9686)',
 	'color(display-p3 0.2353 0.5059 0.9608)',
 ]
-// read from Map
 export const indigoGradient: Gradient = [
 	'color(display-p3 0.3765 0.4745 0.8392)',
 	'color(display-p3 0.2667 0.3647 0.7216)',
 ]
-// read from News, Copy Article
 export const purpleGradient: Gradient = [
 	'color(display-p3 0.5882 0.4196 0.8392)',
 	'color(display-p3 0.4745 0.3137 0.7176)',
 ]
-// read from Encode Media
 export const violetGradient: Gradient = [
 	'color(display-p3 0.7922 0.5765 0.9647)',
 	'color(display-p3 0.6745 0.4627 0.8627)',
 ]
-// read from Calendar
 export const pinkGradient: Gradient = [
 	'color(display-p3 0.9451 0.651 0.9294)',
 	'color(display-p3 0.898 0.5451 0.8039)',
 ]
-// read from Credit Cards
 export const grayGradient: Gradient = [
 	'color(display-p3 0.6235 0.6549 0.698)',
 	'color(display-p3 0.5098 0.5412 0.5843)',
 ]
-// read from Campus Dictionary
 export const sageGradient: Gradient = [
 	'color(display-p3 0.6745 0.7608 0.6824)',
 	'color(display-p3 0.5569 0.6431 0.5647)',
 ]
-// read from Map
 export const tanGradient: Gradient = [
 	'color(display-p3 0.7569 0.6667 0.5569)',
 	'color(display-p3 0.6392 0.549 0.4392)',

--- a/modules/colors/gradients.ts
+++ b/modules/colors/gradients.ts
@@ -20,14 +20,15 @@ export type Gradient = [string, string]
 // The inner stop can only be read off a real card, and there is now a capture of
 // all fifteen.
 //
-// Four of them (orange, gold, sage, tan) come from JPEGs rather than PNGs. Their
-// outer stops still come from the picker, and their inner stops were derived by
-// applying each card's own measured outer-to-inner transform to that exact
-// outer, so the compression's colour shift largely cancels rather than being
-// baked in. Orange needed one more step: its capture is shifted enough that the
-// outer read 24/255 off the picker and the saturation ratio came out at 0.974,
-// outside the 0.78-0.94 the other fourteen span, so it takes the fitted ratio
-// and keeps only its own (unremarkable) value term.
+// Gold is the one colour whose only capture is a JPEG. Its outer stop still
+// comes from the picker, and its inner was derived by applying that card's own
+// measured outer-to-inner transform to the exact outer, so the compression's
+// colour shift largely cancels rather than being baked in. Orange, sage and tan
+// were read the same way at first and have since been re-measured from a
+// lossless capture: sage came back identical and tan within 2/255, which is the
+// best evidence available that the technique holds. Orange moved by 9 -- its
+// JPEG was shifted enough to throw the saturation ratio out of family -- so the
+// direct reading replaces it.
 //
 // Health, not Shortcuts, is the reference for the card's *shape*: see button.tsx
 // for the padding and icon metrics that keep the cards at Health's compact
@@ -36,7 +37,7 @@ export type Gradient = [string, string]
 // measured: Directory
 export const redGradient: Gradient = ['#ed7c85', '#e66369']
 // measured: Important Contacts
-export const orangeGradient: Gradient = ['#f9977c', '#ed8467']
+export const orangeGradient: Gradient = ['#f1a083', '#ed8467']
 // measured: Important Contacts
 export const goldGradient: Gradient = ['#f8bb77', '#eba65a']
 // measured: SIS, Save To Reader
@@ -62,4 +63,4 @@ export const grayGradient: Gradient = ['#9fa7b2', '#828a95']
 // measured: Campus Dictionary
 export const sageGradient: Gradient = ['#acc2ae', '#8ea490']
 // measured: Map
-export const tanGradient: Gradient = ['#c3ac90', '#a38c70']
+export const tanGradient: Gradient = ['#c1aa8e', '#a38c70']

--- a/modules/colors/gradients.ts
+++ b/modules/colors/gradients.ts
@@ -1,20 +1,54 @@
+/// A card's gradient, as [inner, outer]. Shortcuts paints its cards with a
+/// radial gradient anchored at the top edge's centre, so these are the colour
+/// at that point and the colour it has faded to by the far corners -- not a
+/// top/bottom or left/right pair.
 export type Gradient = [string, string]
 
 // MARK: gradients
-// Pixel-sampled from the iOS system list-color picker (Reminders app,
-// symbol color grid) -- each pair is that swatch's top -> bottom color.
-export const redGradient: Gradient = ['#dd6e6d', '#db5e5e']
-export const orangeGradient: Gradient = ['#eb896c', '#eb7d5c']
-export const goldGradient: Gradient = ['#e8a95e', '#e69d4e']
-export const yellowGradient: Gradient = ['#e1c341', '#dfbe3f']
-export const greenGradient: Gradient = ['#63c067', '#59b957']
-export const mintGradient: Gradient = ['#5cc6ac', '#58c1a3']
-export const lightBlueGradient: Gradient = ['#85c5e9', '#77bfe4']
-export const blueGradient: Gradient = ['#4991f6', '#3d84f6']
-export const indigoGradient: Gradient = ['#576ebf', '#445db8']
-export const purpleGradient: Gradient = ['#7d59b1', '#6e46a9']
-export const violetGradient: Gradient = ['#aa77d4', '#9f69cf']
-export const pinkGradient: Gradient = ['#dc88c8', '#d87bc0']
-export const grayGradient: Gradient = ['#889199', '#7b838e']
-export const sageGradient: Gradient = ['#9aad9c', '#8ea490']
-export const tanGradient: Gradient = ['#b9a58c', '#b09b7e']
+//
+// Sampled from the Shortcuts cards themselves, on an iPhone 14 Pro.
+//
+// The outer stop of every colour is the bottom edge of that colour's swatch in
+// the Shortcuts colour picker: measured against eight real cards, the two agree
+// to within 3/255, so the picker gives a consistent reading for all fifteen.
+// The inner stop can only be read off a real card, and the captures cover
+// eleven of the fifteen. The remaining four are derived from the relationship
+// fitted to those eleven -- hue held, saturation x0.889, value moved 0.453 of
+// the way to 1.0 -- which reproduces the measured inners to within 19/255 on
+// the worst channel. Measured beats derived wherever both exist, hence the
+// mixture below.
+//
+// Health, not Shortcuts, is the reference for the card's *shape*: see button.tsx
+// for the padding and icon metrics that keep the cards at Health's compact
+// height.
+
+// measured: Directory
+export const redGradient: Gradient = ['#ed7c85', '#e66369']
+// derived
+export const orangeGradient: Gradient = ['#f5957a', '#ed8467']
+// derived
+export const goldGradient: Gradient = ['#f4b46e', '#eba65a']
+// measured: SIS, Save To Reader
+export const yellowGradient: Gradient = ['#f8d94f', '#f0bd42']
+// measured: Menus, Code Remotely
+export const greenGradient: Gradient = ['#7fe07e', '#67c263']
+// measured: Repeat with Each, GIF to MP4
+export const mintGradient: Gradient = ['#6ae6c7', '#5bc8a9']
+// measured: Streaming Media
+export const lightBlueGradient: Gradient = ['#5dcbf9', '#4eadf0']
+// measured: Hours
+export const blueGradient: Gradient = ['#539ef7', '#3c81f5']
+// measured: Map
+export const indigoGradient: Gradient = ['#6079d6', '#445db8']
+// measured: News, Copy Article
+export const purpleGradient: Gradient = ['#966bd6', '#7950b7']
+// measured: Encode Media
+export const violetGradient: Gradient = ['#ca93f6', '#ac76dc']
+// measured: Calendar
+export const pinkGradient: Gradient = ['#f1a6ed', '#e58bcd']
+// measured: Credit Cards
+export const grayGradient: Gradient = ['#9fa7b2', '#828a95']
+// derived
+export const sageGradient: Gradient = ['#b5cdb7', '#8ea490']
+// derived
+export const tanGradient: Gradient = ['#cdb394', '#a38c70']

--- a/modules/colors/gradients.ts
+++ b/modules/colors/gradients.ts
@@ -2,11 +2,17 @@
 /// radial gradient anchored at the top edge's centre, so these are the colour
 /// at that point and the colour it has faded to by the far corners -- not a
 /// top/bottom or left/right pair.
+///
+/// Both are Display P3, which is the space the screenshots they were sampled
+/// from are in and the space Shortcuts draws them in. They are *not* sRGB hex
+/// and must not be handed to anything that will read them as such: pass them
+/// through `displayP3` first. See display-p3.ts.
 export type Gradient = [string, string]
 
 // MARK: gradients
 //
-// Sampled from the Shortcuts cards themselves, on an iPhone 14 Pro.
+// Sampled from the Shortcuts cards themselves, on an iPhone 14 Pro. Every value
+// below is Display P3 -- see the note on Gradient.
 //
 // The outer stop of every colour is the bottom edge of that colour's swatch in
 // the Shortcuts colour picker: measured against eight real cards, the two agree

--- a/modules/colors/gradients.ts
+++ b/modules/colors/gradients.ts
@@ -1,25 +1,20 @@
 export type Gradient = [string, string]
 
 // MARK: gradients
-export const redToPurple: Gradient = ['rgb(249,64,77)', 'rgb(217,37,111)']
-export const orangeToRed: Gradient = ['rgb(250,120,37)', 'rgb(242,38,83)']
-export const yellowToGoldDark: Gradient = ['rgb(234,185,29)', 'rgb(226,123,19)']
-export const yellowToGoldLight: Gradient = ['rgb(238,209,0)', 'rgb(237,158,0)']
-export const yellowToGoldMid: Gradient = ['rgb(238,209,0)', 'rgb(234,185,29)']
-export const grassToLime: Gradient = ['rgb(125,209,24)', 'rgb(88,186,34)']
-export const seafoamToGrass: Gradient = ['rgb(15,201,121)', 'rgb(58,181,42)']
-export const tealToSeafoam: Gradient = ['rgb(3,220,156)', 'rgb(19,188,156)']
-export const lightBlueToBlueLight: Gradient = [
-	'rgb(1,194,199)',
-	'rgb(10,158,196)',
-]
-export const lightBlueToBlueDark: Gradient = [
-	'rgb(5,187,219)',
-	'rgb(25,145,234)',
-]
-export const darkBlueToIndigo: Gradient = ['rgb(48,112,228)', 'rgb(95,72,229)']
-export const purpleToIndigo: Gradient = ['rgb(129,88,252)', 'rgb(92,80,236)']
-export const magentaToPurple: Gradient = ['rgb(213,69,196)', 'rgb(160,50,230)']
-export const pinkToHotpink: Gradient = ['rgb(248,102,149)', 'rgb(209,44,159)']
-export const grayToDarkGray: Gradient = ['rgb(118,134,157)', 'rgb(85,96,124)']
-export const navyToNavy: Gradient = ['rgb(32,67,107)', 'rgb(0,48,104)']
+// Pixel-sampled from the iOS system list-color picker (Reminders app,
+// symbol color grid) -- each pair is that swatch's top -> bottom color.
+export const redGradient: Gradient = ['#dd6e6d', '#db5e5e']
+export const orangeGradient: Gradient = ['#eb896c', '#eb7d5c']
+export const goldGradient: Gradient = ['#e8a95e', '#e69d4e']
+export const yellowGradient: Gradient = ['#e1c341', '#dfbe3f']
+export const greenGradient: Gradient = ['#63c067', '#59b957']
+export const mintGradient: Gradient = ['#5cc6ac', '#58c1a3']
+export const lightBlueGradient: Gradient = ['#85c5e9', '#77bfe4']
+export const blueGradient: Gradient = ['#4991f6', '#3d84f6']
+export const indigoGradient: Gradient = ['#576ebf', '#445db8']
+export const purpleGradient: Gradient = ['#7d59b1', '#6e46a9']
+export const violetGradient: Gradient = ['#aa77d4', '#9f69cf']
+export const pinkGradient: Gradient = ['#dc88c8', '#d87bc0']
+export const grayGradient: Gradient = ['#889199', '#7b838e']
+export const sageGradient: Gradient = ['#9aad9c', '#8ea490']
+export const tanGradient: Gradient = ['#b9a58c', '#b09b7e']

--- a/modules/colors/index.ts
+++ b/modules/colors/index.ts
@@ -1,5 +1,6 @@
 export {firstReadable} from './util'
 
 export * from './colors'
+export * from './display-p3'
 export * from './gradients'
 export * from './platform'

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -1,12 +1,21 @@
 import * as React from 'react'
-import {Button, Text, VStack} from '@expo/ui/swift-ui'
+import {useColorScheme} from 'react-native'
+import {
+	Button,
+	RoundedRectangle,
+	Spacer,
+	Text,
+	VStack,
+	ZStack,
+} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
-	background,
+	aspectRatio,
 	buttonStyle,
 	contentShape,
 	font,
 	foregroundColor,
+	foregroundStyle,
 	frame,
 	padding,
 	shapes,
@@ -21,9 +30,16 @@ type Props = {
 }
 
 export const CELL_MARGIN = 10
-const CELL_RADIUS = 17
-const cellVerticalPadding = 8
-const cellHorizontalPadding = 4
+
+/// Matched from the Apple Health category-card screenshot: a 525x346px
+/// (3x) card is a ~1.517:1 width:height ratio, with a corner radius of
+/// roughly 23% of the card's height (~80px at 3x, on a 346px-tall card).
+/// The radius is expressed as a point value tuned for a typical two-column
+/// card width on a standard iPhone, since @expo/ui has no way to compute a
+/// modifier value from the runtime-resolved card size.
+const CELL_ASPECT_RATIO = 1.517
+const CELL_RADIUS = 27
+const cellPadding = 16
 
 /// SwiftUI has no "fill the available width" constant reachable from JS, so we
 /// cap the frame at a width no phone reaches and let the stack divide the space.
@@ -44,13 +60,6 @@ const ICON_SIZE = 32
 const ICON_TEXT_STYLE = 'title'
 const TITLE_TEXT_STYLE = 'subheadline'
 
-/// `layer.cornerRadius` on iOS defaults to circular corners, which is what the
-/// React Native `borderRadius` produced.
-const cellShape = shapes.roundedRectangle({
-	cornerRadius: CELL_RADIUS,
-	roundedCornerStyle: 'circular',
-})
-
 /// `view.icon` comes from the view data rather than from a literal, so a typo
 /// or a rename upstream reaches this as an undefined lookup. Fail with a
 /// message naming the icon instead of letting String.fromCodePoint throw a
@@ -67,17 +76,18 @@ function entypoGlyph(name: keyof typeof EntypoGlyphs): string {
 }
 
 export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
+	let scheme = useColorScheme()
 	let foreground =
-		view.foreground === 'light'
-			? homescreenForegroundLight
-			: homescreenForegroundDark
+		scheme === 'dark' ? homescreenForegroundDark : homescreenForegroundLight
 	let glyph = entypoGlyph(view.icon)
+	let [gradientTop, gradientBottom] = view.gradient
 
 	return (
 		<Button
 			modifiers={[
 				buttonStyle('plain'),
 				frame({maxWidth: FILL_WIDTH}),
+				aspectRatio({ratio: CELL_ASPECT_RATIO, contentMode: 'fit'}),
 				accessibilityLabel(view.title),
 			]}
 			onPress={onPress}
@@ -86,40 +96,56 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 			    SwiftUI derives a button's tappable region from its label, so
 			    putting contentShape on the Button leaves only the icon and title
 			    tappable rather than the whole tile. */}
-			<VStack
+			<ZStack
+				alignment="topLeading"
 				modifiers={[
-					padding({
-						top: cellVerticalPadding,
-						bottom: cellVerticalPadding / 2,
-						horizontal: cellHorizontalPadding,
-					}),
-					frame({maxWidth: FILL_WIDTH}),
-					background(view.tint, cellShape),
-					contentShape(cellShape),
-				]}
-				spacing={0}
-			>
-				<Text
-					modifiers={[
-						font({
-							family: ICON_FONT_FAMILY,
-							size: ICON_SIZE,
-							textStyle: ICON_TEXT_STYLE,
+					contentShape(
+						shapes.roundedRectangle({
+							cornerRadius: CELL_RADIUS,
+							roundedCornerStyle: 'continuous',
 						}),
-						foregroundColor(foreground),
-					]}
-				>
-					{glyph}
-				</Text>
-				<Text
+					),
+				]}
+			>
+				<RoundedRectangle
+					cornerRadius={CELL_RADIUS}
 					modifiers={[
-						font({textStyle: TITLE_TEXT_STYLE}),
-						foregroundColor(foreground),
+						foregroundStyle({
+							type: 'linearGradient',
+							colors: [gradientTop, gradientBottom],
+							startPoint: {x: 0.5, y: 0},
+							endPoint: {x: 0.5, y: 1},
+						}),
 					]}
+				/>
+				<VStack
+					alignment="leading"
+					modifiers={[padding({all: cellPadding})]}
+					spacing={4}
 				>
-					{view.title}
-				</Text>
-			</VStack>
+					<Text
+						modifiers={[
+							font({
+								family: ICON_FONT_FAMILY,
+								size: ICON_SIZE,
+								textStyle: ICON_TEXT_STYLE,
+							}),
+							foregroundColor(foreground),
+						]}
+					>
+						{glyph}
+					</Text>
+					<Spacer />
+					<Text
+						modifiers={[
+							font({textStyle: TITLE_TEXT_STYLE}),
+							foregroundColor(foreground),
+						]}
+					>
+						{view.title}
+					</Text>
+				</VStack>
+			</ZStack>
 		</Button>
 	)
 }

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -18,6 +18,7 @@ import {
 	frame,
 	imageScale,
 	padding,
+	shadow,
 	shapes,
 } from '@expo/ui/swift-ui/modifiers'
 import {displayP3} from '@frogpond/colors'
@@ -54,6 +55,14 @@ const CELL_RADIUS = 27
 /// size because the alternative is plumbing the rendered card's bounds back out
 /// to JS, and a few points either way only shifts where the fade bottoms out.
 const CELL_GRADIENT_RADIUS = 129
+/// Shortcuts tints a card's shadow with the card's own colour rather than
+/// using a neutral one: measured below a gold card, the page reads #fff2cb
+/// against a neutral #fbfcf7 four pixels out and stays tinted about thirty
+/// pixels down. That is roughly a fifth of the card's colour once blurred,
+/// which this radius reaches from a rather stronger source alpha.
+const CELL_SHADOW_RADIUS = 8
+const CELL_SHADOW_Y = 2
+const CELL_SHADOW_ALPHA = 0.4
 const cellPadding = 16
 /// The vertical insets are not symmetric with the horizontal one, nor with each
 /// other. Both are written as whole pixels at 3x because that is how they were
@@ -144,6 +153,20 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 				<RoundedRectangle
 					cornerRadius={CELL_RADIUS}
 					modifiers={[
+						// Only in light mode. A shadow tinted with the card's own colour
+						// has nothing to darken against a black background, so it reads
+						// as the card glowing rather than sitting above the page --
+						// measured on Shortcuts' own dark grid, the gap between cards is
+						// #000000 to the pixel, with no halo at all.
+						...(dark
+							? []
+							: [
+									shadow({
+										radius: CELL_SHADOW_RADIUS,
+										y: CELL_SHADOW_Y,
+										color: displayP3(gradientOuter, CELL_SHADOW_ALPHA),
+									}),
+								]),
 						foregroundStyle({
 							type: 'radialGradient',
 							colors: [displayP3(gradientInner), displayP3(gradientOuter)],

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -19,6 +19,7 @@ import {
 	padding,
 	shapes,
 } from '@expo/ui/swift-ui/modifiers'
+import {displayP3} from '@frogpond/colors'
 import type {ViewType} from '../views'
 import {
 	homescreenIconDark,
@@ -138,7 +139,7 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 					modifiers={[
 						foregroundStyle({
 							type: 'radialGradient',
-							colors: [gradientInner, gradientOuter],
+							colors: [displayP3(gradientInner), displayP3(gradientOuter)],
 							center: {x: 0.5, y: 0},
 							startRadius: 0,
 							endRadius: CELL_GRADIENT_RADIUS,

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -93,12 +93,10 @@ const ICON_BOX_HEIGHT = 86 / 3
 /// 17pt semibold, which is what Health's card titles measure at every text size
 /// captured.
 ///
-/// Titles have to fit on one line. Health wraps to two and grows the card to
-/// suit, but this version of @expo/ui's Text doesn't honor lineLimit(2) here
-/// whatever frame and multilineTextAlignment modifiers it's given, so anything
-/// too long truncates with an ellipsis instead. Every current title fits at the
-/// default text size; a longer one added later will need shortening rather than
-/// a smaller font, which would break the match with Health.
+/// Long titles wrap to a second line and the row grows to fit, as Health's do.
+/// That only works because the cards sit in a Grid: laid out as two independent
+/// columns they truncated with an ellipsis instead, whatever lineLimit and
+/// multilineTextAlignment modifiers they were given.
 const TITLE_TEXT_STYLE = 'headline'
 
 export function HomeScreenButton({view, onPress}: Props): React.ReactNode {

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -111,9 +111,9 @@ const ICON_BOX_HEIGHT = 86 / 3
 /// captured.
 ///
 /// Long titles wrap to a second line and the row grows to fit, as Health's do.
-/// That only works because the cards sit in a Grid: laid out as two independent
-/// columns they truncated with an ellipsis instead, whatever lineLimit and
-/// multilineTextAlignment modifiers they were given.
+/// That depends on the cards sitting in a Grid: in two independent columns they
+/// truncate to an ellipsis instead, whatever lineLimit and
+/// multilineTextAlignment modifiers they are given.
 const TITLE_TEXT_STYLE = 'headline'
 
 export function HomeScreenButton({view, onPress}: Props): React.ReactNode {

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react'
 import {useColorScheme} from 'react-native'
-import {Button, RoundedRectangle, Text, VStack, ZStack} from '@expo/ui/swift-ui'
+import {
+	Button,
+	Image,
+	RoundedRectangle,
+	Text,
+	VStack,
+	ZStack,
+} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
 	buttonStyle,
@@ -12,16 +19,24 @@ import {
 	padding,
 	shapes,
 } from '@expo/ui/swift-ui/modifiers'
-import EntypoGlyphs from '@react-native-vector-icons/entypo/glyphmaps/Entypo.json'
 import type {ViewType} from '../views'
-import {homescreenForegroundDark, homescreenForegroundLight} from './colors'
+import {
+	homescreenIconDark,
+	homescreenIconLight,
+	homescreenTitleDark,
+	homescreenTitleLight,
+} from './colors'
 
 type Props = {
 	view: ViewType
 	onPress: () => void
 }
 
+/// Gap between cards, both within a column and between the two columns.
 export const CELL_MARGIN = 10
+/// Health's grid uses a wider margin at the screen edge than between cards
+/// (measured: 16pt outer vs. 10pt between cards).
+export const SCREEN_MARGIN = 16
 
 /// Health's category cards size to content, not a fixed aspect ratio --
 /// single-line titles (e.g. "Cycle Tracking", ~94pt tall) render noticeably
@@ -30,64 +45,77 @@ export const CELL_MARGIN = 10
 /// uses one fixed corner radius (~27pt) regardless of card height, not one
 /// proportional to it.
 const CELL_RADIUS = 27
+/// Shortcuts' cards fade from a bright point at the top edge's centre out to
+/// their far corners, so the gradient has to reach the two bottom ones: on a
+/// 393pt screen the card is 175.5 x 94pt, which puts them
+/// hypot(175.5 / 2, 94) ~= 129pt away. It's a constant rather than a measured
+/// size because the alternative is plumbing the rendered card's bounds back out
+/// to JS, and a few points either way only shifts where the fade bottoms out.
+const CELL_GRADIENT_RADIUS = 129
 const cellPadding = 16
+/// The vertical insets are not symmetric with the horizontal one, nor with each
+/// other. Both are written as whole pixels at 3x because that is how they were
+/// measured, against Health's own "Heart" card on the iPhone 14 Pro these
+/// numbers describe.
+///
+/// The top inset is set by the title rather than the icon: the SF Symbol we can
+/// render comes out two pixels shorter than Health's (see ICON_TEXT_STYLE), and
+/// of the two the title is the one worth landing exactly. The bottom inset then
+/// only has to bring the card's own height back to Health's.
+const cellPaddingTop = 56 / 3
+const cellPaddingBottom = 49.5 / 3
 const cellIconTitleGap = 10
 
 /// SwiftUI has no "fill the available width" constant reachable from JS, so we
 /// cap the frame at a width no phone reaches and let the stack divide the space.
 export const FILL_WIDTH = 10_000
 
-/// The Entypo glyphs come from the app-wide font registered through `UIAppFonts`
-/// in Info.plist; SwiftUI addresses it by its family name.
-const ICON_FONT_FAMILY = 'Entypo'
-const ICON_SIZE = 32
-// SwiftUI's .system(size:) is fixed; pairing a size with a text style makes the
-// font scale with Dynamic Type the way the React Native Text it replaced did.
-//
-// For the icon the family is a custom font, so this maps to
-// Font.custom(_:size:relativeTo:) and ICON_SIZE governs the rendered size. For
-// the title there is no family, so the text style's own size wins --
-// headline is 17pt, matched by pixel-comparing rendered title text against
-// Health's own card titles (see button.tsx's git history for the
-// measurement). There is deliberately no title size constant: passing one
-// alongside a text style has no effect, so it would only mislead.
-//
-// At this size, the two longest current titles ("Important Contacts",
-// "Campus Dictionary") truncate with an ellipsis instead of wrapping: this
-// version of @expo/ui's Text doesn't honor lineLimit(2) here regardless of
-// the frame/multilineTextAlignment modifiers tried. Chosen deliberately --
-// pixel-matching Health's title size over avoiding truncation -- pending an
-// @expo/ui fix or update.
+/// Health scales its card icons with Dynamic Type: measured across three text
+/// sizes its Heart glyph runs 72 -> 83 -> 106px while the title runs
+/// 108 -> 129 -> 169px, so the icon is sized by a text style and not by a fixed
+/// point size. @expo/ui ignores `Image`'s `size` prop whenever a `font` modifier
+/// carries a `textStyle`, which leaves the built-in styles as the only scalable
+/// sizes we can ask for.
+///
+/// `title` is the closest of them: it draws the glyph 82x75 against Health's
+/// 83x77. A fixed 28.67pt size matches Health exactly at the default text size,
+/// but is then 23px too small at 130%, so those two pixels buy a card that
+/// tracks Health across the whole Dynamic Type range.
 const ICON_TEXT_STYLE = 'title'
+/// SF Symbols don't share a common height -- across Health's own cards the ink
+/// runs from 77px for `heart.fill` to 104px for its mobility glyph -- so a card
+/// that sizes to its icon comes out a different height for every view. Health
+/// pins the icon into a fixed box instead and centres the glyph in it: measured
+/// across six of its cards the ink heights vary by 27px while their centres all
+/// land within a pixel and a half of each other, and every single-line card is
+/// exactly 283px tall. 86px at 3x puts that centre where Health has it.
+const ICON_BOX_HEIGHT = 86 / 3
+/// 17pt semibold, which is what Health's card titles measure at every text size
+/// captured.
+///
+/// Titles have to fit on one line. Health wraps to two and grows the card to
+/// suit, but this version of @expo/ui's Text doesn't honor lineLimit(2) here
+/// whatever frame and multilineTextAlignment modifiers it's given, so anything
+/// too long truncates with an ellipsis instead. Every current title fits at the
+/// default text size; a longer one added later will need shortening rather than
+/// a smaller font, which would break the match with Health.
 const TITLE_TEXT_STYLE = 'headline'
-
-/// `view.icon` comes from the view data rather than from a literal, so a typo
-/// or a rename upstream reaches this as an undefined lookup. Fail with a
-/// message naming the icon instead of letting String.fromCodePoint throw a
-/// RangeError that takes the whole home screen down with it.
-function entypoGlyph(name: keyof typeof EntypoGlyphs): string {
-	let codepoint: number | undefined = EntypoGlyphs[name]
-	if (typeof codepoint !== 'number') {
-		throw new Error(
-			`Unknown Entypo icon "${String(name)}". It is not in the glyphmap at ` +
-				'@react-native-vector-icons/entypo/glyphmaps/Entypo.json.',
-		)
-	}
-	return String.fromCodePoint(codepoint)
-}
 
 export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 	let scheme = useColorScheme()
-	let foreground =
-		scheme === 'dark' ? homescreenForegroundDark : homescreenForegroundLight
-	let glyph = entypoGlyph(view.icon)
-	let [gradientTop, gradientBottom] = view.gradient
+	let dark = scheme === 'dark'
+	let titleColor = dark ? homescreenTitleDark : homescreenTitleLight
+	let iconColor = dark ? homescreenIconDark : homescreenIconLight
+	let [gradientInner, gradientOuter] = view.gradient
 
 	return (
 		<Button
 			modifiers={[
 				buttonStyle('plain'),
-				frame({maxWidth: FILL_WIDTH}),
+				// maxHeight as well as maxWidth: the row is an HStack, so this is what
+				// makes a card grow to match a taller one beside it instead of
+				// leaving a gap under itself.
+				frame({maxWidth: FILL_WIDTH, maxHeight: FILL_WIDTH}),
 				accessibilityLabel(view.title),
 			]}
 			onPress={onPress}
@@ -111,38 +139,40 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 					cornerRadius={CELL_RADIUS}
 					modifiers={[
 						foregroundStyle({
-							type: 'linearGradient',
-							colors: [gradientTop, gradientBottom],
-							startPoint: {x: 0.5, y: 0},
-							endPoint: {x: 0.5, y: 1},
+							type: 'radialGradient',
+							colors: [gradientInner, gradientOuter],
+							center: {x: 0.5, y: 0},
+							startRadius: 0,
+							endRadius: CELL_GRADIENT_RADIUS,
 						}),
 					]}
 				/>
 				<VStack
 					alignment="leading"
-					modifiers={[padding({all: cellPadding})]}
+					modifiers={[
+						padding({
+							top: cellPaddingTop,
+							bottom: cellPaddingBottom,
+							horizontal: cellPadding,
+						}),
+					]}
 					spacing={cellIconTitleGap}
 				>
-					<Text
+					<Image
+						color={iconColor}
 						modifiers={[
-							font({
-								family: ICON_FONT_FAMILY,
-								size: ICON_SIZE,
-								textStyle: ICON_TEXT_STYLE,
-							}),
-							foregroundColor(foreground),
+							font({textStyle: ICON_TEXT_STYLE}),
+							frame({height: ICON_BOX_HEIGHT}),
 						]}
-					>
-						{glyph}
-					</Text>
+						systemName={view.icon}
+					/>
 					<Text
 						modifiers={[
 							font({
 								textStyle: TITLE_TEXT_STYLE,
-								weight: 'bold',
-								design: 'rounded',
+								weight: 'semibold',
 							}),
-							foregroundColor(foreground),
+							foregroundColor(titleColor),
 						]}
 					>
 						{view.title}

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import {useColorScheme} from 'react-native'
 import {
 	Button,
-	Circle,
 	Image,
 	RoundedRectangle,
 	Text,
@@ -24,8 +23,6 @@ import {
 import {displayP3} from '@frogpond/colors'
 import type {ViewType} from '../views'
 import {
-	homescreenBadgeDark,
-	homescreenBadgeLight,
 	homescreenIconDark,
 	homescreenIconLight,
 	homescreenTitleDark,
@@ -101,12 +98,6 @@ const ICON_IMAGE_SCALE = 'large'
 /// land within a pixel and a half of each other, and every single-line card is
 /// exactly 283px tall. 86px at 3x puts that centre where Health has it.
 const ICON_BOX_HEIGHT = 86 / 3
-/// A corner badge saying what the card will do: Shortcuts puts a play button
-/// there, and the same spot can say whether a tile opens a screen in the app or
-/// hands off to the web. Measured off Shortcuts: a 29pt disc, inset from the
-/// top and trailing edges by the same amount as the card's own padding.
-const BADGE_DIAMETER = 88 / 3
-const BADGE_TEXT_STYLE = 'footnote'
 /// 17pt semibold, which is what Health's card titles measure at every text size
 /// captured.
 ///
@@ -121,12 +112,7 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 	let dark = scheme === 'dark'
 	let titleColor = dark ? homescreenTitleDark : homescreenTitleLight
 	let iconColor = dark ? homescreenIconDark : homescreenIconLight
-	let badgeFill = dark ? homescreenBadgeDark : homescreenBadgeLight
 	let [gradientInner, gradientOuter] = view.gradient
-	// A web link leaves the app; a native view does not, and the arrow is the
-	// same one a disclosure uses.
-	let badgeSymbol: ViewType['icon'] =
-		view.type === 'view' ? 'arrow.forward' : 'globe'
 
 	return (
 		<Button
@@ -200,27 +186,6 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 					>
 						{view.title}
 					</Text>
-				</VStack>
-				<VStack
-					modifiers={[
-						frame({
-							maxWidth: FILL_WIDTH,
-							maxHeight: FILL_WIDTH,
-							alignment: 'topTrailing',
-						}),
-						padding({top: cellPadding, trailing: cellPadding}),
-					]}
-				>
-					<ZStack
-						modifiers={[frame({width: BADGE_DIAMETER, height: BADGE_DIAMETER})]}
-					>
-						<Circle modifiers={[foregroundStyle(badgeFill)]} />
-						<Image
-							color={titleColor}
-							modifiers={[font({textStyle: BADGE_TEXT_STYLE})]}
-							systemName={badgeSymbol}
-						/>
-					</ZStack>
 				</VStack>
 			</ZStack>
 		</Button>

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import {useColorScheme} from 'react-native'
 import {
 	Button,
+	Circle,
 	Image,
 	RoundedRectangle,
 	Text,
@@ -16,12 +17,15 @@ import {
 	foregroundColor,
 	foregroundStyle,
 	frame,
+	imageScale,
 	padding,
 	shapes,
 } from '@expo/ui/swift-ui/modifiers'
 import {displayP3} from '@frogpond/colors'
 import type {ViewType} from '../views'
 import {
+	homescreenBadgeDark,
+	homescreenBadgeLight,
 	homescreenIconDark,
 	homescreenIconLight,
 	homescreenTitleDark,
@@ -71,18 +75,24 @@ const cellIconTitleGap = 10
 /// cap the frame at a width no phone reaches and let the stack divide the space.
 export const FILL_WIDTH = 10_000
 
-/// Health scales its card icons with Dynamic Type: measured across three text
-/// sizes its Heart glyph runs 72 -> 83 -> 106px while the title runs
-/// 108 -> 129 -> 169px, so the icon is sized by a text style and not by a fixed
-/// point size. @expo/ui ignores `Image`'s `size` prop whenever a `font` modifier
-/// carries a `textStyle`, which leaves the built-in styles as the only scalable
-/// sizes we can ask for.
+/// The icon's size has to survive Dynamic Type: Health's own glyph runs
+/// 72 -> 83 -> 106px across three text sizes while its title runs
+/// 108 -> 129 -> 169px, so it is sized by a text style rather than by a fixed
+/// point size. `Image`'s `size` prop is ignored whenever a `font` modifier
+/// carries a `textStyle`, so the text style is the only way in.
 ///
-/// `title` is the closest of them: it draws the glyph 82x75 against Health's
-/// 83x77. A fixed 28.67pt size matches Health exactly at the default text size,
-/// but is then 23px too small at 130%, so those two pixels buy a card that
-/// tracks Health across the whole Dynamic Type range.
-const ICON_TEXT_STYLE = 'title'
+/// Shortcuts, whose look these cards otherwise take, draws the same glyph
+/// smaller than Health: 72x67px against 83x76 on a Heart card in each, a ratio
+/// of 0.87. No text style lands there on its own -- `title` is 15% over and
+/// `title2` 10% under -- but `imageScale` multiplies whatever the style
+/// resolves to, and `title3` with it scaled up measures 0.906. That is as close
+/// as this gets while the icon still grows with the text.
+const ICON_TEXT_STYLE = 'title3'
+/// `imageScale` is an environment value, so it applies to a view's descendants
+/// and not to the view it is set on. Set on the Image it does nothing at all,
+/// which reads as the modifier being unsupported; it has to sit on an ancestor.
+/// `scaleEffect` is genuinely inert here either way.
+const ICON_IMAGE_SCALE = 'large'
 /// SF Symbols don't share a common height -- across Health's own cards the ink
 /// runs from 77px for `heart.fill` to 104px for its mobility glyph -- so a card
 /// that sizes to its icon comes out a different height for every view. Health
@@ -91,6 +101,12 @@ const ICON_TEXT_STYLE = 'title'
 /// land within a pixel and a half of each other, and every single-line card is
 /// exactly 283px tall. 86px at 3x puts that centre where Health has it.
 const ICON_BOX_HEIGHT = 86 / 3
+/// A corner badge saying what the card will do: Shortcuts puts a play button
+/// there, and the same spot can say whether a tile opens a screen in the app or
+/// hands off to the web. Measured off Shortcuts: a 29pt disc, inset from the
+/// top and trailing edges by the same amount as the card's own padding.
+const BADGE_DIAMETER = 88 / 3
+const BADGE_TEXT_STYLE = 'footnote'
 /// 17pt semibold, which is what Health's card titles measure at every text size
 /// captured.
 ///
@@ -105,7 +121,12 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 	let dark = scheme === 'dark'
 	let titleColor = dark ? homescreenTitleDark : homescreenTitleLight
 	let iconColor = dark ? homescreenIconDark : homescreenIconLight
+	let badgeFill = dark ? homescreenBadgeDark : homescreenBadgeLight
 	let [gradientInner, gradientOuter] = view.gradient
+	// A web link leaves the app; a native view does not, and the arrow is the
+	// same one a disclosure uses.
+	let badgeSymbol: ViewType['icon'] =
+		view.type === 'view' ? 'arrow.forward' : 'globe'
 
 	return (
 		<Button
@@ -157,14 +178,17 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 					]}
 					spacing={cellIconTitleGap}
 				>
-					<Image
-						color={iconColor}
-						modifiers={[
-							font({textStyle: ICON_TEXT_STYLE}),
-							frame({height: ICON_BOX_HEIGHT}),
-						]}
-						systemName={view.icon}
-					/>
+					{/* imageScale has to sit on an ancestor of the Image, not on it. */}
+					<ZStack modifiers={[imageScale(ICON_IMAGE_SCALE)]}>
+						<Image
+							color={iconColor}
+							modifiers={[
+								font({textStyle: ICON_TEXT_STYLE}),
+								frame({height: ICON_BOX_HEIGHT}),
+							]}
+							systemName={view.icon}
+						/>
+					</ZStack>
 					<Text
 						modifiers={[
 							font({
@@ -176,6 +200,27 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 					>
 						{view.title}
 					</Text>
+				</VStack>
+				<VStack
+					modifiers={[
+						frame({
+							maxWidth: FILL_WIDTH,
+							maxHeight: FILL_WIDTH,
+							alignment: 'topTrailing',
+						}),
+						padding({top: cellPadding, trailing: cellPadding}),
+					]}
+				>
+					<ZStack
+						modifiers={[frame({width: BADGE_DIAMETER, height: BADGE_DIAMETER})]}
+					>
+						<Circle modifiers={[foregroundStyle(badgeFill)]} />
+						<Image
+							color={titleColor}
+							modifiers={[font({textStyle: BADGE_TEXT_STYLE})]}
+							systemName={badgeSymbol}
+						/>
+					</ZStack>
 				</VStack>
 			</ZStack>
 		</Button>

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -47,10 +47,19 @@ const ICON_SIZE = 32
 // For the icon the family is a custom font, so this maps to
 // Font.custom(_:size:relativeTo:) and ICON_SIZE governs the rendered size. For
 // the title there is no family, so the text style's own size wins --
-// subheadline is 15pt. There is deliberately no title size constant: passing
-// one alongside a text style has no effect, so it would only mislead.
+// headline is 17pt, matched by pixel-comparing rendered title text against
+// Health's own card titles (see button.tsx's git history for the
+// measurement). There is deliberately no title size constant: passing one
+// alongside a text style has no effect, so it would only mislead.
+//
+// At this size, the two longest current titles ("Important Contacts",
+// "Campus Dictionary") truncate with an ellipsis instead of wrapping: this
+// version of @expo/ui's Text doesn't honor lineLimit(2) here regardless of
+// the frame/multilineTextAlignment modifiers tried. Chosen deliberately --
+// pixel-matching Health's title size over avoiding truncation -- pending an
+// @expo/ui fix or update.
 const ICON_TEXT_STYLE = 'title'
-const TITLE_TEXT_STYLE = 'subheadline'
+const TITLE_TEXT_STYLE = 'headline'
 
 /// `view.icon` comes from the view data rather than from a literal, so a typo
 /// or a rename upstream reaches this as an undefined lookup. Fail with a

--- a/source/views/home/button.tsx
+++ b/source/views/home/button.tsx
@@ -1,16 +1,8 @@
 import * as React from 'react'
 import {useColorScheme} from 'react-native'
-import {
-	Button,
-	RoundedRectangle,
-	Spacer,
-	Text,
-	VStack,
-	ZStack,
-} from '@expo/ui/swift-ui'
+import {Button, RoundedRectangle, Text, VStack, ZStack} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
-	aspectRatio,
 	buttonStyle,
 	contentShape,
 	font,
@@ -31,15 +23,15 @@ type Props = {
 
 export const CELL_MARGIN = 10
 
-/// Matched from the Apple Health category-card screenshot: a 525x346px
-/// (3x) card is a ~1.517:1 width:height ratio, with a corner radius of
-/// roughly 23% of the card's height (~80px at 3x, on a 346px-tall card).
-/// The radius is expressed as a point value tuned for a typical two-column
-/// card width on a standard iPhone, since @expo/ui has no way to compute a
-/// modifier value from the runtime-resolved card size.
-const CELL_ASPECT_RATIO = 1.517
+/// Health's category cards size to content, not a fixed aspect ratio --
+/// single-line titles (e.g. "Cycle Tracking", ~94pt tall) render noticeably
+/// shorter than two-line ones ("Body Measurements", ~115pt tall). Measured
+/// corner-inset profiles are identical between the two, confirming Health
+/// uses one fixed corner radius (~27pt) regardless of card height, not one
+/// proportional to it.
 const CELL_RADIUS = 27
 const cellPadding = 16
+const cellIconTitleGap = 10
 
 /// SwiftUI has no "fill the available width" constant reachable from JS, so we
 /// cap the frame at a width no phone reaches and let the stack divide the space.
@@ -87,7 +79,6 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 			modifiers={[
 				buttonStyle('plain'),
 				frame({maxWidth: FILL_WIDTH}),
-				aspectRatio({ratio: CELL_ASPECT_RATIO, contentMode: 'fit'}),
 				accessibilityLabel(view.title),
 			]}
 			onPress={onPress}
@@ -121,7 +112,7 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 				<VStack
 					alignment="leading"
 					modifiers={[padding({all: cellPadding})]}
-					spacing={4}
+					spacing={cellIconTitleGap}
 				>
 					<Text
 						modifiers={[
@@ -135,10 +126,13 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 					>
 						{glyph}
 					</Text>
-					<Spacer />
 					<Text
 						modifiers={[
-							font({textStyle: TITLE_TEXT_STYLE}),
+							font({
+								textStyle: TITLE_TEXT_STYLE,
+								weight: 'bold',
+								design: 'rounded',
+							}),
 							foregroundColor(foreground),
 						]}
 					>

--- a/source/views/home/colors.ts
+++ b/source/views/home/colors.ts
@@ -13,8 +13,8 @@ import {displayP3} from '@frogpond/colors'
 /// White and black are the same colour in sRGB and Display P3, so unlike the
 /// card gradients these need no conversion -- but they go through the same
 /// helper so every colour on this screen reaches SwiftUI by one route.
-export const homescreenTitleLight = displayP3('#ffffff')
-export const homescreenIconLight = displayP3('#ffffff', 0.79)
+export const homescreenTitleLight = displayP3('color(display-p3 1 1 1)')
+export const homescreenIconLight = displayP3('color(display-p3 1 1 1 / 0.79)')
 
-export const homescreenTitleDark = displayP3('#000000')
-export const homescreenIconDark = displayP3('#000000', 0.81)
+export const homescreenTitleDark = displayP3('color(display-p3 0 0 0)')
+export const homescreenIconDark = displayP3('color(display-p3 0 0 0 / 0.81)')

--- a/source/views/home/colors.ts
+++ b/source/views/home/colors.ts
@@ -1,2 +1,12 @@
-export const homescreenForegroundLight = 'rgba(255, 255, 255, 0.9)'
-export const homescreenForegroundDark = 'rgba(0, 0, 0, 0.65)'
+/// Health draws a card's title in opaque white but knocks its icon back to
+/// roughly 79% -- both measured off the "Heart" card by solving
+/// `ink = a*white + (1-a)*card` per channel against the gradient colour in the
+/// same column. The red channel is useless for that fit (the card is already
+/// ~236 there), so the figure comes from green and blue.
+export const homescreenTitleLight = 'rgb(255, 255, 255)'
+export const homescreenIconLight = 'rgba(255, 255, 255, 0.79)'
+
+/// Dark mode is unmeasured -- there's no Health reference capture for it yet --
+/// so both keep the value the light pair used before it was split.
+export const homescreenTitleDark = 'rgba(0, 0, 0, 0.65)'
+export const homescreenIconDark = 'rgba(0, 0, 0, 0.65)'

--- a/source/views/home/colors.ts
+++ b/source/views/home/colors.ts
@@ -18,10 +18,3 @@ export const homescreenIconLight = displayP3('color(display-p3 1 1 1 / 0.79)')
 
 export const homescreenTitleDark = displayP3('color(display-p3 0 0 0)')
 export const homescreenIconDark = displayP3('color(display-p3 0 0 0 / 0.81)')
-
-/// The disc behind the corner badge. Shortcuts sits its play button on a wash
-/// of the foreground colour rather than a solid fill -- measured off a gold
-/// card, the disc lifts the card's own colour by about a fifth of the way to
-/// white without changing its hue.
-export const homescreenBadgeLight = displayP3('color(display-p3 1 1 1 / 0.2)')
-export const homescreenBadgeDark = displayP3('color(display-p3 0 0 0 / 0.2)')

--- a/source/views/home/colors.ts
+++ b/source/views/home/colors.ts
@@ -1,15 +1,20 @@
+import {displayP3} from '@frogpond/colors'
+
 /// Health draws a card's title in opaque white but knocks its icon back to
 /// roughly 79% -- both measured off the "Heart" card by solving
 /// `ink = a*white + (1-a)*card` per channel against the gradient colour in the
 /// same column. The red channel is useless for that fit (the card is already
 /// ~236 there), so the figure comes from green and blue.
-export const homescreenTitleLight = 'rgb(255, 255, 255)'
-export const homescreenIconLight = 'rgba(255, 255, 255, 0.79)'
-
+///
 /// Dark mode mirrors it, measured the same way over four cards: the title is
 /// opaque black and the icon lands within a couple of points of the light
-/// mode's knock-back. Health keeps the same card gradients in both schemes --
-/// across the Heart card they differ by at most 6/255 -- so only these two
-/// colours change.
-export const homescreenTitleDark = 'rgb(0, 0, 0)'
-export const homescreenIconDark = 'rgba(0, 0, 0, 0.81)'
+/// mode's knock-back.
+///
+/// White and black are the same colour in sRGB and Display P3, so unlike the
+/// card gradients these need no conversion -- but they go through the same
+/// helper so every colour on this screen reaches SwiftUI by one route.
+export const homescreenTitleLight = displayP3('#ffffff')
+export const homescreenIconLight = displayP3('#ffffff', 0.79)
+
+export const homescreenTitleDark = displayP3('#000000')
+export const homescreenIconDark = displayP3('#000000', 0.81)

--- a/source/views/home/colors.ts
+++ b/source/views/home/colors.ts
@@ -18,3 +18,10 @@ export const homescreenIconLight = displayP3('color(display-p3 1 1 1 / 0.79)')
 
 export const homescreenTitleDark = displayP3('color(display-p3 0 0 0)')
 export const homescreenIconDark = displayP3('color(display-p3 0 0 0 / 0.81)')
+
+/// The disc behind the corner badge. Shortcuts sits its play button on a wash
+/// of the foreground colour rather than a solid fill -- measured off a gold
+/// card, the disc lifts the card's own colour by about a fifth of the way to
+/// white without changing its hue.
+export const homescreenBadgeLight = displayP3('color(display-p3 1 1 1 / 0.2)')
+export const homescreenBadgeDark = displayP3('color(display-p3 0 0 0 / 0.2)')

--- a/source/views/home/colors.ts
+++ b/source/views/home/colors.ts
@@ -6,7 +6,10 @@
 export const homescreenTitleLight = 'rgb(255, 255, 255)'
 export const homescreenIconLight = 'rgba(255, 255, 255, 0.79)'
 
-/// Dark mode is unmeasured -- there's no Health reference capture for it yet --
-/// so both keep the value the light pair used before it was split.
-export const homescreenTitleDark = 'rgba(0, 0, 0, 0.65)'
-export const homescreenIconDark = 'rgba(0, 0, 0, 0.65)'
+/// Dark mode mirrors it, measured the same way over four cards: the title is
+/// opaque black and the icon lands within a couple of points of the light
+/// mode's knock-back. Health keeps the same card gradients in both schemes --
+/// across the Heart card they differ by at most 6/255 -- so only these two
+/// colours change.
+export const homescreenTitleDark = 'rgb(0, 0, 0)'
+export const homescreenIconDark = 'rgba(0, 0, 0, 0.81)'

--- a/source/views/home/index.tsx
+++ b/source/views/home/index.tsx
@@ -139,20 +139,17 @@ export const NavigationOptions: NativeStackNavigationOptions = {
 	// A large title that collapses as the grid scrolls, over a bar the cards
 	// show through rather than disappear behind.
 	//
-	// Deliberately no headerBlurEffect. It sets a UIBlurEffect material, which is
-	// how a bar was blurred before iOS 26, and asking for one on 26 or later
-	// replaces the glass the system would otherwise put there. Both ends of that
-	// ladder were tried on iOS 27 and both read as the older effect:
-	// systemChromeMaterial let 11/255 of the card behind it through and
-	// systemUltraThinMaterial looked plainly pre-glass, against 29/255 for asking
-	// for nothing and 63/255 for Shortcuts itself.
+	// There is deliberately no headerBlurEffect. It sets a UIBlurEffect material,
+	// which is how a bar is blurred before iOS 26, and asking for one on 26 or
+	// later replaces the glass the system puts there: the thickest material
+	// leaves 11/255 of the card behind it showing and the thinnest reads plainly
+	// pre-glass, against 29/255 for asking for nothing at all.
 	//
-	// That last gap looks like the limit of what is reachable from here rather
-	// than something left untuned: Shortcuts' bar lifts black to #1d2429 where
-	// ours leaves it at #060c0f, and that luminosity is the part of glass a blur
-	// material does not have. The other iOS 26 route, scrollEdgeEffects, needs a
-	// React Native ScrollView it can find in the screen's descendants, and this
-	// screen scrolls in SwiftUI.
+	// Shortcuts manages 63/255, and the rest of that gap is not reachable from
+	// here. Its bar lifts black to #1d2429 where this one leaves it at #060c0f,
+	// and that luminosity is the part of glass a blur material does not have.
+	// The other iOS 26 route, scrollEdgeEffects, needs a React Native ScrollView
+	// among the screen's descendants, and this screen scrolls in SwiftUI.
 	headerLargeTitleEnabled: true,
 	headerTransparent: true,
 }

--- a/source/views/home/index.tsx
+++ b/source/views/home/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {StyleSheet} from 'react-native'
+import {PlatformColor, StyleSheet} from 'react-native'
 import {
 	Grid,
 	Host,
@@ -126,6 +126,35 @@ export const NavigationKey = 'Home'
 export const NavigationOptions: NativeStackNavigationOptions = {
 	title: 'All About Olaf',
 	headerRight: (props) => <OpenSettingsButton {...props} />,
+	// The cards carry their own colour and their own shadow, so the grouped grey
+	// the navigation theme gives every other screen reads as a panel behind them
+	// -- Shortcuts and Health both set their grid on the plain background. This
+	// is scoped to this screen rather than changed in the theme, which the rest
+	// of the app still wants. systemBackground rather than a literal, so it
+	// follows the appearance the way the theme's own colour would.
+	contentStyle: {backgroundColor: PlatformColor('systemBackground')},
+	// The separator under the bar draws a line across the top of that same
+	// background; neither app it copies has one.
+	headerShadowVisible: false,
+	// A large title that collapses as the grid scrolls, over a bar the cards
+	// show through rather than disappear behind.
+	//
+	// Deliberately no headerBlurEffect. It sets a UIBlurEffect material, which is
+	// how a bar was blurred before iOS 26, and asking for one on 26 or later
+	// replaces the glass the system would otherwise put there. Both ends of that
+	// ladder were tried on iOS 27 and both read as the older effect:
+	// systemChromeMaterial let 11/255 of the card behind it through and
+	// systemUltraThinMaterial looked plainly pre-glass, against 29/255 for asking
+	// for nothing and 63/255 for Shortcuts itself.
+	//
+	// That last gap looks like the limit of what is reachable from here rather
+	// than something left untuned: Shortcuts' bar lifts black to #1d2429 where
+	// ours leaves it at #060c0f, and that luminosity is the part of glass a blur
+	// material does not have. The other iOS 26 route, scrollEdgeEffects, needs a
+	// React Native ScrollView it can find in the screen's descendants, and this
+	// screen scrolls in SwiftUI.
+	headerLargeTitleEnabled: true,
+	headerTransparent: true,
 }
 
 export type NavigationParams = undefined

--- a/source/views/home/index.tsx
+++ b/source/views/home/index.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react'
 import {StyleSheet} from 'react-native'
-import {Host, HStack, RNHostView, ScrollView, VStack} from '@expo/ui/swift-ui'
+import {
+	Grid,
+	Host,
+	RNHostView,
+	ScrollView,
+	Spacer,
+	VStack,
+} from '@expo/ui/swift-ui'
 import {
 	accessibilityIdentifier,
 	frame,
@@ -8,10 +15,15 @@ import {
 } from '@expo/ui/swift-ui/modifiers'
 
 import {AllViews} from '../views'
+import type {ViewType} from '../views'
 import {FaqBannerGroup} from '../faqs'
 import {FAQ_TARGETS} from '../faqs/constants'
-import {partitionByIndex} from '../../lib/partition-by-index'
-import {CELL_MARGIN, FILL_WIDTH, HomeScreenButton} from './button'
+import {
+	CELL_MARGIN,
+	FILL_WIDTH,
+	HomeScreenButton,
+	SCREEN_MARGIN,
+} from './button'
 import {openUrl} from '@frogpond/open-url'
 import {OpenSettingsButton} from '@frogpond/navigation-buttons'
 import {UnofficialAppNotice} from './notice'
@@ -21,7 +33,7 @@ import {NativeStackNavigationOptions} from '@react-navigation/native-stack'
 
 const styles = StyleSheet.create({
 	banner: {
-		marginHorizontal: CELL_MARGIN,
+		marginHorizontal: SCREEN_MARGIN,
 		marginTop: CELL_MARGIN,
 		marginBottom: CELL_MARGIN / 2,
 	},
@@ -30,13 +42,26 @@ const styles = StyleSheet.create({
 	},
 })
 
+/// Health lays its cards out as a grid, not as two columns: both cards in a row
+/// share a height, so a two-line title on one side lifts the card beside it too.
+/// Independent columns can't express that -- each card sizes to its own content
+/// and the two sides drift out of step as the taller ones accumulate -- so the
+/// views are grouped into rows and handed to a real Grid.
+function inPairs(views: ViewType[]): ViewType[][] {
+	let rows: ViewType[][] = []
+	for (let i = 0; i < views.length; i += 2) {
+		rows.push(views.slice(i, i + 2))
+	}
+	return rows
+}
+
 function HomePage(): React.ReactNode {
 	let navigation = useNavigation()
 	let isDev = useIsDevMode()
 	let allViews = AllViews().filter(
 		(view) => !view.disabled && (isDev || !view.devOnly),
 	)
-	let columns = partitionByIndex(allViews)
+	let rows = inPairs(allViews)
 
 	// SwiftUI owns the scrolling. Wrapping this in a React Native ScrollView
 	// instead puts that scroll view between the touch and the SwiftUI buttons,
@@ -50,7 +75,7 @@ function HomePage(): React.ReactNode {
 			<ScrollView>
 				<VStack
 					modifiers={[
-						padding({all: CELL_MARGIN}),
+						padding({all: SCREEN_MARGIN}),
 						frame({maxWidth: FILL_WIDTH}),
 					]}
 					spacing={CELL_MARGIN}
@@ -61,14 +86,10 @@ function HomePage(): React.ReactNode {
 						<FaqBannerGroup style={styles.banner} target={FAQ_TARGETS.HOME} />
 					</RNHostView>
 
-					<HStack alignment="top" spacing={CELL_MARGIN}>
-						{columns.map((contents, i) => (
-							<VStack
-								key={i}
-								modifiers={[frame({maxWidth: FILL_WIDTH})]}
-								spacing={CELL_MARGIN}
-							>
-								{contents.map((view) => (
+					<Grid horizontalSpacing={CELL_MARGIN} verticalSpacing={CELL_MARGIN}>
+						{rows.map((row, i) => (
+							<Grid.Row key={i}>
+								{row.map((view) => (
 									<HomeScreenButton
 										key={view.type === 'view' ? view.view : view.title}
 										onPress={() => {
@@ -83,9 +104,13 @@ function HomePage(): React.ReactNode {
 										view={view}
 									/>
 								))}
-							</VStack>
+								{/* An odd number of views leaves the last row half empty.
+								    Health leaves that slot blank rather than letting the
+								    lone card run the full width. */}
+								{row.length === 1 ? <Spacer /> : null}
+							</Grid.Row>
 						))}
-					</HStack>
+					</Grid>
 
 					<UnofficialAppNotice />
 				</VStack>

--- a/source/views/views.ts
+++ b/source/views/views.ts
@@ -109,7 +109,7 @@ export const AllViews = (): Array<ViewType> => {
 		{
 			type: 'view',
 			view: importantContacts,
-			title: 'Campus Help',
+			title: 'Important Contacts',
 			icon: 'phone.fill',
 			gradient: c.orangeGradient,
 		},
@@ -123,7 +123,7 @@ export const AllViews = (): Array<ViewType> => {
 		{
 			type: 'view',
 			view: dictionary,
-			title: 'Dictionary',
+			title: 'Campus Dictionary',
 			icon: 'character.book.closed.fill',
 			gradient: c.pinkGradient,
 		},

--- a/source/views/views.ts
+++ b/source/views/views.ts
@@ -1,6 +1,6 @@
 import * as c from '@frogpond/colors'
 import type {Gradient} from '@frogpond/colors'
-import type EntypoGlyphs from '@react-native-vector-icons/entypo/glyphmaps/Entypo.json'
+import type {ImageProps} from '@expo/ui/swift-ui'
 import {RootViewsParamList} from '../navigation/types'
 
 import {NavigationKey as menus} from './menus'
@@ -22,7 +22,15 @@ const courseSearch: keyof RootViewsParamList = 'CourseSearch'
 
 type CommonView = {
 	title: string
-	icon: keyof typeof EntypoGlyphs
+	/// An SF Symbol name. Health builds its category cards from SF Symbols, so
+	/// matching its glyph weight and Dynamic Type behaviour means drawing from
+	/// the same set rather than from an icon font.
+	///
+	/// Taken from `Image` rather than from `sf-symbols-typescript` directly: the
+	/// names this accepts should be exactly the names the component can render,
+	/// and that package is only reachable here as one of @expo/ui's own
+	/// dependencies.
+	icon: NonNullable<ImageProps['systemName']>
 	gradient: Gradient
 	disabled?: boolean
 	devOnly?: boolean
@@ -46,21 +54,21 @@ export const AllViews = (): Array<ViewType> => {
 			type: 'view',
 			view: menus,
 			title: 'Menus',
-			icon: 'bowl',
+			icon: 'fork.knife',
 			gradient: c.greenGradient,
 		},
 		{
 			type: 'view',
 			view: sis,
 			title: 'SIS',
-			icon: 'fingerprint',
+			icon: 'person.text.rectangle.fill',
 			gradient: c.goldGradient,
 		},
 		{
 			type: 'view',
 			view: hours,
 			title: 'Building Hours',
-			icon: 'clock',
+			icon: 'clock.fill',
 			gradient: c.blueGradient,
 		},
 		{
@@ -74,84 +82,84 @@ export const AllViews = (): Array<ViewType> => {
 			type: 'view',
 			view: directory,
 			title: 'Directory',
-			icon: 'v-card',
+			icon: 'person.crop.rectangle.fill',
 			gradient: c.redGradient,
 		},
 		{
 			type: 'view',
 			view: streaming,
 			title: 'Streaming Media',
-			icon: 'video',
+			icon: 'play.rectangle.fill',
 			gradient: c.lightBlueGradient,
 		},
 		{
 			type: 'view',
 			view: news,
 			title: 'News',
-			icon: 'news',
+			icon: 'newspaper.fill',
 			gradient: c.purpleGradient,
 		},
 		{
 			type: 'url',
 			url: 'https://map.stolaf.edu/',
 			title: 'Campus Map',
-			icon: 'map',
+			icon: 'map.fill',
 			gradient: c.indigoGradient,
 		},
 		{
 			type: 'view',
 			view: importantContacts,
-			title: 'Important Contacts',
-			icon: 'phone',
+			title: 'Campus Help',
+			icon: 'phone.fill',
 			gradient: c.orangeGradient,
 		},
 		{
 			type: 'view',
 			view: transportation,
 			title: 'Transportation',
-			icon: 'address',
+			icon: 'bus.fill',
 			gradient: c.grayGradient,
 		},
 		{
 			type: 'view',
 			view: dictionary,
-			title: 'Campus Dictionary',
-			icon: 'open-book',
+			title: 'Dictionary',
+			icon: 'character.book.closed.fill',
 			gradient: c.pinkGradient,
 		},
 		{
 			type: 'view',
 			view: studentOrgs,
 			title: 'Student Orgs',
-			icon: 'globe',
+			icon: 'person.3.fill',
 			gradient: c.sageGradient,
 		},
 		{
 			type: 'view',
 			view: more,
 			title: 'More',
-			icon: 'link',
+			icon: 'ellipsis.circle.fill',
 			gradient: c.mintGradient,
 		},
 		{
 			type: 'view',
 			view: printJobs,
 			title: 'stoPrint',
-			icon: 'print',
+			icon: 'printer.fill',
 			gradient: c.yellowGradient,
 		},
 		{
 			type: 'view',
 			view: courseSearch,
 			title: 'Course Catalog',
-			icon: 'graduation-cap',
+			icon: 'graduationcap.fill',
 			gradient: c.tanGradient,
 		},
 		{
 			type: 'view',
 			view: reddit,
 			title: 'Communities',
-			icon: 'chat',
+			icon: 'bubble.left.and.bubble.right.fill',
 			gradient: c.orangeGradient,
 			devOnly: true,
 		},

--- a/source/views/views.ts
+++ b/source/views/views.ts
@@ -1,4 +1,5 @@
 import * as c from '@frogpond/colors'
+import type {Gradient} from '@frogpond/colors'
 import type EntypoGlyphs from '@react-native-vector-icons/entypo/glyphmaps/Entypo.json'
 import {RootViewsParamList} from '../navigation/types'
 
@@ -22,8 +23,7 @@ const courseSearch: keyof RootViewsParamList = 'CourseSearch'
 type CommonView = {
 	title: string
 	icon: keyof typeof EntypoGlyphs
-	foreground: 'light' | 'dark'
-	tint: string
+	gradient: Gradient
 	disabled?: boolean
 	devOnly?: boolean
 }
@@ -47,128 +47,112 @@ export const AllViews = (): Array<ViewType> => {
 			view: menus,
 			title: 'Menus',
 			icon: 'bowl',
-			foreground: 'light',
-			tint: c.grassToLime[0],
+			gradient: c.greenGradient,
 		},
 		{
 			type: 'view',
 			view: sis,
 			title: 'SIS',
 			icon: 'fingerprint',
-			foreground: 'light',
-			tint: c.yellowToGoldDark[0],
+			gradient: c.goldGradient,
 		},
 		{
 			type: 'view',
 			view: hours,
 			title: 'Building Hours',
 			icon: 'clock',
-			foreground: 'light',
-			tint: c.lightBlueToBlueDark[0],
+			gradient: c.blueGradient,
 		},
 		{
 			type: 'view',
 			view: calendar,
 			title: 'Calendar',
 			icon: 'calendar',
-			foreground: 'light',
-			tint: c.magentaToPurple[0],
+			gradient: c.violetGradient,
 		},
 		{
 			type: 'view',
 			view: directory,
 			title: 'Directory',
 			icon: 'v-card',
-			foreground: 'light',
-			tint: c.redToPurple[0],
+			gradient: c.redGradient,
 		},
 		{
 			type: 'view',
 			view: streaming,
 			title: 'Streaming Media',
 			icon: 'video',
-			foreground: 'light',
-			tint: c.lightBlueToBlueLight[0],
+			gradient: c.lightBlueGradient,
 		},
 		{
 			type: 'view',
 			view: news,
 			title: 'News',
 			icon: 'news',
-			foreground: 'light',
-			tint: c.purpleToIndigo[0],
+			gradient: c.purpleGradient,
 		},
 		{
 			type: 'url',
 			url: 'https://map.stolaf.edu/',
 			title: 'Campus Map',
 			icon: 'map',
-			foreground: 'light',
-			tint: c.navyToNavy[0],
+			gradient: c.indigoGradient,
 		},
 		{
 			type: 'view',
 			view: importantContacts,
 			title: 'Important Contacts',
 			icon: 'phone',
-			foreground: 'light',
-			tint: c.orangeToRed[0],
+			gradient: c.orangeGradient,
 		},
 		{
 			type: 'view',
 			view: transportation,
 			title: 'Transportation',
 			icon: 'address',
-			foreground: 'light',
-			tint: c.grayToDarkGray[0],
+			gradient: c.grayGradient,
 		},
 		{
 			type: 'view',
 			view: dictionary,
 			title: 'Campus Dictionary',
 			icon: 'open-book',
-			foreground: 'light',
-			tint: c.pinkToHotpink[0],
+			gradient: c.pinkGradient,
 		},
 		{
 			type: 'view',
 			view: studentOrgs,
 			title: 'Student Orgs',
 			icon: 'globe',
-			foreground: 'light',
-			tint: c.darkBlueToIndigo[0],
+			gradient: c.sageGradient,
 		},
 		{
 			type: 'view',
 			view: more,
 			title: 'More',
 			icon: 'link',
-			foreground: 'light',
-			tint: c.seafoamToGrass[0],
+			gradient: c.mintGradient,
 		},
 		{
 			type: 'view',
 			view: printJobs,
 			title: 'stoPrint',
 			icon: 'print',
-			foreground: 'light',
-			tint: c.tealToSeafoam[0],
+			gradient: c.yellowGradient,
 		},
 		{
 			type: 'view',
 			view: courseSearch,
 			title: 'Course Catalog',
 			icon: 'graduation-cap',
-			foreground: 'light',
-			tint: c.lavender,
+			gradient: c.tanGradient,
 		},
 		{
 			type: 'view',
 			view: reddit,
 			title: 'Communities',
 			icon: 'chat',
-			foreground: 'light',
-			tint: c.orangeToRed[0],
+			gradient: c.orangeGradient,
 			devOnly: true,
 		},
 	]


### PR DESCRIPTION
- rework the home screen tiles as a mix of Health.app and Shortcuts.app
  - Use Health's dark mode and icon spacing
  - Drop Shortcuts' action button
  - Use Shortcuts' colors and icon sizing
  - Use Shortcuts' light-mode glow-shadow
  - Use Shortcuts' radial gradient effect
- use DisplayP3 colors, which required a custom parser until RN finishes shipping support
  - UIColor supports it, we just had to invoke the constructor in a certain way
- as such, we redid all of the gradients to match Shortcuts' gradients
- also ported the home screen to a SwiftUI Grid view instead of two columns
- and tried to fix up the nav bar to be glass, but failed on that effort
- did make it transparent when not scrolled, though
- enabled the Large Title on the homescreen
- enabled sf-symbol type safety

## Screenshots

| Light | Dark | Larger text |
| --- | --- | --- |
| <img width="300" alt="Home screen, light mode" src="https://github.com/user-attachments/assets/c59bc5e1-cdc8-470b-bcea-d67bc37d4e65" /> | <img width="300" alt="Home screen, dark mode" src="https://github.com/user-attachments/assets/c6159513-3da9-4d9a-8c30-ea6646bb3b99" /> | <img width="300" alt="Home screen at a larger Dynamic Type size" src="https://github.com/user-attachments/assets/3c7eff48-f9b9-4f2a-9cf1-d9bc9c769abf" /> |

