### PR TITLE
Set NO_EXPLICIT_MODULES to quieten Xcode a bit

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -197,6 +197,13 @@ jobs:
           brew install ccache
           ccache --set-config=max_size=2G
           ccache --zero-stats
+          # The wrapper React Native points CC at ends with
+          # `exec $CCACHE_BINARY clang "$@"`, which reads the environment.
+          # CocoaPods sets CCACHE_BINARY as an Xcode build setting, and a build
+          # setting is not an environment variable at compile time -- so the
+          # wrapper expands to plain `clang`, silently, and caches nothing. The
+          # cache has come back empty since at least June for want of this line.
+          echo "CCACHE_BINARY=$(command -v ccache)" >> "$GITHUB_ENV"
 
       # The hashless restore-keys are the point rather than a fallback: ccache
       # addresses each object by its preprocessed source, compiler and flags, so

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -214,7 +214,7 @@ jobs:
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/Library/Caches/ccache
-          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}/run=${{ github.run_id }}
+          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}/run=${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/
             ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=master/
@@ -269,7 +269,7 @@ jobs:
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/Library/Caches/ccache
-          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}/run=${{ github.run_id }}
+          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}/run=${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Save iOS app to cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -196,7 +196,6 @@ jobs:
         run: |
           brew install ccache
           ccache --set-config=max_size=2G
-          ccache --zero-stats
           # The wrapper React Native points CC at ends with
           # `exec $CCACHE_BINARY clang "$@"`, which reads the environment.
           # CocoaPods sets CCACHE_BINARY as an Xcode build setting, and a build
@@ -220,6 +219,13 @@ jobs:
             ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/
             ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=master/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}
             ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=master/
+
+      # After the restore, not before: ccache keeps its counters inside the
+      # cache directory, so zeroing them first only to restore the previous
+      # run's file leaves the two runs' figures added together -- a warm run
+      # that hit everything reads as 50% next to the cold run that filled it.
+      - name: Zero the ccache statistics
+        run: ccache --zero-stats
 
       - name: Generate the native project
         run: mise run prebuild

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -192,14 +192,39 @@ jobs:
       - name: Install pnpm dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install and configure ccache
+        run: |
+          brew install ccache
+          ccache --set-config=max_size=2G
+          ccache --zero-stats
+
+      # The hashless restore-keys are the point rather than a fallback: ccache
+      # addresses each object by its preprocessed source, compiler and flags, so
+      # a directory built from neighbouring sources still answers most of the
+      # compiles, and a stale entry is never wrong -- it is simply re-hashed.
+      # That is also why this cache wants restoring on the runs that build from
+      # scratch, which is where it pays for itself.
+      - name: Restore/save ccache
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}
+          restore-keys: |
+            ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/
+            ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=master/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}
+            ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=master/
+
       - name: Generate the native project
         run: mise run prebuild
+        env:
+          USE_CCACHE: '1'
 
       - name: Build UITest bundle
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'ci/skip-e2e') }}
         env:
           SKIP_BUNDLING: 'true'
           CODE_SIGNING_DISABLED: 'true'
+          USE_CCACHE: '1'
         run: |
           set -o pipefail
           xcodebuild build-for-testing \
@@ -213,6 +238,13 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             | xcbeautify --renderer github-actions
+
+      # Read this to judge whether Xcode's explicit modules are bypassing the
+      # ccache compiler wrapper: a hit rate near zero on a warm cache is the
+      # symptom, and CLANG_ENABLE_EXPLICIT_MODULES = NO was the old remedy.
+      - name: Show ccache stats
+        if: always()
+        run: ccache --show-stats
 
       - name: Save iOS app to cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -210,14 +210,13 @@ jobs:
       # compiles, and a stale entry is never wrong -- it is simply re-hashed.
       # That is also why this cache wants restoring on the runs that build from
       # scratch, which is where it pays for itself.
-      - name: Restore/save ccache
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - name: Restore ccache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/Library/Caches/ccache
-          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}
+          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}/run=${{ github.run_id }}
           restore-keys: |
             ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/
-            ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=master/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}
             ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=master/
 
       # After the restore, not before: ccache keeps its counters inside the
@@ -258,6 +257,19 @@ jobs:
       - name: Show ccache stats
         if: always()
         run: ccache --show-stats
+
+      # Saved under a key no read will ever match, so every build writes a new
+      # entry and the prefixes above restore the newest. actions/cache declines
+      # to save when the restore hit its primary key, which suits a cache of
+      # build output but not this one: ccache grows with every compile, so a
+      # single matching key would freeze it at whatever it held first. Ours had
+      # frozen at 19kB, written before the compiler wrapper worked.
+      - name: Save ccache
+        if: always()
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}/run=${{ github.run_id }}
 
       - name: Save iOS app to cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4

--- a/app.config.ts
+++ b/app.config.ts
@@ -176,6 +176,11 @@ const config: ExpoConfig = {
 					// Expo SDK 57 needs at least 16.4; the project has run ahead of
 					// that since SDK 56, and the Podfile must not drift from it.
 					deploymentTarget: '18.6',
+
+					// Point CC/CXX at React Native's ccache wrappers, which only CI
+					// asks for. A local build gets the plain compiler unless the
+					// environment opts in.
+					ccacheEnabled: process.env.USE_CCACHE === '1',
 				},
 			},
 		],

--- a/app.config.ts
+++ b/app.config.ts
@@ -192,6 +192,7 @@ const config: ExpoConfig = {
 		'./plugins/with-xcuitest-target',
 		'./plugins/with-binary-stripping',
 		'./plugins/with-inhibit-pod-warnings',
+		'./plugins/with-explicit-modules',
 	],
 }
 

--- a/plugins/__tests__/with-explicit-modules.test.ts
+++ b/plugins/__tests__/with-explicit-modules.test.ts
@@ -1,0 +1,40 @@
+import {readFileSync} from 'node:fs'
+import {join} from 'node:path'
+
+import {disableExplicitModules} from '../with-explicit-modules'
+
+const STOCK_PODFILE = readFileSync(join(__dirname, 'fixtures/Podfile'), 'utf8')
+
+describe('disableExplicitModules', () => {
+	it('turns explicit modules off', () => {
+		expect(disableExplicitModules(STOCK_PODFILE)).toContain(
+			"build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'",
+		)
+	})
+
+	it('runs after react_native_post_install, so the setting survives it', () => {
+		let result = disableExplicitModules(STOCK_PODFILE)
+		expect(result.indexOf('react_native_post_install')).toBeLessThan(
+			result.indexOf('CLANG_ENABLE_EXPLICIT_MODULES'),
+		)
+	})
+
+	it('stays inside post_install, where the pods project exists', () => {
+		let result = disableExplicitModules(STOCK_PODFILE)
+		let postInstall = result.indexOf('post_install do |installer|')
+		let setting = result.indexOf('CLANG_ENABLE_EXPLICIT_MODULES')
+		expect(postInstall).toBeGreaterThan(-1)
+		expect(postInstall).toBeLessThan(setting)
+	})
+
+	it('is idempotent', () => {
+		let once = disableExplicitModules(STOCK_PODFILE)
+		expect(disableExplicitModules(once)).toBe(once)
+	})
+
+	it('complains rather than quietly leaving the notes in place', () => {
+		expect(() => disableExplicitModules('target "App" do\nend\n')).toThrow(
+			/react_native_post_install/u,
+		)
+	})
+})

--- a/plugins/with-explicit-modules.ts
+++ b/plugins/with-explicit-modules.ts
@@ -1,0 +1,73 @@
+import {readFileSync, writeFileSync} from 'node:fs'
+import {join} from 'node:path'
+
+import {ConfigPlugin, withDangerousMod} from '@expo/config-plugins'
+
+// The whole react_native_post_install call, however its arguments are wrapped:
+// the closing paren has to sit at the same indentation as the call itself.
+const ANCHOR = /^([ \t]*)react_native_post_install\([\s\S]*?^\1\)\n/mu
+
+const SETTING = 'CLANG_ENABLE_EXPLICIT_MODULES'
+
+/**
+ * Say out loud that a ccache build has no explicit modules.
+ *
+ * ccache is reached by pointing CC and CXX at wrapper scripts, and Xcode will
+ * not build explicit modules with a compiler it cannot recognise. It works this
+ * out on its own and carries on without them, but it says so once per target --
+ * five hundred and forty-two notes in a build here -- and a reader has to know
+ * the whole story to tell that from a warning worth acting on.
+ *
+ * The alternative Xcode suggests, C_COMPILER_LAUNCHER with
+ * CLANG_ENABLE_EXPLICIT_MODULES_WITH_COMPILER_LAUNCHER, does keep explicit
+ * modules, and was measured: it drives clang in -cc1 mode, which ccache rejects
+ * as an unsupported compiler option, so every call becomes uncacheable. A build
+ * with the launcher caches nothing at all. The two features cannot both be had,
+ * and caching is the one worth keeping -- it takes the iOS build from about
+ * seventeen minutes to six.
+ */
+export function disableExplicitModules(contents: string): string {
+	if (contents.includes(SETTING)) {
+		return contents
+	}
+
+	let match = ANCHOR.exec(contents)
+	if (!match) {
+		throw new Error(
+			'with-explicit-modules: could not find the `react_native_post_install` call in the Podfile. The Expo template moved it; update this plugin rather than letting five hundred notes back into the build log.',
+		)
+	}
+
+	let [call, indent] = match
+	let block = [
+		`${indent}installer.pods_project.targets.each do |target|`,
+		`${indent}  target.build_configurations.each do |build_configuration|`,
+		`${indent}    build_configuration.build_settings['${SETTING}'] = 'NO'`,
+		`${indent}  end`,
+		`${indent}end`,
+		'',
+	].join('\n')
+
+	return contents.replace(call, `${call}\n${block}`)
+}
+
+/**
+ * Only when the build is going through ccache. A build without it keeps its
+ * explicit modules, which is the faster arrangement when nothing is cached.
+ */
+const withExplicitModules: ConfigPlugin = (config) =>
+	process.env.USE_CCACHE === '1'
+		? withDangerousMod(config, [
+				'ios',
+				(mod) => {
+					let podfile = join(mod.modRequest.platformProjectRoot, 'Podfile')
+					writeFileSync(
+						podfile,
+						disableExplicitModules(readFileSync(podfile, 'utf8')),
+					)
+					return mod
+				},
+			])
+		: config
+
+export default withExplicitModules


### PR DESCRIPTION
without this plugin (we used to set this in Podfile), Xcode generates ~500 warning lines like

```
note: Explicit modules is enabled but the compiler was not recognized; 
disable explicit modules with CLANG_ENABLE_EXPLICIT_MODULES=NO,
or use C_COMPILER_LAUNCHER with CLANG_ENABLE_EXPLICIT_MODULES_WITH_COMPILER_LAUNCHER=YES
if using a compatible launcher (in target 'ExpoKeepAwake' from project 'Pods')
```

i had claude try `C_COMPILER_LAUNCHER` and that, uh, didn't work.