### PR TITLE
Declare screen titles with Stack.Title

### DIFF
--- a/app/(component-library)/BadgeLibrary.tsx
+++ b/app/(component-library)/BadgeLibrary.tsx
@@ -66,7 +66,7 @@ const SolidBadgeExamples = (): React.ReactNode => (
 export default function BadgeLibraryPage(): React.ReactNode {
 	return (
 		<>
-			<Stack.Screen options={{title: 'Badges'}} />
+			<Stack.Title>Badges</Stack.Title>
 			<LibraryWrapper>
 				<>
 					<OutlineBadgeExamples />

--- a/app/(component-library)/ButtonLibrary.tsx
+++ b/app/(component-library)/ButtonLibrary.tsx
@@ -90,7 +90,7 @@ const ButtonExample = (): React.ReactNode => {
 export default function ButtonLibraryPage(): React.ReactNode {
 	return (
 		<>
-			<Stack.Screen options={{title: 'Buttons'}} />
+			<Stack.Title>Buttons</Stack.Title>
 			<LibraryWrapper>
 				<>
 					<Section header="@frogpond/tableview/cells">

--- a/app/(component-library)/ColorsLibrary.tsx
+++ b/app/(component-library)/ColorsLibrary.tsx
@@ -241,7 +241,7 @@ export const NavigationKey = 'ColorsInfoView'
 export default function ColorsLibraryPage(): React.ReactNode {
 	return (
 		<>
-			<Stack.Screen options={{title: 'Colors'}} />
+			<Stack.Title>Colors</Stack.Title>
 			<LibraryWrapper>
 				<>
 					<Section header="Platform Colors">

--- a/app/(component-library)/ContextMenuLibrary.tsx
+++ b/app/(component-library)/ContextMenuLibrary.tsx
@@ -46,7 +46,7 @@ const SingleMenu = (): React.ReactNode => {
 export default function ContextMenuLibraryPage(): React.ReactNode {
 	return (
 		<>
-			<Stack.Screen options={{title: 'Context Menus'}} />
+			<Stack.Title>Context Menus</Stack.Title>
 			<LibraryWrapper>
 				<SingleMenu />
 			</LibraryWrapper>

--- a/app/(home)/BusRouteDetail.tsx
+++ b/app/(home)/BusRouteDetail.tsx
@@ -243,14 +243,14 @@ export default function BusRouteDetailPage(): React.ReactNode {
 		refetch,
 	} = useQuery(busLineOptions(lineName))
 
-	let screen = (
-		<Stack.Screen options={{title: line ? `${line.line} Schedule` : ''}} />
+	let screenTitle = (
+		<Stack.Title>{line ? `${line.line} Schedule` : ''}</Stack.Title>
 	)
 
 	if (isLoading) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<LoadingView />
 			</>
 		)
@@ -259,7 +259,7 @@ export default function BusRouteDetailPage(): React.ReactNode {
 	if (error) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView
 					buttonText="Try Again"
 					onPress={refetch}
@@ -274,7 +274,7 @@ export default function BusRouteDetailPage(): React.ReactNode {
 	if (!line) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView text={`Could not find the "${lineName}" bus line.`} />
 			</>
 		)
@@ -287,7 +287,7 @@ export default function BusRouteDetailPage(): React.ReactNode {
 	if (!stop) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView text={`Could not find the stop "${stopName}".`} />
 			</>
 		)
@@ -295,7 +295,7 @@ export default function BusRouteDetailPage(): React.ReactNode {
 
 	return (
 		<>
-			{screen}
+			{screenTitle}
 			<BusRouteDetailView line={line} stop={stop} subtitle={subtitle} />
 		</>
 	)

--- a/app/(home)/Contacts/[title].tsx
+++ b/app/(home)/Contacts/[title].tsx
@@ -62,12 +62,12 @@ export default function ContactsDetailPage(): React.ReactNode {
 	// Set from the route param immediately, then from the resolved contact
 	// once it loads -- so the header never falls back to the raw route name
 	// while loading, erroring, or failing to find the contact.
-	let screen = <Stack.Screen options={{title: contact?.title ?? title}} />
+	let screenTitle = <Stack.Title>{contact?.title ?? title}</Stack.Title>
 
 	if (isLoading) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<LoadingView />
 			</>
 		)
@@ -76,7 +76,7 @@ export default function ContactsDetailPage(): React.ReactNode {
 	if (error) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView
 					buttonText="Try Again"
 					onPress={refetch}
@@ -91,7 +91,7 @@ export default function ContactsDetailPage(): React.ReactNode {
 	if (!contact) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView text={`Could not find contact "${title}".`} />
 			</>
 		)
@@ -113,7 +113,7 @@ export default function ContactsDetailPage(): React.ReactNode {
 
 	return (
 		<>
-			{screen}
+			{screenTitle}
 			<ScrollView contentInsetAdjustmentBehavior="automatic">
 				{headerImage ? (
 					<Image resizeMode="cover" source={headerImage} style={styles.image} />

--- a/app/(home)/CourseDetail.tsx
+++ b/app/(home)/CourseDetail.tsx
@@ -251,12 +251,12 @@ export default function CourseDetailPage(): React.ReactNode {
 
 	// The route param is a course id, meaningless to a user, so the title
 	// stays empty until the course loads rather than falling back to it.
-	let screen = <Stack.Screen options={{title: course?.name ?? ''}} />
+	let screenTitle = <Stack.Title>{course?.name ?? ''}</Stack.Title>
 
 	if (termLoading || courseLoading) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<LoadingView />
 			</>
 		)
@@ -265,7 +265,7 @@ export default function CourseDetailPage(): React.ReactNode {
 	if (error) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView
 					buttonText="Try Again"
 					onPress={refetch}
@@ -280,7 +280,7 @@ export default function CourseDetailPage(): React.ReactNode {
 	if (!course) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView text="Could not find this course." />
 			</>
 		)
@@ -288,7 +288,7 @@ export default function CourseDetailPage(): React.ReactNode {
 
 	return (
 		<>
-			{screen}
+			{screenTitle}
 			<CourseDetailView course={course} />
 		</>
 	)

--- a/app/(home)/CourseSearch.tsx
+++ b/app/(home)/CourseSearch.tsx
@@ -20,10 +20,6 @@ let _debounce = debounce((query: string, callback: () => void) => {
 	}
 }, 1500)
 
-const NavigationOptions = {
-	title: 'Course Catalog',
-}
-
 function CourseSearchView(): React.ReactNode {
 	let router = useRouter()
 
@@ -126,7 +122,7 @@ let styles = StyleSheet.create({
 export default function CourseSearchPage(): React.ReactNode {
 	return (
 		<>
-			<Stack.Screen options={NavigationOptions} />
+			<Stack.Title>Course Catalog</Stack.Title>
 			<CourseSearchView />
 		</>
 	)

--- a/app/(home)/CourseSearch.tsx
+++ b/app/(home)/CourseSearch.tsx
@@ -1,7 +1,6 @@
 import * as c from '@frogpond/colors'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 import {Stack, useRouter} from 'expo-router'
-import {debounce} from 'lodash'
 import * as React from 'react'
 import {useEffect} from 'react'
 import {useMemo} from 'react'
@@ -14,11 +13,8 @@ import {
 import {RecentItemsList} from '../../source/features/sis/components/recents-list'
 import {useFilters} from '../../source/features/sis/course-search/lib/build-filters'
 
-let _debounce = debounce((query: string, callback: () => void) => {
-	if (query.length >= 2) {
-		callback()
-	}
-}, 1500)
+const SEARCH_DEBOUNCE_MS = 1500
+const MIN_QUERY_LENGTH = 2
 
 function CourseSearchView(): React.ReactNode {
 	let router = useRouter()
@@ -40,8 +36,20 @@ function CourseSearchView(): React.ReactNode {
 		[router],
 	)
 
+	// Re-running on every keystroke clears the previous timer, which is the
+	// debounce; the cleanup also cancels a pending search on unmount, so
+	// navigating away mid-type cannot push a results screen afterwards.
 	useEffect(() => {
-		_debounce(typedQuery, () => showSearchResult(typedQuery))
+		if (typedQuery.length < MIN_QUERY_LENGTH) {
+			return
+		}
+
+		let timer = setTimeout(
+			() => showSearchResult(typedQuery),
+			SEARCH_DEBOUNCE_MS,
+		)
+
+		return () => clearTimeout(timer)
 	}, [showSearchResult, typedQuery])
 
 	let recentFilterDescriptions = useMemo(

--- a/app/(home)/CourseSearchResults.tsx
+++ b/app/(home)/CourseSearchResults.tsx
@@ -289,7 +289,7 @@ let styles = StyleSheet.create({
 export default function CourseSearchResultsPage(): React.ReactNode {
 	return (
 		<>
-			<Stack.Screen options={{title: 'Course Catalog'}} />
+			<Stack.Title>Course Catalog</Stack.Title>
 			<CourseSearchResultsView />
 		</>
 	)

--- a/app/(home)/Dictionary/[word]/edit.tsx
+++ b/app/(home)/Dictionary/[word]/edit.tsx
@@ -117,7 +117,7 @@ function DictionaryEditorLoader(): React.ReactNode {
 export default function DictionaryEditorPage(): React.ReactNode {
 	return (
 		<>
-			<Stack.Screen options={{title: 'Suggest an edit'}} />
+			<Stack.Title>Suggest an edit</Stack.Title>
 			<DictionaryEditorLoader />
 		</>
 	)

--- a/app/(home)/Dictionary/[word]/index.tsx
+++ b/app/(home)/Dictionary/[word]/index.tsx
@@ -44,12 +44,12 @@ export default function DictionaryDetailPage(): React.ReactNode {
 		refetch,
 	} = useQuery(wordByTermOptions(word))
 
-	let screen = <Stack.Screen options={{title: entry?.word ?? word}} />
+	let screenTitle = <Stack.Title>{entry?.word ?? word}</Stack.Title>
 
 	if (isLoading) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<LoadingView />
 			</>
 		)
@@ -58,7 +58,7 @@ export default function DictionaryDetailPage(): React.ReactNode {
 	if (error) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView
 					buttonText="Try Again"
 					onPress={refetch}
@@ -73,7 +73,7 @@ export default function DictionaryDetailPage(): React.ReactNode {
 	if (!entry) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView text={`Could not find the word "${word}".`} />
 			</>
 		)
@@ -87,7 +87,7 @@ export default function DictionaryDetailPage(): React.ReactNode {
 
 	return (
 		<>
-			{screen}
+			{screenTitle}
 			<Container>
 				<Term selectable={true}>{entry.word}</Term>
 				<Markdown

--- a/app/(home)/Dictionary/index.tsx
+++ b/app/(home)/Dictionary/index.tsx
@@ -166,7 +166,7 @@ function DictionaryView(): React.ReactNode {
 export default function DictionaryPage(): React.ReactNode {
 	return (
 		<>
-			<Stack.Screen options={{title: 'Campus Dictionary'}} />
+			<Stack.Title>Campus Dictionary</Stack.Title>
 			<DictionaryView />
 		</>
 	)

--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -39,14 +39,14 @@ export default function DirectoryDetailPage(): React.ReactNode {
 		),
 	)
 
-	let screen = (
-		<Stack.Screen options={{title: contact?.displayName ?? 'Contact'}} />
+	let screenTitle = (
+		<Stack.Title>{contact?.displayName ?? 'Contact'}</Stack.Title>
 	)
 
 	if (isLoading) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<LoadingView />
 			</>
 		)
@@ -55,7 +55,7 @@ export default function DirectoryDetailPage(): React.ReactNode {
 	if (error) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView
 					buttonText="Try Again"
 					onPress={refetch}
@@ -70,7 +70,7 @@ export default function DirectoryDetailPage(): React.ReactNode {
 	if (!contact) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView text="Could not find this directory entry." />
 			</>
 		)
@@ -90,7 +90,7 @@ export default function DirectoryDetailPage(): React.ReactNode {
 
 	return (
 		<>
-			{screen}
+			{screenTitle}
 			<ScrollView contentInsetAdjustmentBehavior="automatic">
 				<Image
 					accessibilityIgnoresInvertColors={true}

--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -131,7 +131,7 @@ export default function DirectoryPage(): React.ReactNode {
 
 	return (
 		<>
-			<Stack.Screen options={{title: params.queryParam ?? 'Directory'}} />
+			<Stack.Title>{params.queryParam ?? 'Directory'}</Stack.Title>
 			<DirectoryView />
 		</>
 	)

--- a/app/(home)/KRLXSchedule.tsx
+++ b/app/(home)/KRLXSchedule.tsx
@@ -25,7 +25,7 @@ export default function KRLXSchedulePage(): React.ReactNode {
 
 	return (
 		<>
-			<Stack.Screen options={{title: 'KRLX Schedule'}} />
+			<Stack.Title>KRLX Schedule</Stack.Title>
 			<CccCalendarView
 				onPressEvent={onPressEvent}
 				poweredBy={KRLX_POWERED_BY}

--- a/app/(home)/KSTOSchedule.tsx
+++ b/app/(home)/KSTOSchedule.tsx
@@ -25,7 +25,7 @@ export default function KSTOSchedulePage(): React.ReactNode {
 
 	return (
 		<>
-			<Stack.Screen options={{title: 'KSTO Schedule'}} />
+			<Stack.Title>KSTO Schedule</Stack.Title>
 			<CccCalendarView
 				onPressEvent={onPressEvent}
 				poweredBy={KSTO_POWERED_BY}

--- a/app/(home)/RedditPostDetail.tsx
+++ b/app/(home)/RedditPostDetail.tsx
@@ -430,7 +430,7 @@ export default function RedditPostDetailPage(): React.ReactNode {
 
 	return (
 		<>
-			<Stack.Screen options={{title: communityName}} />
+			<Stack.Title>{communityName}</Stack.Title>
 			<RedditPostDetailLoader />
 		</>
 	)

--- a/app/(home)/StudentOrgs/[name].tsx
+++ b/app/(home)/StudentOrgs/[name].tsx
@@ -40,12 +40,12 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 	let {name} = useLocalSearchParams<{name: string}>()
 	let {data: org, isLoading, error, refetch} = useQuery(orgByNameOptions(name))
 
-	let screen = <Stack.Screen options={{title: org?.name ?? name}} />
+	let screenTitle = <Stack.Title>{org?.name ?? name}</Stack.Title>
 
 	if (isLoading) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<LoadingView />
 			</>
 		)
@@ -54,7 +54,7 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 	if (error) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView
 					buttonText="Try Again"
 					onPress={refetch}
@@ -69,7 +69,7 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 	if (!org) {
 		return (
 			<>
-				{screen}
+				{screenTitle}
 				<NoticeView text={`Could not find student org "${name}".`} />
 			</>
 		)
@@ -88,7 +88,7 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 
 	return (
 		<>
-			{screen}
+			{screenTitle}
 			<ScrollView contentInsetAdjustmentBehavior="automatic">
 				<TableView>
 					<Text selectable={true} style={styles.name}>

--- a/app/(home)/index.tsx
+++ b/app/(home)/index.tsx
@@ -164,13 +164,13 @@ export default function HomePage(): React.ReactNode {
 		<>
 			<Stack.Screen
 				options={{
-					title: 'All About Olaf',
 					contentStyle: {backgroundColor: PlatformColor('systemBackground')},
 					headerShadowVisible: false,
 					headerLargeTitleEnabled: true,
 					headerTransparent: true,
 				}}
 			/>
+			<Stack.Title>All About Olaf</Stack.Title>
 			<Stack.Toolbar placement="right">
 				<Stack.Toolbar.Button
 					accessibilityLabel="Open Settings"

--- a/app/(settings)/Debug/index.tsx
+++ b/app/(settings)/Debug/index.tsx
@@ -8,7 +8,7 @@ export default function DebugPage(): React.ReactNode {
 
 	return (
 		<>
-			<Stack.Screen options={{title: 'Debug'}} />
+			<Stack.Title>Debug</Stack.Title>
 			<Stack.Toolbar placement="right">
 				<Stack.Toolbar.Button
 					accessibilityLabel="Close Screen"

--- a/app/(settings)/ReportProblem.tsx
+++ b/app/(settings)/ReportProblem.tsx
@@ -43,24 +43,22 @@ export default function ReportProblemPage(): React.ReactNode {
 
 	return (
 		<>
-			<Stack.Screen>
-				<Stack.Title>Report a Problem</Stack.Title>
-				<Stack.Toolbar placement="left">
-					<Stack.Toolbar.Button
-						accessibilityLabel="Close Screen"
-						icon="xmark"
-						onPress={() => navigation.goBack()}
-					/>
-				</Stack.Toolbar>
-				<Stack.Toolbar placement="right">
-					<Stack.Toolbar.Button
-						accessibilityLabel="Submit"
-						disabled={message.trim().length === 0}
-						icon="paperplane"
-						onPress={submit}
-					/>
-				</Stack.Toolbar>
-			</Stack.Screen>
+			<Stack.Title>Report a Problem</Stack.Title>
+			<Stack.Toolbar placement="left">
+				<Stack.Toolbar.Button
+					accessibilityLabel="Close Screen"
+					icon="xmark"
+					onPress={() => navigation.goBack()}
+				/>
+			</Stack.Toolbar>
+			<Stack.Toolbar placement="right">
+				<Stack.Toolbar.Button
+					accessibilityLabel="Submit"
+					disabled={message.trim().length === 0}
+					icon="paperplane"
+					onPress={submit}
+				/>
+			</Stack.Toolbar>
 
 			<Host style={styles.host}>
 				<Form>

--- a/app/(settings)/_layout.tsx
+++ b/app/(settings)/_layout.tsx
@@ -4,9 +4,9 @@ import {Stack} from 'expo-router'
 export default function SettingsLayout(): React.ReactNode {
 	return (
 		<Stack screenOptions={{headerBackButtonDisplayMode: 'minimal'}}>
-			<Stack.Screen name="Credits" options={{title: 'Credits'}} />
-			<Stack.Screen name="Privacy" options={{title: 'Privacy'}} />
-			<Stack.Screen name="Legal" options={{title: 'Legal'}} />
+			<Stack.Screen name="Credits" />
+			<Stack.Screen name="Privacy" />
+			<Stack.Screen name="Legal" />
 			<Stack.Screen name="ReportProblem" options={{presentation: 'modal'}} />
 			<Stack.Screen
 				name="NetworkLogger"


### PR DESCRIPTION
Stacked on #7693 — review that one first; this branch's base should be retargeted to `master` once it merges.

Expo Router 57 deprecates `Stack.Screen.Title` in favour of `Stack.Title`, and its own docs say to prefer the composition components over an options object when configuring a header from inside a page component. Titles were the last header concern still going through `options`, so this moves them across.

## What changed

**Every page that set only a title drops `Stack.Screen` entirely.** 19 screens, static and dynamic alike:

```tsx
-<Stack.Screen options={{title: 'Campus Dictionary'}} />
+<Stack.Title>Campus Dictionary</Stack.Title>

-let screen = <Stack.Screen options={{title: entry?.word ?? word}} />
+let screenTitle = <Stack.Title>{entry?.word ?? word}</Stack.Title>
```

The detail screens hold that element in a variable reused across their loading/error/empty branches. It's a title now rather than a screen, so the variable is renamed to match.

**The home screen keeps its `Stack.Screen`** for the four options with no component form (`contentStyle`, `headerShadowVisible`, `headerLargeTitleEnabled`, `headerTransparent`), with the title pulled out alongside it. `Stack.Title` does have a `large` prop, but it writes the deprecated `headerLargeTitle` alias, so large-title config stays on `headerLargeTitleEnabled` in the options object.

**The last `NavigationOptions` constant is gone.** #7693 already stripped the `as React.ComponentProps<typeof Stack.Screen>['options']` cast off it; with the title inlined the constant has nothing left in it.

**Two duplicate declarations dropped.** Credits, Privacy and Legal each declared a title twice — once in `(settings)/_layout.tsx`, once as their own `Stack.Title`. Composition options win the merge in `mergeOptions`, so the layout copies never applied.

**`ReportProblem` flattened.** It was the one screen nesting its `Title` and `Toolbar`s inside `Stack.Screen`; now siblings, like everywhere else.

Layout-level titles in `(home)/_layout.tsx` are left alone — `Menus`, `News`, `SIS` and friends are `NativeTabs` groups whose stack title has no in-screen declaration to move it to.

## Second commit: the course search debounce

Separable from the above, in the same file, and a behaviour change rather than a refactor — drop the commit if you'd rather keep this PR to titles.

`debounce()` was called at module scope in `CourseSearch.tsx`, so a single timer was shared by every mount of the screen, and the effect driving it had no cleanup. Typing and then navigating away inside the 1.5s window left the pending call to fire and push `/CourseSearchResults` onto whatever screen had replaced it.

```tsx
useEffect(() => {
	if (typedQuery.length < MIN_QUERY_LENGTH) return
	let timer = setTimeout(() => showSearchResult(typedQuery), SEARCH_DEBOUNCE_MS)
	return () => clearTimeout(timer)
}, [showSearchResult, typedQuery])
```

Each keystroke re-runs the effect, which clears the previous timer — the same trailing-edge debounce, but per instance and cancelled on unmount. The short-query case behaves identically (lodash rescheduled then no-op'd on the length guard; this just never schedules). Drops the `lodash` import from the file.

## Verification

`prettier`, `eslint --max-warnings=0`, `tsc --noEmit` and `jest` all clean — 55 suites, 351 passed, 45 snapshots. Not yet run on a device; the header changes are worth a look on a real build, particularly the home screen's large title and the modal presentations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8iTDiXiQfNbEWSExPiDFz)_