### PR TITLE
Fix course catalog search crash and notes whitespace

### DIFF
--- a/app/(home)/CourseDetail.tsx
+++ b/app/(home)/CourseDetail.tsx
@@ -15,6 +15,7 @@ import {
 } from '@frogpond/tableview/cells'
 import * as c from '@frogpond/colors'
 import {deptNum} from '../../source/features/sis/course-search/lib/format-dept-num'
+import {formatCourseNotes} from '../../source/features/sis/course-search/lib/format-course-notes'
 import groupBy from 'lodash/groupBy'
 import map from 'lodash/map'
 import zip from 'lodash/zip'
@@ -130,7 +131,7 @@ function Notes({course}: {course: CourseType}) {
 		return null
 	}
 
-	let notesText = course.notes.join(' ')
+	let notesText = formatCourseNotes(course.notes)
 
 	let notes =
 		Platform.OS === 'ios' ? (

--- a/source/features/sis/course-search/lib/__tests__/execute-search.test.ts
+++ b/source/features/sis/course-search/lib/__tests__/execute-search.test.ts
@@ -1,0 +1,53 @@
+import {describe, expect, test} from '@jest/globals'
+import type {CourseType} from '../../../../../lib/course-search'
+import {applySearch} from '../execute-search'
+
+function makeCourse(overrides: Partial<CourseType> = {}): CourseType {
+	return {
+		clbid: 1,
+		credits: 1,
+		crsid: 1,
+		department: 'SPAN',
+		enrolled: 0,
+		instructors: ['Ford Prefect'],
+		level: 100,
+		max: 20,
+		name: 'Beginning Spanish',
+		number: 101,
+		offerings: [],
+		spaceAvailable: true,
+		pn: false,
+		prerequisites: false,
+		semester: 1,
+		status: 'O',
+		term: 20241,
+		title: 'Beginning Spanish',
+		type: 'Research',
+		year: 2024,
+		...overrides,
+	}
+}
+
+describe('applySearch', () => {
+	test('matches a course whose name contains the query', () => {
+		expect(applySearch('spanish', makeCourse())).toBe(true)
+	})
+
+	test('matches a course by instructor name', () => {
+		let course = makeCourse({name: 'Organic Chemistry', title: 'Organic Chemistry'})
+		expect(applySearch('prefect', course)).toBe(true)
+	})
+
+	test('does not match when the query is absent from every field', () => {
+		expect(applySearch('astronomy', makeCourse())).toBe(false)
+	})
+
+	test('handles a course with no instructors field', () => {
+		let course = makeCourse({
+			name: 'Organic Chemistry',
+			title: 'Organic Chemistry',
+			instructors: undefined,
+		})
+		expect(applySearch('spanish', course)).toBe(false)
+	})
+})

--- a/source/features/sis/course-search/lib/__tests__/format-course-notes.test.ts
+++ b/source/features/sis/course-search/lib/__tests__/format-course-notes.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, test} from '@jest/globals'
+import {formatCourseNotes} from '../format-course-notes'
+
+describe('formatCourseNotes', () => {
+	test('collapses runs of whitespace inside a note', () => {
+		expect(
+			formatCourseNotes([
+				'Prerequisite: CSCI 251.                Not open to first-year students.',
+			]),
+		).toBe('Prerequisite: CSCI 251. Not open to first-year students.')
+	})
+
+	test('joins multiple notes with a single space', () => {
+		expect(formatCourseNotes(['Prerequisite: CSCI 251.', 'Not open to first-year students.'])).toBe(
+			'Prerequisite: CSCI 251. Not open to first-year students.',
+		)
+	})
+
+	test('trims leading and trailing whitespace', () => {
+		expect(formatCourseNotes(['  Meets in Regents Hall.  '])).toBe('Meets in Regents Hall.')
+	})
+
+	test('normalises tabs and newlines to single spaces', () => {
+		expect(formatCourseNotes(['Lab section\trequired.\n\nSee instructor.'])).toBe(
+			'Lab section required. See instructor.',
+		)
+	})
+})

--- a/source/features/sis/course-search/lib/execute-search.ts
+++ b/source/features/sis/course-search/lib/execute-search.ts
@@ -16,7 +16,7 @@ export function applySearch(query: string, course: Course): boolean {
 		return true
 	}
 
-	let {instructors} = course
+	let {instructors = []} = course
 	if (instructors.some((instructorName) => keywordSearch(query, instructorName.toLowerCase(), 1))) {
 		return true
 	}

--- a/source/features/sis/course-search/lib/format-course-notes.ts
+++ b/source/features/sis/course-search/lib/format-course-notes.ts
@@ -1,0 +1,4 @@
+/** Join a course's notes into one line, collapsing the stray whitespace runs the catalog data ships with. */
+export function formatCourseNotes(notes: string[]): string {
+	return notes.join(' ').replace(/\s+/gu, ' ').trim()
+}

--- a/source/features/sis/course-search/row.tsx
+++ b/source/features/sis/course-search/row.tsx
@@ -3,6 +3,7 @@ import {StyleSheet} from 'react-native'
 import type {CourseType} from '../../../lib/course-search/types'
 import {ListRow, Title, Detail} from '@frogpond/lists'
 import {deptNum} from './lib/format-dept-num'
+import {formatCourseNotes} from './lib/format-course-notes'
 import {Row} from '@frogpond/layout'
 
 type Props = {
@@ -31,7 +32,7 @@ export const CourseRow = (props: Props): React.ReactNode => {
 
 			{course.notes && (
 				<Detail lines={1} style={[styles.italics, styles.row]}>
-					{course.notes.join(' ')}
+					{formatCourseNotes(course.notes)}
 				</Detail>
 			)}
 		</ListRow>

--- a/source/lib/course-search/types.ts
+++ b/source/lib/course-search/types.ts
@@ -13,7 +13,7 @@ export type RawCourseType = {
 	description?: string[]
 	enrolled: number
 	gereqs?: string[]
-	instructors: string[]
+	instructors?: string[]
 	level: number
 	max: number
 	name: string
@@ -39,7 +39,7 @@ export type CourseType = {
 	description?: string[]
 	enrolled: number
 	gereqs?: string[]
-	instructors: string[]
+	instructors?: string[]
 	level: number
 	max: number
 	name: string


### PR DESCRIPTION
## Course search crashed on some queries

`CourseType.instructors` was typed as always-present, but the catalog data ships courses with no `instructors` field. `applySearch` called `.some()` on it directly, so any search that reached such a course — `spanish` being the reported one — threw `TypeError: Cannot read property 'some' of undefined` and took down the Course Catalog screen.

- default `instructors` to `[]` in `applySearch`, matching its sibling fields (`title`, `gereqs`)
- mark `instructors` optional on `RawCourseType` / `CourseType`; the other consumers (`row.tsx`, `CourseDetail.tsx`) already guard for its absence

## Notes had stray whitespace

Catalog notes contain long runs of spaces mid-string, e.g. 
```
`Prerequisite: CSCI 251.                Not open to first-year students.`
```

<img width="386" height="92" src="https://github.com/user-attachments/assets/601a5e28-56c8-413b-841f-a7f6ecff8ba8" />

<img width="386" height="92" src="https://github.com/user-attachments/assets/9e421ca4-2361-4f65-8f15-2abfab238018" />

- new `formatCourseNotes` helper joins the notes and collapses whitespace
- used on both the search row and the course detail screen

## Tests

- `execute-search.test.ts` — `applySearch` branch behavior, incl. the missing-instructors case (reproduces the reported error before the fix)
- `format-course-notes.test.ts` — whitespace collapsing, multi-note join, trim, tabs/newlines

`mise run agent:pre-commit` green (tsc, oxlint, oxfmt, 1153 Jest tests).