### PR TITLE
Rebase #7704 (misc fixes) onto #7656 (expo-router migration)

### DIFF
--- a/app/(component-library)/_layout.tsx
+++ b/app/(component-library)/_layout.tsx
@@ -2,5 +2,5 @@ import * as React from 'react'
 import {Stack} from 'expo-router'
 
 export default function ComponentLibraryLayout(): React.ReactNode {
-	return <Stack />
+	return <Stack screenOptions={{headerBackButtonDisplayMode: 'minimal'}} />
 }

--- a/app/(home)/_layout.tsx
+++ b/app/(home)/_layout.tsx
@@ -3,7 +3,7 @@ import {Stack} from 'expo-router'
 
 export default function HomeLayout(): React.ReactNode {
 	return (
-		<Stack>
+		<Stack screenOptions={{headerBackButtonDisplayMode: 'minimal'}}>
 			<Stack.Screen name="Menus" options={{title: 'Menus'}} />
 			<Stack.Screen
 				name="Streaming Media"

--- a/app/(settings)/ReportProblem.tsx
+++ b/app/(settings)/ReportProblem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {StyleSheet} from 'react-native'
+import {Alert, StyleSheet} from 'react-native'
 import {Form, Host, Section, TextField} from '@expo/ui/swift-ui'
 import {
 	autocorrectionDisabled,
@@ -25,12 +25,20 @@ export default function ReportProblemPage(): React.ReactNode {
 	let [email, setEmail] = React.useState('')
 
 	let submit = () => {
-		submitReport({
+		let submitted = submitReport({
 			message: message.trim(),
 			name: name.trim() || undefined,
 			email: email.trim() || undefined,
 		})
-		navigation.goBack()
+
+		if (submitted) {
+			navigation.goBack()
+		} else {
+			Alert.alert(
+				'Sentry is disabled',
+				'Problem reporting only works in production builds.',
+			)
+		}
 	}
 
 	return (

--- a/app/(settings)/_layout.tsx
+++ b/app/(settings)/_layout.tsx
@@ -3,7 +3,7 @@ import {Stack} from 'expo-router'
 
 export default function SettingsLayout(): React.ReactNode {
 	return (
-		<Stack>
+		<Stack screenOptions={{headerBackButtonDisplayMode: 'minimal'}}>
 			<Stack.Screen name="Credits" options={{title: 'Credits'}} />
 			<Stack.Screen name="Privacy" options={{title: 'Privacy'}} />
 			<Stack.Screen name="Legal" options={{title: 'Legal'}} />

--- a/data/faqs.yaml
+++ b/data/faqs.yaml
@@ -26,7 +26,7 @@ faqs:
 
       Balances login now appears to require Google sign-in on St. Olaf's end, which the All About Olaf app can't currently access or support.
 
-      We'll update this if this change.
+      We'll update this if this changes.
     bannerTitle: Login and Balances Unavailable
     bannerText: Balances login now appears to require Google sign-in on St. Olaf's end, which the All About Olaf app can't currently access or support.
     targets:

--- a/modules/tableview/cells/toggle.tsx
+++ b/modules/tableview/cells/toggle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {StyleSheet, Switch, View} from 'react-native'
+import {Switch} from 'react-native'
 import {Cell} from '@frogpond/tableview'
 import {useTheme} from '@frogpond/app-theme'
 
@@ -17,17 +17,15 @@ export function CellToggle(props: PropsType): React.ReactNode {
 	let {value, onChange, label, detail, disabled} = props
 
 	let toggle = (
-		<View style={styles.toggleContainer}>
-			<Switch
-				disabled={disabled}
-				onValueChange={onChange}
-				trackColor={{
-					true: colors.primary,
-					false: undefined,
-				}}
-				value={value}
-			/>
-		</View>
+		<Switch
+			disabled={disabled}
+			onValueChange={onChange}
+			trackColor={{
+				true: colors.primary,
+				false: undefined,
+			}}
+			value={value}
+		/>
 	)
 
 	return (
@@ -39,9 +37,3 @@ export function CellToggle(props: PropsType): React.ReactNode {
 		/>
 	)
 }
-
-const styles = StyleSheet.create({
-	toggleContainer: {
-		justifyContent: 'center',
-	},
-})

--- a/modules/tableview/cells/toggle.tsx
+++ b/modules/tableview/cells/toggle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {Switch} from 'react-native'
+import {StyleSheet, Switch, View} from 'react-native'
 import {Cell} from '@frogpond/tableview'
 import {useTheme} from '@frogpond/app-theme'
 
@@ -17,15 +17,17 @@ export function CellToggle(props: PropsType): React.ReactNode {
 	let {value, onChange, label, detail, disabled} = props
 
 	let toggle = (
-		<Switch
-			disabled={disabled}
-			onValueChange={onChange}
-			trackColor={{
-				true: colors.primary,
-				false: undefined,
-			}}
-			value={value}
-		/>
+		<View style={styles.toggleContainer}>
+			<Switch
+				disabled={disabled}
+				onValueChange={onChange}
+				trackColor={{
+					true: colors.primary,
+					false: undefined,
+				}}
+				value={value}
+			/>
+		</View>
 	)
 
 	return (
@@ -37,3 +39,9 @@ export function CellToggle(props: PropsType): React.ReactNode {
 		/>
 	)
 }
+
+const styles = StyleSheet.create({
+	toggleContainer: {
+		justifyContent: 'center',
+	},
+})

--- a/source/features/faqs/banner.tsx
+++ b/source/features/faqs/banner.tsx
@@ -238,37 +238,37 @@ type Palette = {
 
 const SEVERITY_MAP: Record<FaqSeverity, Palette> = {
 	notice: {
-		background: c.white as ColorValue,
+		background: c.secondarySystemGroupedBackground as ColorValue,
 		border: c.separator as ColorValue,
 		text: c.label as ColorValue,
 		secondaryText: c.secondaryLabel as ColorValue,
 		link: c.link as ColorValue,
 		icon: 'information-circle',
 		iconColor: c.systemBlue as ColorValue,
-		dismissBackground: c.secondarySystemBackground as ColorValue,
+		dismissBackground: c.tertiarySystemGroupedBackground as ColorValue,
 		dismissText: c.systemBlue as ColorValue,
 	},
 	info: {
-		background: '#f0f9ff',
-		border: '#b6e0fe',
-		text: '#0f172a',
-		secondaryText: '#0f172a',
-		link: '#075985',
+		background: c.secondarySystemGroupedBackground as ColorValue,
+		border: c.systemBlue as ColorValue,
+		text: c.label as ColorValue,
+		secondaryText: c.secondaryLabel as ColorValue,
+		link: c.link as ColorValue,
 		icon: 'help-circle',
-		iconColor: '#075985',
-		dismissBackground: '#dbeafe',
-		dismissText: '#1d4ed8',
+		iconColor: c.systemBlue as ColorValue,
+		dismissBackground: c.tertiarySystemGroupedBackground as ColorValue,
+		dismissText: c.systemBlue as ColorValue,
 	},
 	alert: {
-		background: '#fef2f2',
-		border: '#fecaca',
-		text: '#7f1d1d',
-		secondaryText: '#7f1d1d',
-		link: '#b91c1c',
+		background: c.secondarySystemGroupedBackground as ColorValue,
+		border: c.systemRed as ColorValue,
+		text: c.label as ColorValue,
+		secondaryText: c.secondaryLabel as ColorValue,
+		link: c.systemRed as ColorValue,
 		icon: 'alert-circle',
-		iconColor: '#b91c1c',
-		dismissBackground: '#fee2e2',
-		dismissText: '#b91c1c',
+		iconColor: c.systemRed as ColorValue,
+		dismissBackground: c.tertiarySystemGroupedBackground as ColorValue,
+		dismissText: c.systemRed as ColorValue,
 	},
 }
 
@@ -315,7 +315,11 @@ export function FaqBannerPresentation({
 					{faq.bannerTitle ?? faq.question}
 				</Text>
 				{faq.dismissable ? (
-					<View
+					<Pressable
+						accessibilityLabel="Dismiss FAQ banner"
+						accessibilityRole="button"
+						hitSlop={8}
+						onPress={(e) => e.stopPropagation()}
 						style={[
 							styles.dismissButton,
 							{backgroundColor: palette.dismissBackground},
@@ -324,7 +328,7 @@ export function FaqBannerPresentation({
 						<Text style={[styles.dismissText, {color: palette.dismissText}]}>
 							×
 						</Text>
-					</View>
+					</Pressable>
 				) : null}
 			</View>
 			{faq.bannerText ? (

--- a/source/features/settings/screens/overview/report-problem/__tests__/submit.test.ts
+++ b/source/features/settings/screens/overview/report-problem/__tests__/submit.test.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/react-native'
 import {submitReport} from '../submit'
 
 jest.mock('@sentry/react-native', () => ({captureFeedback: jest.fn()}))
+jest.mock('@frogpond/constants', () => ({IS_PRODUCTION: true}))
 jest.mock('expo-device', () => ({
 	brand: 'Apple',
 	modelName: 'iPhone 14 Pro',
@@ -20,12 +21,13 @@ describe('submitReport', () => {
 	})
 
 	it('sends the message, name, email, and device tags to Sentry', () => {
-		submitReport({
+		let result = submitReport({
 			message: 'it crashed',
 			name: 'Wren',
 			email: 'wren@example.com',
 		})
 
+		expect(result).toBe(true)
 		expect(Sentry.captureFeedback).toHaveBeenCalledTimes(1)
 		expect(Sentry.captureFeedback).toHaveBeenCalledWith({
 			message: 'it crashed',
@@ -53,5 +55,24 @@ describe('submitReport', () => {
 				email: undefined,
 			}),
 		)
+	})
+})
+
+describe('submitReport in non-production', () => {
+	it('returns false and does not call Sentry.captureFeedback', () => {
+		jest.resetModules()
+		jest.doMock('@frogpond/constants', () => ({IS_PRODUCTION: false}))
+		jest.doMock('@sentry/react-native', () => ({captureFeedback: jest.fn()}))
+		const SentryDev =
+			// eslint-disable-next-line @typescript-eslint/no-require-imports -- re-require after jest.doMock to pick up the mocked deps
+			require('@sentry/react-native') as typeof import('@sentry/react-native')
+		const {submitReport: submitReportDev} =
+			// eslint-disable-next-line @typescript-eslint/no-require-imports -- re-require after jest.doMock to pick up the mocked deps
+			require('../submit') as typeof import('../submit')
+
+		let result = submitReportDev({message: 'it crashed'})
+
+		expect(result).toBe(false)
+		expect(SentryDev.captureFeedback).not.toHaveBeenCalled()
 	})
 })

--- a/source/features/settings/screens/overview/report-problem/submit.ts
+++ b/source/features/settings/screens/overview/report-problem/submit.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-native'
 import * as Application from 'expo-application'
 import * as Device from 'expo-device'
+import {IS_PRODUCTION} from '@frogpond/constants'
 
 type SubmitReportArgs = {
 	message: string
@@ -8,7 +9,11 @@ type SubmitReportArgs = {
 	email?: string
 }
 
-export function submitReport(args: SubmitReportArgs): void {
+export function submitReport(args: SubmitReportArgs): boolean {
+	if (!IS_PRODUCTION) {
+		return false
+	}
+
 	let {message, name, email} = args
 
 	Sentry.captureFeedback({
@@ -25,4 +30,6 @@ export function submitReport(args: SubmitReportArgs): void {
 			buildNumber: Application.nativeBuildVersion,
 		},
 	})
+
+	return true
 }


### PR DESCRIPTION
Rebases #7704's commits onto the head of #7656 (the react-navigation → expo-router migration), so #7704 can land after #7656 merges without conflicts.

## Changes

Same 8 commits as #7704, replayed onto #7656's tip:

- Fix typo in FAQ answer text
- Vertically center the toggle switch in table cells (later reverted within the same set of commits — net no-op, matching #7704)
- Use minimal back button display mode instead of custom text
- Use adaptive system colors for FAQ banners and fix dismiss button
- Wrap app in `GestureHandlerRootView` for gesture handler v2+ / its revert — both dropped as no-ops, since #7656's `app/_layout.tsx` already wraps the app in `GestureHandlerRootView`
- Present "Report a Problem", disable send outside production

## Conflict resolution notes

#7656 restructured navigation to expo-router's file-based routing, so several of #7704's changes had to be re-targeted at their new locations instead of applying verbatim:

- **Back button style** (`headerBackButtonDisplayMode: 'minimal'`): originally set via `screenOptions` on `source/navigation/routes.tsx`'s stack navigators (now deleted). Re-applied as `screenOptions` on the corresponding `<Stack>` in `app/(home)/_layout.tsx`, `app/(settings)/_layout.tsx`, and `app/(component-library)/_layout.tsx`.
- **Report a Problem screen**: `source/views/settings/screens/overview/report-problem/screen.tsx` was replaced by `app/(settings)/ReportProblem.tsx` in #7656, with a different UI (toolbar submit button instead of a form `Button`/`Alert`). Re-implemented the "disabled outside production" behavior there using `Alert.alert(...)`, consistent with how other screens in `app/` already do this, since `submitReport` (moved to `source/features/settings/screens/overview/report-problem/submit.ts`) already carried its `IS_PRODUCTION` boolean-return change forward cleanly via auto-merge.
- **GestureHandlerRootView wrap / revert pair**: both were dropped since `source/app.tsx` no longer exists (replaced by `app/_layout.tsx`, which already includes this wrapping) and the pair was a no-op in #7704 too.

## Verification

- `tsc --noEmit` — clean
- `eslint` — clean
- `jest` — 354 tests, 351 passed, 3 skipped, all suites green
- `prettier --check` — clean on touched files

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANrByhExKH9bGrS2379QX7)_