### PR TITLE
Scope GITHUB_TOKEN permissions in the remaining workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '17 8 * * *'
 
+permissions:
+  contents: read
+
 env:
   MISE_RUBY_COMPILE: 'false'
 

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -13,6 +13,13 @@ on:
   schedule:
     - cron: '0 */6 * * *'
 
+# actions: write to delete cache entries; pull-requests: read so `gh pr view`
+# can tell which PR refs are still open.
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -3,6 +3,10 @@ name: Validate/Deploy Data
 on:
   push: {branches: [master]}
 
+# The final step force-pushes the bundled data to the gh-pages branch.
+permissions:
+  contents: write
+
 env:
   MISE_RUBY_COMPILE: 'false'
 


### PR DESCRIPTION
Closes the four open CodeQL "Workflow does not contain permissions" alerts (https://github.com/StoDevX/AAO-React-Native/security/code-scanning/7, https://github.com/StoDevX/AAO-React-Native/security/code-scanning/93, https://github.com/StoDevX/AAO-React-Native/security/code-scanning/94, https://github.com/StoDevX/AAO-React-Native/security/code-scanning/95).

Without an explicit `permissions:` block, a workflow's `GITHUB_TOKEN` inherits whatever the repository's default happens to be — which can be read/write on every scope. `check.yml`, `dependency-review.yml`, and `copilot-setup-steps.yml` already declared theirs; these three were the stragglers.

| Workflow | Permissions | Why |
| --- | --- | --- |
| `build-and-deploy.yml` | `contents: read` | Only checks out and builds. Signing and TestFlight upload go through App Store Connect and a separate PAT for the keys repo, not `GITHUB_TOKEN`. |
| `cache-cleanup.yml` | `actions: write`, `contents: read`, `pull-requests: read` | `gh cache delete` needs `actions: write`; `gh pr view` needs `pull-requests: read`; checkout and the `git/ref` API lookup need `contents: read`. |
| `deploy-data.yml` | `contents: write` | Force-pushes the bundled data to `gh-pages`. |

## Verification

- `python3 -c "import yaml…"` parses all six workflow files and reports the expected permissions on each.
- `prettier --check` passes on the three changed files.

`mise` isn't available in this environment, so `mise run agent:pre-commit` couldn't run — the change is YAML-only under `.github/workflows/`, so lint, tsc, and Jest have nothing to say about it, but that's worth a note.

---
_Generated by [Claude Code](https://claude.ai/code/session_017H8DzMMWBQ7PKjdSZk1ngB)_