### PR TITLE
Strip HTML tags with the parser instead of a regex

### DIFF
--- a/modules/food-menu/lib/build-filters.ts
+++ b/modules/food-menu/lib/build-filters.ts
@@ -28,7 +28,7 @@ export function buildFilters(
 	const allDietaryRestrictions = Object.values(corIcons).map((cor) => ({
 		title: decode(cor.label),
 		image: cor.image ? {uri: cor.image} : null,
-		detail: cor.description ? decode(fastGetTrimmedText(cor.description)) : '',
+		detail: cor.description ? fastGetTrimmedText(cor.description) : '',
 	}))
 
 	// Decide which meal will be selected by default

--- a/modules/html-lib/__tests__/remove-html.test.ts
+++ b/modules/html-lib/__tests__/remove-html.test.ts
@@ -40,6 +40,12 @@ describe('removeHtml', () => {
 		expect(fastGetTrimmedText('  <p>a\n\n  b</p>  ')).toBe('a b')
 	})
 
+	it('handles deeply nested markup without overflowing the stack', () => {
+		const depth = 20_000
+		const input = `${'<div>'.repeat(depth)}deep${'</div>'.repeat(depth)}`
+		expect(fastGetTrimmedText(input)).toBe('deep')
+	})
+
 	it('runs in linear time on many unclosed angle brackets', () => {
 		// Guards the ReDoS the old `/<[^>]*>/gu` implementation was flagged for:
 		// a string of many '<' with no closing '>' made it backtrack.

--- a/modules/html-lib/__tests__/remove-html.test.ts
+++ b/modules/html-lib/__tests__/remove-html.test.ts
@@ -1,0 +1,52 @@
+import {fastGetTrimmedText, removeHtml} from '../index'
+
+describe('removeHtml', () => {
+	it('strips tags, leaving the text content', () => {
+		expect(removeHtml('<p>Hello world</p>')).toBe('Hello world')
+	})
+
+	it('separates text split by a tag with a space', () => {
+		expect(fastGetTrimmedText('one<br>two')).toBe('one two')
+		expect(fastGetTrimmedText('<b>one</b><i>two</i>')).toBe('one two')
+	})
+
+	it('decodes character entities', () => {
+		expect(fastGetTrimmedText('Bread &amp; Butter')).toBe('Bread & Butter')
+		expect(fastGetTrimmedText('<p>caf&eacute;</p>')).toBe('café')
+	})
+
+	it('does not treat a decoded entity as markup', () => {
+		expect(fastGetTrimmedText('&lt;b&gt;not bold&lt;/b&gt;')).toBe(
+			'<b>not bold</b>',
+		)
+	})
+
+	it('drops script and style bodies', () => {
+		expect(fastGetTrimmedText('<style>p {color: red}</style>Hi')).toBe('Hi')
+		expect(fastGetTrimmedText('<script>alert(1)</script>Hi')).toBe('Hi')
+	})
+
+	it('keeps text from unclosed and malformed tags', () => {
+		expect(fastGetTrimmedText('<p>unclosed')).toBe('unclosed')
+		expect(fastGetTrimmedText('a < b')).toBe('a < b')
+	})
+
+	it('handles plain text without markup', () => {
+		expect(fastGetTrimmedText('Student Worker')).toBe('Student Worker')
+		expect(fastGetTrimmedText('')).toBe('')
+	})
+
+	it('collapses whitespace and trims', () => {
+		expect(fastGetTrimmedText('  <p>a\n\n  b</p>  ')).toBe('a b')
+	})
+
+	it('runs in linear time on many unclosed angle brackets', () => {
+		// Guards the ReDoS the old `/<[^>]*>/gu` implementation was flagged for:
+		// a string of many '<' with no closing '>' made it backtrack.
+		const input = `${'<'.repeat(50_000)}!`
+		const start = process.hrtime.bigint()
+		fastGetTrimmedText(input)
+		const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6
+		expect(elapsedMs).toBeLessThan(1000)
+	})
+})

--- a/modules/html-lib/index.ts
+++ b/modules/html-lib/index.ts
@@ -17,12 +17,39 @@ export function innerTextWithSpaces(elem: AnyNode): string {
 	return textContent(elem).split(/\s+/u).join(' ').trim()
 }
 
-export function removeHtmlWithRegex(str: string): string {
-	return str.replace(/<[^>]*>/gu, ' ')
+function collectText(nodes: ChildNode[], out: string[]): void {
+	for (const node of nodes) {
+		if (isText(node)) {
+			out.push(node.data)
+			continue
+		}
+
+		if (!isTag(node)) continue
+
+		// `<script>` and `<style>` bodies are code, not prose; dropping them
+		// keeps stylesheets and JS out of what we render as text.
+		const tag = node.name.toLowerCase()
+		if (tag === 'script' || tag === 'style') continue
+
+		collectText(node.children, out)
+	}
+}
+
+/**
+ * Strips HTML tags from a string, leaving only its text content.
+ *
+ * Text runs separated by a tag are joined with a space, so `a<br>b` becomes
+ * `a b` rather than `ab`. Character entities are decoded — callers do not need
+ * to run the result through `decode`.
+ */
+export function removeHtml(str: string): string {
+	const parts: string[] = []
+	collectText(parseHtml(str).children, parts)
+	return parts.join(' ')
 }
 
 export function fastGetTrimmedText(str: string): string {
-	return removeHtmlWithRegex(str).replace(/\s+/gu, ' ').trim()
+	return removeHtml(str).replace(/\s+/gu, ' ').trim()
 }
 
 // ── Structured HTML-to-text utilities ─────────────────────────────────────

--- a/modules/html-lib/index.ts
+++ b/modules/html-lib/index.ts
@@ -18,7 +18,11 @@ export function innerTextWithSpaces(elem: AnyNode): string {
 }
 
 function collectText(nodes: ChildNode[], out: string[]): void {
-	for (const node of nodes) {
+	// An explicit stack rather than recursion: the markup here is uncontrolled,
+	// and deeply nested input would otherwise overflow the call stack.
+	const stack: ChildNode[] = nodes.slice().reverse()
+
+	for (let node = stack.pop(); node !== undefined; node = stack.pop()) {
 		if (isText(node)) {
 			out.push(node.data)
 			continue
@@ -31,7 +35,11 @@ function collectText(nodes: ChildNode[], out: string[]): void {
 		const tag = node.name.toLowerCase()
 		if (tag === 'script' || tag === 'style') continue
 
-		collectText(node.children, out)
+		// Pushed in reverse so they pop back off in document order.
+		const {children} = node
+		for (let i = children.length - 1; i >= 0; i -= 1) {
+			stack.push(children[i])
+		}
 	}
 }
 


### PR DESCRIPTION
Resolves the CodeQL `js/polynomial-redos` alert on `modules/html-lib/index.ts:21`.

`@frogpond/html-lib` already parses HTML with `htmlparser2`, so this now uses the same parser rather than adding a dependency. 

Resolves https://github.com/StoDevX/AAO-React-Native/security/code-scanning/1

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1tMgYUBZ4mQygyAi2BZN5)_