### PR TITLE
Add "All Events" toggle to the calendar category picker

### DIFF
--- a/modules/ccc-calendar/calendar-picker.tsx
+++ b/modules/ccc-calendar/calendar-picker.tsx
@@ -3,10 +3,8 @@ import {Stack} from 'expo-router'
 import {Host, Image, Menu, Section, Toggle} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
-	buttonStyle,
 	foregroundStyle,
 	menuActionDismissBehavior,
-	tint,
 } from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
 
@@ -23,13 +21,6 @@ type Props = {
 
 const STAYS_OPEN = [menuActionDismissBehavior('disabled')]
 const LABEL = accessibilityLabel('Category filter')
-const ACTIVE_STYLE = [
-	LABEL,
-	buttonStyle('borderedProminent'),
-	tint(c.systemBlue),
-	foregroundStyle(c.white),
-]
-const INACTIVE_STYLE = [LABEL, foregroundStyle(c.label)]
 
 export function CalendarPicker({
 	categories,
@@ -38,7 +29,10 @@ export function CalendarPicker({
 	onTodayPress,
 }: Props): React.ReactNode {
 	let isActive = selectedCategory !== null
-	let menuModifiers = isActive ? ACTIVE_STYLE : INACTIVE_STYLE
+	// Keep the modifier list structurally identical every render — only the
+	// colour value changes. Swapping modifier types/count rebuilds the native
+	// Menu and closes it mid-interaction.
+	let menuModifiers = [LABEL, foregroundStyle(isActive ? c.systemBlue : c.label)]
 
 	let handleToggle = (cat: string) => {
 		onSelectCategory(selectedCategory === cat ? null : cat)
@@ -64,6 +58,13 @@ export function CalendarPicker({
 									onIsOnChange={() => handleToggle(cat)}
 								/>
 							))}
+							{/* Rendered last so it sits at the visual top of the section */}
+							<Toggle
+								isOn={selectedCategory === null}
+								key="__all__"
+								label="All Events"
+								onIsOnChange={() => onSelectCategory(null)}
+							/>
 						</Section>
 					</Menu>
 				</Host>


### PR DESCRIPTION
## What

- Adds an **All Events** toggle at the top of the calendar category picker's St. Olaf section. It's on when no category filter is set; tapping it clears any active filter. Re-tapping while already on is a no-op.
- Fixes the picker Menu collapsing mid-interaction: the `<Menu>` `modifiers` prop was switching between two structurally different arrays (`borderedProminent` + `tint` + white foreground vs. a plain foreground) depending on filter state. Swapping modifier types and count forces SwiftUI to rebuild the native Menu, closing the open popover. Now a single fixed-shape `[LABEL, foregroundStyle(...)]` list is used, varying only the icon color.

## Visual change

The active-filter affordance is now a blue calendar icon instead of a filled blue pill.

## Testing

`mise run agent:pre-commit` — tsc, oxlint, oxfmt, and Jest all pass. Menu open/close and toggle behavior is not Jest-testable (no layout pass); worth an XCUITest under `uitests/` if we want it covered.