### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/source/features/settings/screens/overview/use-server-discovery.ts
+++ b/source/features/settings/screens/overview/use-server-discovery.ts
@@ -42,7 +42,8 @@ export const useServerDiscovery = (): DiscoveredServer[] => {
 		const zeroconf = new Zeroconf()
 
 		const onResolved = (service: ResolvedService) => {
-			const path = service.txt?.path || '/v1/'
+			const path =
+				service.txt?.path && service.txt.path !== '' ? service.txt.path : '/v1/'
 			const url = `http://${formatHost(service)}:${service.port}${path}`
 			setServers((prev) => {
 				const already = prev.some((s) => s.url === url)


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/StoDevX/AAO-React-Native/security/quality/ai-findings)._

> When `service.txt.path` is an empty string (as tested in the test file at line 68), the logical OR will still use the empty string instead of defaulting to '/v1/'. This causes the test expectation at line 73 to fail because the URL becomes 'http://192.168.0.10:3000' instead of 'http://192.168.0.10:3000/v1/'. Use nullish coalescing (`??`) or explicitly check for empty string: `const path = service.txt?.path && service.txt.path !== '' ? service.txt.path : '/v1/'`.
