### PR TITLE
Quiet bundle-data, and document the simulator workflows

### DIFF
--- a/.claude/skills/run-on-simulator/SKILL.md
+++ b/.claude/skills/run-on-simulator/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: run-on-simulator
+description: Use when you need to look at the app itself on a simulator - checking a change by eye, screenshotting a screen, or reproducing something by hand, rather than running the XCUITests or building to a phone
+---
+
+# Run the App on a Simulator
+
+For seeing a change with your own eyes. To *assert* something about a screen,
+write an XCUITest instead — see `run-uitests`. For a physical iPhone, see
+`build-to-device`.
+
+## The whole thing, headless
+
+```bash
+# 1. Build and install. Slow the first time (30+ min), incremental after.
+mise run ios          # expect it to fail at the last step; see below
+
+# 2. Boot a simulator.
+xcrun simctl list devices available | grep iPhone
+xcrun simctl boot <UDID>; xcrun simctl bootstatus <UDID> -b
+
+# 3. Serve the JavaScript, and wait until it answers.
+npx expo start --port 8081 > /tmp/metro.log 2>&1 &
+until curl -sf http://localhost:8081/status | grep -q running; do sleep 1; done
+
+# 4. Launch it pointed at Metro, and look.
+xcrun simctl openurl <UDID> \
+  "NFMTHAZVS9.com.drewvolz.stolaf://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"
+xcrun simctl io <UDID> screenshot /tmp/shot.png    # then Read the png
+```
+
+No GUI is needed at any point. `simctl` drives a booted simulator whether or
+not anything is on screen, and `io screenshot` reads the framebuffer directly.
+
+## The two steps that mislead
+
+**`mise run ios` fails at the end, after doing the useful work.** It builds,
+signs and installs, then tries to raise the Simulator GUI and reports:
+
+```
+CommandError: Simulator app did not open fast enough.
+Try opening Simulator first, then running your app.
+```
+
+Take its advice only once you have checked the GUI exists. Some Xcode installs
+have no `$(xcode-select -p)/Applications/` directory at all, so
+`open -a Simulator` answers `Unable to find application named 'Simulator'` and
+no amount of retrying will help. **The app is installed either way** — the
+failure is in raising a window, not in the build. Ignore it and go to step 2.
+
+**`simctl launch` gets you a red screen.** Launching by bundle id alone:
+
+```bash
+xcrun simctl launch <UDID> NFMTHAZVS9.com.drewvolz.stolaf   # DON'T
+```
+
+starts the app with no idea where Metro is, and it renders `No script URL
+provided. Make sure the packager is running…`, which reads like a broken Metro
+rather than a missing argument. The `openurl` deep link in step 4 is what
+passes the packager address in. Note the URL is percent-encoded — `%3A%2F%2F`
+for `://`.
+
+## Bundle identifiers
+
+| `APP_VARIANT` | Bundle id |
+| --- | --- |
+| unset / `production` | `NFMTHAZVS9.com.drewvolz.stolaf` |
+| `development` | `NFMTHAZVS9.com.drewvolz.stolaf.dev` |
+
+The URL scheme matches the bundle id, so a dev-variant build wants
+`…stolaf.dev://expo-development-client/?url=…`. Two builds claiming one scheme
+is undefined behaviour, which is why they differ.
+
+## Notes
+
+- **`expo run:ios` does not use `ios/build`.** It writes to
+  `~/Library/Developer/Xcode/DerivedData/AllAboutOlaf-<hash>/`, so it neither
+  reuses nor contends with a UITest build — it pays its own full build the
+  first time. Deleting `ios/build` will not reclaim it.
+- Metro serves whatever is on disk on the next launch, so **JavaScript changes
+  need no rebuild**: edit, then re-run step 4. Only native changes need
+  `mise run ios` again.
+- Reset to a first-launch state with
+  `xcrun simctl uninstall <UDID> <BUNDLE ID>`, or wipe everything with
+  `xcrun simctl erase <UDID>` on a shut-down device.
+- A screenshot of a booted-but-idle simulator is a real screenshot; unlike a
+  sleeping phone, there is no black-screen trap here.

--- a/.claude/skills/run-uitests/SKILL.md
+++ b/.claude/skills/run-uitests/SKILL.md
@@ -48,9 +48,13 @@ Three things that bite on the second run:
   `rm -rf` it first, as above.
 - **It appends `.xcresult` for you.** `-resultBundlePath /tmp/results` writes
   `/tmp/results.xcresult`, which is the path every later command wants.
-- **Pick a simulator on the runtime the build targeted.** The bundle is named
-  for it — `AllAboutOlaf_iphonesimulator27.0-arm64-x86_64.xctestrun` — and a
-  device on an older runtime will not run it.
+- **The version in the bundle's name is the SDK, not a runtime.**
+  `AllAboutOlaf_iphonesimulator27.0-arm64-x86_64.xctestrun` is built by the
+  Xcode 27 SDK and runs on any installed runtime that SDK supports — iOS 26.5
+  at the time of writing. Do not go hunting for a matching runtime; there is
+  no iOS 27. `xcrun simctl list runtimes` shows what you have.
+- **`find` picks an arbitrary bundle if there is more than one.** There is
+  normally one, but pass the path explicitly if `find` returns several.
 
 Steps 1 and 4 are the commands CI runs (`.github/workflows/check.yml`, jobs
 `ios-build` and `ios-uitest`), so a local failure and a CI failure mean the same
@@ -142,8 +146,15 @@ silently did nothing is indistinguishable from one that worked.
 - `ios/build` is derived data for this checkout alone, so an existing one is
   safe to build on top of — step 1 is worth running anyway, since it is
   incremental and settles whether the bundle matches your sources.
-- Network-backed screens really do hit the network here. Assert on things the
-  screen decides — a field's contents, which empty state appeared — rather than
-  on particular records, unless the test is about the data.
+- **A failure message that exists in no source file means stale derived data.**
+  If an assertion string cannot be found by grepping `uitests/` or the built
+  test binary, stop trusting the run: `rm -rf ios/build` and rebuild. Seen once
+  after a build was killed part-way through.
+- **Network-backed screens really do hit the live server here — nothing is
+  stubbed.** Assert on what the screen decides, not on records it was handed: a
+  field's contents, which empty state appeared, whether a list got shorter.
+  Naming a row that St. Olaf can rename writes a test that fails on someone
+  else's schedule. When a test genuinely needs to name one, say so in a comment
+  next to the constant, so whoever it breaks for knows why.
 - CI sharding lives in `scripts/split-uitests.py`; `-only-testing` takes
   `Bundle/Class/method` and can be repeated.

--- a/.claude/skills/run-uitests/SKILL.md
+++ b/.claude/skills/run-uitests/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: run-uitests
+description: Use when a change needs checking against the running app on a simulator - XCUITests in uitests/, proving a UI fix red then green, or getting a screenshot of a screen out of a test run
+---
+
+# Run the UITests on a Simulator
+
+The tests in `uitests/` are the only place this repo can answer what a screen
+actually looks like and does. Jest cannot: it has no layout pass, no
+compositor, and no hit testing, so a Jest assertion about a colour, a size, a
+tap target or a native control is asserting the props we passed in.
+
+## The four commands
+
+```bash
+# 1. Build the app and the test bundle. Slow the first time, incremental after.
+SKIP_BUNDLING=true CODE_SIGNING_DISABLED=true xcodebuild build-for-testing \
+  -workspace ios/AllAboutOlaf.xcworkspace -scheme AllAboutOlaf \
+  -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build \
+  -only-testing:AllAboutOlafUITests \
+  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+# 2. Boot a simulator and wait for it.
+xcrun simctl list devices available | grep iPhone   # pick a UDID
+xcrun simctl boot <UDID>; xcrun simctl bootstatus <UDID> -b
+
+# 3. Serve the JavaScript. Background it, then wait until it answers.
+npx expo start --port 8081 &
+until curl -sf http://localhost:8081/status | grep -q running; do sleep 1; done
+
+# 4. Run one test, or a suite, or the lot.
+rm -rf /tmp/results.xcresult
+xcodebuild test-without-building \
+  -xctestrun $(find ios/build/Build/Products -name '*.xctestrun' -print -quit) \
+  -destination "platform=iOS Simulator,id=<UDID>" \
+  -only-testing:AllAboutOlafUITests/ModuleDirectoryTests/testSomething \
+  -resultBundlePath /tmp/results
+```
+
+Pipe step 4 through `grep -E "^Test Case|error:|XCTAssert|Executed|\*\*"`.
+Unfiltered xcodebuild output is thousands of lines, most of it exported build
+settings, and it will bury the one assertion message you ran the test for.
+
+Three things that bite on the second run:
+
+- **`-resultBundlePath` refuses to overwrite.** You get `xcodebuild: error:
+  Existing file at -resultBundlePath "/tmp/results"` and no test run at all.
+  `rm -rf` it first, as above.
+- **It appends `.xcresult` for you.** `-resultBundlePath /tmp/results` writes
+  `/tmp/results.xcresult`, which is the path every later command wants.
+- **Pick a simulator on the runtime the build targeted.** The bundle is named
+  for it — `AllAboutOlaf_iphonesimulator27.0-arm64-x86_64.xctestrun` — and a
+  device on an older runtime will not run it.
+
+Steps 1 and 4 are the commands CI runs (`.github/workflows/check.yml`, jobs
+`ios-build` and `ios-uitest`), so a local failure and a CI failure mean the same
+thing. The *destination* is not the same: CI resolves an `iPhone 17e` on a
+pinned runtime, which a local machine usually does not have.
+
+## Why step 3 is what makes this affordable
+
+`SKIP_BUNDLING=true` leaves no `main.jsbundle` inside the `.app`, so a Debug
+build fetches from Metro on every launch, and `UITestCase.setUp` cold-launches
+the app for every single test.
+
+**Editing JavaScript therefore needs no rebuild — just run step 4 again.** That
+is what makes it cheap to watch a test fail before trusting it:
+
+1. Write the test and the fix.
+2. Revert *just the fix* (`git checkout <file>`, or keep a copy in `/tmp`).
+3. Run step 4. **Read the failure message.** It should describe the bug you set
+   out to fix, in the words a user would use.
+4. Restore the fix. Run step 4 again.
+
+A UI test you have never seen fail proves nothing. A cancelled-swipe test whose
+gesture never engaged passes just as green as one that works, and so does a test
+that swiped away from a field that was empty to begin with. Skipping this step
+is how a broken feature ends up looking covered.
+
+## Getting the picture out
+
+`capture("some name")` on any `Screen` attaches a screenshot with
+`.keepAlways`. Pull it out of the result bundle and actually look at it:
+
+```bash
+rm -rf /tmp/shots
+xcrun xcresulttool export attachments --path /tmp/results.xcresult \
+  --output-path /tmp/shots     # then Read the .png
+```
+
+**The exported files are named by UUID, not by your capture name.** The name
+you passed survives only as `suggested name` in the command's own output and in
+`/tmp/shots/manifest.json`, so with more than one capture, read the manifest to
+work out which png is which.
+
+Put the `capture` *before* the assertion it illustrates. `UITestCase` sets
+`continueAfterFailure = false`, so anything after a failed assertion never runs
+— a capture placed afterwards is missing from exactly the run you needed it for.
+For a whole-screen shot with no one assertion behind it, put it after whichever
+check proves the screen is up and before the one most likely to fail.
+
+## Writing a new test
+
+Screen objects live in `uitests/Screens/`, one struct per screen conforming to
+`Screen`, with `@discardableResult` methods returning `Self` so tests read as a
+chain. See `uitests/CLAUDE.md` for the conventions.
+
+**A brand-new `.swift` file needs `mise run prebuild` before it will build.**
+`plugins/with-xcuitest-target.ts` walks `uitests/` at prebuild time and writes
+one `PBXFileReference` per file, so the Xcode project lists them individually —
+a file added afterwards is invisible to the build, and nothing warns you.
+Editing an existing file needs no prebuild.
+
+### Gestures the simulator can actually express
+
+A cancelled back-swipe — begin the interactive pop, then abandon it:
+
+```swift
+let edge = app.coordinate(withNormalizedOffset: CGVector(dx: 0.0, dy: 0.5))
+let partway = app.coordinate(withNormalizedOffset: CGVector(dx: 0.35, dy: 0.5))
+edge.press(forDuration: 0.2, thenDragTo: partway,
+           withVelocity: .slow, thenHoldForDuration: 1.0)
+```
+
+UIKit decides an interactive pop on distance *and* release velocity, so the
+hold is load-bearing: it drains the velocity, and a fast flick from the same
+place completes the pop instead of cancelling it.
+
+**Assert the precondition before the action.** Read a search field's text back
+after typing it, confirm a row exists before tapping it. Otherwise a test that
+silently did nothing is indistinguishable from one that worked.
+
+## Notes
+
+- **Do not commit while a build is running.** The pre-commit hook stashes
+  unstaged files to test only what is staged, which reverts your working tree
+  mid-compile and can bake the wrong sources into the bundle. Finish the build,
+  or commit first.
+- Simulator and device builds share `ios/build/build.db`. Running both at once
+  gets `database is locked`, which reads like a real build failure. See
+  `build-to-device`.
+- `ios/build` is derived data for this checkout alone, so an existing one is
+  safe to build on top of — step 1 is worth running anyway, since it is
+  incremental and settles whether the bundle matches your sources.
+- Network-backed screens really do hit the network here. Assert on things the
+  screen decides — a field's contents, which empty state appeared — rather than
+  on particular records, unless the test is about the data.
+- CI sharding lives in `scripts/split-uitests.py`; `-only-testing` takes
+  `Bundle/Class/method` and can be repeated.

--- a/scripts/bundle-data-dir.mjs
+++ b/scripts/bundle-data-dir.mjs
@@ -32,9 +32,14 @@ export function bundleDataDir({fromDir, toFile}) {
 	files.sort(new Intl.Collator(undefined, {numeric: true}).compare)
 
 	let loaded = files.map((fpath) => {
-		console.log(fpath)
 		let contents = fs.readFileSync(fpath, 'utf-8')
-		return load(contents)
+		try {
+			return load(contents)
+		} catch (err) {
+			// js-yaml reports a line and column but not which file they are in,
+			// and this runs over several hundred of them.
+			throw new Error(`${fpath}: ${err.message}`, {cause: err})
+		}
 	})
 	let dated = {data: loaded}
 	let output = JSON.stringify(dated) + '\n'

--- a/scripts/bundle-data.mjs
+++ b/scripts/bundle-data.mjs
@@ -21,11 +21,28 @@ const findDirsIn = (pth) => readDir(pth).filter((entry) => isDir(path.join(pth, 
 const findFilesIn = (pth) => readDir(pth).filter((entry) => isFile(path.join(pth, entry)))
 
 const args = process.argv.slice(2)
-const fromDir = args[0]
-const toDir = args[1]
-if (!fromDir || !toDir || fromDir === '-h' || fromDir === '--help') {
-	console.error('usage: node bundle-data.js <from-dir> <to-dir>')
+const flags = args.filter((arg) => arg.startsWith('--'))
+const [fromDir, toDir] = args.filter((arg) => !arg.startsWith('--'))
+if (!fromDir || !toDir || flags.includes('--help')) {
+	console.error('usage: node bundle-data.js [--verbose] <from-dir> <to-dir>')
 	process.exit(1)
+}
+
+const verbose = flags.includes('--verbose')
+
+// Naming and timing every file is a few hundred lines of output, and this
+// script runs ahead of tsc, jest, and so every pre-commit hook -- enough noise
+// to bury whatever the reader ran the command for. Report a count by default
+// and keep the detail for whoever asks for it.
+const step = (label, work) => {
+	if (!verbose) {
+		work()
+		return
+	}
+	console.log(label)
+	console.time(label)
+	work()
+	console.timeEnd(label)
 }
 
 fs.mkdirSync(toDir, {recursive: true})
@@ -35,10 +52,7 @@ const dirs = findDirsIn(fromDir)
 dirs.forEach((dirname) => {
 	let input = path.join(fromDir, dirname)
 	let output = path.join(toDir, dirname) + '.json'
-	console.log(`bundle-data-dir ${input} ${output}`)
-	console.time(`bundle-data-dir ${input} ${output}`)
-	bundleDataDir({fromDir: input, toFile: output})
-	console.timeEnd(`bundle-data-dir ${input} ${output}`)
+	step(`bundle-data-dir ${input} ${output}`, () => bundleDataDir({fromDir: input, toFile: output}))
 })
 
 // Convert these files into JSON equivalents
@@ -52,16 +66,16 @@ files.forEach((file) => {
 	// Get the absolute paths to the input and output files
 	let input = path.join(fromDir, file)
 	let output = path.join(toDir, file).replace(/\.(.*)$/u, '.json')
-	console.log(`convert-data-file ${input} ${output}`)
-	console.time(`convert-data-file ${input} ${output}`)
-	convertDataFile({fromFile: input, toFile: output})
-	if (file.endsWith('.css')) {
-		let dest = output.replace(/\.json/u, '.css')
-		convertDataFile({fromFile: input, toFile: dest, toFileType: 'css'})
-	}
-	console.timeEnd(`convert-data-file ${input} ${output}`)
+	step(`convert-data-file ${input} ${output}`, () => {
+		convertDataFile({fromFile: input, toFile: output})
+		if (file.endsWith('.css')) {
+			let dest = output.replace(/\.json/u, '.css')
+			convertDataFile({fromFile: input, toFile: dest, toFileType: 'css'})
+		}
+	})
 })
 
+let built = 0
 for (let [file, builder] of specialFiles.entries()) {
 	let source = path.join(fromDir, file)
 	if (!fs.existsSync(source)) {
@@ -69,8 +83,10 @@ for (let [file, builder] of specialFiles.entries()) {
 	}
 
 	let output = path.join(toDir, file).replace(/\.(.*)$/u, '.json')
-	console.log(`${builder.name} ${source} ${output}`)
-	console.time(`${builder.name} ${source} ${output}`)
-	builder({sourceFile: source, outputFile: output})
-	console.timeEnd(`${builder.name} ${source} ${output}`)
+	step(`${builder.name} ${source} ${output}`, () =>
+		builder({sourceFile: source, outputFile: output}),
+	)
+	built += 1
 }
+
+console.log(`bundle-data: ${dirs.length} directories and ${files.length + built} files -> ${toDir}`)

--- a/uitests/CLAUDE.md
+++ b/uitests/CLAUDE.md
@@ -7,7 +7,8 @@ pass and cannot see any of it.
 
 **To run these, use the `run-uitests` skill.** It covers the build/run commands,
 proving a test red before trusting it, and pulling screenshots out of a result
-bundle.
+bundle. To drive the app by hand instead of asserting on it, see
+`run-on-simulator`.
 
 ## Layout
 

--- a/uitests/CLAUDE.md
+++ b/uitests/CLAUDE.md
@@ -46,7 +46,14 @@ struct, so a literal in a test is drift waiting to happen.
 component lands as varies — button, other, cell — so prefer
 `app.element(matching:)` from `XCUITestHelpers.swift`. Pressable-wrapped rows
 often carry a concatenated label, which is what `elementWithLabel(startingWith:)`
-is for.
+is for — but it is prefix matching, so a later row named as an extension of an
+earlier one will match both.
+
+**A `Stack.SearchBar` is `app.searchFields.firstMatch`**, wherever the screen
+puts it — the bottom-toolbar placement most screens use here is reached the same
+way as a header one. `searchField.value as? String` returns the placeholder, not
+`nil`, when the field is empty. The SwiftUI `TextField` on the Carleton map is
+the exception: that one is `app.textFields[...]`.
 
 **Retry a dropped tap; do not lengthen the timeout.** A row is hittable as soon
 as its host mounts, but its action has to reach JavaScript — a tap synthesized

--- a/uitests/CLAUDE.md
+++ b/uitests/CLAUDE.md
@@ -1,0 +1,69 @@
+# UITests
+
+XCUITests against the real app on a simulator. This is where anything about
+appearance or interaction is tested — tint, spacing, truncation, tap targets,
+menu and sheet presentation, safe areas, gestures — because Jest has no layout
+pass and cannot see any of it.
+
+**To run these, use the `run-uitests` skill.** It covers the build/run commands,
+proving a test red before trusting it, and pulling screenshots out of a result
+bundle.
+
+## Layout
+
+| Path | What it holds |
+| --- | --- |
+| `Module*Tests.swift` | One test class per feature, subclassing `UITestCase` |
+| `Screens/*.swift` | One screen object per screen, conforming to `Screen` |
+| `Screen.swift` | The `Screen` protocol and the helpers every screen inherits |
+| `UITestCase.swift` | Base class: launch arguments, fresh state, `app` |
+| `TestIdentifiers.swift` | Every identifier and label string, shared with the app |
+| `XCUITestHelpers.swift` | `XCUIApplication`/`XCUIElement` query extensions |
+
+## Conventions
+
+**Screen objects hold the queries; tests hold the intent.** A test should read
+as a chain of named steps, with no `app.buttons[...]` in it:
+
+```swift
+func testCancelledSwipeBackKeepsTheQuery() throws {
+    DirectoryScreen(app: app)
+        .navigate()
+        .search(for: "olaf")
+        .cancelSwipeBack()
+        .verifySearchText("olaf")
+}
+```
+
+Screen methods are `@discardableResult` and return `Self`. Assertions live in
+the screen object with a message saying what should have been true.
+
+**Identifiers go in `TestIdentifiers.swift`, never inline.** React Native's
+`testID` maps to `accessibilityIdentifier` on iOS, and the app reads the same
+struct, so a literal in a test is drift waiting to happen.
+
+**Query by identifier, not by element type.** The XCUITest type a React Native
+component lands as varies — button, other, cell — so prefer
+`app.element(matching:)` from `XCUITestHelpers.swift`. Pressable-wrapped rows
+often carry a concatenated label, which is what `elementWithLabel(startingWith:)`
+is for.
+
+**Retry a dropped tap; do not lengthen the timeout.** A row is hittable as soon
+as its host mounts, but its action has to reach JavaScript — a tap synthesized
+in between lands natively and does nothing. Waiting longer never fixes a tap
+that was dropped, so tap again. `navigateFromHome` is the pattern.
+
+**Assert the precondition before the action.** Read a field's text back after
+typing it; confirm a row exists before tapping. A test that silently did nothing
+otherwise passes exactly like one that worked.
+
+## Two things that will catch you out
+
+**A new `.swift` file needs `mise run prebuild`.**
+`plugins/with-xcuitest-target.ts` walks this directory at prebuild time and
+writes one `PBXFileReference` per file, so a file added afterwards is invisible
+to the build and nothing warns you. Editing an existing file is fine.
+
+**Every test cold-launches the app** with `--uitesting` and `--reset-state`, so
+UserDefaults and AsyncStorage start empty each time. Anything a test needs
+turned on — dev mode, a persisted setting — it has to turn on itself.


### PR DESCRIPTION
Working on reducing the context usage for robots

1. Add a skill for running ui tests
2. Add CLAUDE.md in uitests/
3. Make bundle-data quiet by default