### PR TITLE
Order calendar events by start time before grouping them

### DIFF
--- a/modules/event-list/__tests__/event-list.test.tsx
+++ b/modules/event-list/__tests__/event-list.test.tsx
@@ -20,6 +20,12 @@ const POWERED_BY = {title: 'Powered by the St. Olaf calendar', href: 'https://ex
 const NOW = moment('2026-08-17T12:00:00Z')
 
 const STOLAF_SOURCE = {id: 'stolaf', title: 'St. Olaf', color: 'blue', kind: 'remote' as const}
+const NORTHFIELD_SOURCE = {
+	id: 'northfield',
+	title: 'Northfield',
+	color: 'indigo',
+	kind: 'remote' as const,
+}
 
 /**
  * What every parser writes for an all-day event, and what `times.ts` reads to
@@ -52,6 +58,24 @@ function makeEvent(overrides: Partial<EventType> = {}): EventType {
 
 function makeEntry(overrides: Partial<EventType> = {}) {
 	return {sourceId: 'stolaf', key: 'a', event: makeEvent(overrides)}
+}
+
+/** A two-hour event on a given calendar, for the ordering tests below. */
+function entryOn(sourceId: string, key: string, startTime: string, title = 'Recital') {
+	let start = moment(startTime)
+	return {
+		sourceId,
+		key,
+		event: makeEvent({title, startTime: start, endTime: start.clone().add(2, 'hours')}),
+	}
+}
+
+/**
+ * Every section header in the order it renders. Headers carry an en dash
+ * between weekday and date, which no row text does.
+ */
+function sectionHeaders(): string[] {
+	return screen.getAllByText(/ \u2013 /u).map((node) => node.props.children as string)
 }
 
 describe('EventList', () => {
@@ -348,5 +372,94 @@ describe('EventList', () => {
 		)
 
 		expect(screen.getByText(/No calendars/u)).toBeTruthy()
+	})
+
+	test('day sections read in date order however the calendars were merged', async () => {
+		// `useMergedEvents` hands over one calendar's events at a time, so a
+		// second calendar's earlier days arrive after a first calendar's later
+		// ones -- today included.
+		let events = [
+			entryOn('stolaf', 'late', '2026-08-25T15:00:00Z'),
+			entryOn('stolaf', 'later', '2026-09-01T15:00:00Z'),
+			entryOn('northfield', 'today', '2026-08-17T15:00:00Z'),
+			entryOn('northfield', 'soon', '2026-08-20T15:00:00Z'),
+		]
+
+		await render(
+			<EventList
+				events={events}
+				failed={[]}
+				now={NOW}
+				onPressEvent={jest.fn()}
+				onRefresh={jest.fn()}
+				poweredBy={POWERED_BY}
+				refreshing={false}
+				sources={[STOLAF_SOURCE, NORTHFIELD_SOURCE]}
+			/>,
+		)
+
+		expect(sectionHeaders()).toEqual([
+			'Monday – Aug 17',
+			'Thursday – Aug 20',
+			'Tuesday – Aug 25',
+			'Tuesday – Sep 1',
+		])
+	})
+
+	test('rows within a shared day read in time order however the calendars were merged', async () => {
+		let events = [
+			entryOn('stolaf', 'afternoon', '2026-08-20T20:00:00Z', 'Afternoon Recital'),
+			entryOn('northfield', 'morning', '2026-08-20T14:00:00Z', 'Morning Recital'),
+		]
+
+		await render(
+			<EventList
+				events={events}
+				failed={[]}
+				now={NOW}
+				onPressEvent={jest.fn()}
+				onRefresh={jest.fn()}
+				poweredBy={POWERED_BY}
+				refreshing={false}
+				sources={[STOLAF_SOURCE, NORTHFIELD_SOURCE]}
+			/>,
+		)
+
+		let titles = screen.getAllByText(/Recital$/u).map((node) => node.props.children as string)
+
+		expect(titles).toEqual(['Morning Recital', 'Afternoon Recital'])
+	})
+
+	test('an ongoing event leads the list even when its calendar is merged last', async () => {
+		let events = [
+			entryOn('stolaf', 'today', '2026-08-17T15:00:00Z'),
+			{
+				sourceId: 'northfield',
+				key: 'spanning',
+				event: makeEvent({
+					title: 'Museum Exhibition',
+					startTime: moment('2026-08-10T15:00:00Z'),
+					endTime: moment('2026-08-24T15:00:00Z'),
+					isOngoing: true,
+				}),
+			},
+		]
+
+		await render(
+			<EventList
+				events={events}
+				failed={[]}
+				now={NOW}
+				onPressEvent={jest.fn()}
+				onRefresh={jest.fn()}
+				poweredBy={POWERED_BY}
+				refreshing={false}
+				sources={[STOLAF_SOURCE, NORTHFIELD_SOURCE]}
+			/>,
+		)
+
+		expect(
+			screen.getAllByText(/^(Ongoing|Monday – Aug 17)$/u).map((node) => node.props.children),
+		).toEqual(['Ongoing', 'Monday – Aug 17'])
 	})
 })

--- a/modules/event-list/__tests__/event-list.test.tsx
+++ b/modules/event-list/__tests__/event-list.test.tsx
@@ -20,12 +20,6 @@ const POWERED_BY = {title: 'Powered by the St. Olaf calendar', href: 'https://ex
 const NOW = moment('2026-08-17T12:00:00Z')
 
 const STOLAF_SOURCE = {id: 'stolaf', title: 'St. Olaf', color: 'blue', kind: 'remote' as const}
-const NORTHFIELD_SOURCE = {
-	id: 'northfield',
-	title: 'Northfield',
-	color: 'indigo',
-	kind: 'remote' as const,
-}
 
 /**
  * What every parser writes for an all-day event, and what `times.ts` reads to
@@ -58,24 +52,6 @@ function makeEvent(overrides: Partial<EventType> = {}): EventType {
 
 function makeEntry(overrides: Partial<EventType> = {}) {
 	return {sourceId: 'stolaf', key: 'a', event: makeEvent(overrides)}
-}
-
-/** A two-hour event on a given calendar, for the ordering tests below. */
-function entryOn(sourceId: string, key: string, startTime: string, title = 'Recital') {
-	let start = moment(startTime)
-	return {
-		sourceId,
-		key,
-		event: makeEvent({title, startTime: start, endTime: start.clone().add(2, 'hours')}),
-	}
-}
-
-/**
- * Every section header in the order it renders. Headers carry an en dash
- * between weekday and date, which no row text does.
- */
-function sectionHeaders(): string[] {
-	return screen.getAllByText(/ \u2013 /u).map((node) => node.props.children as string)
 }
 
 describe('EventList', () => {
@@ -372,94 +348,5 @@ describe('EventList', () => {
 		)
 
 		expect(screen.getByText(/No calendars/u)).toBeTruthy()
-	})
-
-	test('day sections read in date order however the calendars were merged', async () => {
-		// `useMergedEvents` hands over one calendar's events at a time, so a
-		// second calendar's earlier days arrive after a first calendar's later
-		// ones -- today included.
-		let events = [
-			entryOn('stolaf', 'late', '2026-08-25T15:00:00Z'),
-			entryOn('stolaf', 'later', '2026-09-01T15:00:00Z'),
-			entryOn('northfield', 'today', '2026-08-17T15:00:00Z'),
-			entryOn('northfield', 'soon', '2026-08-20T15:00:00Z'),
-		]
-
-		await render(
-			<EventList
-				events={events}
-				failed={[]}
-				now={NOW}
-				onPressEvent={jest.fn()}
-				onRefresh={jest.fn()}
-				poweredBy={POWERED_BY}
-				refreshing={false}
-				sources={[STOLAF_SOURCE, NORTHFIELD_SOURCE]}
-			/>,
-		)
-
-		expect(sectionHeaders()).toEqual([
-			'Monday – Aug 17',
-			'Thursday – Aug 20',
-			'Tuesday – Aug 25',
-			'Tuesday – Sep 1',
-		])
-	})
-
-	test('rows within a shared day read in time order however the calendars were merged', async () => {
-		let events = [
-			entryOn('stolaf', 'afternoon', '2026-08-20T20:00:00Z', 'Afternoon Recital'),
-			entryOn('northfield', 'morning', '2026-08-20T14:00:00Z', 'Morning Recital'),
-		]
-
-		await render(
-			<EventList
-				events={events}
-				failed={[]}
-				now={NOW}
-				onPressEvent={jest.fn()}
-				onRefresh={jest.fn()}
-				poweredBy={POWERED_BY}
-				refreshing={false}
-				sources={[STOLAF_SOURCE, NORTHFIELD_SOURCE]}
-			/>,
-		)
-
-		let titles = screen.getAllByText(/Recital$/u).map((node) => node.props.children as string)
-
-		expect(titles).toEqual(['Morning Recital', 'Afternoon Recital'])
-	})
-
-	test('an ongoing event leads the list even when its calendar is merged last', async () => {
-		let events = [
-			entryOn('stolaf', 'today', '2026-08-17T15:00:00Z'),
-			{
-				sourceId: 'northfield',
-				key: 'spanning',
-				event: makeEvent({
-					title: 'Museum Exhibition',
-					startTime: moment('2026-08-10T15:00:00Z'),
-					endTime: moment('2026-08-24T15:00:00Z'),
-					isOngoing: true,
-				}),
-			},
-		]
-
-		await render(
-			<EventList
-				events={events}
-				failed={[]}
-				now={NOW}
-				onPressEvent={jest.fn()}
-				onRefresh={jest.fn()}
-				poweredBy={POWERED_BY}
-				refreshing={false}
-				sources={[STOLAF_SOURCE, NORTHFIELD_SOURCE]}
-			/>,
-		)
-
-		expect(
-			screen.getAllByText(/^(Ongoing|Monday – Aug 17)$/u).map((node) => node.props.children),
-		).toEqual(['Ongoing', 'Monday – Aug 17'])
 	})
 })

--- a/modules/event-list/__tests__/sections.test.ts
+++ b/modules/event-list/__tests__/sections.test.ts
@@ -1,0 +1,102 @@
+import {describe, expect, test} from '@jest/globals'
+import moment from 'moment-timezone'
+import {deriveDayFlags, type EventType} from '@frogpond/event-type'
+
+import {groupEvents} from '../sections'
+import type {SourcedEvent} from '../types'
+
+const NOW = moment('2026-08-17T12:00:00Z')
+
+function makeEvent(overrides: Partial<EventType> = {}): EventType {
+	let startTime = overrides.startTime ?? moment('2026-08-17T15:00:00Z')
+	let endTime = overrides.endTime ?? startTime.clone().add(2, 'hours')
+	let {isMultiDay, isSameInstant} = deriveDayFlags(false, startTime.toDate(), endTime.toDate())
+
+	return {
+		title: 'New Faculty Orientation',
+		description: 'Seminars across campus.',
+		location: 'Kings Dining',
+		startTime,
+		endTime,
+		isAllDay: false,
+		isMultiDay,
+		isSameInstant,
+		isOngoing: false,
+		links: [],
+		config: {startTime: true, endTime: true, subtitle: 'location'},
+		...overrides,
+	}
+}
+
+/** A two-hour event on a given calendar, keyed so assertions can name it. */
+function entryOn(sourceId: string, key: string, startTime: string): SourcedEvent {
+	return {sourceId, key, event: makeEvent({startTime: moment(startTime)})}
+}
+
+describe('groupEvents', () => {
+	test('orders day sections by date however the calendars were merged', () => {
+		// `useMergedEvents` hands over one calendar's events at a time, so a
+		// second calendar's earlier days arrive after a first calendar's later
+		// ones -- today included.
+		let sections = groupEvents(
+			[
+				entryOn('stolaf', 'late', '2026-08-25T15:00:00Z'),
+				entryOn('stolaf', 'later', '2026-09-01T15:00:00Z'),
+				entryOn('northfield', 'today', '2026-08-17T15:00:00Z'),
+				entryOn('northfield', 'soon', '2026-08-20T15:00:00Z'),
+			],
+			NOW,
+		)
+
+		expect(sections.map((section) => section.key)).toEqual([
+			'Today',
+			'2026-08-20',
+			'2026-08-25',
+			'2026-09-01',
+		])
+	})
+
+	test('orders rows within a shared day by time however the calendars were merged', () => {
+		let sections = groupEvents(
+			[
+				entryOn('stolaf', 'afternoon', '2026-08-20T20:00:00Z'),
+				entryOn('northfield', 'morning', '2026-08-20T14:00:00Z'),
+			],
+			NOW,
+		)
+
+		expect(sections).toHaveLength(1)
+		expect(sections[0].data.map((entry) => entry.key)).toEqual(['morning', 'afternoon'])
+	})
+
+	test('leads with Ongoing even when its calendar is merged last', () => {
+		let spanning = {
+			sourceId: 'northfield',
+			key: 'exhibition',
+			event: makeEvent({
+				startTime: moment('2026-08-10T15:00:00Z'),
+				endTime: moment('2026-08-24T15:00:00Z'),
+				isOngoing: true,
+			}),
+		}
+
+		let sections = groupEvents([entryOn('stolaf', 'today', '2026-08-17T15:00:00Z'), spanning], NOW)
+
+		expect(sections.map((section) => section.key)).toEqual(['Ongoing', 'Today'])
+	})
+
+	test('titles today’s section from now, and flags it as today', () => {
+		let sections = groupEvents(
+			[
+				entryOn('stolaf', 'today', '2026-08-17T15:00:00Z'),
+				entryOn('stolaf', 'tomorrow', '2026-08-18T15:00:00Z'),
+			],
+			NOW,
+		)
+
+		expect(sections.map((section) => [section.title, section.isToday])).toEqual([
+			['Monday – Aug 17', true],
+			['Tuesday – Aug 18', false],
+		])
+	})
+})

--- a/modules/event-list/event-list.tsx
+++ b/modules/event-list/event-list.tsx
@@ -20,13 +20,11 @@ import {
 	scrollTargetLayout,
 } from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
-import toPairs from 'lodash/toPairs'
-import groupBy from 'lodash/groupBy'
 import type {Moment} from 'moment-timezone'
 import {NoticeView} from '@frogpond/notice'
 import {DayPickerStrip, deriveDays, type DayPickerStripHandle} from './day-picker-strip'
 import {EventListRow} from './event-list-row'
-import {formatSectionHeader} from './times'
+import {groupEvents} from './sections'
 import {CalendarSource, PoweredBy, SourcedEvent} from './types'
 
 type Props = {
@@ -43,55 +41,6 @@ type Props = {
 
 export type EventListHandle = {
 	scrollToToday: () => void
-}
-
-type EventSection = {
-	readonly key: string
-	readonly title: string
-	readonly isToday: boolean
-	readonly data: SourcedEvent[]
-}
-
-/**
- * Groups events into an `Ongoing` group and one group per day, with today's
- * events together regardless of the timezone quirks in `event.startTime`.
- *
- * Day groups are keyed on an unambiguous ISO date rather than on their
- * display title, which is locale-aware and computed separately below.
- *
- * Events are put in start-time order first. `useMergedEvents` hands over one
- * calendar's events at a time, so without this a second calendar's earlier
- * days sit behind a first calendar's later ones -- today included, which
- * leaves the list opening a month out and the day-picker strip parked there
- * with it. `groupBy` keeps each group where its first member put it, so
- * ordering the events is what orders the sections; it also orders the rows
- * inside a day two calendars share. An ongoing event starts before today by
- * definition, so `Ongoing` leads the list without a rule of its own.
- */
-function groupEvents(events: readonly SourcedEvent[], now: Moment): Array<EventSection> {
-	let ordered = [...events].sort(
-		(one, two) => one.event.startTime.valueOf() - two.event.startTime.valueOf(),
-	)
-
-	let grouped = groupBy(ordered, (entry) => {
-		if (entry.event.isOngoing) {
-			return 'Ongoing'
-		}
-		if (entry.event.startTime.isSame(now, 'day')) {
-			return 'Today'
-		}
-		return entry.event.startTime.format('YYYY-MM-DD') // google returns events in CST
-	})
-
-	return toPairs(grouped).map(([key, data]) => {
-		if (key === 'Ongoing') {
-			return {key, title: 'Ongoing', isToday: false, data}
-		}
-		if (key === 'Today') {
-			return {key, title: formatSectionHeader(now), isToday: true, data}
-		}
-		return {key, title: formatSectionHeader(data[0].event.startTime), isToday: false, data}
-	})
 }
 
 /**

--- a/modules/event-list/event-list.tsx
+++ b/modules/event-list/event-list.tsx
@@ -58,9 +58,22 @@ type EventSection = {
  *
  * Day groups are keyed on an unambiguous ISO date rather than on their
  * display title, which is locale-aware and computed separately below.
+ *
+ * Events are put in start-time order first. `useMergedEvents` hands over one
+ * calendar's events at a time, so without this a second calendar's earlier
+ * days sit behind a first calendar's later ones -- today included, which
+ * leaves the list opening a month out and the day-picker strip parked there
+ * with it. `groupBy` keeps each group where its first member put it, so
+ * ordering the events is what orders the sections; it also orders the rows
+ * inside a day two calendars share. An ongoing event starts before today by
+ * definition, so `Ongoing` leads the list without a rule of its own.
  */
 function groupEvents(events: readonly SourcedEvent[], now: Moment): Array<EventSection> {
-	let grouped = groupBy(events, (entry) => {
+	let ordered = [...events].sort(
+		(one, two) => one.event.startTime.valueOf() - two.event.startTime.valueOf(),
+	)
+
+	let grouped = groupBy(ordered, (entry) => {
 		if (entry.event.isOngoing) {
 			return 'Ongoing'
 		}

--- a/modules/event-list/sections.ts
+++ b/modules/event-list/sections.ts
@@ -1,0 +1,55 @@
+import groupBy from 'lodash/groupBy'
+import toPairs from 'lodash/toPairs'
+import type {Moment} from 'moment-timezone'
+
+import {formatSectionHeader} from './times'
+import type {SourcedEvent} from './types'
+
+export interface EventSection {
+	readonly key: string
+	readonly title: string
+	readonly isToday: boolean
+	readonly data: SourcedEvent[]
+}
+
+/**
+ * Groups events into an `Ongoing` group and one group per day, with today's
+ * events together regardless of the timezone quirks in `event.startTime`.
+ *
+ * Day groups are keyed on an unambiguous ISO date rather than on their
+ * display title, which is locale-aware and computed separately.
+ *
+ * Events are put in start-time order first. `useMergedEvents` hands over one
+ * calendar's events at a time, so without this a second calendar's earlier
+ * days sit behind a first calendar's later ones -- today included, which
+ * leaves the list opening a month out and the day-picker strip parked there
+ * with it. `groupBy` keeps each group where its first member put it, so
+ * ordering the events is what orders the sections; it also orders the rows
+ * inside a day two calendars share. An ongoing event starts before today by
+ * definition, so `Ongoing` leads the list without a rule of its own.
+ */
+export function groupEvents(events: readonly SourcedEvent[], now: Moment): EventSection[] {
+	let ordered = Array.from(events).sort(
+		(one, two) => one.event.startTime.valueOf() - two.event.startTime.valueOf(),
+	)
+
+	let grouped = groupBy(ordered, (entry) => {
+		if (entry.event.isOngoing) {
+			return 'Ongoing'
+		}
+		if (entry.event.startTime.isSame(now, 'day')) {
+			return 'Today'
+		}
+		return entry.event.startTime.format('YYYY-MM-DD') // google returns events in CST
+	})
+
+	return toPairs(grouped).map(([key, data]) => {
+		if (key === 'Ongoing') {
+			return {key, title: 'Ongoing', isToday: false, data}
+		}
+		if (key === 'Today') {
+			return {key, title: formatSectionHeader(now), isToday: true, data}
+		}
+		return {key, title: formatSectionHeader(data[0].event.startTime), isToday: false, data}
+	})
+}


### PR DESCRIPTION
Turns out we weren't sorting the events before we grouped them, so we'd wind up prepending one origin-sorted list to another.

Closes https://github.com/StoDevX/AAO-React-Native/issues/7829