### PR TITLE
Use SFSymbol names in FAQ Banners

### DIFF
--- a/app/(component-library)/FaqBannerLibrary.tsx
+++ b/app/(component-library)/FaqBannerLibrary.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {StyleSheet} from 'react-native'
+import {Alert, StyleSheet} from 'react-native'
 import {Section} from '@frogpond/tableview'
 import {Stack} from 'expo-router'
 
@@ -128,7 +128,17 @@ const BannerSection = ({header, faqs}: {header: string; faqs: Faq[]}): React.Rea
 	// section drops the cell chrome that would clip and divide them.
 	<Section header={header} hideSeparator={true} roundedCorners={false}>
 		{faqs.map((faq) => (
-			<FaqBannerPresentation key={faq.id} faq={faq} style={styles.banner} />
+			// Both handlers report which banner fired them, so a dismiss tap that
+			// leaks through to the card shows up as the wrong alert. Passing
+			// onDismiss also puts the dismiss control back in the accessibility
+			// tree, which is how it renders in the app.
+			<FaqBannerPresentation
+				key={faq.id}
+				faq={faq}
+				onDismiss={() => Alert.alert('Dismissed', faq.id)}
+				onPress={() => Alert.alert('Tapped', faq.id)}
+				style={styles.banner}
+			/>
 		))}
 	</Section>
 )

--- a/app/(component-library)/FaqBannerLibrary.tsx
+++ b/app/(component-library)/FaqBannerLibrary.tsx
@@ -1,61 +1,157 @@
 import * as React from 'react'
-import {ScrollView, StyleSheet, Text, View} from 'react-native'
-import * as c from '@frogpond/colors'
-import {Stack, useNavigation} from 'expo-router'
+import {StyleSheet} from 'react-native'
+import {Section} from '@frogpond/tableview'
+import {Stack} from 'expo-router'
 
-import {FaqBanner} from '../../source/features/faqs/banner'
-import {fallbackFaqs} from '../../source/features/faqs/local-faqs'
+import {FaqBannerPresentation} from '../../source/features/faqs/banner'
+import type {Faq} from '../../source/features/faqs/types'
+import {LibraryWrapper} from '../../source/features/settings/screens/overview/component-library/base/library-wrapper'
+
+/**
+ * Builds a preview Faq. Only the fields a banner actually reads are worth
+ * varying, so the rest get inert defaults.
+ */
+function fixture(overrides: Partial<Faq> & Pick<Faq, 'id' | 'bannerTitle'>): Faq {
+	return {
+		question: overrides.bannerTitle,
+		answer: '',
+		targets: [],
+		bannerText: 'Every banner reads its palette from its severity.',
+		severity: 'notice',
+		dismissable: false,
+		...overrides,
+	}
+}
+
+const severityExamples: Faq[] = [
+	fixture({id: 'severity-notice', bannerTitle: 'notice', severity: 'notice'}),
+	fixture({id: 'severity-info', bannerTitle: 'info', severity: 'info'}),
+	fixture({id: 'severity-alert', bannerTitle: 'alert', severity: 'alert'}),
+]
+
+const iconExamples: Faq[] = [
+	fixture({
+		id: 'icon-default',
+		bannerTitle: 'default for severity',
+		bannerText: 'No icon field, so the severity supplies one.',
+		severity: 'info',
+	}),
+	fixture({
+		id: 'icon-override',
+		bannerTitle: 'icon: megaphone',
+		bannerText: 'Any SF Symbol name overrides the severity default.',
+		severity: 'info',
+		icon: 'megaphone',
+	}),
+	fixture({
+		id: 'icon-override-alert',
+		bannerTitle: 'icon: wrench.and.screwdriver',
+		bannerText: 'The override applies on every severity.',
+		severity: 'alert',
+		icon: 'wrench.and.screwdriver',
+	}),
+]
+
+const colorExamples: Faq[] = [
+	fixture({
+		id: 'color-background',
+		bannerTitle: 'backgroundColor only',
+		severity: 'alert',
+		backgroundColor: '#fef3f2',
+	}),
+	fixture({
+		id: 'color-foreground',
+		bannerTitle: 'foregroundColor only',
+		bannerText: 'Foreground drives both the title and the body text.',
+		severity: 'alert',
+		foregroundColor: '#b42318',
+	}),
+	fixture({
+		id: 'color-both',
+		bannerTitle: 'both overrides',
+		bannerText: 'This is the palette the live SIS banner ships with.',
+		severity: 'alert',
+		backgroundColor: '#fef3f2',
+		foregroundColor: '#b42318',
+	}),
+]
+
+const dismissExamples: Faq[] = [
+	fixture({
+		id: 'dismiss-false',
+		bannerTitle: 'dismissable: false',
+		bannerText: 'No dismiss control is rendered at all.',
+		severity: 'info',
+	}),
+	fixture({
+		id: 'dismiss-true',
+		bannerTitle: 'dismissable: true',
+		bannerText: 'The dismiss control appears in the header row.',
+		severity: 'info',
+		dismissable: true,
+	}),
+]
+
+const textExamples: Faq[] = [
+	fixture({
+		id: 'text-title-only',
+		bannerTitle: 'title only, no body',
+		bannerText: '',
+		severity: 'notice',
+	}),
+	fixture({
+		id: 'text-custom-cta',
+		bannerTitle: 'custom bannerCta',
+		bannerText: 'The call to action defaults to "Learn more".',
+		severity: 'notice',
+		bannerCta: 'Read the announcement',
+	}),
+	fixture({
+		id: 'text-long-title',
+		bannerTitle:
+			'A banner title long enough to wrap onto several lines, which is what happens when a headline is written as a sentence',
+		bannerText: 'The title flexes, so the dismiss control keeps its place.',
+		severity: 'notice',
+		dismissable: true,
+	}),
+	fixture({
+		id: 'text-long-body',
+		bannerTitle: 'long body',
+		bannerText:
+			'Balances login now appears to require Google sign-in on St. Olaf’s end, which the All About Olaf app cannot currently access or support. We will update this banner if that changes, and until then the login screen stays disabled rather than failing halfway through.',
+		severity: 'notice',
+	}),
+]
+
+const BannerSection = ({header, faqs}: {header: string; faqs: Faq[]}): React.ReactNode => (
+	// Banners are standalone cards with their own corners and borders, so the
+	// section drops the cell chrome that would clip and divide them.
+	<Section header={header} hideSeparator={true} roundedCorners={false}>
+		{faqs.map((faq) => (
+			<FaqBannerPresentation key={faq.id} faq={faq} style={styles.banner} />
+		))}
+	</Section>
+)
 
 export default function FaqBannerLibraryPage(): React.ReactNode {
-	const navigation = useNavigation()
 	return (
 		<>
-			<Stack.Screen options={{presentation: 'card'}} />
 			<Stack.Title>FAQ Banners</Stack.Title>
-			<Stack.Toolbar placement="right">
-				<Stack.Toolbar.Button
-					accessibilityLabel="Close Screen"
-					icon="xmark"
-					onPress={() => navigation.goBack()}
-				/>
-			</Stack.Toolbar>
-
-			<ScrollView
-				contentContainerStyle={styles.container}
-				contentInsetAdjustmentBehavior="automatic"
-			>
-				{fallbackFaqs.map((banner) => (
-					<View key={banner.id} style={styles.example}>
-						<Text style={styles.exampleTitle}>Targets: {banner.targets.join(', ')}</Text>
-						<FaqBanner
-							faqId={banner.id}
-							onPressOverride={() => undefined}
-							style={styles.banner}
-							target={banner.targets[0]}
-						/>
-					</View>
-				))}
-			</ScrollView>
+			<LibraryWrapper>
+				<>
+					<BannerSection faqs={severityExamples} header="Severity" />
+					<BannerSection faqs={iconExamples} header="Icon" />
+					<BannerSection faqs={colorExamples} header="Color overrides" />
+					<BannerSection faqs={dismissExamples} header="Dismissable" />
+					<BannerSection faqs={textExamples} header="Text" />
+				</>
+			</LibraryWrapper>
 		</>
 	)
 }
 
 const styles = StyleSheet.create({
-	container: {
-		paddingVertical: 32,
-		paddingHorizontal: 16,
-		gap: 16,
-	},
-	example: {
-		gap: 6,
-	},
-	exampleTitle: {
-		color: c.secondaryLabel,
-		fontSize: 12,
-		textTransform: 'uppercase',
-		letterSpacing: 0.5,
-	},
 	banner: {
-		marginVertical: 2,
+		marginBottom: 12,
 	},
 })

--- a/data/faqs.yaml
+++ b/data/faqs.yaml
@@ -15,7 +15,7 @@ faqs:
     targets:
       - 'Faq'
     severity: alert
-    icon: email-circle
+    icon: envelope.circle
     dismissable: false
     updatedAt: '2025-12-14T00:00:00Z'
 
@@ -34,7 +34,7 @@ faqs:
       - Settings
       - SettingsRoot
     severity: alert
-    icon: alert-circle
+    icon: exclamationmark.circle
     backgroundColor: '#fef3f2'
     foregroundColor: '#b42318'
     dismissable: false

--- a/source/features/faqs/banner.tsx
+++ b/source/features/faqs/banner.tsx
@@ -132,7 +132,7 @@ export function FaqBanner({style, target, faqId, onPressOverride}: Props): React
 					<Pressable
 						accessibilityLabel="Dismiss FAQ banner"
 						accessibilityRole="button"
-						hitSlop={8}
+						hitSlop={DISMISS_HIT_SLOP}
 						onPress={onDismiss}
 						style={[
 							styles.dismissButton,
@@ -303,7 +303,7 @@ export function FaqBannerPresentation({
 						accessibilityElementsHidden={!onDismiss}
 						accessibilityLabel={onDismiss ? 'Dismiss FAQ banner' : undefined}
 						accessibilityRole={onDismiss ? 'button' : undefined}
-						hitSlop={8}
+						hitSlop={DISMISS_HIT_SLOP}
 						importantForAccessibility={onDismiss ? 'yes' : 'no-hide-descendants'}
 						onPress={(e: GestureResponderEvent) => {
 							e.stopPropagation()
@@ -346,6 +346,9 @@ function shouldShowAfterDelay(faq: Faq, dismissedAt?: number): boolean {
 
 	return Date.now() - dismissedAt >= faq.repeatRule.intervalMs
 }
+
+/** Pads the 24pt dismiss button out to the 44pt minimum touch target. */
+const DISMISS_HIT_SLOP = 10
 
 const styles = StyleSheet.create({
 	container: {


### PR DESCRIPTION
- Use SFSymbol names for FAQ Banner icons
  - Follow-up to #7778
- Adjust hitslot target of banner's pressable to 10 to get a 44x44 minimum target
  - Caught by Claude in our project's [mobile priorities](https://github.com/StoDevX/AAO-React-Native/blob/master/CLAUDE.md#:~:text=Touch%20targets:%20Minimum%2044x44pt%20on%20all%20interactive%20elements) for touch targets
- Update FAQ Banners in the developer settings component library to show more variations

---

SFSymbol icon data fixes

State | ~
--|--
Before | <img width="442" height="192" alt="Screenshot 2026-08-17 at 7 27 05 PM" src="https://github.com/user-attachments/assets/9e3c0035-3d26-4eba-a9ab-5b4d7f6cb645" />
After | <img width="442" height="192" alt="Screenshot 2026-08-17 at 7 27 26 PM" src="https://github.com/user-attachments/assets/164b368b-f56a-4032-a117-2f21ee681645" />

FAQ Banner Component Library
~|~|~
--|--|--
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 19 22 31" src="https://github.com/user-attachments/assets/3dd4cdbe-a823-4d5a-9fea-e7ae27cbcebd" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 19 22 55" src="https://github.com/user-attachments/assets/c5d0c63f-0b76-4842-a042-2f765e2456b2" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 19 23 07" src="https://github.com/user-attachments/assets/cd5489ad-3698-4a8c-8c7e-4b2d0a58bec2" />