### PR TITLE
Adopt the UIScene lifecycle

### DIFF
--- a/.claude/skills/build-to-device/SKILL.md
+++ b/.claude/skills/build-to-device/SKILL.md
@@ -92,6 +92,64 @@ xcrun devicectl list devices
 xcrun devicectl device install app --device <DEVICE UDID> "$APP"
 ```
 
+## Verifying it worked, without touching the phone
+
+`devicectl` can install, launch, screenshot and report processes, which is
+enough to confirm a build runs before handing it over. Do that -- an install
+that succeeds says nothing about whether the app survives launch.
+
+```bash
+xcrun devicectl device process launch --device <UDID> \
+  --activate --terminate-existing <BUNDLE ID>
+# alive? a count of 1 means it is still up a moment later
+xcrun devicectl device info processes --device <UDID> | grep -c AllAboutOlaf
+xcrun devicectl device capture screenshot --device <UDID> --destination shot.png
+```
+
+**A screenshot of a sleeping phone is black, not blank.** The status bar and
+home indicator still composite, so the result looks exactly like a running app
+that renders nothing -- and it will have you debugging a rendering fault that
+does not exist. Ask for the screen to be woken, or trust the process count over
+the picture.
+
+Note `--destination` on `capture screenshot`; `--output` is not a flag, and
+`--activate` matters because a launch without it can leave the app backgrounded.
+
+## Where the crash log actually is
+
+Device crash reports do **not** sync to `~/Library/Logs/CrashReporter/`. Looking
+there and finding nothing means nothing.
+
+`--console` is no better for an early crash: it only forwards stdout, so a
+process that dies before React Native starts prints not one line and reports
+`exit code 0`, which reads as a clean exit rather than a trap.
+
+The reports are in a sysdiagnose, one per launch attempt:
+
+```bash
+xcrun devicectl device sysdiagnose --device <UDID> --destination /tmp/sysdiag
+# ~190 MB; list first, extract only what you need
+tar -tzf /tmp/sysdiag/*.tar.gz | grep AllAboutOlaf
+tar -xzf /tmp/sysdiag/*.tar.gz '<path>/crashes_and_spins/Retired/AllAboutOlaf-*.ips'
+```
+
+An `.ips` is JSON with a one-line header. `termination`, `exception` and the
+triggered thread's frames name the fault directly -- which is how the iOS 27
+UIScene trap was found after several wrong guesses at signing, entitlements and
+bundle format.
+
+## Two things that are not the problem
+
+Both look plausible when a device build misbehaves, and both were measured not
+to matter here:
+
+- **The JS bundle does not need Hermes bytecode.** `mise run bundle:ios` emits
+  plain JavaScript and a device runs it. Do not "fix" that task: CI feeds its
+  output to simulator UITests and is correct as it stands.
+- **The app does not need re-signing after injection.** Copying files in breaks
+  the seal -- `codesign -v` says `a sealed resource is missing or invalid` --
+  and it installs and runs anyway.
+
 ## Notes
 
 - Keep derived data at `ios/build`. React Native's

--- a/app.config.ts
+++ b/app.config.ts
@@ -140,6 +140,30 @@ const config: ExpoConfig = {
 		infoPlist: {
 			CFBundleDisplayName: variant.displayName,
 
+			// iOS 27 traps at launch in
+			// `__UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption`
+			// for any app that has not adopted the UIScene lifecycle -- what was
+			// a runtime warning through iOS 26 is now EXC_BREAKPOINT before
+			// React Native starts, so the app dies with no JS error and no
+			// usable console output.
+			//
+			// Declaring the manifest is the adoption UIKit checks for. There is
+			// deliberately no `UISceneConfigurations`: without one UIKit creates
+			// a default scene and the window AppDelegate already builds keeps
+			// working, so this stays a plist change rather than a rewrite of how
+			// the root view is hosted.
+			UIApplicationSceneManifest: {
+				UIApplicationSupportsMultipleScenes: false,
+				UISceneConfigurations: {
+					UIWindowSceneSessionRoleApplication: [
+						{
+							UISceneConfigurationName: 'Default Configuration',
+							UISceneDelegateClassName: '$(PRODUCT_MODULE_NAME).SceneDelegate',
+						},
+					],
+				},
+			},
+
 			CADisableMinimumFrameDurationOnPhone: true,
 			ITSAppUsesNonExemptEncryption: false,
 

--- a/plugins/with-app-delegate-customizations.ts
+++ b/plugins/with-app-delegate-customizations.ts
@@ -90,6 +90,48 @@ export function patchAppDelegate(contents: string): string {
 	return result
 }
 
+/// iOS 27 traps at launch for any app that has not adopted the UIScene
+/// lifecycle, so the app declares a scene manifest -- and once it does, UIKit
+/// owns the scene and stops presenting the window AppDelegate builds. The app
+/// launched to a black screen until something handed that window to the scene.
+///
+/// This keeps React Native's startup where it already is, in
+/// `didFinishLaunchingWithOptions`, and only adopts the window that startup
+/// produced. Moving the whole of it into the scene delegate would be the more
+/// thorough adoption and a much larger change to generated code.
+///
+/// Appended to AppDelegate.swift rather than written as its own file: a new
+/// source file would have to be threaded into the generated Xcode project,
+/// and Swift does not care which file a class lives in.
+const SCENE_DELEGATE = `
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else { return }
+    guard
+      let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+      let existing = appDelegate.window
+    else { return }
+
+    existing.windowScene = windowScene
+    self.window = existing
+    existing.makeKeyAndVisible()
+  }
+}
+`
+
+export function appendSceneDelegate(contents: string): string {
+	if (contents.includes('class SceneDelegate')) {
+		return contents
+	}
+	return `${contents.trimEnd()}\n${SCENE_DELEGATE}`
+}
+
 const withAppDelegateCustomizations: ConfigPlugin = (config) =>
 	withAppDelegate(config, (mod) => {
 		if (mod.modResults.language !== 'swift') {
@@ -98,7 +140,9 @@ const withAppDelegateCustomizations: ConfigPlugin = (config) =>
 			)
 		}
 
-		mod.modResults.contents = patchAppDelegate(mod.modResults.contents)
+		mod.modResults.contents = appendSceneDelegate(
+			patchAppDelegate(mod.modResults.contents),
+		)
 		return mod
 	})
 


### PR DESCRIPTION
Adopt the UIScene lifecycle

iOS 27 traps at launch in
`__UIApplicationEvaluateRuntimeIssueForNoSceneLifecycleAdoption` for any
app that has not adopted UIScene. What was a runtime warning through iOS
26 is now EXC_BREAKPOINT on thread 0, raised inside
`-[UIApplication workspace:didCreateScene:...]` before React Native
starts -- so the app dies with no JS error, no console output and an exit
that reads as clean. On a 27.0 beta device this app never reached its
first screen; simulators on 26.x are unaffected, which is why every
simulator check passed.

This is not specific to the map work below it. Any build of this app,
`master` included, traps on iOS 27, so it is a ship blocker once 27 is
public rather than a fix for one branch.

Declaring `UIApplicationSceneManifest` is the adoption UIKit checks for.
That also hands scene ownership to UIKit, which then does not present the
window AppDelegate builds in `didFinishLaunchingWithOptions`, so the
manifest needs a scene delegate beside it. This one adopts the window
that React Native's startup already produced rather than moving that
startup, which would be a far larger change to generated code.

The delegate is appended to AppDelegate.swift rather than added as its
own file, so no new source has to be threaded into the generated Xcode
project.

Verified on an iPhone 14 Pro running 27.0 beta: the app launches, stays
up and renders.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

