### PR TITLE
Keep the linked department, and always title the screen Directory

### DIFF
--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -10,6 +10,7 @@ import {LoadingView, NoticeView} from '@frogpond/notice'
 import {SearchBar} from '../../../source/components/search-bar'
 import {formatResults} from '../../../source/features/directory/helpers'
 import {directoryEntriesOptions} from '../../../source/features/directory/query'
+import {resolveSearch} from '../../../source/features/directory/resolve-search'
 import type {DirectoryItem, DirectorySearchTypeEnum} from '../../../source/features/directory/types'
 import {SymbolView} from 'expo-symbols'
 
@@ -22,16 +23,17 @@ function DirectoryView(): React.ReactNode {
 	}>()
 
 	// Tapping a department opens a fresh copy of this screen with the name
-	// already in the params, so they seed the search: the route names the
-	// department at mount, and the query for it can go out on the first render
-	// rather than after a debounce.
+	// already in the params, so the route names the department at mount and the
+	// query for it can go out on the first render rather than after a debounce.
 	let departmentLink = params?.queryType === 'department' ? params.queryParam : undefined
 
-	let [searchQueryType, setSearchQueryType] = React.useState<DirectorySearchTypeEnum>(
-		departmentLink ? 'department' : 'query',
-	)
-	let [typedQuery, setTypedQuery] = React.useState(departmentLink ?? '')
-	let searchQuery = useDebounce(typedQuery, 500)
+	let [typedQuery, setTypedQuery] = React.useState('')
+	let debouncedQuery = useDebounce(typedQuery, 500)
+
+	let {query: searchQuery, type: searchQueryType} = resolveSearch({
+		departmentLink,
+		typedQuery: debouncedQuery,
+	})
 
 	let {
 		data = {results: []},
@@ -43,22 +45,16 @@ function DirectoryView(): React.ReactNode {
 	} = useQuery(directoryEntriesOptions(searchQuery, searchQueryType))
 
 	// The search chrome is bound to component state (the change handler
-	// updates typedQuery/searchQueryType), so it can't move to a static
-	// outer component. Compute it once and render it in every branch, so
-	// the user always has a search bar to type into or clear.
+	// updates typedQuery), so it can't move to a static outer component.
+	// Compute it once and render it in every branch, so the user always has a
+	// search bar to type into or clear.
 	let searchChrome = (
 		<>
 			<Stack.Toolbar placement="bottom">
 				<Stack.Toolbar.SearchBarSlot />
 			</Stack.Toolbar>
 
-			<SearchBar
-				onChangeText={(text) => {
-					setSearchQueryType('query')
-					setTypedQuery(text)
-				}}
-				value={typedQuery}
-			/>
+			<SearchBar onChangeText={setTypedQuery} value={typedQuery} />
 		</>
 	)
 
@@ -105,6 +101,7 @@ function DirectoryView(): React.ReactNode {
 						refreshing={isRefetching}
 						renderItem={({item, index}) => (
 							<DirectoryItemRow
+								index={index}
 								item={item}
 								onPress={() =>
 									router.push({
@@ -149,14 +146,27 @@ function NoSearchPerformed() {
 	)
 }
 
+/**
+ * Every result row carries this prefix so XCUITest can ask whether the list
+ * has any rows without naming someone the college can rename. Mirror it in
+ * `TestIdentifiers.Directory`.
+ */
+const DIRECTORY_ROW_PREFIX = 'directory-row-'
+
 type DirectoryItemRowProps = {
 	item: DirectoryItem
+	index: number
 	onPress: () => void
 }
 
-function IosDirectoryItemRow({item, onPress}: DirectoryItemRowProps) {
+function IosDirectoryItemRow({item, index, onPress}: DirectoryItemRowProps) {
 	return (
-		<ListRow fullWidth={true} onPress={onPress} style={styles.row}>
+		<ListRow
+			fullWidth={true}
+			onPress={onPress}
+			style={styles.row}
+			testID={`${DIRECTORY_ROW_PREFIX}${index}`}
+		>
 			<Image source={{uri: item.thumbnail}} style={styles.image} />
 			<Column flex={1}>
 				<Title lines={1}>{item.displayName}</Title>

--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -3,14 +3,14 @@ import {FlatList, Image, StyleSheet, Text, View} from 'react-native'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
 import {Column} from '@frogpond/layout'
-import {Detail, ListRow, ListSeparator, Title} from '@frogpond/lists'
+import {Detail, ListRow, ListSectionHeader, ListSeparator, Title} from '@frogpond/lists'
 import * as c from '@frogpond/colors'
 import {useDebounce} from '@frogpond/use-debounce'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 import {SearchBar} from '../../../source/components/search-bar'
 import {formatResults} from '../../../source/features/directory/helpers'
 import {directoryEntriesOptions} from '../../../source/features/directory/query'
-import {resolveSearch} from '../../../source/features/directory/resolve-search'
+import {resolveSearch, searchHeading} from '../../../source/features/directory/resolve-search'
 import type {DirectoryItem, DirectorySearchTypeEnum} from '../../../source/features/directory/types'
 import {SymbolView} from 'expo-symbols'
 
@@ -30,10 +30,12 @@ function DirectoryView(): React.ReactNode {
 	let [typedQuery, setTypedQuery] = React.useState('')
 	let debouncedQuery = useDebounce(typedQuery, 500)
 
-	let {query: searchQuery, type: searchQueryType} = resolveSearch({
-		departmentLink,
-		typedQuery: debouncedQuery,
-	})
+	let search = resolveSearch({departmentLink, typedQuery: debouncedQuery})
+	let {query: searchQuery, type: searchQueryType} = search
+
+	// The title reads "Directory" wherever the screen was opened from, so a
+	// linked search names itself over its results instead.
+	let heading = searchHeading(search)
 
 	let {
 		data = {results: []},
@@ -92,6 +94,7 @@ function DirectoryView(): React.ReactNode {
 				) : (
 					<FlatList
 						ItemSeparatorComponent={IndentedListSeparator}
+						ListHeaderComponent={heading ? <ListSectionHeader title={heading} /> : null}
 						contentInsetAdjustmentBehavior="automatic"
 						data={items}
 						keyExtractor={(_item, index) => String(index)}
@@ -123,11 +126,9 @@ function DirectoryView(): React.ReactNode {
 }
 
 export default function DirectoryPage(): React.ReactNode {
-	let params = useLocalSearchParams<{queryParam?: string}>()
-
 	return (
 		<>
-			<Stack.Title>{params.queryParam ?? 'Directory'}</Stack.Title>
+			<Stack.Title>Directory</Stack.Title>
 			<DirectoryView />
 		</>
 	)

--- a/modules/lists/list-row.tsx
+++ b/modules/lists/list-row.tsx
@@ -32,6 +32,7 @@ type PropsType = PropsWithChildren<{
 	fullHeight?: boolean
 	spacing?: {left?: number; right?: number}
 	onPress?: () => void
+	testID?: string
 }>
 
 export function ListRow(props: PropsType): React.ReactNode {
@@ -43,6 +44,7 @@ export function ListRow(props: PropsType): React.ReactNode {
 		spacing: {left: leftSpacing = 15, right: rightSpacing = null} = {},
 		fullWidth = false,
 		fullHeight = false,
+		testID,
 	} = props
 
 	const arrowPosition = props.arrowPosition || (onPress ? 'center' : 'none')
@@ -69,11 +71,15 @@ export function ListRow(props: PropsType): React.ReactNode {
 
 	if (onPress) {
 		return (
-			<Touchable onPress={onPress} style={wrapperStyle}>
+			<Touchable onPress={onPress} style={wrapperStyle} testID={testID}>
 				{content}
 			</Touchable>
 		)
 	}
 
-	return <View style={wrapperStyle}>{content}</View>
+	return (
+		<View style={wrapperStyle} testID={testID}>
+			{content}
+		</View>
+	)
 }

--- a/source/components/search-bar.tsx
+++ b/source/components/search-bar.tsx
@@ -10,7 +10,7 @@ type StackNavigation = NativeStackNavigationProp<Record<string, object | undefin
 type NativeSearchBarProps = React.ComponentProps<typeof Stack.SearchBar>
 
 export type SearchBarProps = Omit<NativeSearchBarProps, 'onChangeText' | 'ref'> & {
-	/** The query the screen believes it is showing results for. */
+	/** The text the screen believes the field is showing. */
 	value: string
 	/** Called with the field's new text when the reader types. */
 	onChangeText: (text: string) => void

--- a/source/features/directory/__tests__/resolve-search.test.ts
+++ b/source/features/directory/__tests__/resolve-search.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from '@jest/globals'
-import {resolveSearch} from '../resolve-search'
+import {resolveSearch, searchHeading} from '../resolve-search'
 
 describe('resolveSearch', () => {
 	test('runs what the reader typed', () => {
@@ -30,5 +30,15 @@ describe('resolveSearch', () => {
 			query: 'olaf',
 			type: 'query',
 		})
+	})
+})
+
+describe('searchHeading', () => {
+	test('names the department a linked search is answering', () => {
+		expect(searchHeading({query: 'Music', type: 'department'})).toBe('Music')
+	})
+
+	test('leaves a search the reader typed unheaded', () => {
+		expect(searchHeading({query: 'olaf', type: 'query'})).toBeNull()
 	})
 })

--- a/source/features/directory/__tests__/resolve-search.test.ts
+++ b/source/features/directory/__tests__/resolve-search.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, test} from '@jest/globals'
+import {resolveSearch} from '../resolve-search'
+
+describe('resolveSearch', () => {
+	test('runs what the reader typed', () => {
+		expect(resolveSearch({departmentLink: undefined, typedQuery: 'olaf'})).toEqual({
+			query: 'olaf',
+			type: 'query',
+		})
+	})
+
+	test('runs nothing when nobody has typed and no department was linked', () => {
+		expect(resolveSearch({departmentLink: undefined, typedQuery: ''})).toEqual({
+			query: '',
+			type: 'query',
+		})
+	})
+
+	// An empty field is also how the search bar's cancel button reports itself,
+	// so this is the case that decides what cancelling lands the reader on.
+	test('runs the linked department while the field is empty', () => {
+		expect(resolveSearch({departmentLink: 'Music', typedQuery: ''})).toEqual({
+			query: 'Music',
+			type: 'department',
+		})
+	})
+
+	test('runs what the reader typed over the linked department', () => {
+		expect(resolveSearch({departmentLink: 'Music', typedQuery: 'olaf'})).toEqual({
+			query: 'olaf',
+			type: 'query',
+		})
+	})
+})

--- a/source/features/directory/resolve-search.ts
+++ b/source/features/directory/resolve-search.ts
@@ -29,3 +29,15 @@ export function resolveSearch({departmentLink, typedQuery}: ResolveSearchArgs): 
 
 	return {query: '', type: 'query'}
 }
+
+/**
+ * The name a search shows above its results, or null when there is nothing to
+ * name. A search the reader typed answers only for itself; every other kind was
+ * opened from something named, and the results mean little without saying what.
+ */
+export function searchHeading(search: {
+	query: string
+	type: DirectorySearchTypeEnum
+}): string | null {
+	return search.type === 'query' ? null : search.query
+}

--- a/source/features/directory/resolve-search.ts
+++ b/source/features/directory/resolve-search.ts
@@ -1,0 +1,31 @@
+import type {DirectorySearchTypeEnum} from './types'
+
+type ResolveSearchArgs = {
+	/** The department the screen was opened for, if it was opened for one. */
+	departmentLink: string | undefined
+	/** Whatever is in the search field. */
+	typedQuery: string
+}
+
+/**
+ * The search a Directory screen should be running.
+ *
+ * A screen opened from a department link keeps that department as its
+ * baseline: it is what the list shows before anyone types, and what an emptied
+ * field falls back to. The search bar's cancel button reports itself by
+ * emptying the field, so this is what puts the department results back.
+ */
+export function resolveSearch({departmentLink, typedQuery}: ResolveSearchArgs): {
+	query: string
+	type: DirectorySearchTypeEnum
+} {
+	if (typedQuery) {
+		return {query: typedQuery, type: 'query'}
+	}
+
+	if (departmentLink) {
+		return {query: departmentLink, type: 'department'}
+	}
+
+	return {query: '', type: 'query'}
+}

--- a/uitests/ModuleDirectoryTests.swift
+++ b/uitests/ModuleDirectoryTests.swift
@@ -21,4 +21,24 @@ class ModuleDirectoryTests: UITestCase {
 			.capture("Directory after a cancelled swipe back")
 			.verifySearchText("olaf")
 	}
+
+	/// A screen opened from a department link is showing that department, and
+	/// the title says so. Cancelling a search the reader never started has to
+	/// leave both alone -- otherwise the list empties while the title goes on
+	/// naming a department, and the only way back is to navigate in again.
+	func testCancellingSearchKeepsTheLinkedDepartment() throws {
+		let department = TestIdentifiers.Directory.department
+
+		DirectoryScreen(app: app)
+			.navigate()
+			.search(for: "registrar")
+			.openDepartment(
+				of: TestIdentifiers.Directory.departmentalEntry, named: department)
+			.verifyTitle(department)
+			.verifyResultsListed()
+			.cancelSearch()
+			.capture("Directory department screen after cancelling search")
+			.verifyTitle(department)
+			.verifyResultsListed()
+	}
 }

--- a/uitests/ModuleDirectoryTests.swift
+++ b/uitests/ModuleDirectoryTests.swift
@@ -34,11 +34,28 @@ class ModuleDirectoryTests: UITestCase {
 			.search(for: "registrar")
 			.openDepartment(
 				of: TestIdentifiers.Directory.departmentalEntry, named: department)
-			.verifyTitle(department)
+			.verifyDepartmentHeading(department)
 			.verifyResultsListed()
 			.cancelSearch()
 			.capture("Directory department screen after cancelling search")
-			.verifyTitle(department)
+			.verifyDepartmentHeading(department)
+			.verifyResultsListed()
+	}
+
+	/// The title stays "Directory" wherever the screen was opened from, so a
+	/// department has to name itself above its own results -- otherwise nothing
+	/// on screen says whose names these are.
+	func testDepartmentLinkIsNamedAboveTheResults() throws {
+		let department = TestIdentifiers.Directory.department
+
+		DirectoryScreen(app: app)
+			.navigate()
+			.search(for: "registrar")
+			.openDepartment(
+				of: TestIdentifiers.Directory.departmentalEntry, named: department)
+			.capture("Directory opened from a department link")
+			.verifyDirectoryTitle()
+			.verifyDepartmentHeading(department)
 			.verifyResultsListed()
 	}
 }

--- a/uitests/Screens/DirectoryScreen.swift
+++ b/uitests/Screens/DirectoryScreen.swift
@@ -48,6 +48,63 @@ struct DirectoryScreen: Screen {
 		verifyTitle(TestIdentifiers.Buttons.directory)
 	}
 
+	/// Open the entry named `name` and follow the department it belongs to,
+	/// landing on a Directory screen the route seeded with that department.
+	@discardableResult
+	func openDepartment(of name: String, named department: String) -> Self {
+		let entry = app.elementWithLabel(startingWith: name)
+		XCTAssertTrue(
+			entry.waitForExistence(timeout: 30),
+			"\(name) should be among the results")
+		entry.tap()
+
+		let departmentCell = app.elementWithLabel(startingWith: department)
+		XCTAssertTrue(
+			departmentCell.waitForExistence(timeout: 30),
+			"\(name) should list \(department) as its department")
+		departmentCell.tap()
+		return self
+	}
+
+	/// Dismiss the search bar the way its own cancel button does.
+	///
+	/// The tap is retried, and each attempt tries a coordinate as well as the
+	/// element. A pushed screen leaves full-width containers above the toolbar
+	/// in the tree, so XCUITest finds no hit point for the field and reports
+	/// it unhittable even while a finger reaches it perfectly well.
+	@discardableResult
+	func cancelSearch() -> Self {
+		let field = searchField
+		XCTAssertTrue(
+			field.waitForExistence(timeout: 30),
+			"Directory should offer a search field")
+
+		let cancel = app.buttonLabelled(TestIdentifiers.Search.cancelButton)
+		for _ in 1...3 {
+			field.tap()
+			if cancel.waitForExistence(timeout: 5) { break }
+			field.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+			if cancel.waitForExistence(timeout: 5) { break }
+		}
+
+		XCTAssertTrue(
+			cancel.exists,
+			"Tapping the search field should reveal its cancel button")
+		cancel.tap()
+		return self
+	}
+
+	/// Assert the list has results in it, without naming any of them: which
+	/// people a department holds is the college's business, not this test's.
+	@discardableResult
+	func verifyResultsListed() -> Self {
+		let firstRow = app.element(matching: "\(TestIdentifiers.Directory.rowPrefix)0")
+		XCTAssertTrue(
+			firstRow.waitForExistence(timeout: 30),
+			"The directory list should have results in it")
+		return self
+	}
+
 	@discardableResult
 	func checkSearchPromptVisible() -> Self {
 		let searchPrompt = app.staticTexts[TestIdentifiers.Directory.searchPrompt].firstMatch

--- a/uitests/Screens/DirectoryScreen.swift
+++ b/uitests/Screens/DirectoryScreen.swift
@@ -94,6 +94,19 @@ struct DirectoryScreen: Screen {
 		return self
 	}
 
+	/// Assert the department the screen was opened for is named above the list.
+	///
+	/// The screen's title reads "Directory" whatever it is showing, so a static
+	/// text carrying the department name can only be the section heading.
+	@discardableResult
+	func verifyDepartmentHeading(_ department: String) -> Self {
+		let heading = app.staticTexts[department].firstMatch
+		XCTAssertTrue(
+			heading.waitForExistence(timeout: 30),
+			"\(department) should be named above the results")
+		return self
+	}
+
 	/// Assert the list has results in it, without naming any of them: which
 	/// people a department holds is the college's business, not this test's.
 	@discardableResult

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -26,6 +26,13 @@ struct TestIdentifiers {
 		static let closeScreen = "Close Screen"
 	}
 
+	/// Labels UIKit gives a `Stack.SearchBar`'s own controls. In the bottom
+	/// placement this app uses, the cancel button is the round one beside the
+	/// field, and UIKit labels it "close" rather than "Cancel".
+	enum Search {
+		static let cancelButton = "close"
+	}
+
 	enum Streaming {
 		static let list = "stream-list"
 		static let webcams = "screen-streaming-webcams"
@@ -221,6 +228,14 @@ struct TestIdentifiers {
 
 	enum Directory {
 		static let searchPrompt = "Search the Directory"
+		static let rowPrefix = "directory-row-"
+
+		/// A directory entry with no title, email or profile, so its detail
+		/// screen carries exactly one element labelled with its department --
+		/// and it is a desk rather than a person, so the college is unlikely to
+		/// rename it out from under this test.
+		static let departmentalEntry = "Registrar Fax"
+		static let department = "Registrar\u{2019}s Office"
 	}
 
 	// MARK: - Course Catalog

--- a/uitests/XCUITestHelpers.swift
+++ b/uitests/XCUITestHelpers.swift
@@ -26,6 +26,13 @@ extension XCUIApplication {
 				TestIdentifiers.Menus.foodRowPrefix, label))
 	}
 
+	/// Find a button by the label UIKit gave it. Buttons the system builds --
+	/// a search bar's cancel button, say -- carry no accessibility identifier,
+	/// so the usual subscript, which matches identifiers, never finds them.
+	func buttonLabelled(_ label: String) -> XCUIElement {
+		buttons.matching(NSPredicate(format: "label == %@", label)).firstMatch
+	}
+
 	/// Find any accessible element whose label starts with the given text.
 	/// Useful for React Native Pressable-wrapped elements whose accessibility
 	/// label is the concatenation of child text content (which may include


### PR DESCRIPTION
Closes https://github.com/StoDevX/AAO-React-Native/issues/7852

## Screenshots

Both taken on a department screen reached from Registrar Fax → Registrar's Office.

**Tapping the search bar's cancel button**

| Before | After |
| --- | --- |
| <img width="300" alt="Title reads Registrar's Office over an empty Search the Directory state" src="https://github.com/user-attachments/assets/71d6a249-581c-4573-bf30-fa94fd4fb031"> | <img width="300" alt="Title reads Directory, Registrar's Office section heading, seven results listed" src="https://github.com/user-attachments/assets/487efb16-1689-4de4-9807-64b3179493fe"> |

**Arriving from a department link**

| Before | After |
| --- | --- |
| <img width="300" alt="Title reads Registrar's Office with no section heading above the results" src="https://github.com/user-attachments/assets/62ead799-c99b-4b7b-bb30-3822e3204f4b"> | <img width="300" alt="Title reads Directory with a Registrar's Office section heading above the results" src="https://github.com/user-attachments/assets/ed64f55b-7c49-4f09-a20e-20e668caf839"> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)