### PR TITLE
Clear the FAQ banner test's query clients

### DIFF
--- a/source/features/faqs/__tests__/banner.test.tsx
+++ b/source/features/faqs/__tests__/banner.test.tsx
@@ -34,14 +34,36 @@ const buildResponse = (faqs: Faq[]): FaqQueryData => ({
 	legacyText: undefined,
 })
 
+// Every query left without observers gets a garbage-collection timeout, and
+// React Query's default is five minutes -- long enough to outlive the run and
+// leave the Jest worker to be force-killed rather than exiting on its own.
+// Testing Library registers its unmounting afterEach when it is imported, and
+// Jest runs afterEach hooks in registration order, so by the time this one
+// runs the components are gone and every gc timeout has been armed.
+const trackedQueryClients: QueryClient[] = []
+
+const trackQueryClient = (queryClient: QueryClient): QueryClient => {
+	trackedQueryClients.push(queryClient)
+	return queryClient
+}
+
+afterEach(() => {
+	for (let queryClient of trackedQueryClients) {
+		queryClient.clear()
+	}
+	trackedQueryClients.length = 0
+})
+
 // Seeded data has to be fresh, not merely present: a stale entry makes the
 // query refetch the moment a component mounts, and the mocked queryFn's
 // rejection then lands mid-test and empties the banner out from under the
 // assertions.
 const buildQueryClient = (faqs: Faq[]): QueryClient => {
-	const queryClient = new QueryClient({
-		defaultOptions: {queries: {retry: false, staleTime: Infinity}},
-	})
+	const queryClient = trackQueryClient(
+		new QueryClient({
+			defaultOptions: {queries: {retry: false, staleTime: Infinity}},
+		}),
+	)
 	queryClient.setQueryData<FaqQueryData>(FAQS_QUERY_KEY, buildResponse(faqs))
 	return queryClient
 }
@@ -50,9 +72,11 @@ const buildQueryClient = (faqs: Faq[]): QueryClient => {
 /// refetch -- which the mocked queryFn then fails, driving the query into its
 /// error state while the cached faqs are still perfectly good.
 const buildStaleQueryClient = (faqs: Faq[]): QueryClient => {
-	const queryClient = new QueryClient({
-		defaultOptions: {queries: {retry: false}},
-	})
+	const queryClient = trackQueryClient(
+		new QueryClient({
+			defaultOptions: {queries: {retry: false}},
+		}),
+	)
 	queryClient.setQueryData<FaqQueryData>(FAQS_QUERY_KEY, buildResponse(faqs))
 	return queryClient
 }


### PR DESCRIPTION
Every `mise run test` ended with:

> A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown.

## Root cause

The suites all passed; one Jest worker just would not exit. Dumping the worker's
active resources when it received the force-exit `SIGTERM` showed seven pending
timers, every one of them from React Query:

```
[setTimeout delay=300000 REFED]
    at TimeoutManager.setTimeout (@tanstack/query-core/src/timeoutManager.ts:108)
    at Query.scheduleGc (@tanstack/query-core/src/removable.ts:18)
    at Query.removeObserver (@tanstack/query-core/src/query.ts:377)
    at QueryObserver.destroy (@tanstack/query-core/src/queryObserver.ts:135)
    ...
    at commitHookPassiveUnmountEffects (react-reconciler)
```

When a query's last observer unmounts, React Query arms a garbage-collection
timeout to drop the cached entry. The default `gcTime` is five minutes, so each
of those timers sat refed in the worker's event loop long after the run
finished. Seven timers, seven renders — all of them in
`source/features/faqs/__tests__/banner.test.tsx`, the only test file that builds
its own `QueryClient`. Jest gives a worker 500ms to exit after the run, then
kills it and prints the warning.

`--detectOpenHandles` never surfaced this, because it forces the run in-band and
the main process exits on its own regardless.

## The change

The test file now tracks each `QueryClient` it builds and calls `clear()` on
them in an `afterEach`, which destroys the queries and with them their gc
timeouts. Testing Library registers its unmounting `afterEach` at import time
and Jest runs `afterEach` hooks in registration order, so the components are
already gone — and every gc timeout already armed — by the time the new hook
runs.

## Verification

- `npx jest` three times: 55 suites, 351 passed / 3 skipped, no warning
- Re-ran under the timer tracer: no worker receives `SIGTERM` anymore
- `prettier`, `eslint`, `tsc --noEmit` all clean

---
_Generated by [Claude Code](https://claude.ai/code/session_011NWjyxb5Z3Fet1zE81tgw6)_