### PR TITLE
Keep the event sheet's toolbar items on every presentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,17 @@ The feature uses `react-native-zeroconf` (native pod). If the pod hasn't been li
 
 **Before committing:** Always run `mise run agent:pre-commit` before committing any changes. This formats code with oxfmt, runs oxlint, checks TypeScript types, and runs Jest tests. Do not commit if any step fails.
 
+**Patching a native dependency:** `pnpm patch` gives the patched package a new
+`node_modules/.pnpm/<name>@<version>_patch_hash=…` directory, but `ios/Pods`
+still points at the pre-patch path until you run `mise run prebuild`. Until then
+Xcode compiles the unpatched copy and edits under `node_modules/<name>` are
+silently ignored — builds succeed, tests pass, and nothing says why. After
+adding or changing a patch that touches native code, run `mise run prebuild` and
+confirm `ios/Pods/Pods.xcodeproj/project.pbxproj` names the `patch_hash` path.
+To prove a build really picked a change up, put an `NSLog` in the patched source
+and watch for it with `xcrun simctl spawn <UDID> log stream`; grepping the
+source file only tells you what is on disk, not what got compiled.
+
 **Dependency upgrades:** Whenever you upgrade a dependency whose version is mentioned in this file (e.g., React Native, React Navigation, React Query, Redux Toolkit, TypeScript, Jest, Fastlane), update the version reference in CLAUDE.md as part of the same change. Stale version references in this file mislead future sessions about the project's current state.
 
 ## Superpowers Skills Framework

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,11 @@ const esmPackages = [
 	'@expo',
 	'@maplibre/maplibre-react-native',
 	'ky',
+	// delay and its ESM-only transitive deps; add-to-device-calendar imports
+	// delay, so its component cannot even load under Jest without these
+	'delay',
+	'unlimited-timeout',
+	'random-int',
 	// css-select v7+ and its ESM-only transitive deps
 	'css-select',
 	'boolbase',

--- a/modules/add-to-device-calendar/__tests__/add-to-calendar.test.tsx
+++ b/modules/add-to-device-calendar/__tests__/add-to-calendar.test.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react'
+import {afterEach, beforeEach, describe, expect, it, jest} from '@jest/globals'
+import {Text} from 'react-native'
+import {act, render} from '@testing-library/react-native'
+import delay from 'delay'
+import moment from 'moment'
+import type {EventType} from '@frogpond/event-type'
+import {AddToCalendar} from '../add-to-calendar'
+import {addToCalendar} from '../lib'
+
+jest.mock('../lib', () => ({addToCalendar: jest.fn()}))
+
+let saveEvent = jest.mocked(addToCalendar)
+
+function generateEvent(): EventType {
+	return {
+		title: 'Founders Day',
+		description: 'A celebration',
+		location: 'Buntrock',
+		startTime: moment('2026-09-01T17:00:00Z'),
+		endTime: moment('2026-09-01T19:00:00Z'),
+		isAllDay: false,
+		isMultiDay: false,
+		isSameInstant: false,
+		isOngoing: false,
+		links: [],
+		categories: [],
+		config: {startTime: false, endTime: false, subtitle: 'description'},
+	}
+}
+
+/**
+ * Renders the button and hands back its press handler alongside the rendered
+ * label, so a test can drive the save the way a tap would and read back what
+ * the button says. The render prop is the component's whole output, so the
+ * message is the only thing worth drawing.
+ */
+async function renderButton(): Promise<{press: () => void; label: () => string}> {
+	let press = (): void => {
+		throw new Error('the render prop never ran, so there is no button to press')
+	}
+
+	let view = await render(
+		<AddToCalendar
+			compactMessages={true}
+			event={generateEvent()}
+			render={({message, onPress}) => {
+				press = onPress
+				return <Text testID="cta">{message || 'Add to Calendar'}</Text>
+			}}
+		/>,
+	)
+
+	return {
+		press: () => press(),
+		label: () => view.getByTestId('cta').props.children as string,
+	}
+}
+
+/**
+ * Runs the clock forward and lets whatever that released settle. The awaited
+ * microtask is what carries a resolved `delay` through to the `setState` after
+ * it, so the message a test reads back is the one the timer produced.
+ */
+const advanceBy = async (ms: number): Promise<void> => {
+	await act(async () => {
+		jest.advanceTimersByTime(ms)
+		await Promise.resolve()
+	})
+}
+
+describe('AddToCalendar', () => {
+	beforeEach(() => {
+		jest.useFakeTimers()
+	})
+
+	afterEach(() => {
+		jest.useRealTimers()
+		jest.clearAllMocks()
+	})
+
+	it('holds the saving message long enough to be read', async () => {
+		saveEvent.mockResolvedValue('saved')
+
+		let {press, label} = await renderButton()
+		await act(async () => {
+			press()
+			await Promise.resolve()
+		})
+
+		expect(label()).toBe('Saving…')
+
+		await advanceBy(500)
+
+		expect(label()).toBe('Saved')
+	})
+
+	it('lets a slow save satisfy that wait rather than following it', async () => {
+		// The floor is on how long the message shows, not on how long the save
+		// takes -- a save that already outlasts it needs nothing added.
+		saveEvent.mockImplementation(async () => {
+			await delay(800)
+			return 'saved'
+		})
+
+		let {press, label} = await renderButton()
+		await act(async () => {
+			press()
+			await Promise.resolve()
+		})
+
+		await advanceBy(800)
+
+		expect(label()).toBe('Saved')
+	})
+
+	it('clears the message when the save is cancelled', async () => {
+		saveEvent.mockResolvedValue('cancelled')
+
+		let {press, label} = await renderButton()
+		await act(async () => {
+			press()
+			await Promise.resolve()
+		})
+		await advanceBy(500)
+
+		expect(label()).toBe('Add to Calendar')
+	})
+})

--- a/modules/add-to-device-calendar/add-to-calendar.ts
+++ b/modules/add-to-device-calendar/add-to-calendar.ts
@@ -40,13 +40,16 @@ export class AddToCalendar extends React.Component<Props, State> {
 		const start = Date.now()
 		this.setState(() => ({message: MESSAGES.active}))
 
-		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
+		const result = await addToCalendar(event)
+
+		// Hold the active message for half a second. A save that returns at once
+		// otherwise flashes it past too fast to read, which looks broken -- and
+		// timing this around the save rather than before it means a save slower
+		// than that pays nothing extra.
 		const elapsed = Date.now() - start
 		if (elapsed < 500) {
 			await delay(500 - elapsed)
 		}
-
-		const result = await addToCalendar(event)
 
 		if (result === 'saved') {
 			this.setState(() => ({message: MESSAGES.success, disabled: true}))

--- a/patches/expo-router@57.0.17.patch
+++ b/patches/expo-router@57.0.17.patch
@@ -1,0 +1,20 @@
+diff --git a/ios/Toolbar/RouterToolbarHostView.swift b/ios/Toolbar/RouterToolbarHostView.swift
+index 3b2a9ad76dc98966a508553a36606477c99a9bd8..2e28fd5297930f7c44b0c186e0382dddad4066b8 100644
+--- a/ios/Toolbar/RouterToolbarHostView.swift
++++ b/ios/Toolbar/RouterToolbarHostView.swift
+@@ -171,6 +171,15 @@ class RouterToolbarHostView: RouterViewWithLogger, LinkPreviewMenuUpdatable {
+       // Use cached controller since responder chain may be broken
+       if let controller = cachedController {
+         controller.setToolbarItems(nil, animated: true)
++        // react-native-screens reuses a modal's navigation controller for the
++        // next presentation. Leaving its toolbar showing makes the next
++        // screen's unhide a no-op, and that screen's bar items never reach the
++        // bar -- it comes up empty. Only the modal's own controller is safe to
++        // hide: a pushed screen shares its stack with the one underneath,
++        // whose toolbar has to stay up.
++        if let nav = controller.navigationController, nav.viewControllers.count <= 1 {
++          nav.setToolbarHidden(true, animated: false)
++        }
+       }
+       cachedController = nil  // Clear cache when removed from window
+     } else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   '@sentry/cli': '-'
 
 patchedDependencies:
+  expo-router@57.0.17: 0b91589e38d917efe592a7f7c48ca650048b2d4ef63842502628f4d7e86d6a0c
   react-native-change-icon@5.0.0: 7576d2a458dd256e90b703b84345bf87a19dfa2e3dea523e4691e395dfddfcff
   react-native@0.86.2: 6ca2e1225f38672b073b92b9d13f24feebbe9e37ba67708a3f1569275ce99191
 
@@ -222,7 +223,7 @@ importers:
         version: 57.0.14(react-native-worklets@0.10.4)(react-native@0.86.2)(react@19.2.8)
       expo-router:
         specifier: 57.0.17
-        version: 57.0.17(@babel/core@7.29.7)(@expo/log-box@57.0.4)(@expo/metro-runtime@57.0.14)(@testing-library/react-native@14.0.1)(@types/react@19.2.18)(expo-constants@57.0.15)(expo-font@57.0.1)(expo-linking@57.0.8)(expo@57.0.17)(react-native-gesture-handler@3.2.1)(react-native-reanimated@4.5.1)(react-native-safe-area-context@5.9.1)(react-native-screens@4.27.0)(react-native-worklets@0.10.4)(react-native@0.86.2)(react@19.2.8)(supports-color@8.1.1)
+        version: 57.0.17(patch_hash=0b91589e38d917efe592a7f7c48ca650048b2d4ef63842502628f4d7e86d6a0c)(@babel/core@7.29.7)(@expo/log-box@57.0.4)(@expo/metro-runtime@57.0.14)(@testing-library/react-native@14.0.1)(@types/react@19.2.18)(expo-constants@57.0.15)(expo-font@57.0.1)(expo-linking@57.0.8)(expo@57.0.17)(react-native-gesture-handler@3.2.1)(react-native-reanimated@4.5.1)(react-native-safe-area-context@5.9.1)(react-native-screens@4.27.0)(react-native-worklets@0.10.4)(react-native@0.86.2)(react@19.2.8)(supports-color@8.1.1)
       expo-symbols:
         specifier: 57.0.2
         version: 57.0.2(expo-font@57.0.1)(expo@57.0.17)(react-native@0.86.2)(react@19.2.8)
@@ -6300,7 +6301,7 @@ snapshots:
       ws: 8.21.3
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.17(@babel/core@7.29.7)(@expo/log-box@57.0.4)(@expo/metro-runtime@57.0.14)(@testing-library/react-native@14.0.1)(@types/react@19.2.18)(expo-constants@57.0.15)(expo-font@57.0.1)(expo-linking@57.0.8)(expo@57.0.17)(react-native-gesture-handler@3.2.1)(react-native-reanimated@4.5.1)(react-native-safe-area-context@5.9.1)(react-native-screens@4.27.0)(react-native-worklets@0.10.4)(react-native@0.86.2)(react@19.2.8)(supports-color@8.1.1)
+      expo-router: 57.0.17(patch_hash=0b91589e38d917efe592a7f7c48ca650048b2d4ef63842502628f4d7e86d6a0c)(@babel/core@7.29.7)(@expo/log-box@57.0.4)(@expo/metro-runtime@57.0.14)(@testing-library/react-native@14.0.1)(@types/react@19.2.18)(expo-constants@57.0.15)(expo-font@57.0.1)(expo-linking@57.0.8)(expo@57.0.17)(react-native-gesture-handler@3.2.1)(react-native-reanimated@4.5.1)(react-native-safe-area-context@5.9.1)(react-native-screens@4.27.0)(react-native-worklets@0.10.4)(react-native@0.86.2)(react@19.2.8)(supports-color@8.1.1)
       react-native: 0.86.2(patch_hash=6ca2e1225f38672b073b92b9d13f24feebbe9e37ba67708a3f1569275ce99191)(@babel/core@7.29.7)(@react-native/jest-preset@0.86.2)(@react-native/metro-config@0.86.2)(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -6575,7 +6576,7 @@ snapshots:
       react: 19.2.8
     optionalDependencies:
       '@expo/metro-runtime': 57.0.14(@expo/log-box@57.0.4)(expo@57.0.17)(react-native@0.86.2)(react@19.2.8)
-      expo-router: 57.0.17(@babel/core@7.29.7)(@expo/log-box@57.0.4)(@expo/metro-runtime@57.0.14)(@testing-library/react-native@14.0.1)(@types/react@19.2.18)(expo-constants@57.0.15)(expo-font@57.0.1)(expo-linking@57.0.8)(expo@57.0.17)(react-native-gesture-handler@3.2.1)(react-native-reanimated@4.5.1)(react-native-safe-area-context@5.9.1)(react-native-screens@4.27.0)(react-native-worklets@0.10.4)(react-native@0.86.2)(react@19.2.8)(supports-color@8.1.1)
+      expo-router: 57.0.17(patch_hash=0b91589e38d917efe592a7f7c48ca650048b2d4ef63842502628f4d7e86d6a0c)(@babel/core@7.29.7)(@expo/log-box@57.0.4)(@expo/metro-runtime@57.0.14)(@testing-library/react-native@14.0.1)(@types/react@19.2.18)(expo-constants@57.0.15)(expo-font@57.0.1)(expo-linking@57.0.8)(expo@57.0.17)(react-native-gesture-handler@3.2.1)(react-native-reanimated@4.5.1)(react-native-safe-area-context@5.9.1)(react-native-screens@4.27.0)(react-native-worklets@0.10.4)(react-native@0.86.2)(react@19.2.8)(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8606,7 +8607,7 @@ snapshots:
     dependencies:
       react-native: 0.86.2(patch_hash=6ca2e1225f38672b073b92b9d13f24feebbe9e37ba67708a3f1569275ce99191)(@babel/core@7.29.7)(@react-native/jest-preset@0.86.2)(@react-native/metro-config@0.86.2)(@types/react@19.2.18)(react@19.2.8)(supports-color@8.1.1)
 
-  expo-router@57.0.17(@babel/core@7.29.7)(@expo/log-box@57.0.4)(@expo/metro-runtime@57.0.14)(@testing-library/react-native@14.0.1)(@types/react@19.2.18)(expo-constants@57.0.15)(expo-font@57.0.1)(expo-linking@57.0.8)(expo@57.0.17)(react-native-gesture-handler@3.2.1)(react-native-reanimated@4.5.1)(react-native-safe-area-context@5.9.1)(react-native-screens@4.27.0)(react-native-worklets@0.10.4)(react-native@0.86.2)(react@19.2.8)(supports-color@8.1.1):
+  expo-router@57.0.17(patch_hash=0b91589e38d917efe592a7f7c48ca650048b2d4ef63842502628f4d7e86d6a0c)(@babel/core@7.29.7)(@expo/log-box@57.0.4)(@expo/metro-runtime@57.0.14)(@testing-library/react-native@14.0.1)(@types/react@19.2.18)(expo-constants@57.0.15)(expo-font@57.0.1)(expo-linking@57.0.8)(expo@57.0.17)(react-native-gesture-handler@3.2.1)(react-native-reanimated@4.5.1)(react-native-safe-area-context@5.9.1)(react-native-screens@4.27.0)(react-native-worklets@0.10.4)(react-native@0.86.2)(react@19.2.8)(supports-color@8.1.1):
     dependencies:
       '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.17)(react-native@0.86.2)(react@19.2.8)
       '@expo/metro-runtime': 57.0.14(@expo/log-box@57.0.4)(expo@57.0.17)(react-native@0.86.2)(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -130,5 +130,6 @@ overrides:
 saveExact: true
 savePrefix: ''
 patchedDependencies:
+  expo-router@57.0.17: patches/expo-router@57.0.17.patch
   react-native-change-icon@5.0.0: patches/react-native-change-icon@5.0.0.patch
   react-native@0.86.2: patches/react-native@0.86.2.patch

--- a/uitests/ModuleCalendarTests.swift
+++ b/uitests/ModuleCalendarTests.swift
@@ -153,4 +153,19 @@ class ModuleCalendarTests: UITestCase {
 			.verifyAddToCalendarButton()
 			.capture("17-event-detail-add-to-calendar")
 	}
+
+	/// The sheet's bottom bar has to survive being reopened. react-native-screens
+	/// reuses one navigation controller for every presentation of a modal, so a
+	/// screen that leaves its toolbar showing on the way out makes the next
+	/// screen's unhide a no-op -- and that screen's bar items never reach the
+	/// bar, leaving the button drawn but untitled. It looked fine the first time
+	/// and blank every time after, which is why one presentation never caught it.
+	func testAddToCalendarSurvivesReopeningTheSheet() throws {
+		let screen = CalendarScreen(app: app).navigate()
+
+		screen.openFirstEvent().verifyAddToCalendarButton().closeEventDetail()
+
+		screen.openFirstEvent().capture("18-add-to-calendar-after-reopening")
+		screen.verifyAddToCalendarButton()
+	}
 }

--- a/uitests/Screens/CalendarScreen.swift
+++ b/uitests/Screens/CalendarScreen.swift
@@ -332,4 +332,18 @@ struct CalendarScreen: Screen {
 			"The event detail should offer Add to calendar in its bottom bar")
 		return self
 	}
+
+	/// Dismiss the event detail sheet, landing back on the calendar list.
+	@discardableResult
+	func closeEventDetail() -> Self {
+		let close = app.buttons[TestIdentifiers.Calendar.closeEventDetail]
+		XCTAssertTrue(
+			close.waitForExistence(timeout: 30),
+			"The event detail should offer a Close button")
+		close.tap()
+		XCTAssertTrue(
+			app.buttons[TestIdentifiers.Calendar.picker].waitForExistence(timeout: 30),
+			"Dismissing the event detail should land back on the calendar")
+		return self
+	}
 }

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -154,6 +154,9 @@ struct TestIdentifiers {
 		/// The bottom-bar action on the event detail sheet. A bar item's
 		/// identifier is its title, which is what XCUITest matches on.
 		static let addToCalendar = "Add to Calendar"
+		/// Dismisses the event detail sheet. A header bar item carrying only an
+		/// SF Symbol, so its accessibility label is the only thing to find it by.
+		static let closeEventDetail = "Close"
 		/// Returns the list to the top. A bar item, so its title is its
 		/// identifier.
 		static let today = "Today"


### PR DESCRIPTION
Fixes #7827.

## What was wrong

Reopening an event sheet left the **Add to Calendar** button drawn but with no
text. First open looked fine; every open after it was blank.

The cause is in expo-router 57.0.17 (unchanged in 57.0.19), not in our code —
which is why hardcoding the tint and the text in `EventDetail` changed nothing.

react-native-screens reuses **one navigation controller for every presentation
of a modal**. `RouterToolbarHostView` cleared its bar items on the way out but
left the toolbar *showing*, so the next screen presented into that controller
found it already unhidden. Its own `setToolbarHidden(false, animated:)` became a
no-op, and its bar items never reached the bar.

The logs show every presentation handing UIKit an identical, correct item — the
only thing that differs is `isToolbarHidden` on entry:

| | round 1 (renders) | round 2 (blank) |
| --- | --- | --- |
| screen VC | `0x148d11400` | `0x148d13200` (new) |
| nav controller | `0x10a9de400` | `0x10a9de400` (**same**) |
| `UIToolbar` | `0x14a1a6580` | `0x14a1a6580` (**same**) |
| `isToolbarHidden` on entry | `yes` | **`no`** |
| items handed over | `[nil, "Add to Calendar", nil]` | `[nil, "Add to Calendar", nil]` |

Hiding the toolbar on teardown restores the state the next presentation expects.
The `viewControllers.count <= 1` guard limits that to a modal's own controller —
a pushed screen shares its stack with the screen underneath, whose toolbar has
to stay up.

## Also here

`AddToCalendar.addEvent` measured its half-second floor from before the message
was set to right after, which is nothing, so it always waited the full 500ms and
*then* started saving. Every save cost half a second it did not need. Measuring
around the save keeps what the floor was for while letting a slow save satisfy
it.

That component could not be loaded under Jest at all — `delay` and its
transitive deps ship ESM-only and were not in the transform allowlist, which is
why `lib.ts` had tests and the component had none. `jest.config.js` unblocks it.

## Verifying

`testAddToCalendarSurvivesReopeningTheSheet` opens the sheet, dismisses it, and
opens it again. Confirmed red without the patch and green with it, on builds
proven fresh by a runtime `NSLog` marker; all 11 `ModuleCalendarTests` pass.
Jest: 121 suites, 1123 tests.

Jest cannot see this one — it has no layout pass and no compositor, so the blank
button is only visible to an XCUITest against the simulator.

| before | after |
| --- | --- |
| button drawn, no title | "Add to Calendar" |

## Worth knowing before merging

- **The patch needs `mise run prebuild`.** `pnpm patch` gives the package a new
  `.pnpm/…_patch_hash=…` directory, and `ios/Pods` keeps pointing at the
  pre-patch path until prebuild reruns. Until then Xcode silently compiles the
  unpatched copy. This cost me three misleading test runs, so there is a
  `CLAUDE.md` note about it.
- **Regenerating the patch reintroduces a bad hunk.** `pnpm patch-commit`
  emitted a spurious deletion of `ExpoRouterModule.kt`; I stripped it by hand.
- **The UIKit mechanism is inferred, not observed.**
  `navigationController.toolbar.items` is empty even when the CTA renders
  correctly, so on iOS 26 the bar actually drawn is private and I could not
  inspect it. What is proven is the causal link: leaving the toolbar unhidden
  breaks the next presentation, re-hiding it fixes it, deterministically.
- Worth reporting upstream so the patch can eventually be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
