### PR TITLE
Retry UITests that fail on a slow simulator

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -336,15 +336,17 @@ jobs:
           # Every test cold-launches the app in setUp, and on hosted runners that
           # launch sometimes outruns the 30s the screen objects allow the view tree
           # to mount, so whichever test lands on a slow moment fails. Retry rather
-          # than wait longer -- a stalled launch is not a slow one. Each repetition
-          # takes a fresh test host, since a wedged DTServiceHub never recovers in
-          # the process that saw it fail.
+          # than wait longer -- a stalled launch is not a slow one, and setUp gives
+          # each attempt a fresh app.
+          #
+          # Leave -test-repetition-relaunch-enabled off. It repeats the whole bundle
+          # instead of just the failures, which would run every passing test three
+          # times over and take the shard past its timeout.
           xcodebuild test-without-building \
             -xctestrun $(find ios/build/Build/Products -name '*.xctestrun' -print -quit) \
             -destination "platform=iOS Simulator,id=${{ steps.udid.outputs.udid }}" \
             ${{ matrix.tests }} \
             -retry-tests-on-failure \
-            -test-repetition-relaunch-enabled YES \
             -resultBundlePath uitest-results \
             | xcbeautify --renderer github-actions
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -333,10 +333,18 @@ jobs:
         timeout-minutes: 25
         run: |
           set -o pipefail
+          # Every test cold-launches the app in setUp, and on hosted runners that
+          # launch sometimes outruns the 30s the screen objects allow the view tree
+          # to mount, so whichever test lands on a slow moment fails. Retry rather
+          # than wait longer -- a stalled launch is not a slow one. Each repetition
+          # takes a fresh test host, since a wedged DTServiceHub never recovers in
+          # the process that saw it fail.
           xcodebuild test-without-building \
             -xctestrun $(find ios/build/Build/Products -name '*.xctestrun' -print -quit) \
             -destination "platform=iOS Simulator,id=${{ steps.udid.outputs.udid }}" \
             ${{ matrix.tests }} \
+            -retry-tests-on-failure \
+            -test-repetition-relaunch-enabled YES \
             -resultBundlePath uitest-results \
             | xcbeautify --renderer github-actions
 


### PR DESCRIPTION
the github actions runners are REALLY FLAKY today. Add native retries (defaults to 3?) to the UITest step.