### PR TITLE
Give the search bar back its text after a cancelled swipe back

### DIFF
--- a/app/(home)/CourseSearch.tsx
+++ b/app/(home)/CourseSearch.tsx
@@ -8,6 +8,7 @@ import {useAppSelector} from '../../source/redux/hooks'
 import {selectRecentFilters, selectRecentSearches} from '../../source/redux/parts/courses'
 import {RecentItemsList} from '../../source/features/sis/components/recents-list'
 import {useFilters} from '../../source/features/sis/course-search/lib/build-filters'
+import {SearchBar} from '../../source/components/search-bar'
 
 const SEARCH_DEBOUNCE_MS = 1500
 const MIN_QUERY_LENGTH = 2
@@ -70,11 +71,7 @@ function CourseSearchView(): React.ReactNode {
 				<Stack.Toolbar.SearchBarSlot />
 			</Stack.Toolbar>
 
-			<Stack.SearchBar
-				onChangeText={(event) => {
-					setTypedQuery(event.nativeEvent.text)
-				}}
-			/>
+			<SearchBar onChangeText={setTypedQuery} value={typedQuery} />
 
 			<View style={[styles.container, styles.common]}>
 				<ScrollView

--- a/app/(home)/CourseSearchResults.tsx
+++ b/app/(home)/CourseSearchResults.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../source/features/sis/course-search/lib/execute-search'
 import {useCourseData} from '../../source/features/sis/course-search/query'
 import {UseQueryResult} from '@tanstack/react-query'
+import {SearchBar} from '../../source/components/search-bar'
 
 function doSearch(args: {
 	query: string
@@ -221,9 +222,10 @@ function CourseSearchResultsView(): React.ReactNode {
 				<Stack.Toolbar.SearchBarSlot />
 			</Stack.Toolbar>
 
-			<Stack.SearchBar
-				onChangeText={(event) => setSearchQuery(event.nativeEvent.text)}
+			<SearchBar
+				onChangeText={setSearchQuery}
 				placeholder="Search for a course"
+				value={searchQuery}
 			/>
 
 			<SectionList

--- a/app/(home)/Dictionary/index.tsx
+++ b/app/(home)/Dictionary/index.tsx
@@ -20,6 +20,7 @@ import {useDebounce} from '@frogpond/use-debounce'
 import deburr from 'lodash/deburr'
 import groupBy from 'lodash/groupBy'
 import words from 'lodash/words'
+import {SearchBar} from '../../../source/components/search-bar'
 
 function splitToArray(str: string) {
 	return words(deburr(str.toLowerCase()))
@@ -81,7 +82,7 @@ function DictionaryView(): React.ReactNode {
 				<Stack.Toolbar.SearchBarSlot />
 			</Stack.Toolbar>
 
-			<Stack.SearchBar onChangeText={(event) => setQuery(event.nativeEvent.text)} />
+			<SearchBar onChangeText={setQuery} value={query} />
 		</>
 	)
 

--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -7,6 +7,7 @@ import {Detail, ListRow, ListSeparator, Title} from '@frogpond/lists'
 import * as c from '@frogpond/colors'
 import {useDebounce} from '@frogpond/use-debounce'
 import {LoadingView, NoticeView} from '@frogpond/notice'
+import {SearchBar} from '../../../source/components/search-bar'
 import {formatResults} from '../../../source/features/directory/helpers'
 import {directoryEntriesOptions} from '../../../source/features/directory/query'
 import type {DirectoryItem, DirectorySearchTypeEnum} from '../../../source/features/directory/types'
@@ -51,11 +52,12 @@ function DirectoryView(): React.ReactNode {
 				<Stack.Toolbar.SearchBarSlot />
 			</Stack.Toolbar>
 
-			<Stack.SearchBar
-				onChangeText={(event) => {
+			<SearchBar
+				onChangeText={(text) => {
 					setSearchQueryType('query')
-					setTypedQuery(event.nativeEvent.text)
+					setTypedQuery(text)
 				}}
+				value={typedQuery}
 			/>
 		</>
 	)

--- a/app/(home)/More/index.tsx
+++ b/app/(home)/More/index.tsx
@@ -9,9 +9,10 @@ import {ListSeparator, ListSectionHeader, largeListProps, Title, ListRow} from '
 import {LinkValue} from '../../../source/features/more/types'
 
 import {Stack} from 'expo-router'
-import {deburr, words} from 'lodash'
+import {filterLinkGroups} from '../../../source/features/more/helpers'
 import {searchLinksOptions} from '../../../source/features/more/query'
 import {useQuery} from '@tanstack/react-query'
+import {SearchBar} from '../../../source/components/search-bar'
 
 const styles = StyleSheet.create({
 	wrapper: {
@@ -25,32 +26,13 @@ const styles = StyleSheet.create({
 	},
 })
 
-function splitToArray(str: string) {
-	return words(deburr(str.toLowerCase()))
-}
-
-function linkToArray(data: LinkValue) {
-	return Array.from(new Set(splitToArray(data.label)))
-}
-
 function MoreView(): React.ReactNode {
 	let [query, setQuery] = React.useState('')
-	let searchQuery = useDebounce(query.toLowerCase(), 200)
+	let searchQuery = useDebounce(query, 200)
 
 	let {data = [], error, refetch, isLoading, isError, isRefetching} = useQuery(searchLinksOptions)
 
-	let filtered = React.useMemo(() => {
-		let filteredData = []
-		for (let {title, data: items} of data) {
-			let filteredItems = items.filter((value) =>
-				linkToArray(value).some((item) => item.includes(searchQuery)),
-			)
-			if (filteredItems.length) {
-				filteredData.push({title, data: items})
-			}
-		}
-		return filteredData
-	}, [data, searchQuery])
+	let filtered = React.useMemo(() => filterLinkGroups(data, searchQuery), [data, searchQuery])
 
 	if (isError) {
 		return (
@@ -68,7 +50,7 @@ function MoreView(): React.ReactNode {
 				<Stack.Toolbar.SearchBarSlot />
 			</Stack.Toolbar>
 
-			<Stack.SearchBar onChangeText={(event) => setQuery(event.nativeEvent.text)} />
+			<SearchBar onChangeText={setQuery} value={query} />
 
 			<SectionList
 				ItemSeparatorComponent={ListSeparator}

--- a/app/(home)/StudentOrgs/index.tsx
+++ b/app/(home)/StudentOrgs/index.tsx
@@ -22,6 +22,7 @@ import {Stack, useRouter} from 'expo-router'
 import memoize from 'lodash/memoize'
 import {studentOrgsOptions} from '../../../source/features/student-orgs/query'
 import {useQuery} from '@tanstack/react-query'
+import {SearchBar} from '../../../source/components/search-bar'
 
 const splitToArray = memoize((str: string) => words(deburr(str.toLowerCase())))
 
@@ -97,7 +98,7 @@ function StudentOrgsView(): React.ReactNode {
 				<Stack.Toolbar.SearchBarSlot />
 			</Stack.Toolbar>
 
-			<Stack.SearchBar onChangeText={(ev) => setQuery(ev.nativeEvent.text)} />
+			<SearchBar onChangeText={setQuery} value={query} />
 		</>
 	)
 

--- a/app/(settings)/APITest.tsx
+++ b/app/(settings)/APITest.tsx
@@ -7,6 +7,7 @@ import * as c from '@frogpond/colors'
 import {useQuery} from '@tanstack/react-query'
 import {Stack, useNavigation, useRouter} from 'expo-router'
 
+import {SearchBar} from '../../source/components/search-bar'
 import {
 	ServerRoute,
 	serverRoutesOptions,
@@ -15,6 +16,11 @@ import {
 export default function APITestPage(): React.ReactNode {
 	const navigation = useNavigation()
 	let router = useRouter()
+
+	// The path is only read when the reader hits Search, but it has to be held
+	// here as well: the search field is the one place it lives otherwise, and a
+	// swipe back that is begun and abandoned empties it.
+	let [path, setPath] = React.useState('')
 
 	let {
 		data: groupedRoutes = [],
@@ -67,16 +73,17 @@ export default function APITestPage(): React.ReactNode {
 				<Stack.Toolbar.SearchBarSlot />
 			</Stack.Toolbar>
 
-			<Stack.SearchBar
+			<SearchBar
 				autoCapitalize="none"
+				onChangeText={setPath}
 				onSearchButtonPress={(ev) => {
-					let filterPath = ev.nativeEvent.text
 					router.push({
 						pathname: '/APITestDetail',
-						params: {displayName: filterPath},
+						params: {displayName: ev.nativeEvent.text},
 					})
 				}}
 				placeholder="/path/to/uri"
+				value={path}
 			/>
 
 			<View style={styles.serverRouteContainer}>

--- a/source/components/search-bar.tsx
+++ b/source/components/search-bar.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import {Stack, useNavigation} from 'expo-router'
+import type {NativeStackNavigationProp} from 'expo-router'
+import type {SearchBarCommands} from 'react-native-screens'
+
+// expo-router does not re-export react-navigation's `ParamListBase`, and this
+// component only needs the stack's event map, not any screen's params.
+type StackNavigation = NativeStackNavigationProp<Record<string, object | undefined>>
+
+type NativeSearchBarProps = React.ComponentProps<typeof Stack.SearchBar>
+
+export type SearchBarProps = Omit<NativeSearchBarProps, 'onChangeText' | 'ref'> & {
+	/** The query the screen believes it is showing results for. */
+	value: string
+	/** Called with the field's new text when the reader types. */
+	onChangeText: (text: string) => void
+}
+
+/**
+ * The native search bar, kept in step with the query its screen is showing.
+ *
+ * `Stack.SearchBar` has no `value` prop — the text lives in UIKit, and React
+ * only ever hears about it through `onChangeText`. Beginning an interactive
+ * swipe back tears the search field down, so cancelling that swipe returns the
+ * reader to a screen whose results answer a query the search bar no longer
+ * displays. Pushing our copy of the text back through the imperative handle is
+ * the only way to close that gap.
+ *
+ * Restoring does not feed back into `onChangeText`: UIKit only calls its
+ * delegate for text the reader typed, not for text set on the field.
+ */
+export function SearchBar({value, onChangeText, ...props}: SearchBarProps): React.ReactNode {
+	let navigation = useNavigation<StackNavigation>()
+	let searchBar = React.useRef<SearchBarCommands>(null)
+
+	React.useEffect(() => {
+		return navigation.addListener('gestureCancel', () => {
+			searchBar.current?.setText(value)
+		})
+	}, [navigation, value])
+
+	return (
+		<Stack.SearchBar
+			ref={searchBar}
+			{...props}
+			onChangeText={(event) => onChangeText(event.nativeEvent.text)}
+		/>
+	)
+}

--- a/source/features/more/__tests__/helpers.test.ts
+++ b/source/features/more/__tests__/helpers.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {filterLinkGroups} from '../helpers'
+import type {LinkGroup} from '../types'
+
+const groups: LinkGroup[] = [
+	{
+		title: 'Academics',
+		data: [
+			{label: 'Registrar', url: 'https://wp.stolaf.edu/registrar/'},
+			{label: 'Academic Calendar', url: 'https://wp.stolaf.edu/calendar/'},
+		],
+	},
+	{
+		title: 'Student Life',
+		data: [
+			{label: 'Residence Life', url: 'https://wp.stolaf.edu/reslife/'},
+			{label: 'Dining Services', url: 'https://wp.stolaf.edu/dining/'},
+		],
+	},
+	{
+		title: 'Libraries',
+		data: [{label: 'Rølvaag Library', url: 'https://wp.stolaf.edu/library/'}],
+	},
+]
+
+describe('filterLinkGroups', () => {
+	test('returns every group untouched when the query is empty', () => {
+		expect(filterLinkGroups(groups, '')).toEqual(groups)
+	})
+
+	test('drops the links that do not match', () => {
+		expect(filterLinkGroups(groups, 'registrar')).toEqual([
+			{title: 'Academics', data: [{label: 'Registrar', url: 'https://wp.stolaf.edu/registrar/'}]},
+		])
+	})
+
+	test('drops a group once none of its links match', () => {
+		expect(filterLinkGroups(groups, 'dining')).toEqual([
+			{
+				title: 'Student Life',
+				data: [{label: 'Dining Services', url: 'https://wp.stolaf.edu/dining/'}],
+			},
+		])
+	})
+
+	test('matches any word of a label, not just the first', () => {
+		expect(filterLinkGroups(groups, 'calendar')).toEqual([
+			{
+				title: 'Academics',
+				data: [{label: 'Academic Calendar', url: 'https://wp.stolaf.edu/calendar/'}],
+			},
+		])
+	})
+
+	test('ignores the case of the query', () => {
+		expect(filterLinkGroups(groups, 'ReGiStRaR')).toEqual([
+			{title: 'Academics', data: [{label: 'Registrar', url: 'https://wp.stolaf.edu/registrar/'}]},
+		])
+	})
+
+	// Several of the labels this searches carry Norwegian vowels, and nobody
+	// types them: "Rølvaag" has to be reachable from an ASCII keyboard.
+	test('finds an accented label from its unaccented spelling', () => {
+		expect(filterLinkGroups(groups, 'rolvaag')).toEqual([
+			{
+				title: 'Libraries',
+				data: [{label: 'Rølvaag Library', url: 'https://wp.stolaf.edu/library/'}],
+			},
+		])
+	})
+
+	test('finds an accented label from its accented spelling too', () => {
+		expect(filterLinkGroups(groups, 'rølvaag')).toEqual([
+			{
+				title: 'Libraries',
+				data: [{label: 'Rølvaag Library', url: 'https://wp.stolaf.edu/library/'}],
+			},
+		])
+	})
+
+	test('returns nothing when no link matches', () => {
+		expect(filterLinkGroups(groups, 'zamboni')).toEqual([])
+	})
+})

--- a/source/features/more/helpers.ts
+++ b/source/features/more/helpers.ts
@@ -1,0 +1,29 @@
+import {deburr, words} from 'lodash'
+
+import type {LinkGroup, LinkValue} from './types'
+
+const labelWords = (link: LinkValue): string[] => {
+	return Array.from(new Set(words(deburr(link.label.toLowerCase()))))
+}
+
+/**
+ * Narrow the A-Z link groups to the links whose label matches `query`, dropping
+ * any group left with nothing in it.
+ *
+ * A link matches when any word of its label contains the query, so "cal" finds
+ * "Academic Calendar" from the middle of the name. Both sides are stripped of
+ * their accents first: plenty of these labels are Norwegian, and "Rølvaag" has
+ * to be reachable from a keyboard that cannot type ø.
+ */
+export const filterLinkGroups = (groups: LinkGroup[], query: string): LinkGroup[] => {
+	let needle = deburr(query.toLowerCase())
+
+	let filtered: LinkGroup[] = []
+	for (let {title, data} of groups) {
+		let links = data.filter((link) => labelWords(link).some((word) => word.includes(needle)))
+		if (links.length) {
+			filtered.push({title, data: links})
+		}
+	}
+	return filtered
+}

--- a/uitests/ModuleDirectoryTests.swift
+++ b/uitests/ModuleDirectoryTests.swift
@@ -7,4 +7,18 @@ class ModuleDirectoryTests: UITestCase {
 			.verifyDirectoryTitle()
 			.checkSearchPromptVisible()
 	}
+
+	/// The search field holds the query and nothing else does, so a swipe back
+	/// that is begun and then abandoned has to give it back intact -- otherwise
+	/// the reader returns to a list of results with nothing on screen saying
+	/// what was searched for.
+	func testCancelledSwipeBackKeepsTheQuery() throws {
+		DirectoryScreen(app: app)
+			.navigate()
+			.search(for: "olaf")
+			.cancelSwipeBack()
+			.verifyDirectoryTitle()
+			.capture("Directory after a cancelled swipe back")
+			.verifySearchText("olaf")
+	}
 }

--- a/uitests/Screen.swift
+++ b/uitests/Screen.swift
@@ -81,6 +81,26 @@ extension Screen {
 		return self
 	}
 
+	/// Pull the screen most of the way off with the back gesture, then let go
+	/// without completing it, so the stack settles back where it started.
+	///
+	/// The drag stops short of half the width and moves slowly: UIKit decides an
+	/// interactive pop on how far the finger travelled and how fast it was going
+	/// when it lifted, so a slow release at a third of the way across is read as
+	/// "put it back". Holding before the release is what drains the velocity --
+	/// a fast flick from the same place would complete the pop instead.
+	@discardableResult
+	func cancelSwipeBack() -> Self {
+		let edge = app.coordinate(withNormalizedOffset: CGVector(dx: 0.0, dy: 0.5))
+		let partway = app.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.5))
+		edge.press(
+			forDuration: 0.2,
+			thenDragTo: partway,
+			withVelocity: .slow,
+			thenHoldForDuration: 1.0)
+		return self
+	}
+
 	/// Assert that a navigation-bar or section title is visible.
 	@discardableResult
 	func verifyTitle(_ title: String) -> Self {

--- a/uitests/Screens/DirectoryScreen.swift
+++ b/uitests/Screens/DirectoryScreen.swift
@@ -3,9 +3,44 @@ import XCTest
 struct DirectoryScreen: Screen {
 	let app: XCUIApplication
 
+	private var searchField: XCUIElement {
+		app.searchFields.firstMatch
+	}
+
 	@discardableResult
 	func navigate() -> Self {
 		navigateFromHome(to: TestIdentifiers.Buttons.directory)
+	}
+
+	@discardableResult
+	func search(for text: String) -> Self {
+		XCTAssertTrue(
+			searchField.waitForExistence(timeout: 30),
+			"Directory should offer a search field")
+		searchField.tap()
+		searchField.typeText(text)
+
+		// The field is the one place the typed text is held, so read it back
+		// before going on: a test that swiped away from an empty field would
+		// pass no matter what the swipe did to it.
+		XCTAssertEqual(
+			searchField.value as? String, text,
+			"Typing should put the query in the search field")
+		return self
+	}
+
+	@discardableResult
+	func verifySearchText(_ text: String) -> Self {
+		let field = searchField
+		let predicate = NSPredicate(format: "value == %@", text)
+		let settled = XCTWaiter().wait(
+			for: [XCTNSPredicateExpectation(predicate: predicate, object: field)],
+			timeout: 10)
+		XCTAssertEqual(
+			settled, .completed,
+			"Search field should still read \(text), but reads "
+				+ "\(field.value as? String ?? "nothing")")
+		return self
 	}
 
 	@discardableResult


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/7800

Also fixes an issue where the More screen's search bar did not actually filter the list