### PR TITLE
Fix day picker strip and tests for date/times in the calendar

### DIFF
--- a/modules/event-list/__tests__/day-picker-strip.test.tsx
+++ b/modules/event-list/__tests__/day-picker-strip.test.tsx
@@ -6,124 +6,96 @@ import {describe, expect, jest, test} from '@jest/globals'
 import {DayPickerStrip, deriveDays} from '../day-picker-strip'
 import type {SourcedEvent} from '../types'
 
+// A Sunday, so "this week" runs 2026-08-23 (Sun) through 2026-08-29 (Sat).
 const NOW = moment('2026-08-23T12:00:00Z')
+
+function event(iso: string, isOngoing = false): SourcedEvent {
+	return {
+		sourceId: 'a',
+		key: iso,
+		event: {startTime: moment(iso), isOngoing},
+	} as unknown as SourcedEvent
+}
+
+function isoDays(days: ReturnType<typeof deriveDays>): string[] {
+	return days.map((d) => d.format('YYYY-MM-DD'))
+}
 
 describe('deriveDays', () => {
 	test('returns empty array when events is empty', () => {
-		let result = deriveDays([], NOW)
-		expect(result).toEqual([])
+		expect(deriveDays([], NOW)).toEqual([])
 	})
 
-	test('returns today when only today has events', () => {
-		let events = [
-			{
-				sourceId: 'a',
-				key: 'k',
-				event: {startTime: moment('2026-08-23T14:00:00Z'), isOngoing: false},
-			},
-		]
-		let result = deriveDays(events as unknown as SourcedEvent[], NOW)
-		expect(result).toHaveLength(1)
-		expect(result[0].isSame(NOW, 'day')).toBe(true)
+	test('returns empty array when every event is in the past or ongoing', () => {
+		let events = [event('2026-08-22T10:00:00Z'), event('2026-09-15T10:00:00Z', true)]
+		expect(deriveDays(events, NOW)).toEqual([])
 	})
 
-	test('returns days in order starting from today', () => {
-		let events = [
-			{
-				sourceId: 'a',
-				key: '1',
-				event: {startTime: moment('2026-08-25T10:00:00Z'), isOngoing: false},
-			},
-			{
-				sourceId: 'a',
-				key: '2',
-				event: {startTime: moment('2026-08-23T10:00:00Z'), isOngoing: false},
-			},
-			{
-				sourceId: 'a',
-				key: '3',
-				event: {startTime: moment('2026-08-24T10:00:00Z'), isOngoing: false},
-			},
-		]
-		let result = deriveDays(events as unknown as SourcedEvent[], NOW)
-		expect(result).toHaveLength(3)
-		expect(result[0].format('YYYY-MM-DD')).toBe('2026-08-23')
-		expect(result[1].format('YYYY-MM-DD')).toBe('2026-08-24')
-		expect(result[2].format('YYYY-MM-DD')).toBe('2026-08-25')
+	test('spans whole weeks, Sunday through Saturday', () => {
+		let result = deriveDays([event('2026-08-25T10:00:00Z')], NOW)
+		expect(result).toHaveLength(7)
+		expect(result[0].day()).toBe(0)
+		expect(result[6].day()).toBe(6)
+		expect(isoDays(result)[0]).toBe('2026-08-23')
+		expect(isoDays(result).at(-1)).toBe('2026-08-29')
 	})
 
-	test('excludes days before today', () => {
-		let events = [
-			{
-				sourceId: 'a',
-				key: '1',
-				event: {startTime: moment('2026-08-22T10:00:00Z'), isOngoing: false},
-			},
-			{
-				sourceId: 'a',
-				key: '2',
-				event: {startTime: moment('2026-08-23T10:00:00Z'), isOngoing: false},
-			},
-		]
-		let result = deriveDays(events as unknown as SourcedEvent[], NOW)
-		expect(result).toHaveLength(1)
-		expect(result[0].format('YYYY-MM-DD')).toBe('2026-08-23')
+	test('leads with Sunday of the current week regardless of the first event', () => {
+		let result = deriveDays([event('2026-08-27T10:00:00Z')], NOW)
+		expect(isoDays(result)[0]).toBe('2026-08-23')
 	})
 
-	test('excludes ongoing events from day derivation', () => {
-		let events = [
-			{
-				sourceId: 'a',
-				key: '1',
-				event: {startTime: moment('2026-08-20T10:00:00Z'), isOngoing: true},
-			},
-			{
-				sourceId: 'a',
-				key: '2',
-				event: {startTime: moment('2026-08-23T10:00:00Z'), isOngoing: false},
-			},
-		]
-		let result = deriveDays(events as unknown as SourcedEvent[], NOW)
-		expect(result).toHaveLength(1)
-		expect(result[0].format('YYYY-MM-DD')).toBe('2026-08-23')
+	test("extends through the Saturday of the last event's week", () => {
+		// Last event is Wed 2026-09-02, so the strip runs to Sat 2026-09-05.
+		let result = deriveDays([event('2026-08-23T10:00:00Z'), event('2026-09-02T10:00:00Z')], NOW)
+		expect(isoDays(result).at(-1)).toBe('2026-09-05')
+		expect(result).toHaveLength(14)
 	})
 
-	test('deduplicates days with multiple events', () => {
-		let events = [
-			{
-				sourceId: 'a',
-				key: '1',
-				event: {startTime: moment('2026-08-23T09:00:00Z'), isOngoing: false},
-			},
-			{
-				sourceId: 'a',
-				key: '2',
-				event: {startTime: moment('2026-08-23T14:00:00Z'), isOngoing: false},
-			},
-		]
-		let result = deriveDays(events as unknown as SourcedEvent[], NOW)
-		expect(result).toHaveLength(1)
+	test('returns a continuous run of unique ascending days', () => {
+		let result = deriveDays(
+			[event('2026-09-02T10:00:00Z'), event('2026-08-23T10:00:00Z'), event('2026-08-23T18:00:00Z')],
+			NOW,
+		)
+		let iso = isoDays(result)
+		expect(new Set(iso).size).toBe(iso.length)
+		for (let i = 1; i < result.length; i++) {
+			expect(result[i].diff(result[i - 1], 'days')).toBe(1)
+		}
 	})
 
-	test('fills in gap days between events', () => {
+	test('excludes past and ongoing events from the range end', () => {
 		let events = [
-			{
-				sourceId: 'a',
-				key: '1',
-				event: {startTime: moment('2026-08-23T10:00:00Z'), isOngoing: false},
-			},
-			{
-				sourceId: 'a',
-				key: '2',
-				event: {startTime: moment('2026-08-26T10:00:00Z'), isOngoing: false},
-			},
+			event('2026-08-22T10:00:00Z'),
+			event('2026-09-20T10:00:00Z', true),
+			event('2026-08-24T10:00:00Z'),
 		]
-		let result = deriveDays(events as unknown as SourcedEvent[], NOW)
-		expect(result).toHaveLength(4)
-		expect(result[0].format('YYYY-MM-DD')).toBe('2026-08-23')
-		expect(result[1].format('YYYY-MM-DD')).toBe('2026-08-24')
-		expect(result[2].format('YYYY-MM-DD')).toBe('2026-08-25')
-		expect(result[3].format('YYYY-MM-DD')).toBe('2026-08-26')
+		let result = deriveDays(events, NOW)
+		// Only the 2026-08-24 event counts, so the strip is just this week.
+		expect(isoDays(result)).toEqual([
+			'2026-08-23',
+			'2026-08-24',
+			'2026-08-25',
+			'2026-08-26',
+			'2026-08-27',
+			'2026-08-28',
+			'2026-08-29',
+		])
+	})
+
+	test('fills gap days between events', () => {
+		let result = deriveDays([event('2026-08-24T10:00:00Z'), event('2026-08-27T10:00:00Z')], NOW)
+		expect(isoDays(result)).toContain('2026-08-25')
+		expect(isoDays(result)).toContain('2026-08-26')
+	})
+
+	test('measures the week in the zone of the moment it is given', () => {
+		// 02:00 UTC Sunday is still 21:00 Saturday in this zone, so the week --
+		// and its leading Sunday -- is the earlier one. deriveDays must not
+		// silently reinterpret `now` in UTC.
+		let now = moment.tz('2026-09-06T02:00:00Z', 'America/Chicago')
+		let result = deriveDays([event('2026-09-10T10:00:00Z')], now)
+		expect(result[0].format('YYYY-MM-DD')).toBe('2026-08-30')
 	})
 })
 

--- a/modules/event-list/day-picker-strip.tsx
+++ b/modules/event-list/day-picker-strip.tsx
@@ -32,8 +32,10 @@ const PADDING_HORIZONTAL = 8
 const CIRCLE_SIZE = 32
 
 /**
- * Generates a continuous range of days from today through the last event day.
- * Returns an empty array if there are no future events.
+ * Generates a continuous range of whole weeks, from Sunday of the current week
+ * through the Saturday of the last event's week. Whole weeks keep every day
+ * sitting under a Sunday the strip can snap to. Returns an empty array if
+ * there are no future events.
  */
 export function deriveDays(events: readonly SourcedEvent[], now: Moment): Moment[] {
 	let today = now.clone().startOf('day')
@@ -59,14 +61,13 @@ export function deriveDays(events: readonly SourcedEvent[], now: Moment): Moment
 		return []
 	}
 
-	// Start from Sunday of the current week so the strip always opens on a
-	// week boundary.
 	let sunday = today.clone().startOf('week')
+	let rangeEnd = lastDay.clone().endOf('week')
 
 	let days: Moment[] = []
 	let current = sunday.clone()
 
-	while (current.isSameOrBefore(lastDay, 'day')) {
+	while (current.isSameOrBefore(rangeEnd, 'day')) {
 		days.push(current.clone())
 		current.add(1, 'day')
 	}
@@ -150,9 +151,14 @@ export let DayPickerStrip = React.forwardRef<DayPickerStripHandle, Props>(functi
 		setContainerWidth(event.nativeEvent.layout.width)
 	}, [])
 
+	// Trailing room so the last week's Sunday can still pull to the leading
+	// edge -- scroll inset, not day cells, so there is no empty week to swipe
+	// into. A full week already fills a phone; wider screens need the rest.
+	let trailingInset = Math.max(0, containerWidth - 7 * CELL_TOTAL_WIDTH)
+
 	let maxScroll = Math.max(
 		0,
-		PADDING_HORIZONTAL * 2 + days.length * CELL_TOTAL_WIDTH - containerWidth,
+		PADDING_HORIZONTAL * 2 + trailingInset + days.length * CELL_TOTAL_WIDTH - containerWidth,
 	)
 
 	let offsetForIndex = React.useCallback(
@@ -165,15 +171,21 @@ export let DayPickerStrip = React.forwardRef<DayPickerStripHandle, Props>(functi
 
 	/**
 	 * Where each week begins, as a scroll offset paired with the day it lands
-	 * on. The range starts at today rather than at a Sunday, so these are found
-	 * by walking the days rather than by a fixed stride.
+	 * on, and a place the strip can come to rest. A week start whose offset
+	 * would clamp against `maxScroll` can't pull to the leading edge, so it is
+	 * dropped -- its days still render, they are just not a snap stop. The first
+	 * cell always stays, even on a strip too short to scroll.
 	 */
 	let weekStarts = React.useMemo(() => {
 		return days
 			.map((day, index) => ({day, index}))
-			.filter(({day, index}) => index === 0 || day.day() === 0)
+			.filter(({day, index}) => {
+				if (index === 0) return true
+				if (day.day() !== 0) return false
+				return PADDING_HORIZONTAL + index * CELL_TOTAL_WIDTH - CELL_MARGIN <= maxScroll
+			})
 			.map(({day, index}) => ({day, offset: offsetForIndex(index)}))
-	}, [days, offsetForIndex])
+	}, [days, offsetForIndex, maxScroll])
 
 	let scrollToDay = React.useCallback(
 		(day: Moment) => {
@@ -247,7 +259,10 @@ export let DayPickerStrip = React.forwardRef<DayPickerStripHandle, Props>(functi
 	return (
 		<View style={styles.container} onLayout={handleLayout}>
 			<ScrollView
-				contentContainerStyle={styles.scrollContent}
+				contentContainerStyle={[
+					styles.scrollContent,
+					{paddingRight: PADDING_HORIZONTAL + trailingInset},
+				]}
 				decelerationRate="fast"
 				horizontal={true}
 				onMomentumScrollEnd={handleMomentumScrollEnd}

--- a/uitests/Screens/CalendarScreen.swift
+++ b/uitests/Screens/CalendarScreen.swift
@@ -227,8 +227,8 @@ struct CalendarScreen: Screen {
 		return self
 	}
 
-	/// Sunday of the current week leads the strip, so its cell should be the
-	/// leftmost one.
+	/// Sunday of the strip's week leads it, so that cell should be the leftmost
+	/// one. The week is measured from the app's frozen clock, not the live one.
 	@discardableResult
 	func verifySundayLeadsTheStrip() -> Self {
 		verifyStripIsPresent()
@@ -240,13 +240,15 @@ struct CalendarScreen: Screen {
 
 		var calendar = Calendar(identifier: .gregorian)
 		calendar.locale = Locale(identifier: "en_US_POSIX")
+		calendar.timeZone = TestIdentifiers.Calendar.campusTimeZone
 		let sunday = calendar.date(
-			from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date())
+			from: calendar.dateComponents(
+				[.yearForWeekOfYear, .weekOfYear], from: TestIdentifiers.Calendar.frozenNow)
 		)!
 		let expected = TestIdentifiers.Calendar.dayCell(sunday)
 		XCTAssertEqual(
 			first.identifier, expected,
-			"The strip should start at Sunday of this week")
+			"The strip should start at Sunday of the frozen week (expected \(expected))")
 		return self
 	}
 

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -165,11 +165,26 @@ struct TestIdentifiers {
 		/// Mirrored by `EVENT_ROW_PREFIX` in `modules/event-list/event-list-row.tsx`.
 		static let eventRowPrefix = "event-row-"
 
-		/// The identifier of the cell for a given day.
+		/// Campus time. The app anchors every day to it (`setTimezone`
+		/// in `source/init/constants.ts`) so a student in another zone still sees
+		/// campus dates; a test reasoning about "today" or a week boundary works
+		/// in the same zone.
+		static let campusTimeZone = TimeZone(identifier: "America/Chicago")!
+
+		/// The instant the app freezes its clock to under `isUITesting`, so a
+		/// test reasons about "today" the way the app does rather than off the
+		/// live wall clock. Mirrors `UITEST_FROZEN_DATE` in
+		/// `modules/timer/index.ts` (`2026-09-05T12:00:00-05:00`, a Saturday).
+		static let frozenNow = Foundation.Calendar(identifier: .gregorian).date(
+			from: DateComponents(timeZone: campusTimeZone, year: 2026, month: 9, day: 5, hour: 12)
+		)!
+
+		/// The identifier of the cell for a given day, formatted in campus time.
 		static func dayCell(_ date: Date) -> String {
 			let formatter = DateFormatter()
 			formatter.calendar = Foundation.Calendar(identifier: .gregorian)
 			formatter.locale = Locale(identifier: "en_US_POSIX")
+			formatter.timeZone = campusTimeZone
 			formatter.dateFormat = "yyyy-MM-dd"
 			return dayCellPrefix + formatter.string(from: date)
 		}


### PR DESCRIPTION
JS and Native

Both #7858 and #7855 will need these test fixes (and anything new)

commit | about
--|--
ce414428f | deriveDays → whole weeks through the last event's Saturday; component gets a trailing scroll inset + snap-set filter so every week's Sunday reaches the leading edge without empty cells. deriveDays tests rewritten to the new contract.   
2d497ae02 | verifySundayLeadsTheStrip measures the expected week from UITEST_FROZEN_DATE (mirrored as frozenNow), not live Date()

Test fixes
- TestIdentifiers.swift — added frozenNow, mirroring UITEST_FROZEN_DATE.
- CalendarScreen.swift — verifySundayLeadsTheStrip derives the week from frozenNow, not Date(); removed the temp debug string. campusTimeZone stays (the calendar and the dayCell formatter must agree on zone or the ISO string is off by a day).

Swipe/snap-to fixes
- day-picker-strip.tsx — deriveDays now ends on the Saturday of the last event's week (whole weeks); component adds trailingInset so the last Sunday pins to the leading edge without empty day cells, plus a weekStarts reachability guard.
- day-picker-strip.test.tsx — deriveDays tests rewritten to the whole-weeks contract. 103 event-list tests pass, tsc clean.