### PR TITLE
run synchronously before paint to eliminate race

### DIFF
--- a/source/features/transportation/bus/components/progress-chunk.tsx
+++ b/source/features/transportation/bus/components/progress-chunk.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {useCallback, useEffect, useRef, useState} from 'react'
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react'
 import * as c from '@frogpond/colors'
 import {
 	AccessibilityInfo,
@@ -147,7 +147,7 @@ export function ProgressChunk(props: Props): React.ReactNode {
 		})
 	}, [])
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (!showBusOnBar || busProgress == null) {
 			hasPositioned.current = false
 			return


### PR DESCRIPTION
The bus was at food co-op at 6:12pm, and then at 6:13pm, it jumped to being nearly on top of cub/target, then 6:14pm put itself correctly a little below food co-op dot? This happens at the first minute after departing a stop.

Looking at the timing — the bus jumped wrong at 6:13pm then corrected at 6:14pm — a race between the animated value's initialization and the effect that sets its position.

When busProgress first arrives in a row, the effect runs to set the position, but useEffect fires after paint. So there's one frame where animatedPosition is still at its initial value (0) before the effect corrects it. Normally that's just a flash, but if the effect's dependencies weren't quite right or the animation was still settling from a previous state, you'd see a sustained bad position.

Switching to useLayoutEffect lets it run synchronously before paint, which eliminates the race.