### PR TITLE
Fix Add to calendar, and enforce the deprecation rule that would have caught it

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -97,6 +97,13 @@
     "typescript/no-inferrable-types": "warn",
     "typescript/no-non-null-assertion": "warn",
     "typescript/no-require-imports": "error",
+    // Needs type information, so it reports only when the type-aware pass
+    // runs -- which `options.typeAware` above already turns on for every
+    // `mise run lint`, no extra task or CLI flag. It earns the ~0.8s that
+    // pass costs: every legacy expo-calendar method `add-to-device-calendar`
+    // called was a stub that throws at runtime, and nothing else in the
+    // toolchain -- tsc, jest, the non-type-aware rules -- said a word.
+    "typescript/no-deprecated": "error",
     "typescript/no-empty-function": "warn",
     "typescript/no-explicit-any": "warn",
     // Off: the codebase has ~140 places where an async function is passed

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -178,7 +178,7 @@ export default function MapPage(): React.ReactNode {
 				<GeoJSONSource data={footprints} id="campus-buildings" onPress={handleBuildingPress}>
 					<Layer
 						id="campus-buildings-hit"
-						style={{fillColor: c.gold, fillOpacity: FOOTPRINT_OPACITY}}
+						paint={{'fill-color': c.gold, 'fill-opacity': FOOTPRINT_OPACITY}}
 						type="fill"
 					/>
 				</GeoJSONSource>

--- a/modules/add-to-device-calendar/__tests__/lib.test.ts
+++ b/modules/add-to-device-calendar/__tests__/lib.test.ts
@@ -1,4 +1,4 @@
-import {describe, expect, it, jest} from '@jest/globals'
+import {afterEach, describe, expect, it, jest} from '@jest/globals'
 import {Alert, Linking} from 'react-native'
 import * as Sentry from '@sentry/react-native'
 import * as Calendar from 'expo-calendar'
@@ -8,14 +8,35 @@ import {addToCalendar} from '../lib'
 
 jest.mock('@sentry/react-native', () => ({captureException: jest.fn()}))
 jest.mock('expo-calendar', () => ({
-	getCalendarPermissionsAsync: jest.fn(),
-	requestCalendarPermissionsAsync: jest.fn(),
-	getDefaultCalendarAsync: jest.fn(),
-	createEventAsync: jest.fn(),
+	getCalendarPermissions: jest.fn(),
+	requestCalendarPermissions: jest.fn(),
+	getDefaultCalendarSync: jest.fn(),
 }))
 
+let createEvent = jest.fn<() => Promise<unknown>>()
 let alertSpy = jest.spyOn(Alert, 'alert').mockReturnValue(undefined)
 let openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true)
+// The error path logs alongside reporting to Sentry. Captured rather than
+// left to print, so a passing run stays quiet and the log itself is asserted.
+let consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+
+/**
+ * `getDefaultCalendarSync` hands back an `ExpoCalendar` instance, and
+ * `createEvent` is a method on it. Only that one method is exercised here, so
+ * the stand-in carries only that.
+ */
+function stubDefaultCalendar(): void {
+	jest
+		.mocked(Calendar.getDefaultCalendarSync)
+		.mockReturnValue({id: 'cal-1', createEvent} as unknown as Calendar.ExpoCalendar)
+}
+
+function permissions(
+	status: string,
+	canAskAgain: boolean,
+): ReturnType<typeof Calendar.getCalendarPermissions> {
+	return Promise.resolve({status, canAskAgain} as Calendar.PermissionResponse)
+}
 
 function generateEvent(): EventType {
 	return {
@@ -36,18 +57,16 @@ describe('addToCalendar', () => {
 	})
 
 	it('adds the event to the default calendar when permission is already granted', async () => {
-		jest
-			.mocked(Calendar.getCalendarPermissionsAsync)
-			.mockResolvedValue({status: 'granted', canAskAgain: true} as never)
-		jest.mocked(Calendar.getDefaultCalendarAsync).mockResolvedValue({id: 'cal-1'} as never)
-		jest.mocked(Calendar.createEventAsync).mockResolvedValue('event-1' as never)
+		jest.mocked(Calendar.getCalendarPermissions).mockReturnValue(permissions('granted', true))
+		stubDefaultCalendar()
+		createEvent.mockResolvedValue({id: 'event-1'})
 
 		let event = generateEvent()
 		let result = await addToCalendar(event)
 
 		expect(result).toBe('saved')
-		expect(Calendar.requestCalendarPermissionsAsync).not.toHaveBeenCalled()
-		expect(Calendar.createEventAsync).toHaveBeenCalledWith('cal-1', {
+		expect(Calendar.requestCalendarPermissions).not.toHaveBeenCalled()
+		expect(createEvent).toHaveBeenCalledWith({
 			title: event.title,
 			startDate: event.startTime.toDate(),
 			endDate: event.endTime.toDate(),
@@ -56,48 +75,51 @@ describe('addToCalendar', () => {
 		})
 	})
 
+	it('asks for full calendar access, not the write-only variant', async () => {
+		jest.mocked(Calendar.getCalendarPermissions).mockReturnValue(permissions('granted', true))
+		stubDefaultCalendar()
+		createEvent.mockResolvedValue({id: 'event-1'})
+
+		await addToCalendar(generateEvent())
+
+		// Reading the default calendar needs more than write-only access, which
+		// iOS 17 split out; `writeOnly` defaults to false, so no argument is the
+		// full-access ask.
+		expect(Calendar.getCalendarPermissions).toHaveBeenCalledWith()
+	})
+
 	it('requests permission and adds the event when access has not been decided yet', async () => {
-		jest
-			.mocked(Calendar.getCalendarPermissionsAsync)
-			.mockResolvedValue({status: 'undetermined', canAskAgain: true} as never)
-		jest
-			.mocked(Calendar.requestCalendarPermissionsAsync)
-			.mockResolvedValue({status: 'granted'} as never)
-		jest.mocked(Calendar.getDefaultCalendarAsync).mockResolvedValue({id: 'cal-1'} as never)
-		jest.mocked(Calendar.createEventAsync).mockResolvedValue('event-1' as never)
+		jest.mocked(Calendar.getCalendarPermissions).mockReturnValue(permissions('undetermined', true))
+		jest.mocked(Calendar.requestCalendarPermissions).mockReturnValue(permissions('granted', true))
+		stubDefaultCalendar()
+		createEvent.mockResolvedValue({id: 'event-1'})
 
 		let result = await addToCalendar(generateEvent())
 
 		expect(result).toBe('saved')
-		expect(Calendar.requestCalendarPermissionsAsync).toHaveBeenCalledTimes(1)
-		expect(Calendar.createEventAsync).toHaveBeenCalledTimes(1)
+		expect(Calendar.requestCalendarPermissions).toHaveBeenCalledTimes(1)
+		expect(createEvent).toHaveBeenCalledTimes(1)
 	})
 
 	it('cancels without prompting when the user denies the permission request', async () => {
-		jest
-			.mocked(Calendar.getCalendarPermissionsAsync)
-			.mockResolvedValue({status: 'undetermined', canAskAgain: true} as never)
-		jest
-			.mocked(Calendar.requestCalendarPermissionsAsync)
-			.mockResolvedValue({status: 'denied'} as never)
+		jest.mocked(Calendar.getCalendarPermissions).mockReturnValue(permissions('undetermined', true))
+		jest.mocked(Calendar.requestCalendarPermissions).mockReturnValue(permissions('denied', true))
 
 		let result = await addToCalendar(generateEvent())
 
 		expect(result).toBe('cancelled')
-		expect(Calendar.createEventAsync).not.toHaveBeenCalled()
+		expect(createEvent).not.toHaveBeenCalled()
 		expect(alertSpy).not.toHaveBeenCalled()
 	})
 
 	it('sends the user to Settings when calendar access is already blocked', async () => {
-		jest
-			.mocked(Calendar.getCalendarPermissionsAsync)
-			.mockResolvedValue({status: 'denied', canAskAgain: false} as never)
+		jest.mocked(Calendar.getCalendarPermissions).mockReturnValue(permissions('denied', false))
 
 		let result = await addToCalendar(generateEvent())
 
 		expect(result).toBe('cancelled')
-		expect(Calendar.requestCalendarPermissionsAsync).not.toHaveBeenCalled()
-		expect(Calendar.createEventAsync).not.toHaveBeenCalled()
+		expect(Calendar.requestCalendarPermissions).not.toHaveBeenCalled()
+		expect(createEvent).not.toHaveBeenCalled()
 		expect(alertSpy).toHaveBeenCalledTimes(1)
 
 		let [, , buttons] = alertSpy.mock.calls[0]
@@ -108,16 +130,29 @@ describe('addToCalendar', () => {
 	})
 
 	it('returns error and reports to Sentry when saving the event fails', async () => {
-		jest
-			.mocked(Calendar.getCalendarPermissionsAsync)
-			.mockResolvedValue({status: 'granted', canAskAgain: true} as never)
-		jest.mocked(Calendar.getDefaultCalendarAsync).mockResolvedValue({id: 'cal-1'} as never)
+		jest.mocked(Calendar.getCalendarPermissions).mockReturnValue(permissions('granted', true))
+		stubDefaultCalendar()
 		let error = new Error('boom')
-		jest.mocked(Calendar.createEventAsync).mockRejectedValue(error)
+		createEvent.mockRejectedValue(error)
 
 		let result = await addToCalendar(generateEvent())
 
 		expect(result).toBe('error')
 		expect(Sentry.captureException).toHaveBeenCalledWith(error)
+		expect(consoleErrorSpy).toHaveBeenCalledWith(error)
+	})
+
+	it('returns error and reports to Sentry when the device has no default calendar', async () => {
+		jest.mocked(Calendar.getCalendarPermissions).mockReturnValue(permissions('granted', true))
+		let error = new Error('no default calendar')
+		jest.mocked(Calendar.getDefaultCalendarSync).mockImplementation(() => {
+			throw error
+		})
+
+		let result = await addToCalendar(generateEvent())
+
+		expect(result).toBe('error')
+		expect(Sentry.captureException).toHaveBeenCalledWith(error)
+		expect(consoleErrorSpy).toHaveBeenCalledWith(error)
 	})
 })

--- a/modules/add-to-device-calendar/lib.ts
+++ b/modules/add-to-device-calendar/lib.ts
@@ -17,8 +17,14 @@ function promptSettings(): void {
 	)
 }
 
+/**
+ * Asks for full calendar access rather than the write-only access iOS 17 split
+ * out: `getDefaultCalendarSync` reads the device's calendars, which write-only
+ * access does not cover. `writeOnly` defaults to false, so no argument is the
+ * full-access ask.
+ */
 async function requestCalendarAccess(): Promise<boolean> {
-	let {status, canAskAgain} = await Calendar.getCalendarPermissionsAsync()
+	let {status, canAskAgain} = await Calendar.getCalendarPermissions()
 
 	if (status === 'granted') {
 		return true
@@ -29,7 +35,7 @@ async function requestCalendarAccess(): Promise<boolean> {
 		return false
 	}
 
-	let requested = await Calendar.requestCalendarPermissionsAsync()
+	let requested = await Calendar.requestCalendarPermissions()
 	return requested.status === 'granted'
 }
 
@@ -40,9 +46,11 @@ export async function addToCalendar(event: EventType): Promise<AddToCalendarResu
 			return 'cancelled'
 		}
 
-		let defaultCalendar = await Calendar.getDefaultCalendarAsync()
+		// Synchronous, and throws when the device has no default calendar --
+		// the surrounding try/catch is what turns that into an 'error' result.
+		let defaultCalendar = Calendar.getDefaultCalendarSync()
 
-		await Calendar.createEventAsync(defaultCalendar.id, {
+		await defaultCalendar.createEvent({
 			title: event.title,
 			startDate: event.startTime.toDate(),
 			endDate: event.endTime.toDate(),

--- a/modules/ccc-calendar/device-calendar.ts
+++ b/modules/ccc-calendar/device-calendar.ts
@@ -4,8 +4,9 @@ import type {EventType} from '@frogpond/event-type'
 
 /**
  * iOS 17 split EventKit's calendar permission into write-only and full
- * access. `add-to-device-calendar` only ever needs to write, so it asks for
- * the narrower one; reading the device's events needs this.
+ * access. Both this module and `add-to-device-calendar` need the full one --
+ * reading the device's events here, reading the default calendar there -- so
+ * these wrappers exist to name that ask rather than to narrow it.
  */
 export function requestFullCalendarAccess(): Promise<Calendar.PermissionResponse> {
 	return Calendar.requestCalendarPermissions(false)

--- a/modules/datepicker/basepicker.tsx
+++ b/modules/datepicker/basepicker.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import moment from 'moment-timezone'
 
-import {DateTimePicker, type DateTimePickerEvent} from '@expo/ui/community/datetime-picker'
+import {DateTimePicker, type DateTimePickerChangeEvent} from '@expo/ui/community/datetime-picker'
 
 import {BaseDatetimePickerProps} from './types'
 
@@ -10,12 +10,12 @@ export const BaseDateTimePicker = (props: BaseDatetimePickerProps): React.ReactN
 	let [date, setDate] = React.useState(props.initialDate)
 	let [timezone] = React.useState(props.initialDate.tz() || '')
 
-	const onChange = (_event: DateTimePickerEvent, selectedDate?: Date) => {
+	// `onValueChange` fires only on selection and always carries a date, where
+	// the `onChange` it replaces also fired on dismissal with none. Only the
+	// iOS picker is rendered below, and iOS never dismisses, so the two
+	// behave alike here.
+	const onValueChange = (_event: DateTimePickerChangeEvent, selectedDate: Date) => {
 		props.onChange?.()
-
-		if (!selectedDate) {
-			return
-		}
 
 		setDate(moment(selectedDate))
 		props.onDateChange(moment.tz(selectedDate, timezone))
@@ -23,7 +23,7 @@ export const BaseDateTimePicker = (props: BaseDatetimePickerProps): React.ReactN
 
 	let sharedPlatformProps = {
 		mode: props.mode,
-		onChange: onChange,
+		onValueChange: onValueChange,
 		style: props.style,
 		testID: 'datepicker',
 		// The picker takes an IANA zone name directly, so the wrapper no longer

--- a/modules/event-list/__tests__/event-detail-view.test.tsx
+++ b/modules/event-list/__tests__/event-detail-view.test.tsx
@@ -20,12 +20,12 @@ jest.mock('@expo/ui/swift-ui/modifiers', () => {
 // `modules/add-to-device-calendar/__tests__/lib.test.ts` mocks both.
 jest.mock('@sentry/react-native', () => ({captureException: jest.fn()}))
 jest.mock('expo-calendar', () => ({
-	getCalendarPermissionsAsync: jest.fn(() =>
-		Promise.resolve({status: 'granted', canAskAgain: true}),
-	),
-	requestCalendarPermissionsAsync: jest.fn(() => Promise.resolve({status: 'granted'})),
-	getDefaultCalendarAsync: jest.fn(() => Promise.resolve({id: 'cal-1'})),
-	createEventAsync: jest.fn(() => Promise.resolve('event-1')),
+	getCalendarPermissions: jest.fn(() => Promise.resolve({status: 'granted', canAskAgain: true})),
+	requestCalendarPermissions: jest.fn(() => Promise.resolve({status: 'granted'})),
+	getDefaultCalendarSync: jest.fn(() => ({
+		id: 'cal-1',
+		createEvent: jest.fn(() => Promise.resolve({id: 'event-1'})),
+	})),
 }))
 // `AddToCalendar`'s own component (not `lib.ts`) also pulls in `delay`, an
 // ESM-only package outside jest.config.js's transform allowlist.

--- a/source/features/faqs/schema.ts
+++ b/source/features/faqs/schema.ts
@@ -15,7 +15,7 @@ const platformSchema = z.union([z.literal('ios'), z.literal('android'), z.litera
 const dateTimeString = z
 	.string()
 	.trim()
-	.pipe(z.string().datetime({offset: true}))
+	.pipe(z.iso.datetime({offset: true}))
 
 const conditionRuleSchema = z
 	.object({
@@ -74,7 +74,7 @@ const metadataSchema = z
 		repeatInterval: optionalTrimmedString,
 		conditions: conditionsSchema.optional(),
 	})
-	.passthrough()
+	.loose()
 
 type MetadataInput = z.infer<typeof metadataSchema>
 

--- a/source/features/home/button.tsx
+++ b/source/features/home/button.tsx
@@ -6,7 +6,6 @@ import {
 	buttonStyle,
 	contentShape,
 	font,
-	foregroundColor,
 	foregroundStyle,
 	frame,
 	imageScale,
@@ -194,7 +193,7 @@ export function HomeScreenButton({view, onPress}: Props): React.ReactNode {
 								textStyle: TITLE_TEXT_STYLE,
 								weight: 'semibold',
 							}),
-							foregroundColor(titleColor),
+							foregroundStyle(titleColor),
 						]}
 					>
 						{view.title}

--- a/source/features/settings/components/rows.tsx
+++ b/source/features/settings/components/rows.tsx
@@ -5,7 +5,7 @@ import {
 	buttonStyle,
 	contentShape,
 	disabled as disabledModifier,
-	foregroundColor,
+	foregroundStyle,
 	shapes,
 } from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
@@ -36,7 +36,7 @@ export function NavigationRow(props: RowProps): React.ReactNode {
 			    putting contentShape on the Button leaves only the text and
 			    chevron tappable rather than the whole row. */}
 			<HStack modifiers={[contentShape(shapes.rectangle())]}>
-				<Text modifiers={[foregroundColor(c.label)]}>{title}</Text>
+				<Text modifiers={[foregroundStyle(c.label)]}>{title}</Text>
 				<Spacer />
 				<Image color={c.tertiaryLabel} size={14} systemName="chevron.right" />
 			</HStack>
@@ -57,7 +57,7 @@ export function ActionRow(props: RowProps): React.ReactNode {
 			onPress={onPress}
 		>
 			<HStack modifiers={[contentShape(shapes.rectangle())]}>
-				<Text modifiers={[foregroundColor(c.systemBlue)]}>{title}</Text>
+				<Text modifiers={[foregroundStyle(c.systemBlue)]}>{title}</Text>
 				<Spacer />
 			</HStack>
 		</Button>

--- a/source/features/settings/screens/overview/login-credentials.tsx
+++ b/source/features/settings/screens/overview/login-credentials.tsx
@@ -8,7 +8,7 @@ import {
 	type TextFieldRef,
 	useNativeState,
 } from '@expo/ui/swift-ui'
-import {disabled, foregroundColor, onSubmit, submitLabel} from '@expo/ui/swift-ui/modifiers'
+import {disabled, foregroundStyle, onSubmit, submitLabel} from '@expo/ui/swift-ui/modifiers'
 import {
 	performLogin,
 	credentialsOptions,
@@ -132,7 +132,7 @@ export const CredentialsLoginSection = (): React.ReactNode => {
 			/>
 
 			{!actionPending && logIn.isError && logIn.error instanceof Error && (
-				<Text modifiers={[foregroundColor(sto.red)]}>{logIn.error.message}</Text>
+				<Text modifiers={[foregroundStyle(sto.red)]}>{logIn.error.message}</Text>
 			)}
 		</Section>
 	)

--- a/source/features/transportation/bus/components/day-picker.tsx
+++ b/source/features/transportation/bus/components/day-picker.tsx
@@ -9,7 +9,7 @@ import {
 	background,
 	contentShape,
 	font,
-	foregroundColor,
+	foregroundStyle,
 	padding,
 	shapes,
 	strokeBorder,
@@ -225,7 +225,7 @@ export const DayPickerHeader = ({
 						<SwiftUIText
 							modifiers={[
 								font({textStyle: LABEL_TEXT_STYLE, weight: 'medium'}),
-								foregroundColor(accentColor),
+								foregroundStyle(accentColor),
 							]}
 						>
 							{displayText}

--- a/source/init/sentry.mock.ts
+++ b/source/init/sentry.mock.ts
@@ -21,5 +21,5 @@
 export const install = (): void => {}
 
 export const navigationIntegration = {
-	registerNavigationContainer: (navigationRef: React.MutableRefObject<undefined>) => {},
+	registerNavigationContainer: (navigationRef: React.RefObject<undefined>) => {},
 }


### PR DESCRIPTION
Verified on the simulator, since the tests here mock expo-calendar and cannot settle it: the permission prompt on a fresh install, and the event landing in Apple's Calendar app with its location and notes intact.

| Permission prompt | The event, in Calendar.app |
| --- | --- |
| ![the iOS calendar permission sheet over the event detail screen](https://github.com/user-attachments/assets/c9159278-aee8-4462-bc1f-6f45b6bd3526) | ![Apple's Calendar app showing New Faculty Orientation at Kings Dining, 9 AM](https://github.com/user-attachments/assets/8fb1cfac-2a98-4fe7-9403-da5ae397027c) |
