### PR TITLE
Replace News toolbar with unified source+category picker

### DIFF
--- a/app/(home)/News.tsx
+++ b/app/(home)/News.tsx
@@ -2,52 +2,56 @@ import * as React from 'react'
 import {Stack} from 'expo-router'
 import {useQueries} from '@tanstack/react-query'
 
-import {extractCategories, NewsList} from '../../source/features/news/news-list'
+import {NewsList} from '../../source/features/news/news-list'
 import {NewsPicker} from '../../source/features/news/news-picker'
+import {
+	combineNewsResults,
+	type NewsFeedQuery,
+	type NewsFeeds,
+} from '../../source/features/news/lib/combine'
+import {resolveCategory} from '../../source/features/news/lib/util'
 import {namedNewsOptions} from '../../source/features/news/query'
 import {NEWS_SOURCES} from '../../source/features/news/sources'
 import {useNewsFilterStore} from '../../source/features/news/store'
+
+const NEWS_SOURCE_IDS = NEWS_SOURCES.map((s) => s.id)
+
+// Defined out here so react-query can memoize the fold; a combine rebuilt on
+// every render is re-run on every render.
+const combineNewsFeeds = (results: NewsFeedQuery[]): NewsFeeds =>
+	combineNewsResults(NEWS_SOURCE_IDS, results)
 
 export default function NewsPage(): React.ReactNode {
 	let {selectedSource, selectedCategory, select} = useNewsFilterStore()
 	let source = NEWS_SOURCES.find((s) => s.id === selectedSource) ?? NEWS_SOURCES[0]
 
-	// Fetch all sources to populate the picker with categories
-	let queries = useQueries({
+	// Every source is fetched, not only the one on screen: the picker lists the
+	// categories each source offers, and the Menu has no "opened" callback to
+	// defer the others to. The cost is one extra feed per cold open.
+	let {entriesBySource, categoriesBySource, queryBySource, unavailableSources} = useQueries({
 		queries: NEWS_SOURCES.map((s) => namedNewsOptions(s.id)),
+		combine: combineNewsFeeds,
 	})
 
-	// The query for the currently selected source
-	let currentQueryIndex = NEWS_SOURCES.findIndex((s) => s.id === selectedSource)
-	let currentQuery = queries[currentQueryIndex >= 0 ? currentQueryIndex : 0]
-
-	// Build categories by source from fetched data
-	// Destructure data arrays to satisfy @tanstack/query(no-unstable-deps)
-	let dataArrays = queries.map((q) => q.data)
-	let categoriesBySource = React.useMemo(() => {
-		let result: Record<string, string[]> = {}
-		NEWS_SOURCES.forEach((s, i) => {
-			let data = dataArrays[i] ?? []
-			result[s.id] = extractCategories(data)
-		})
-		return result
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, dataArrays)
+	let categories = categoriesBySource[source.id] ?? []
+	let category = resolveCategory(selectedCategory, categories)
 
 	return (
 		<>
 			<Stack.Screen options={{title: source.title}} />
 			<NewsList
-				query={currentQuery}
-				selectedCategory={selectedCategory}
+				entries={entriesBySource[source.id] ?? []}
+				query={queryBySource[source.id]}
+				selectedCategory={category}
 				thumbnail={source.thumbnail}
 			/>
 			<NewsPicker
 				categoriesBySource={categoriesBySource}
 				onSelect={select}
-				selectedCategory={selectedCategory}
-				selectedSource={selectedSource}
+				selectedCategory={category}
+				selectedSource={source.id}
 				sources={NEWS_SOURCES}
+				unavailableSources={unavailableSources}
 			/>
 		</>
 	)

--- a/app/(home)/News.tsx
+++ b/app/(home)/News.tsx
@@ -1,27 +1,53 @@
 import * as React from 'react'
 import {Stack} from 'expo-router'
-import {useQuery} from '@tanstack/react-query'
-import {useDispatch, useSelector} from 'react-redux'
+import {useQueries} from '@tanstack/react-query'
 
-import {NewsList} from '../../source/features/news/news-list'
+import {extractCategories, NewsList} from '../../source/features/news/news-list'
+import {NewsPicker} from '../../source/features/news/news-picker'
 import {namedNewsOptions} from '../../source/features/news/query'
 import {NEWS_SOURCES} from '../../source/features/news/sources'
-import {selectNewsSource, setNewsSource} from '../../source/redux/parts/settings'
+import {useNewsFilterStore} from '../../source/features/news/store'
 
 export default function NewsPage(): React.ReactNode {
-	let dispatch = useDispatch()
-	let selectedId = useSelector(selectNewsSource)
-	let source = NEWS_SOURCES.find((candidate) => candidate.id === selectedId) ?? NEWS_SOURCES[0]
+	let {selectedSource, selectedCategory, select} = useNewsFilterStore()
+	let source = NEWS_SOURCES.find((s) => s.id === selectedSource) ?? NEWS_SOURCES[0]
+
+	// Fetch all sources to populate the picker with categories
+	let queries = useQueries({
+		queries: NEWS_SOURCES.map((s) => namedNewsOptions(s.id)),
+	})
+
+	// The query for the currently selected source
+	let currentQueryIndex = NEWS_SOURCES.findIndex((s) => s.id === selectedSource)
+	let currentQuery = queries[currentQueryIndex >= 0 ? currentQueryIndex : 0]
+
+	// Build categories by source from fetched data
+	// Destructure data arrays to satisfy @tanstack/query(no-unstable-deps)
+	let dataArrays = queries.map((q) => q.data)
+	let categoriesBySource = React.useMemo(() => {
+		let result: Record<string, string[]> = {}
+		NEWS_SOURCES.forEach((s, i) => {
+			let data = dataArrays[i] ?? []
+			result[s.id] = extractCategories(data)
+		})
+		return result
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, dataArrays)
 
 	return (
 		<>
 			<Stack.Screen options={{title: source.title}} />
 			<NewsList
-				onSelectSource={(id) => dispatch(setNewsSource(id))}
-				query={useQuery(namedNewsOptions(source.id))}
-				selectedSourceId={source.id}
-				sources={NEWS_SOURCES}
+				query={currentQuery}
+				selectedCategory={selectedCategory}
 				thumbnail={source.thumbnail}
+			/>
+			<NewsPicker
+				categoriesBySource={categoriesBySource}
+				onSelect={select}
+				selectedCategory={selectedCategory}
+				selectedSource={selectedSource}
+				sources={NEWS_SOURCES}
 			/>
 		</>
 	)

--- a/source/features/news/__tests__/store.test.ts
+++ b/source/features/news/__tests__/store.test.ts
@@ -1,0 +1,37 @@
+import {useNewsFilterStore} from '../store'
+
+beforeEach(() => {
+	useNewsFilterStore.setState({selectedSource: 'stolaf', selectedCategory: null})
+})
+
+test('starts on St. Olaf News with no category selected', () => {
+	let {selectedSource, selectedCategory} = useNewsFilterStore.getState()
+	expect(selectedSource).toBe('stolaf')
+	expect(selectedCategory).toBeNull()
+})
+
+test('select sets the source and the category together', () => {
+	let {select} = useNewsFilterStore.getState()
+	select('mess', 'Sports')
+	let {selectedSource, selectedCategory} = useNewsFilterStore.getState()
+	expect(selectedSource).toBe('mess')
+	expect(selectedCategory).toBe('Sports')
+})
+
+test('select with null clears the category but keeps the source', () => {
+	useNewsFilterStore.setState({selectedSource: 'mess', selectedCategory: 'Sports'})
+	let {select} = useNewsFilterStore.getState()
+	select('mess', null)
+	let {selectedSource, selectedCategory} = useNewsFilterStore.getState()
+	expect(selectedSource).toBe('mess')
+	expect(selectedCategory).toBeNull()
+})
+
+test('select can switch source and category at once', () => {
+	useNewsFilterStore.setState({selectedSource: 'stolaf', selectedCategory: 'Academics'})
+	let {select} = useNewsFilterStore.getState()
+	select('mess', 'Sports')
+	let {selectedSource, selectedCategory} = useNewsFilterStore.getState()
+	expect(selectedSource).toBe('mess')
+	expect(selectedCategory).toBe('Sports')
+})

--- a/source/features/news/lib/__tests__/categories.test.ts
+++ b/source/features/news/lib/__tests__/categories.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, it} from '@jest/globals'
+import type {StoryType} from '../../types'
+import {extractCategories, filterByCategory, resolveCategory} from '../util'
+
+let story = (props: Partial<StoryType>): StoryType => ({
+	authors: [],
+	categories: [],
+	content: '',
+	excerpt: 'excerpt',
+	title: 'title',
+	...props,
+})
+
+describe('extractCategories', () => {
+	it('should list each category once, sorted A-Z', () => {
+		let stories = [story({categories: ['Sports', 'Academics']}), story({categories: ['Sports']})]
+		expect(extractCategories(stories)).toStrictEqual(['Academics', 'Sports'])
+	})
+
+	it('should tidy categories the same way the rows do', () => {
+		expect(extractCategories([story({categories: ['student   life']})])).toStrictEqual([
+			'Student Life',
+		])
+	})
+
+	it('should tolerate stories with no categories', () => {
+		let noCategories = {...story({}), categories: undefined} as unknown as StoryType
+		expect(extractCategories([noCategories])).toStrictEqual([])
+	})
+
+	it('should read every story it is given, cleaning happening upstream', () => {
+		let wouldBeCleaned = story({categories: ['Sports'], content: '<form>', excerpt: ' '})
+		expect(extractCategories([wouldBeCleaned])).toStrictEqual(['Sports'])
+	})
+})
+
+describe('filterByCategory', () => {
+	let sports = story({categories: ['Sports'], title: 'sports story'})
+	let academics = story({categories: ['Academics'], title: 'academics story'})
+
+	it('should keep every story when no category is chosen', () => {
+		expect(filterByCategory([sports, academics], null)).toStrictEqual([sports, academics])
+	})
+
+	it('should keep only the stories carrying the category', () => {
+		expect(filterByCategory([sports, academics], 'Sports')).toStrictEqual([sports])
+	})
+
+	it('should match on the tidied category', () => {
+		let untidy = story({categories: ['student   life']})
+		expect(filterByCategory([untidy], 'Student Life')).toStrictEqual([untidy])
+	})
+
+	it('should tolerate stories with no categories', () => {
+		let noCategories = {...story({}), categories: undefined} as unknown as StoryType
+		expect(filterByCategory([noCategories], 'Sports')).toStrictEqual([])
+	})
+})
+
+describe('resolveCategory', () => {
+	it('should keep a category the feed still carries', () => {
+		expect(resolveCategory('Sports', ['Academics', 'Sports'])).toBe('Sports')
+	})
+
+	it('should drop a category the feed no longer carries', () => {
+		expect(resolveCategory('Athletics', ['Academics', 'Sports'])).toBeNull()
+	})
+
+	it('should drop any category when the feed offers none', () => {
+		expect(resolveCategory('Sports', [])).toBeNull()
+	})
+
+	it('should leave an unset category unset', () => {
+		expect(resolveCategory(null, ['Sports'])).toBeNull()
+	})
+})

--- a/source/features/news/lib/__tests__/combine.test.ts
+++ b/source/features/news/lib/__tests__/combine.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from '@jest/globals'
+import type {StoryType} from '../../types'
+import {combineNewsResults, type NewsFeedQuery} from '../combine'
+
+let story = (props: Partial<StoryType>): StoryType => ({
+	authors: [],
+	categories: [],
+	content: '',
+	excerpt: 'excerpt',
+	title: 'title',
+	...props,
+})
+
+let query = (props: Partial<NewsFeedQuery>): NewsFeedQuery => ({
+	isLoading: false,
+	isError: false,
+	refetch: () => Promise.resolve(),
+	...props,
+})
+
+describe('combineNewsResults', () => {
+	it('should key each source by id, in the order the queries were given', () => {
+		let results = [
+			query({data: [story({title: 'first'})]}),
+			query({data: [story({title: 'second'})]}),
+		]
+		let {entriesBySource} = combineNewsResults(['stolaf', 'mess'], results)
+		expect(entriesBySource['stolaf']?.map((s) => s.title)).toStrictEqual(['first'])
+		expect(entriesBySource['mess']?.map((s) => s.title)).toStrictEqual(['second'])
+	})
+
+	it('should clean the entries it hands back', () => {
+		let stories = [story({title: 'kept'}), story({content: '<form>', title: 'dropped'})]
+		let {entriesBySource} = combineNewsResults(['stolaf'], [query({data: stories})])
+		expect(entriesBySource['stolaf']?.map((s) => s.title)).toStrictEqual(['kept'])
+	})
+
+	it('should take categories from the cleaned entries only', () => {
+		let dropped = story({categories: ['Sports'], content: '<form>', title: 'dropped'})
+		let {categoriesBySource} = combineNewsResults(['stolaf'], [query({data: [dropped]})])
+		expect(categoriesBySource['stolaf']).toStrictEqual([])
+	})
+
+	it('should give a source with no data an empty feed', () => {
+		let {entriesBySource, categoriesBySource} = combineNewsResults(['stolaf'], [query({})])
+		expect(entriesBySource['stolaf']).toStrictEqual([])
+		expect(categoriesBySource['stolaf']).toStrictEqual([])
+	})
+
+	it('should hand back the query behind each source', () => {
+		let stolaf = query({isLoading: true})
+		let {queryBySource} = combineNewsResults(['stolaf'], [stolaf])
+		expect(queryBySource['stolaf']).toBe(stolaf)
+	})
+
+	it('should name the sources whose fetch failed', () => {
+		let results = [query({isError: true}), query({data: [story({})]})]
+		let {unavailableSources} = combineNewsResults(['stolaf', 'mess'], results)
+		expect(unavailableSources).toStrictEqual(['stolaf'])
+	})
+})

--- a/source/features/news/lib/combine.ts
+++ b/source/features/news/lib/combine.ts
@@ -1,0 +1,50 @@
+import type {StoryType} from '../types'
+import {cleanEntries, extractCategories} from './util'
+
+/** The parts of a news query the screen reads. */
+export type NewsFeedQuery = {
+	data?: StoryType[]
+	isLoading: boolean
+	isError: boolean
+	error?: unknown
+	refetch: () => Promise<unknown>
+}
+
+export type NewsFeeds = {
+	/** Cleaned stories, keyed by source id */
+	entriesBySource: Record<string, StoryType[]>
+	/** Categories offered by each source, keyed by source id */
+	categoriesBySource: Record<string, string[]>
+	/** The query behind each source, keyed by source id */
+	queryBySource: Record<string, NewsFeedQuery>
+	/** Ids of the sources whose fetch failed */
+	unavailableSources: string[]
+}
+
+/**
+ * Fold every source's query into the shape the screen needs. Cleaning happens
+ * once here and both the list and the picker's categories come out of that one
+ * pass, rather than each scanning the same post bodies again.
+ */
+export function combineNewsResults(
+	sourceIds: string[],
+	results: readonly NewsFeedQuery[],
+): NewsFeeds {
+	let entriesBySource: Record<string, StoryType[]> = {}
+	let categoriesBySource: Record<string, string[]> = {}
+	let queryBySource: Record<string, NewsFeedQuery> = {}
+	let unavailableSources: string[] = []
+
+	sourceIds.forEach((id, index) => {
+		let query = results[index]
+		if (!query) return
+
+		let entries = cleanEntries(query.data ?? [])
+		entriesBySource[id] = entries
+		categoriesBySource[id] = extractCategories(entries)
+		queryBySource[id] = query
+		if (query.isError) unavailableSources.push(id)
+	})
+
+	return {entriesBySource, categoriesBySource, queryBySource, unavailableSources}
+}

--- a/source/features/news/lib/util.ts
+++ b/source/features/news/lib/util.ts
@@ -28,3 +28,31 @@ export function truncate(text: string, length: number): string {
 	if (text.length <= length) return text
 	return text.slice(0, length).trimEnd() + '…'
 }
+
+let storyCategories = (story: StoryType): string[] =>
+	(story.categories ?? []).map((category) => trimStoryCateogry(category))
+
+/**
+ * Every category the given stories carry, once each, sorted A-Z. Expects
+ * entries that have already been through `cleanEntries`, so the picker offers
+ * only categories the list can actually show.
+ */
+export function extractCategories(stories: StoryType[]): string[] {
+	let categories = new Set(stories.flatMap((story) => storyCategories(story)))
+	return [...categories].sort((a, b) => a.localeCompare(b))
+}
+
+/** The stories carrying `category`, or all of them when none is chosen. */
+export function filterByCategory(stories: StoryType[], category: string | null): StoryType[] {
+	if (category === null) return stories
+	return stories.filter((story) => storyCategories(story).includes(category))
+}
+
+/**
+ * The chosen category, or null once the feed stops carrying it. A category
+ * that outlives the stories that named it filters the list to nothing while
+ * every switch in the picker reads off, and persistence makes that permanent.
+ */
+export function resolveCategory(category: string | null, categories: string[]): string | null {
+	return category !== null && categories.includes(category) ? category : null
+}

--- a/source/features/news/news-list.tsx
+++ b/source/features/news/news-list.tsx
@@ -7,33 +7,28 @@ import {LoadingView, NoticeView} from '@frogpond/notice'
 import {openUrl} from '@frogpond/open-url'
 import type {StoryType} from './types'
 import {NewsRow} from './news-row'
-import {cleanEntries, trimStoryCateogry} from './lib/util'
+import {filterByCategory} from './lib/util'
 import {emptyStateProps} from './lib/empty-state'
-import {UseQueryResult} from '@tanstack/react-query'
+import type {NewsFeedQuery} from './lib/combine'
 
 type Props = {
-	query: UseQueryResult<StoryType[]>
+	query: NewsFeedQuery
+	/** The selected source's stories, cleaned by the same pass that built the picker's categories */
+	entries: StoryType[]
 	thumbnail: false | ImageResolvedAssetSource
 	selectedCategory: string | null
 }
 
-let getStoryCategories = (story: StoryType) => {
-	return (story.categories ?? []).map((category) => trimStoryCateogry(category))
-}
-
 export const NewsList = (props: Props): React.ReactNode => {
-	let {data = [], error, refetch, isError, isLoading} = props.query
+	let {error, refetch, isError, isLoading} = props.query
+	let {entries, selectedCategory} = props
 
-	let entries = React.useMemo(() => cleanEntries(data), [data])
+	let filteredEntries = React.useMemo(
+		() => filterByCategory(entries, selectedCategory),
+		[entries, selectedCategory],
+	)
 
-	let filteredEntries = React.useMemo(() => {
-		if (props.selectedCategory === null) return entries
-		return entries.filter((story) =>
-			getStoryCategories(story).includes(props.selectedCategory as string),
-		)
-	}, [entries, props.selectedCategory])
-
-	let hasActiveFilter = props.selectedCategory !== null
+	let hasActiveFilter = selectedCategory !== null
 
 	if (isLoading) {
 		return <LoadingView />
@@ -77,13 +72,6 @@ export const NewsList = (props: Props): React.ReactNode => {
 			</VStack>
 		</Host>
 	)
-}
-
-/** Extract unique categories from stories, sorted A-Z */
-export function extractCategories(stories: StoryType[]): string[] {
-	let cleaned = cleanEntries(stories)
-	let cats = new Set(cleaned.flatMap((story) => getStoryCategories(story)))
-	return [...cats].sort()
 }
 
 const styles = StyleSheet.create({

--- a/source/features/news/news-list.tsx
+++ b/source/features/news/news-list.tsx
@@ -1,43 +1,24 @@
 import * as React from 'react'
 import {StyleSheet, type ImageResolvedAssetSource} from 'react-native'
-import {Stack} from 'expo-router'
-import {ContentUnavailableView, Host, List, ProgressView, VStack} from '@expo/ui/swift-ui'
+import {ContentUnavailableView, Host, List, VStack} from '@expo/ui/swift-ui'
 import {listStyle, refreshable} from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
-import {NoticeView} from '@frogpond/notice'
+import {LoadingView, NoticeView} from '@frogpond/notice'
 import {openUrl} from '@frogpond/open-url'
 import type {StoryType} from './types'
-import type {NewsSource} from './sources'
 import {NewsRow} from './news-row'
 import {cleanEntries, trimStoryCateogry} from './lib/util'
 import {emptyStateProps} from './lib/empty-state'
-import {ListType, selectedOptions} from '@frogpond/filter'
 import {UseQueryResult} from '@tanstack/react-query'
 
 type Props = {
 	query: UseQueryResult<StoryType[]>
 	thumbnail: false | ImageResolvedAssetSource
-	sources: NewsSource[]
-	selectedSourceId: string
-	onSelectSource: (id: string) => void
+	selectedCategory: string | null
 }
 
 let getStoryCategories = (story: StoryType) => {
-	return story.categories.map((category) => trimStoryCateogry(category))
-}
-
-let filterStories = (entries: StoryType[], filters: ListType<StoryType>[]) => {
-	return entries.filter((story) => {
-		let enabledCategories = filters.flatMap((f: ListType<StoryType>) =>
-			f.spec.selected.flatMap((s) => s.title),
-		)
-
-		if (enabledCategories.length === 0) {
-			return true
-		}
-
-		return getStoryCategories(story).some((category) => enabledCategories.includes(category))
-	})
+	return (story.categories ?? []).map((category) => trimStoryCateogry(category))
 }
 
 export const NewsList = (props: Props): React.ReactNode => {
@@ -45,170 +26,64 @@ export const NewsList = (props: Props): React.ReactNode => {
 
 	let entries = React.useMemo(() => cleanEntries(data), [data])
 
-	// Only the narrowing the user asked for is state; the categories on offer
-	// come from the feed. Keeping the whole filter in state instead would tie
-	// the reader's choice to the story list, so a refetch that brought new
-	// stories would carry an everything-selected filter in with them.
-	//
-	// Keyed per source rather than one shared value: NewsList is now one
-	// persistent instance across every source, where the old NativeTabs
-	// screens were mounted once each and never lost a tab's filter when the
-	// reader switched away from it. A shared value would silently carry one
-	// source's chosen titles onto another whenever they happened to share a
-	// category name.
-	let [chosenCategoriesBySource, setChosenCategoriesBySource] = React.useState<
-		Record<string, string[] | null>
-	>({})
+	let filteredEntries = React.useMemo(() => {
+		if (props.selectedCategory === null) return entries
+		return entries.filter((story) =>
+			getStoryCategories(story).includes(props.selectedCategory as string),
+		)
+	}, [entries, props.selectedCategory])
 
-	let chosenCategories = chosenCategoriesBySource[props.selectedSourceId] ?? null
+	let hasActiveFilter = props.selectedCategory !== null
 
-	let setChosenCategories = (categories: string[] | null) => {
-		setChosenCategoriesBySource((current) => ({...current, [props.selectedSourceId]: categories}))
+	if (isLoading) {
+		return <LoadingView />
 	}
 
-	let filters = React.useMemo((): ListType<StoryType>[] => {
-		let allCategories = entries.flatMap((story) => getStoryCategories(story))
-
-		if (allCategories.length === 0) {
-			return []
-		}
-
-		let options = [...new Set(allCategories)].sort().map((category) => ({title: category}))
-		let selected = selectedOptions(options, chosenCategories)
-
-		return [
-			{
-				type: 'list',
-				key: 'category',
-				// Selecting nothing is the resting state and shows everything --
-				// the invariant modules/filter/lib/select-options.ts applies on
-				// every subsequent edit.
-				enabled: selected.length > 0,
-				spec: {
-					title: 'Categories',
-					options,
-					selected,
-					// A pull-down however many categories the feed happens to carry.
-					presentation: 'menu',
-					mode: 'OR',
-					displayTitle: true,
-				},
-				apply: {key: 'categories'},
-			},
-		]
-	}, [entries, chosenCategories])
-
-	// News carries exactly one filter (categories); this is that filter, or
-	// undefined when the feed's stories have no categories to offer at all.
-	let categoryFilter = filters[0]
-	let categoryOptions = categoryFilter?.spec.options ?? []
-	let selectedCategoryTitles = categoryFilter
-		? categoryFilter.spec.selected.map((option) => option.title)
-		: []
-
-	let toggleCategory = (title: string) => {
-		let current = chosenCategories ?? []
-		setChosenCategories(
-			current.includes(title) ? current.filter((t) => t !== title) : [...current, title],
+	if (isError) {
+		return (
+			<NoticeView
+				buttonText="Try Again"
+				onPress={refetch}
+				text={`A problem occured while loading: ${error}`}
+			/>
 		)
 	}
 
-	let filteredEntries = filterStories(entries, filters)
-	let hasActiveFilter = filters.some((f) => f.spec.selected.length)
-
 	return (
-		<>
-			{/* @expo/ui needs the scrollable view as the first child to observe
-			    its scroll position -- for the large title to collapse, this has
-			    to come before the toolbar below it, not after. Calendar.tsx has
-			    EventList before CalendarPicker for the same reason. */}
-			{isError ? (
-				// Still a sibling of the toolbar below, not a full-screen
-				// replacement of everything: the source picker is the reader's
-				// obvious way out of a feed that's down, and it would be gone
-				// exactly when it's needed most if this bailed out before the
-				// toolbar ever rendered.
-				<NoticeView
-					buttonText="Try Again"
-					onPress={refetch}
-					text={`A problem occured while loading: ${error}`}
-				/>
-			) : (
-				<Host style={styles.host}>
-					<VStack spacing={0}>
-						<List
-							modifiers={[
-								listStyle('plain'),
-								refreshable(async () => {
-									await refetch()
-								}),
-							]}
-						>
-							{isLoading ? (
-								<ProgressView />
-							) : filteredEntries.length === 0 ? (
-								<ContentUnavailableView
-									systemImage="newspaper"
-									{...emptyStateProps(hasActiveFilter)}
-								/>
-							) : (
-								filteredEntries.map((story, index) => (
-									<NewsRow
-										key={story.title}
-										isLast={index === filteredEntries.length - 1}
-										onPress={(url: string) => openUrl(url)}
-										story={story}
-										thumbnail={props.thumbnail}
-									/>
-								))
-							)}
-						</List>
-					</VStack>
-				</Host>
-			)}
-
-			{/* expo-router: "If multiple instances of [Stack.Toolbar] are
-			    rendered for the same screen, the last one rendered in the
-			    component tree takes precedence" -- they don't merge. So the
-			    category filter and the source picker share this one toolbar
-			    rather than each rendering their own. */}
-			<Stack.Toolbar placement="bottom">
-				<Stack.Toolbar.Menu
-					accessibilityLabel="Categories"
-					hidden={categoryOptions.length === 0}
-					icon="line.3.horizontal.decrease"
-					variant={hasActiveFilter ? 'prominent' : 'plain'}
+		<Host style={styles.host}>
+			<VStack spacing={0}>
+				<List
+					modifiers={[
+						listStyle('plain'),
+						refreshable(async () => {
+							await refetch()
+						}),
+					]}
 				>
-					<Stack.Toolbar.Label>Categories</Stack.Toolbar.Label>
-					{categoryOptions.map((option) => (
-						<Stack.Toolbar.MenuAction
-							isOn={selectedCategoryTitles.includes(option.title)}
-							key={option.title}
-							onPress={() => toggleCategory(option.title)}
-							unstable_keepPresented={true}
-						>
-							{option.title}
-						</Stack.Toolbar.MenuAction>
-					))}
-				</Stack.Toolbar.Menu>
-
-				<Stack.Toolbar.Spacer />
-
-				<Stack.Toolbar.Menu accessibilityLabel="News Sources" icon="newspaper">
-					<Stack.Toolbar.Label>News Sources</Stack.Toolbar.Label>
-					{props.sources.map((source) => (
-						<Stack.Toolbar.MenuAction
-							isOn={source.id === props.selectedSourceId}
-							key={source.id}
-							onPress={() => props.onSelectSource(source.id)}
-						>
-							{source.title}
-						</Stack.Toolbar.MenuAction>
-					))}
-				</Stack.Toolbar.Menu>
-			</Stack.Toolbar>
-		</>
+					{filteredEntries.length === 0 ? (
+						<ContentUnavailableView systemImage="newspaper" {...emptyStateProps(hasActiveFilter)} />
+					) : (
+						filteredEntries.map((story, index) => (
+							<NewsRow
+								key={story.title}
+								isLast={index === filteredEntries.length - 1}
+								onPress={(url: string) => openUrl(url)}
+								story={story}
+								thumbnail={props.thumbnail}
+							/>
+						))
+					)}
+				</List>
+			</VStack>
+		</Host>
 	)
+}
+
+/** Extract unique categories from stories, sorted A-Z */
+export function extractCategories(stories: StoryType[]): string[] {
+	let cleaned = cleanEntries(stories)
+	let cats = new Set(cleaned.flatMap((story) => getStoryCategories(story)))
+	return [...cats].sort()
 }
 
 const styles = StyleSheet.create({

--- a/source/features/news/news-picker.tsx
+++ b/source/features/news/news-picker.tsx
@@ -78,6 +78,11 @@ export function NewsPicker({
 											onIsOnChange={() => handleToggle(source.id, cat)}
 										/>
 									))}
+									<Toggle
+										isOn={isSourceSelected && selectedCategory === null}
+										label="All Stories"
+										onIsOnChange={() => onSelect(source.id, null)}
+									/>
 								</Section>
 							)
 						})}

--- a/source/features/news/news-picker.tsx
+++ b/source/features/news/news-picker.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import {Stack} from 'expo-router'
+import {Host, Image, Menu, Section, Toggle} from '@expo/ui/swift-ui'
+import {
+	accessibilityLabel,
+	buttonStyle,
+	foregroundStyle,
+	menuActionDismissBehavior,
+	tint,
+} from '@expo/ui/swift-ui/modifiers'
+import * as c from '@frogpond/colors'
+import type {NewsSource} from './sources'
+
+/**
+ * Combined source + category picker. Selecting a category implicitly selects
+ * its source. Deselecting a category shows all stories from that source.
+ */
+type Props = {
+	sources: NewsSource[]
+	/** Categories keyed by source id */
+	categoriesBySource: Record<string, string[]>
+	selectedSource: string
+	selectedCategory: string | null
+	onSelect: (source: string, category: string | null) => void
+}
+
+const STAYS_OPEN = [menuActionDismissBehavior('disabled')]
+const LABEL = accessibilityLabel('News filter')
+const ACTIVE_STYLE = [
+	LABEL,
+	buttonStyle('borderedProminent'),
+	tint(c.systemBlue),
+	foregroundStyle(c.white),
+]
+const INACTIVE_STYLE = [LABEL, foregroundStyle(c.label)]
+
+export function NewsPicker({
+	sources,
+	categoriesBySource,
+	selectedSource,
+	selectedCategory,
+	onSelect,
+}: Props): React.ReactNode {
+	let isActive = selectedCategory !== null
+	let menuModifiers = isActive ? ACTIVE_STYLE : INACTIVE_STYLE
+
+	let handleToggle = (source: string, category: string) => {
+		// Tapping selected category deselects it → shows all from that source
+		if (source === selectedSource && category === selectedCategory) {
+			onSelect(source, null)
+		} else {
+			// Tapping any category selects source + category
+			onSelect(source, category)
+		}
+	}
+
+	// Z-A in code → A-Z visually: SwiftUI Menu Section renders bottom-to-top
+	let sortedSources = [...sources].reverse()
+
+	return (
+		<Stack.Toolbar placement="bottom">
+			<Stack.Toolbar.Spacer />
+			<Stack.Toolbar.View>
+				<Host matchContents={true}>
+					<Menu label={<Image systemName="newspaper" />} modifiers={menuModifiers}>
+						{sortedSources.map((source) => {
+							let categories = categoriesBySource[source.id] ?? []
+							let sortedCategories = [...categories].sort((a, b) => b.localeCompare(a))
+							let isSourceSelected = source.id === selectedSource
+
+							return (
+								<Section key={source.id} modifiers={STAYS_OPEN} title={source.title.toUpperCase()}>
+									{sortedCategories.map((cat) => (
+										<Toggle
+											isOn={isSourceSelected && selectedCategory === cat}
+											key={cat}
+											label={cat}
+											onIsOnChange={() => handleToggle(source.id, cat)}
+										/>
+									))}
+								</Section>
+							)
+						})}
+					</Menu>
+				</Host>
+			</Stack.Toolbar.View>
+		</Stack.Toolbar>
+	)
+}

--- a/source/features/news/news-picker.tsx
+++ b/source/features/news/news-picker.tsx
@@ -3,10 +3,8 @@ import {Stack} from 'expo-router'
 import {Host, Image, Menu, Section, Toggle} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
-	buttonStyle,
 	foregroundStyle,
 	menuActionDismissBehavior,
-	tint,
 } from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
 import type {NewsSource} from './sources'
@@ -26,13 +24,6 @@ type Props = {
 
 const STAYS_OPEN = [menuActionDismissBehavior('disabled')]
 const LABEL = accessibilityLabel('News filter')
-const ACTIVE_STYLE = [
-	LABEL,
-	buttonStyle('borderedProminent'),
-	tint(c.systemBlue),
-	foregroundStyle(c.white),
-]
-const INACTIVE_STYLE = [LABEL, foregroundStyle(c.label)]
 
 export function NewsPicker({
 	sources,
@@ -42,7 +33,10 @@ export function NewsPicker({
 	onSelect,
 }: Props): React.ReactNode {
 	let isActive = selectedCategory !== null
-	let menuModifiers = isActive ? ACTIVE_STYLE : INACTIVE_STYLE
+	// Keep the modifier list structurally identical every render — only the
+	// colour value changes. Swapping modifier types/count rebuilds the native
+	// Menu and closes it mid-interaction.
+	let menuModifiers = [LABEL, foregroundStyle(isActive ? c.systemBlue : c.label)]
 
 	let handleToggle = (source: string, category: string) => {
 		// Tapping selected category deselects it → shows all from that source

--- a/source/features/news/news-picker.tsx
+++ b/source/features/news/news-picker.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
 import {Stack} from 'expo-router'
-import {Host, Image, Menu, Section, Toggle} from '@expo/ui/swift-ui'
+import {Button, Host, Image, Menu, Section, Toggle} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
+	disabled,
 	foregroundStyle,
 	menuActionDismissBehavior,
 } from '@expo/ui/swift-ui/modifiers'
@@ -17,6 +18,8 @@ type Props = {
 	sources: NewsSource[]
 	/** Categories keyed by source id */
 	categoriesBySource: Record<string, string[]>
+	/** Ids of the sources whose feed failed to load */
+	unavailableSources: string[]
 	selectedSource: string
 	selectedCategory: string | null
 	onSelect: (source: string, category: string | null) => void
@@ -24,10 +27,12 @@ type Props = {
 
 const STAYS_OPEN = [menuActionDismissBehavior('disabled')]
 const LABEL = accessibilityLabel('News filter')
+const UNAVAILABLE = [disabled(true)]
 
 export function NewsPicker({
 	sources,
 	categoriesBySource,
+	unavailableSources,
 	selectedSource,
 	selectedCategory,
 	onSelect,
@@ -58,13 +63,14 @@ export function NewsPicker({
 				<Host matchContents={true}>
 					<Menu label={<Image systemName="newspaper" />} modifiers={menuModifiers}>
 						{sortedSources.map((source) => {
-							let categories = categoriesBySource[source.id] ?? []
-							let sortedCategories = [...categories].sort((a, b) => b.localeCompare(a))
+							// Already sorted A-Z, and the Menu renders bottom-to-top
+							let categories = [...(categoriesBySource[source.id] ?? [])].reverse()
 							let isSourceSelected = source.id === selectedSource
+							let isUnavailable = unavailableSources.includes(source.id)
 
 							return (
 								<Section key={source.id} modifiers={STAYS_OPEN} title={source.title.toUpperCase()}>
-									{sortedCategories.map((cat) => (
+									{categories.map((cat) => (
 										<Toggle
 											isOn={isSourceSelected && selectedCategory === cat}
 											key={cat}
@@ -77,6 +83,11 @@ export function NewsPicker({
 										label="All Stories"
 										onIsOnChange={() => onSelect(source.id, null)}
 									/>
+									{/* A source that failed to load has no categories to offer;
+									    without this it reads as a source that simply has none. */}
+									{isUnavailable ? (
+										<Button label="Couldn’t load stories" modifiers={UNAVAILABLE} />
+									) : null}
 								</Section>
 							)
 						})}

--- a/source/features/news/store.ts
+++ b/source/features/news/store.ts
@@ -1,0 +1,24 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import {create} from 'zustand'
+import {persist, createJSONStorage} from 'zustand/middleware'
+
+type NewsFilterStore = {
+	selectedSource: string
+	selectedCategory: string | null
+	select: (source: string, category: string | null) => void
+}
+
+export const useNewsFilterStore = create<NewsFilterStore>()(
+	persist(
+		(set) => ({
+			selectedSource: 'stolaf',
+			selectedCategory: null,
+			select: (source, category) => set({selectedSource: source, selectedCategory: category}),
+		}),
+		{
+			name: 'news-filter-preferences',
+			storage: createJSONStorage(() => AsyncStorage),
+			version: 1,
+		},
+	),
+)

--- a/source/redux/parts/__tests__/settings.test.ts
+++ b/source/redux/parts/__tests__/settings.test.ts
@@ -1,12 +1,6 @@
 import {describe, expect, test} from '@jest/globals'
 
-import {
-	reducer,
-	selectEnabledCalendarSources,
-	selectNewsSource,
-	setNewsSource,
-	toggleCalendarSource,
-} from '../settings'
+import {reducer, selectEnabledCalendarSources, toggleCalendarSource} from '../settings'
 import type {RootState} from '../../store'
 
 function initial() {
@@ -62,46 +56,6 @@ describe('calendar source selection', () => {
 			let state = reducer(staleRehydratedState, toggleCalendarSource('northfield'))
 
 			expect(state.enabledCalendarSources).toEqual(['stolaf', 'northfield'])
-		})
-	})
-})
-
-describe('news source selection', () => {
-	// A fresh install opens News on St. Olaf -- the source it opened on
-	// before the picker existed.
-	test('starts on St. Olaf', () => {
-		expect(initial().selectedNewsSource).toBe('stolaf')
-	})
-
-	test('setting the source changes it', () => {
-		let state = reducer(initial(), setNewsSource('mess'))
-
-		expect(state.selectedNewsSource).toBe('mess')
-	})
-
-	// redux-persist's default reconciler (autoMergeLevel1) swaps the whole
-	// `settings` slice in from storage rather than merging field-by-field, so
-	// an install that persisted `settings` before this field existed
-	// rehydrates to exactly this shape -- not a hand-built stand-in for it.
-	describe('rehydrating settings persisted before this field existed', () => {
-		const staleRehydratedState = {
-			unofficialityAcknowledged: true,
-			devModeOverride: false,
-			enabledCalendarSources: ['stolaf'],
-		} as ReturnType<typeof reducer>
-
-		test('the selector falls back to St. Olaf', () => {
-			let rootState = {settings: staleRehydratedState} as RootState
-
-			expect(selectNewsSource(rootState)).toBe('stolaf')
-		})
-
-		test('setting does not throw', () => {
-			expect(() => reducer(staleRehydratedState, setNewsSource('mess'))).not.toThrow()
-
-			let state = reducer(staleRehydratedState, setNewsSource('mess'))
-
-			expect(state.selectedNewsSource).toBe('mess')
 		})
 	})
 })

--- a/source/redux/parts/settings.ts
+++ b/source/redux/parts/settings.ts
@@ -8,7 +8,6 @@ type State = {
 	unofficialityAcknowledged: boolean
 	devModeOverride: boolean
 	enabledCalendarSources: string[]
-	selectedNewsSource: string
 }
 
 // why `as`? see https://redux-toolkit.js.org/tutorials/typescript#:~:text=In%20some%20cases%2C%20TypeScript
@@ -18,8 +17,6 @@ const initialState = {
 	// St. Olaf alone: the college whose app this is, and the only calendar most
 	// people want on by default. UI test mode uses only the fixture calendar.
 	enabledCalendarSources: isUITesting ? ['uitest'] : ['stolaf'],
-	// St. Olaf alone: the source News opened on before the picker existed.
-	selectedNewsSource: 'stolaf',
 } as State
 
 const slice = createSlice({
@@ -42,14 +39,10 @@ const slice = createSlice({
 				? enabledCalendarSources.filter((id) => id !== payload)
 				: [...enabledCalendarSources, payload]
 		},
-		setNewsSource(state, {payload}: PayloadAction<string>) {
-			state.selectedNewsSource = payload
-		},
 	},
 })
 
-export const {acknowledgeAcknowledgement, setDevModeOverride, toggleCalendarSource, setNewsSource} =
-	slice.actions
+export const {acknowledgeAcknowledgement, setDevModeOverride, toggleCalendarSource} = slice.actions
 export const reducer = slice.reducer
 
 export const selectAcknowledgement = (state: RootState): State['unofficialityAcknowledged'] =>
@@ -60,6 +53,3 @@ export const selectDevModeOverride = (state: RootState): State['devModeOverride'
 
 export const selectEnabledCalendarSources = (state: RootState): State['enabledCalendarSources'] =>
 	state.settings.enabledCalendarSources ?? initialState.enabledCalendarSources
-
-export const selectNewsSource = (state: RootState): State['selectedNewsSource'] =>
-	state.settings.selectedNewsSource ?? initialState.selectedNewsSource

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -196,11 +196,8 @@ struct TestIdentifiers {
 		/// Matches NEWS_ROW_PREFIX in source/features/news/news-row.tsx.
 		static let rowPrefix = "news-row-"
 
-		/// The bottom-right toolbar menu's accessibilityLabel, in news-list.tsx.
-		static let picker = "News Sources"
-
-		/// The bottom-left toolbar menu's accessibilityLabel, in news-list.tsx.
-		static let categoryFilter = "Categories"
+		/// The bottom toolbar menu's accessibilityLabel, in news-picker.tsx.
+		static let picker = "News filter"
 	}
 
 	// MARK: - Streaming Media


### PR DESCRIPTION
## Summary

- Port the Calendar picker pattern to News: a single `@expo/ui Menu` with sections per source and category toggles
- Selecting a category implicitly selects its source; deselecting returns to all stories from that source
- Move news filter state from Redux to zustand (matching Calendar)
- Fetch both sources to populate the picker with all categories

## Bug fixes

- **Loading state**: now renders centered (`LoadingView` outside `List`) instead of a thin bar at top
- **Filter button lag**: fixed by using stable `@expo/ui Menu` button style instead of `Stack.Toolbar.Menu` with variant toggling
- **Missing categories**: added `?? []` guard for stories without categories (matches #7854)

## Test plan

- [x] Open News, verify loading spinner is centered
- [x] Open picker, verify both source sections appear with categories
- [x] Tap a category from St. Olaf News → stories filter to that category
- [x] Tap same category again → filter clears, shows all St. Olaf stories
- [x] Tap a category from The Olaf Messenger → switches source and filters
- [x] Verify picker button turns blue when filter is active

https://github.com/user-attachments/assets/42cac856-9e57-48de-bf26-f5052d5335b1
