### PR TITLE
Department roster on the Directory landing, and a list/gallery toggle for results

### DIFF
--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -5,7 +5,7 @@ import {useQuery} from '@tanstack/react-query'
 import {openUrl} from '@frogpond/open-url'
 import {callPhone} from '../../../source/components/call-phone'
 import {sendEmail} from '../../../source/components/send-email'
-import {Title, Detail} from '@frogpond/lists'
+import {Detail} from '@frogpond/lists'
 import {TableView, Section, Cell} from '@frogpond/tableview'
 import {MultiLineLeftDetailCell} from '@frogpond/tableview/cells'
 import * as c from '@frogpond/colors'
@@ -33,7 +33,14 @@ export default function DirectoryDetailPage(): React.ReactNode {
 		refetch,
 	} = useQuery(directoryContactOptions(query, type as DirectorySearchTypeEnum, Number(index)))
 
-	let screenTitle = <Stack.Title>{contact?.displayName ?? 'Contact'}</Stack.Title>
+	// The screen's only copy of the name: a large title that collapses on
+	// scroll, rather than a static heading repeated in the body.
+	let screenTitle = (
+		<>
+			<Stack.Screen options={{headerLargeTitleEnabled: true}} />
+			<Stack.Title>{contact?.displayName ?? 'Contact'}</Stack.Title>
+		</>
+	)
 
 	if (isLoading) {
 		return (
@@ -69,7 +76,6 @@ export default function DirectoryDetailPage(): React.ReactNode {
 	}
 
 	const {
-		displayName,
 		campusLocations,
 		displayTitle,
 		photo,
@@ -90,7 +96,6 @@ export default function DirectoryDetailPage(): React.ReactNode {
 					source={{uri: photo}}
 					style={styles.image}
 				/>
-				<Title style={[styles.header, styles.headerName]}>{displayName}</Title>
 				<Detail style={[styles.header, styles.headerTitle]}>{displayTitle}</Detail>
 
 				<TableView>
@@ -203,12 +208,8 @@ const styles = StyleSheet.create({
 		textAlign: 'center',
 		marginHorizontal: 30,
 	},
-	headerName: {
-		marginTop: 10,
-		fontSize: 22,
-		fontWeight: 'bold',
-	},
 	headerTitle: {
+		marginTop: 10,
 		marginBottom: 10,
 		fontSize: 14,
 	},

--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import {Alert, FlatList, Image, StyleSheet, useWindowDimensions, View} from 'react-native'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
+import {useDispatch, useSelector} from 'react-redux'
 import {useQuery} from '@tanstack/react-query'
 import {
 	Button,
@@ -35,9 +36,14 @@ import * as c from '@frogpond/colors'
 import {useDebounce} from '@frogpond/use-debounce'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 import {SearchBar} from '../../../source/components/search-bar'
+import {
+	selectDirectoryResultsView,
+	setDirectoryResultsView,
+} from '../../../source/redux/parts/settings'
 import {contactsOptions} from '../../../source/features/directory/contacts-query'
 import {DepartmentsList} from '../../../source/features/directory/departments-list'
 import {directoryDepartmentsOptions} from '../../../source/features/directory/departments-query'
+import {DirectoryResultsGrid} from '../../../source/features/directory/directory-results-grid'
 import {formatResults} from '../../../source/features/directory/helpers'
 import {directoryEntriesOptions} from '../../../source/features/directory/query'
 import {resolveSearch, searchHeading} from '../../../source/features/directory/resolve-search'
@@ -52,6 +58,8 @@ import {FILL_WIDTH, SCREEN_MARGIN} from '../../../source/features/home/button'
 
 function DirectoryView(): React.ReactNode {
 	let router = useRouter()
+	let dispatch = useDispatch()
+	let resultsView = useSelector(selectDirectoryResultsView)
 
 	let params = useLocalSearchParams<{
 		queryType?: DirectorySearchTypeEnum
@@ -82,6 +90,17 @@ function DirectoryView(): React.ReactNode {
 		isLoading,
 	} = useQuery(directoryEntriesOptions(searchQuery, searchQueryType))
 
+	let items = data.results ? formatResults(data.results) : []
+
+	// The results toggle only earns toolbar space once there are results to
+	// re-lay-out -- it stays hidden on the landing, the too-short notice, the
+	// error, and the empty states.
+	let hasResults =
+		searchQuery.length >= 2 &&
+		!isLoading &&
+		!(isError && error instanceof Error) &&
+		items.length > 0
+
 	// The search chrome is bound to component state (the change handler
 	// updates typedQuery), so it can't move to a static outer component.
 	// Compute it once and render it in every branch, so the user always has a
@@ -92,6 +111,18 @@ function DirectoryView(): React.ReactNode {
 		<>
 			<Stack.Toolbar placement="bottom">
 				<Stack.Toolbar.SearchBarSlot />
+				{hasResults ? (
+					<>
+						<Stack.Toolbar.Spacer />
+						<Stack.Toolbar.Button
+							accessibilityLabel={resultsView === 'tiles' ? 'Show as list' : 'Show as tiles'}
+							icon={resultsView === 'tiles' ? 'list.bullet' : 'square.grid.2x2'}
+							onPress={() =>
+								dispatch(setDirectoryResultsView(resultsView === 'tiles' ? 'list' : 'tiles'))
+							}
+						/>
+					</>
+				) : null}
 			</Stack.Toolbar>
 
 			<SearchBar onChangeText={setTypedQuery} value={typedQuery} />
@@ -116,7 +147,11 @@ function DirectoryView(): React.ReactNode {
 		)
 	}
 
-	const items = data.results ? formatResults(data.results) : []
+	let openResult = (index: number) =>
+		router.push({
+			pathname: '/Directory/[index]',
+			params: {index: String(index), query: searchQuery, type: searchQueryType},
+		})
 
 	return (
 		<>
@@ -127,6 +162,13 @@ function DirectoryView(): React.ReactNode {
 					<NoticeView text={String(error)} />
 				) : !items.length ? (
 					<NoticeView text={`No results found for "${searchQuery}".`} />
+				) : resultsView === 'tiles' ? (
+					<DirectoryResultsGrid
+						heading={heading}
+						items={items}
+						onRefresh={refetch}
+						onSelectIndex={openResult}
+					/>
 				) : (
 					<FlatList
 						ItemSeparatorComponent={IndentedListSeparator}
@@ -139,20 +181,7 @@ function DirectoryView(): React.ReactNode {
 						onRefresh={refetch}
 						refreshing={isRefetching}
 						renderItem={({item, index}) => (
-							<DirectoryItemRow
-								index={index}
-								item={item}
-								onPress={() =>
-									router.push({
-										pathname: '/Directory/[index]',
-										params: {
-											index: String(index),
-											query: searchQuery,
-											type: searchQueryType,
-										},
-									})
-								}
-							/>
+							<DirectoryItemRow index={index} item={item} onPress={() => openResult(index)} />
 						)}
 					/>
 				)}

--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -111,18 +111,18 @@ function DirectoryView(): React.ReactNode {
 		<>
 			<Stack.Toolbar placement="bottom">
 				<Stack.Toolbar.SearchBarSlot />
-				{hasResults ? (
-					<>
-						<Stack.Toolbar.Spacer />
-						<Stack.Toolbar.Button
-							accessibilityLabel={resultsView === 'tiles' ? 'Show as list' : 'Show as tiles'}
-							icon={resultsView === 'tiles' ? 'list.bullet' : 'square.grid.2x2'}
-							onPress={() =>
-								dispatch(setDirectoryResultsView(resultsView === 'tiles' ? 'list' : 'tiles'))
-							}
-						/>
-					</>
-				) : null}
+				<Stack.Toolbar.Spacer />
+				{/* Always mounted, hidden until there are results to re-lay-out:
+				    `Stack.Toolbar` only reads direct Button/Spacer children, so a
+				    conditionally-rendered fragment of them is dropped entirely. */}
+				<Stack.Toolbar.Button
+					accessibilityLabel={resultsView === 'tiles' ? 'Show as list' : 'Show as tiles'}
+					hidden={!hasResults}
+					icon={resultsView === 'tiles' ? 'list.bullet' : 'square.grid.2x2'}
+					onPress={() =>
+						dispatch(setDirectoryResultsView(resultsView === 'tiles' ? 'list' : 'tiles'))
+					}
+				/>
 			</Stack.Toolbar>
 
 			<SearchBar onChangeText={setTypedQuery} value={typedQuery} />

--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -111,15 +111,10 @@ function DirectoryView(): React.ReactNode {
 		<>
 			<Stack.Toolbar placement="bottom">
 				<Stack.Toolbar.SearchBarSlot />
-			</Stack.Toolbar>
-
-			{/* The results toggle goes in the nav bar, not the bottom toolbar: an
-			    active search bar puts its own cancel button in the bottom
-			    trailing slot and would sit on top of it. Always mounted, hidden
-			    until there are results to re-lay-out -- `Stack.Toolbar` only
-			    reads direct Button children, so a conditional fragment of one is
-			    dropped whole. */}
-			<Stack.Toolbar placement="right">
+				<Stack.Toolbar.Spacer />
+				{/* Always mounted, hidden until there are results to re-lay-out:
+				    `Stack.Toolbar` only reads direct Button/Spacer children, so a
+				    conditionally-rendered fragment of them is dropped entirely. */}
 				<Stack.Toolbar.Button
 					accessibilityLabel={resultsView === 'tiles' ? 'Show as list' : 'Show as tiles'}
 					hidden={!hasResults}
@@ -130,10 +125,7 @@ function DirectoryView(): React.ReactNode {
 				/>
 			</Stack.Toolbar>
 
-			{/* `hideNavigationBar={false}`: iOS hides the whole nav bar while a
-			    search is active by default, which would take the results toggle
-			    down with it. */}
-			<SearchBar hideNavigationBar={false} onChangeText={setTypedQuery} value={typedQuery} />
+			<SearchBar onChangeText={setTypedQuery} value={typedQuery} />
 		</>
 	)
 

--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -111,10 +111,15 @@ function DirectoryView(): React.ReactNode {
 		<>
 			<Stack.Toolbar placement="bottom">
 				<Stack.Toolbar.SearchBarSlot />
-				<Stack.Toolbar.Spacer />
-				{/* Always mounted, hidden until there are results to re-lay-out:
-				    `Stack.Toolbar` only reads direct Button/Spacer children, so a
-				    conditionally-rendered fragment of them is dropped entirely. */}
+			</Stack.Toolbar>
+
+			{/* The results toggle goes in the nav bar, not the bottom toolbar: an
+			    active search bar puts its own cancel button in the bottom
+			    trailing slot and would sit on top of it. Always mounted, hidden
+			    until there are results to re-lay-out -- `Stack.Toolbar` only
+			    reads direct Button children, so a conditional fragment of one is
+			    dropped whole. */}
+			<Stack.Toolbar placement="right">
 				<Stack.Toolbar.Button
 					accessibilityLabel={resultsView === 'tiles' ? 'Show as list' : 'Show as tiles'}
 					hidden={!hasResults}
@@ -125,7 +130,10 @@ function DirectoryView(): React.ReactNode {
 				/>
 			</Stack.Toolbar>
 
-			<SearchBar onChangeText={setTypedQuery} value={typedQuery} />
+			{/* `hideNavigationBar={false}`: iOS hides the whole nav bar while a
+			    search is active by default, which would take the results toggle
+			    down with it. */}
+			<SearchBar hideNavigationBar={false} onChangeText={setTypedQuery} value={typedQuery} />
 		</>
 	)
 

--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -8,8 +8,8 @@ import {
 	HStack,
 	Host,
 	Image as UIImage,
+	List,
 	ProgressView,
-	ScrollView,
 	Spacer,
 	Text as UIText,
 	VStack,
@@ -22,6 +22,10 @@ import {
 	font,
 	foregroundStyle,
 	frame,
+	listRowBackground,
+	listRowInsets,
+	listRowSeparator,
+	listStyle,
 	padding,
 	refreshable,
 } from '@expo/ui/swift-ui/modifiers'
@@ -30,10 +34,10 @@ import {Detail, ListRow, ListSectionHeader, ListSeparator, Title} from '@frogpon
 import * as c from '@frogpond/colors'
 import {useDebounce} from '@frogpond/use-debounce'
 import {LoadingView, NoticeView} from '@frogpond/notice'
-import {openUrl} from '@frogpond/open-url'
-import {callPhone} from '../../../source/components/call-phone'
 import {SearchBar} from '../../../source/components/search-bar'
 import {contactsOptions} from '../../../source/features/directory/contacts-query'
+import {DepartmentsList} from '../../../source/features/directory/departments-list'
+import {directoryDepartmentsOptions} from '../../../source/features/directory/departments-query'
 import {formatResults} from '../../../source/features/directory/helpers'
 import {directoryEntriesOptions} from '../../../source/features/directory/query'
 import {resolveSearch, searchHeading} from '../../../source/features/directory/resolve-search'
@@ -43,11 +47,7 @@ import {
 	inRows,
 	TILE_SPACING,
 } from '../../../source/features/directory/tile-layout'
-import type {
-	ContactType,
-	DirectoryItem,
-	DirectorySearchTypeEnum,
-} from '../../../source/features/directory/types'
+import type {DirectoryItem, DirectorySearchTypeEnum} from '../../../source/features/directory/types'
 import {FILL_WIDTH, SCREEN_MARGIN} from '../../../source/features/home/button'
 
 function DirectoryView(): React.ReactNode {
@@ -101,7 +101,7 @@ function DirectoryView(): React.ReactNode {
 	if (!searchQuery) {
 		return (
 			<>
-				<ImportantContacts />
+				<DirectoryLanding />
 				{searchChrome}
 			</>
 		)
@@ -181,64 +181,73 @@ const CONTACT_GRID_ID = 'directory-contact-grid'
 const STALE_CONTACTS_LABEL = 'Contacts may be out of date'
 
 /**
- * What the Directory screen shows before a search: the curated campus
- * contacts, as tiles.
+ * What the Directory screen shows before a search: the curated campus contacts
+ * as tiles, and the full campus department roster as an inset-grouped list.
  *
- * The contacts are cached to disk by `PersistQueryClientProvider`, so a device
- * that opens this offline still gets the grid. A failed refresh over a good
- * cache is a badge beside the heading rather than an error page -- searching,
- * which is this screen's real job, does not depend on it.
+ * Both queries are cached to disk by `PersistQueryClientProvider`, so a device
+ * that opens this offline still gets both. A failed refresh over good caches is
+ * absorbed -- searching, which is this screen's real job, depends on neither.
  */
-function ImportantContacts(): React.ReactNode {
+function DirectoryLanding(): React.ReactNode {
 	let router = useRouter()
-	let {data: contacts, error, isLoading, refetch} = useQuery(contactsOptions)
+	let {
+		data: contacts,
+		error: contactsError,
+		isLoading: contactsLoading,
+		refetch: refetchContacts,
+	} = useQuery(contactsOptions)
+	let {
+		data: departments,
+		isLoading: departmentsLoading,
+		refetch: refetchDepartments,
+	} = useQuery(directoryDepartmentsOptions)
 	let {fontScale} = useWindowDimensions()
 	let columns = columnsForFontScale(fontScale)
 
-	let onAct = React.useCallback((contact: ContactType) => {
-		if (contact.buttonLink) {
-			openUrl(contact.buttonLink)
-		} else if (contact.phoneNumber) {
-			callPhone(contact.phoneNumber, {title: contact.buttonText})
-		}
-	}, [])
-
-	let showError = React.useCallback(() => {
+	let showContactsError = React.useCallback(() => {
 		Alert.alert(
 			"Couldn't refresh contacts",
-			error instanceof Error ? error.message : 'Unknown error',
+			contactsError instanceof Error ? contactsError.message : 'Unknown error',
 			[
-				{text: 'Try Again', onPress: () => void refetch()},
+				{text: 'Try Again', onPress: () => void refetchContacts()},
 				{text: 'OK', style: 'cancel'},
 			],
 		)
-	}, [error, refetch])
+	}, [contactsError, refetchContacts])
 
-	// headerLargeTitleEnabled has nothing to collapse against here: the only
-	// scrollable in this branch is the SwiftUI ScrollView below, and
-	// react-native-screens has no handle into a Host's content to track it.
-	// Harmless while eight tiles never overflow the screen -- worth knowing
-	// before that stops being true.
+	let refresh = React.useCallback(async () => {
+		await Promise.all([refetchContacts(), refetchDepartments()])
+	}, [refetchContacts, refetchDepartments])
+
 	return (
 		<Host matchContents={false} style={styles.host}>
-			<ScrollView
+			<List
 				modifiers={[
+					listStyle('insetGrouped'),
 					refreshable(async () => {
-						await refetch()
+						await refresh()
 					}),
 				]}
 			>
 				<VStack
-					modifiers={[padding({all: SCREEN_MARGIN}), frame({maxWidth: FILL_WIDTH})]}
+					modifiers={[
+						listRowBackground('clear'),
+						listRowInsets({top: 0, leading: 0, bottom: 0, trailing: 0}),
+						listRowSeparator('hidden'),
+						// Horizontal + top only: the enclosing List owns the gap down
+						// to the Departments section below.
+						padding({horizontal: SCREEN_MARGIN, top: SCREEN_MARGIN}),
+						frame({maxWidth: FILL_WIDTH}),
+					]}
 					spacing={TILE_SPACING}
 				>
 					<HStack modifiers={[frame({maxWidth: FILL_WIDTH})]}>
 						<UIText modifiers={[font({textStyle: 'headline'})]}>Important Contacts</UIText>
 						<Spacer />
-						{error && contacts ? (
+						{contactsError && contacts ? (
 							<Button
 								modifiers={[buttonStyle('plain'), accessibilityLabel(STALE_CONTACTS_LABEL)]}
-								onPress={showError}
+								onPress={showContactsError}
 							>
 								<UIImage color={c.orange} systemName="exclamationmark.triangle.fill" />
 							</Button>
@@ -266,7 +275,6 @@ function ImportantContacts(): React.ReactNode {
 										<ContactTile
 											key={contact.title}
 											contact={contact}
-											onAct={() => onAct(contact)}
 											onPress={() =>
 												router.push({
 													pathname: '/Directory/named/[title]',
@@ -285,7 +293,7 @@ function ImportantContacts(): React.ReactNode {
 								</Grid.Row>
 							))}
 						</Grid>
-					) : isLoading ? (
+					) : contactsLoading ? (
 						<ProgressView />
 					) : (
 						<UIText modifiers={[foregroundStyle(c.secondaryLabel)]}>
@@ -293,7 +301,18 @@ function ImportantContacts(): React.ReactNode {
 						</UIText>
 					)}
 				</VStack>
-			</ScrollView>
+
+				<DepartmentsList
+					departments={departments}
+					isLoading={departmentsLoading}
+					onSelectDepartment={(name) =>
+						router.push({
+							pathname: '/Directory',
+							params: {queryType: 'department', queryParam: name},
+						})
+					}
+				/>
+			</List>
 		</Host>
 	)
 }

--- a/app/(home)/Directory/index.tsx
+++ b/app/(home)/Directory/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {Alert, FlatList, Image, StyleSheet, useWindowDimensions, View} from 'react-native'
+import {Alert, FlatList, Image, StyleSheet, useWindowDimensions} from 'react-native'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
 import {useDispatch, useSelector} from 'react-redux'
 import {useQuery} from '@tanstack/react-query'
@@ -153,39 +153,41 @@ function DirectoryView(): React.ReactNode {
 			params: {index: String(index), query: searchQuery, type: searchQueryType},
 		})
 
+	// The scrollable is the first child, with no wrapping View: a native large
+	// title only collapses against a scroll view the stack can see directly,
+	// and searchChrome (which ends in the bottom toolbar) comes after it.
 	return (
 		<>
-			<View style={styles.wrapper}>
-				{isLoading ? (
-					<LoadingView />
-				) : isError && error instanceof Error ? (
-					<NoticeView text={String(error)} />
-				) : !items.length ? (
-					<NoticeView text={`No results found for "${searchQuery}".`} />
-				) : resultsView === 'tiles' ? (
-					<DirectoryResultsGrid
-						heading={heading}
-						items={items}
-						onRefresh={refetch}
-						onSelectIndex={openResult}
-					/>
-				) : (
-					<FlatList
-						ItemSeparatorComponent={IndentedListSeparator}
-						ListHeaderComponent={heading ? <ListSectionHeader title={heading} /> : null}
-						contentInsetAdjustmentBehavior="automatic"
-						data={items}
-						keyExtractor={(_item, index) => String(index)}
-						keyboardDismissMode="on-drag"
-						keyboardShouldPersistTaps="never"
-						onRefresh={refetch}
-						refreshing={isRefetching}
-						renderItem={({item, index}) => (
-							<DirectoryItemRow index={index} item={item} onPress={() => openResult(index)} />
-						)}
-					/>
-				)}
-			</View>
+			{isLoading ? (
+				<LoadingView />
+			) : isError && error instanceof Error ? (
+				<NoticeView text={String(error)} />
+			) : !items.length ? (
+				<NoticeView text={`No results found for "${searchQuery}".`} />
+			) : resultsView === 'tiles' ? (
+				<DirectoryResultsGrid
+					heading={heading}
+					items={items}
+					onRefresh={refetch}
+					onSelectIndex={openResult}
+				/>
+			) : (
+				<FlatList
+					ItemSeparatorComponent={IndentedListSeparator}
+					ListHeaderComponent={heading ? <ListSectionHeader title={heading} /> : null}
+					contentInsetAdjustmentBehavior="automatic"
+					data={items}
+					keyExtractor={(_item, index) => String(index)}
+					keyboardDismissMode="on-drag"
+					keyboardShouldPersistTaps="never"
+					onRefresh={refetch}
+					refreshing={isRefetching}
+					renderItem={({item, index}) => (
+						<DirectoryItemRow index={index} item={item} onPress={() => openResult(index)} />
+					)}
+					style={styles.wrapper}
+				/>
+			)}
 			{searchChrome}
 		</>
 	)

--- a/app/(home)/Directory/named/[title].tsx
+++ b/app/(home)/Directory/named/[title].tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {StyleSheet, ScrollView, Image, View, Text, TextProps, ViewProps} from 'react-native'
+import {StyleSheet, ScrollView, Image, View, ViewProps} from 'react-native'
 import {Stack, useLocalSearchParams} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
 
@@ -7,7 +7,6 @@ import {contactByTitleOptions} from '../../../../source/features/directory/conta
 import {images as contactImages} from '../../../../images/contacts'
 import {Markdown, type MarkdownStyle} from '@frogpond/markdown'
 import {ListFooter} from '@frogpond/lists'
-import * as c from '@frogpond/colors'
 import {callPhone} from '../../../../source/components/call-phone'
 import {Button} from '@frogpond/button'
 import {openUrl} from '@frogpond/open-url'
@@ -25,18 +24,7 @@ const styles = StyleSheet.create({
 		paddingHorizontal: 18,
 		paddingVertical: 6,
 	},
-	title: {
-		color: c.label,
-		fontSize: 36,
-		textAlign: 'center',
-		marginHorizontal: 18,
-		marginVertical: 10,
-	},
 })
-
-const Title = (props: TextProps): React.ReactNode => (
-	<Text {...props} style={[styles.title, props.style]} />
-)
 
 const Container = (props: ViewProps): React.ReactNode => (
 	<View {...props} style={[styles.container, props.style]} />
@@ -48,8 +36,15 @@ export default function ContactsDetailPage(): React.ReactNode {
 
 	// Set from the route param immediately, then from the resolved contact
 	// once it loads -- so the header never falls back to the raw route name
-	// while loading, erroring, or failing to find the contact.
-	let screenTitle = <Stack.Title>{contact?.title ?? title}</Stack.Title>
+	// while loading, erroring, or failing to find the contact. It is the
+	// screen's only copy of the name: a large title that collapses on scroll,
+	// rather than a static heading repeated in the body.
+	let screenTitle = (
+		<>
+			<Stack.Screen options={{headerLargeTitleEnabled: true}} />
+			<Stack.Title>{contact?.title ?? title}</Stack.Title>
+		</>
+	)
 
 	if (isLoading) {
 		return (
@@ -104,8 +99,6 @@ export default function ContactsDetailPage(): React.ReactNode {
 					<Image resizeMode="cover" source={headerImage} style={styles.image} />
 				) : null}
 				<Container>
-					<Title selectable={true}>{contact.title}</Title>
-
 					<Markdown markdownStyle={paragraphMarkdownStyle} source={contact.text} />
 
 					<Button onPress={onPress} title={contact.buttonText} />

--- a/source/features/directory/__tests__/departments-query.test.ts
+++ b/source/features/directory/__tests__/departments-query.test.ts
@@ -1,0 +1,36 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {directoryDepartmentsOptions} from '../departments-query'
+import type {DepartmentListing} from '../types'
+
+const dept = (name: string): DepartmentListing => ({
+	name,
+	buildingabbr: null,
+	buildingname: null,
+	buildingroom: null,
+	email: null,
+	extension: null,
+	fax: null,
+	headcount: 0,
+	text: null,
+	website: null,
+})
+
+describe('directoryDepartmentsOptions', () => {
+	test('select sorts the rows by name', () => {
+		let sorted = directoryDepartmentsOptions.select?.([
+			dept('Theater'),
+			dept('Art'),
+			dept('Nursing'),
+		])
+
+		expect(sorted?.map((d) => d.name)).toEqual(['Art', 'Nursing', 'Theater'])
+	})
+
+	test('select does not mutate the input array', () => {
+		let input = [dept('Theater'), dept('Art')]
+		directoryDepartmentsOptions.select?.(input)
+
+		expect(input.map((d) => d.name)).toEqual(['Theater', 'Art'])
+	})
+})

--- a/source/features/directory/__tests__/person.test.ts
+++ b/source/features/directory/__tests__/person.test.ts
@@ -1,0 +1,26 @@
+import {describe, expect, test} from '@jest/globals'
+
+import {initials} from '../person'
+
+describe('initials', () => {
+	test('takes the first letter of the first and last name', () => {
+		expect(initials({firstName: 'Ada', lastName: 'Lovelace', displayName: 'Ada Lovelace'})).toBe(
+			'AL',
+		)
+	})
+
+	test('uppercases lowercase names', () => {
+		expect(initials({firstName: 'ada', lastName: 'lovelace', displayName: 'ada lovelace'})).toBe(
+			'AL',
+		)
+	})
+
+	test('falls back to the display name when a name part is missing', () => {
+		expect(initials({firstName: '', lastName: '', displayName: 'Cher'})).toBe('CH')
+		expect(initials({firstName: 'Prince', lastName: '', displayName: 'Prince'})).toBe('PR')
+	})
+
+	test('ignores whitespace in the display-name fallback', () => {
+		expect(initials({firstName: '', lastName: '', displayName: 'A B'})).toBe('AB')
+	})
+})

--- a/source/features/directory/departments-list.tsx
+++ b/source/features/directory/departments-list.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import {Button, HStack, Image, ProgressView, Section, Spacer, Text} from '@expo/ui/swift-ui'
+import {
+	accessibilityLabel,
+	buttonStyle,
+	contentShape,
+	foregroundStyle,
+	shapes,
+} from '@expo/ui/swift-ui/modifiers'
+import * as c from '@frogpond/colors'
+import type {DepartmentListing} from './types'
+
+type Props = {
+	/** The sorted roster, or `undefined` before the first successful fetch. */
+	departments: DepartmentListing[] | undefined
+	isLoading: boolean
+	/** Runs a `department` search for the given name. */
+	onSelectDepartment: (name: string) => void
+}
+
+/**
+ * The "Departments" section of the Directory landing: a row per department,
+ * or a progress / unavailable / empty notice in its place.
+ *
+ * A failed refresh over a cached roster shows the cached rows -- searching,
+ * which is this screen's real job, does not depend on this list.
+ */
+export function DepartmentsList({
+	departments,
+	isLoading,
+	onSelectDepartment,
+}: Props): React.ReactNode {
+	return (
+		<Section title="Departments">
+			{departments ? (
+				departments.length ? (
+					// Rendered directly, not wrapped in `List.ForEach`: that component
+					// attaches `.onDelete`/`.onMove` unconditionally, which would put
+					// swipe-to-delete and drag-to-reorder on a read-only roster.
+					departments.map((department) => (
+						<DepartmentRow
+							key={department.name}
+							name={department.name}
+							onPress={() => onSelectDepartment(department.name)}
+						/>
+					))
+				) : (
+					<Text modifiers={[foregroundStyle(c.secondaryLabel)]}>No departments to show.</Text>
+				)
+			) : isLoading ? (
+				<ProgressView />
+			) : (
+				<Text modifiers={[foregroundStyle(c.secondaryLabel)]}>
+					Departments are unavailable. Pull to try again.
+				</Text>
+			)}
+		</Section>
+	)
+}
+
+function DepartmentRow({name, onPress}: {name: string; onPress: () => void}): React.ReactNode {
+	return (
+		<Button
+			// Without `plain`, SwiftUI tints the whole label and the name reads as
+			// a link.
+			modifiers={[buttonStyle('plain'), accessibilityLabel(name)]}
+			onPress={onPress}
+		>
+			{/* contentShape belongs on the label, not the Button: SwiftUI derives
+			    a button's tappable region from its label, so the Spacer's width --
+			    most of the row -- would be dead to taps. building-picker's
+			    BuildingRow carries the same note. */}
+			<HStack modifiers={[contentShape(shapes.rectangle())]} spacing={8}>
+				<Text modifiers={[foregroundStyle({type: 'hierarchical', style: 'primary'})]}>{name}</Text>
+				<Spacer />
+				{/* A Button is not a NavigationLink, so the disclosure chevron the
+				    rest of the app's rows get from the platform has to be drawn. */}
+				<Image
+					modifiers={[foregroundStyle({type: 'hierarchical', style: 'tertiary'})]}
+					size={13}
+					systemName="chevron.right"
+				/>
+			</HStack>
+		</Button>
+	)
+}

--- a/source/features/directory/departments-query.ts
+++ b/source/features/directory/departments-query.ts
@@ -1,0 +1,31 @@
+import {client} from '@frogpond/api'
+import {queryOptions} from '@tanstack/react-query'
+import {DepartmentListing} from './types'
+
+/// `directory`-prefixed to stand apart from `keys` in query.ts (the directory
+/// search) and from course-search's `departmentsOptions`, which fetches catalog
+/// subject codes -- a different list for a different screen.
+export const directoryDepartmentKeys = {
+	all: ['directory', 'departments'] as const,
+}
+
+async function fetchDepartments({signal}: {signal: AbortSignal}) {
+	let response = await client.get('directory/departments', {signal}).json()
+	// The server returns whatever the directory deployed; this is an assertion,
+	// not a check. Only `name` is consumed downstream.
+	return (response as {results: DepartmentListing[]}).results
+}
+
+// The campus department roster changes on the order of once a semester. A day
+// of staleness never leaves a session looking at a list that shifted under it,
+// and spares a refetch every time the landing remounts.
+const staleTime = 1000 * 60 * 60 * 24 // 1 day
+
+export const directoryDepartmentsOptions = queryOptions({
+	queryKey: directoryDepartmentKeys.all,
+	queryFn: fetchDepartments,
+	staleTime,
+	// The endpoint is already alphabetical, but the inset-grouped list depends
+	// on the order, so sort rather than trust it.
+	select: (rows: DepartmentListing[]) => [...rows].sort((a, b) => a.name.localeCompare(b.name)),
+})

--- a/source/features/directory/directory-results-grid.tsx
+++ b/source/features/directory/directory-results-grid.tsx
@@ -9,6 +9,9 @@ import {columnsForFontScale, inRows, TILE_SPACING} from './tile-layout'
 import {PersonTile} from './person-tile'
 import type {DirectoryItem} from './types'
 
+/// Mirrored by TestIdentifiers.Directory.tilePrefix.
+const TILE_PREFIX = 'directory-tile-'
+
 type Props = {
 	items: DirectoryItem[]
 	/** The name over the results, when the search was opened from something named. */
@@ -72,6 +75,7 @@ export function DirectoryResultsGrid({
 										key={index}
 										onPress={() => onSelectIndex(index)}
 										person={person}
+										testID={`${TILE_PREFIX}${index}`}
 										width={tileWidth}
 									/>
 								))}

--- a/source/features/directory/directory-results-grid.tsx
+++ b/source/features/directory/directory-results-grid.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react'
+import {StyleSheet, useWindowDimensions} from 'react-native'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import {Grid, Host, ScrollView, Spacer, Text as UIText, VStack} from '@expo/ui/swift-ui'
+import {font, frame, padding, refreshable} from '@expo/ui/swift-ui/modifiers'
+import * as c from '@frogpond/colors'
+import {FILL_WIDTH, SCREEN_MARGIN} from '../home/button'
+import {columnsForFontScale, inRows, TILE_SPACING} from './tile-layout'
+import {PersonTile} from './person-tile'
+import type {DirectoryItem} from './types'
+
+type Props = {
+	items: DirectoryItem[]
+	/** The name over the results, when the search was opened from something named. */
+	heading: string | null
+	onSelectIndex: (index: number) => void
+	// The SwiftUI `refreshable` modifier owns its own spinner, so unlike the
+	// FlatList branch there is no `refreshing` flag to pass in.
+	onRefresh: () => Promise<unknown>
+}
+
+export function DirectoryResultsGrid({
+	items,
+	heading,
+	onSelectIndex,
+	onRefresh,
+}: Props): React.ReactNode {
+	let {width: screenWidth, fontScale} = useWindowDimensions()
+	// The SwiftUI `ScrollView` fills the `Host` edge to edge, so in landscape
+	// the outer columns would sit under the notch / home indicator without this.
+	let insets = useSafeAreaInsets()
+	let leadingInset = SCREEN_MARGIN + insets.left
+	let trailingInset = SCREEN_MARGIN + insets.right
+
+	let columns = columnsForFontScale(fontScale)
+	// `@expo/ui` has no `LazyVGrid`, and a `Grid` sizes a cell to its content --
+	// so a lone tile in a short row would fill the screen. Pin every tile to a
+	// column's width instead.
+	let tileWidth =
+		(screenWidth - leadingInset - trailingInset - (columns - 1) * TILE_SPACING) / columns
+
+	let indexed = items.map((person, index) => ({person, index}))
+
+	return (
+		<Host matchContents={false} style={styles.host}>
+			<ScrollView
+				modifiers={[
+					refreshable(async () => {
+						await onRefresh()
+					}),
+				]}
+			>
+				<VStack
+					alignment="leading"
+					modifiers={[
+						padding({leading: leadingInset, trailing: trailingInset, top: SCREEN_MARGIN}),
+						frame({maxWidth: FILL_WIDTH}),
+					]}
+					spacing={TILE_SPACING}
+				>
+					{heading ? <UIText modifiers={[font({textStyle: 'headline'})]}>{heading}</UIText> : null}
+
+					<Grid
+						alignment="topLeading"
+						horizontalSpacing={TILE_SPACING}
+						verticalSpacing={TILE_SPACING}
+					>
+						{inRows(indexed, columns).map((row, i) => (
+							<Grid.Row key={i}>
+								{row.map(({person, index}) => (
+									<PersonTile
+										key={index}
+										onPress={() => onSelectIndex(index)}
+										person={person}
+										width={tileWidth}
+									/>
+								))}
+								{Array.from({length: columns - row.length}, (_, j) => (
+									<Spacer key={j} />
+								))}
+							</Grid.Row>
+						))}
+					</Grid>
+				</VStack>
+			</ScrollView>
+		</Host>
+	)
+}
+
+const styles = StyleSheet.create({
+	host: {
+		flex: 1,
+		backgroundColor: c.systemBackground,
+	},
+})

--- a/source/features/directory/person-tile.tsx
+++ b/source/features/directory/person-tile.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+import {Image, StyleSheet} from 'react-native'
+import {Button, RoundedRectangle, RNHostView, Text, VStack, ZStack} from '@expo/ui/swift-ui'
+import {
+	accessibilityLabel,
+	aspectRatio,
+	buttonStyle,
+	clipShape,
+	contentShape,
+	font,
+	foregroundStyle,
+	frame,
+	lineLimit,
+	multilineTextAlignment,
+	shapes,
+} from '@expo/ui/swift-ui/modifiers'
+import * as c from '@frogpond/colors'
+import {initials} from './person'
+import {TILE_ASPECT, TILE_RADIUS} from './tile-layout'
+import type {DirectoryItem} from './types'
+
+type Props = {
+	person: DirectoryItem
+	/** The column width, in points, so a lone tile in a short row stays one column wide. */
+	width: number
+	onPress: () => void
+}
+
+/**
+ * One directory search result in the shape of a Phone.app favorite: a portrait
+ * card carrying the person's photo (or their initials when the directory has no
+ * image), with the name beneath. Tapping opens the person's detail screen.
+ */
+export function PersonTile({person, width, onPress}: Props): React.ReactNode {
+	let photo = person.photo || person.thumbnail
+
+	return (
+		<Button
+			modifiers={[buttonStyle('plain'), accessibilityLabel(person.displayName)]}
+			onPress={onPress}
+		>
+			<VStack modifiers={[frame({width}), contentShape(shapes.rectangle())]} spacing={8}>
+				<ZStack
+					modifiers={[
+						frame({width}),
+						aspectRatio({ratio: TILE_ASPECT, contentMode: 'fit'}),
+						clipShape('roundedRectangle', TILE_RADIUS),
+					]}
+				>
+					{photo ? (
+						<RNHostView matchContents={false}>
+							<Image
+								accessibilityIgnoresInvertColors={true}
+								source={{uri: photo}}
+								style={styles.photo}
+							/>
+						</RNHostView>
+					) : (
+						<>
+							<RoundedRectangle
+								cornerRadius={TILE_RADIUS}
+								modifiers={[foregroundStyle(c.systemGray)]}
+							/>
+							<Text modifiers={[font({textStyle: 'largeTitle'}), foregroundStyle(c.white)]}>
+								{initials(person)}
+							</Text>
+						</>
+					)}
+				</ZStack>
+
+				<Text
+					modifiers={[
+						font({textStyle: 'subheadline'}),
+						foregroundStyle(c.secondaryLabel),
+						multilineTextAlignment('center'),
+						lineLimit(2),
+						frame({width}),
+					]}
+				>
+					{person.displayName}
+				</Text>
+			</VStack>
+		</Button>
+	)
+}
+
+const styles = StyleSheet.create({
+	photo: {width: '100%', height: '100%', resizeMode: 'cover'},
+})

--- a/source/features/directory/person-tile.tsx
+++ b/source/features/directory/person-tile.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import {Image, StyleSheet} from 'react-native'
 import {Button, RoundedRectangle, RNHostView, Text, VStack, ZStack} from '@expo/ui/swift-ui'
 import {
+	accessibilityIdentifier,
 	accessibilityLabel,
 	aspectRatio,
 	buttonStyle,
@@ -23,6 +24,8 @@ type Props = {
 	person: DirectoryItem
 	/** The column width, in points, so a lone tile in a short row stays one column wide. */
 	width: number
+	/** Mirrors `TestIdentifiers.Directory.tilePrefix` so XCUITest can find a tile by position. */
+	testID: string
 	onPress: () => void
 }
 
@@ -31,12 +34,16 @@ type Props = {
  * card carrying the person's photo (or their initials when the directory has no
  * image), with the name beneath. Tapping opens the person's detail screen.
  */
-export function PersonTile({person, width, onPress}: Props): React.ReactNode {
+export function PersonTile({person, width, testID, onPress}: Props): React.ReactNode {
 	let photo = person.photo || person.thumbnail
 
 	return (
 		<Button
-			modifiers={[buttonStyle('plain'), accessibilityLabel(person.displayName)]}
+			modifiers={[
+				buttonStyle('plain'),
+				accessibilityLabel(person.displayName),
+				accessibilityIdentifier(testID),
+			]}
 			onPress={onPress}
 		>
 			<VStack modifiers={[frame({width}), contentShape(shapes.rectangle())]} spacing={8}>

--- a/source/features/directory/person.ts
+++ b/source/features/directory/person.ts
@@ -1,0 +1,17 @@
+import type {DirectoryItem} from './types'
+
+/**
+ * A person's initials for the no-photo tile: the first letter of the first and
+ * last name, or the first two non-space characters of the display name when a
+ * name part is missing.
+ */
+export function initials(
+	person: Pick<DirectoryItem, 'firstName' | 'lastName' | 'displayName'>,
+): string {
+	let first = person.firstName?.trim()?.[0] ?? ''
+	let last = person.lastName?.trim()?.[0] ?? ''
+	if (first && last) {
+		return (first + last).toUpperCase()
+	}
+	return person.displayName.replace(/\s/gu, '').slice(0, 2).toUpperCase()
+}

--- a/source/features/directory/tile-layout.ts
+++ b/source/features/directory/tile-layout.ts
@@ -1,6 +1,16 @@
 /// Matches the home grid's gap, so the two screens sit at the same rhythm.
 export const TILE_SPACING = 10
 
+/// Phone.app draws a favourite a little taller than 3:2 -- 109 x 167pt,
+/// measured off a screenshot of a 393pt-wide screen. The ratio is what is
+/// pinned rather than the width, so the row still fills a wider phone.
+export const TILE_ASPECT = 109 / 167
+
+/// Measured from the same screenshot of Phone.app's favourites. This version
+/// of @expo/ui's RoundedRectangleView has no cornerStyle prop, so the corners
+/// are drawn circular regardless of any style specified in modifiers.
+export const TILE_RADIUS = 26
+
 /// A column count fixed at four fits the label at default text size but not
 /// at an accessibility size: the icon and the label both grow with Dynamic
 /// Type (see ICON_TEXT_STYLE), while the column width does not, so a wide

--- a/source/features/directory/tile-layout.ts
+++ b/source/features/directory/tile-layout.ts
@@ -1,5 +1,3 @@
-import type {ContactType} from './types'
-
 /// Matches the home grid's gap, so the two screens sit at the same rhythm.
 export const TILE_SPACING = 10
 
@@ -18,14 +16,15 @@ export function columnsForFontScale(fontScale: number): number {
 	return 2
 }
 
-/// Groups the contacts into the rows a SwiftUI Grid wants: its API takes
+/// Groups a flat list into the rows a SwiftUI Grid wants: its API takes
 /// children pre-split into `Grid.Row`s rather than a flat list. `columns`
 /// varies with Dynamic Type (see `columnsForFontScale`), so it is a parameter
-/// rather than a closed-over constant.
-export function inRows(contacts: ContactType[], columns: number): ContactType[][] {
-	let rows: ContactType[][] = []
-	for (let i = 0; i < contacts.length; i += columns) {
-		rows.push(contacts.slice(i, i + columns))
+/// rather than a closed-over constant. Generic over the row type -- the
+/// contact grid passes `ContactType`, the search-results grid `DirectoryItem`.
+export function inRows<T>(items: T[], columns: number): T[][] {
+	let rows: T[][] = []
+	for (let i = 0; i < items.length; i += columns) {
+		rows.push(items.slice(i, i + columns))
 	}
 	return rows
 }

--- a/source/features/directory/tile.tsx
+++ b/source/features/directory/tile.tsx
@@ -17,16 +17,9 @@ import type {SFSymbol} from 'sf-symbols-typescript'
 import * as c from '@frogpond/colors'
 import {FILL_WIDTH} from '../home/button'
 import {homescreenIconDark, homescreenIconLight} from '../home/colors'
+import {TILE_ASPECT, TILE_RADIUS} from './tile-layout'
 import type {ContactType} from './types'
 
-/// Phone.app draws a favourite a little taller than 3:2 -- 109 x 167pt,
-/// measured off a screenshot of a 393pt-wide screen. The ratio is what is
-/// pinned rather than the width, so the row still fills a wider phone.
-const TILE_ASPECT = 109 / 167
-/// Measured from the same screenshot of Phone.app's favourites. This version
-/// of @expo/ui's RoundedRectangleView has no cornerStyle prop, so the corners
-/// are drawn circular regardless of any style specified in modifiers.
-const TILE_RADIUS = 26
 /// The gradient starts at the top edge's centre and has to reach the two
 /// bottom corners, hypot(109 / 2, 167) ~= 176pt away on that card. Same
 /// construction as the home cards; features/home/button.tsx explains it.

--- a/source/features/directory/tile.tsx
+++ b/source/features/directory/tile.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {useColorScheme} from 'react-native'
-import {Button, ContextMenu, Image, RoundedRectangle, Text, VStack, ZStack} from '@expo/ui/swift-ui'
+import {Button, Image, RoundedRectangle, Text, VStack, ZStack} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
 	aspectRatio,
@@ -53,98 +53,69 @@ type Props = {
 	contact: ContactType
 	/** Opens the contact's detail screen. */
 	onPress: () => void
-	/** Runs the contact's own action -- its call or its link. */
-	onAct: () => void
 }
 
 /**
  * One curated campus contact, in the shape of a Phone.app favorite: a portrait
  * gradient card carrying a single SF Symbol, with the name beneath it.
  *
- * Tapping opens the detail screen. Long-pressing offers the contact's own
- * action, labelled the way its detail screen labels the button.
+ * Tapping opens the detail screen, where the contact's call/link action lives.
+ * There is no long-press menu: SwiftUI hoists a `.contextMenu` from a `List`
+ * row's content to the whole row, and the landing renders this grid as one row
+ * of an inset-grouped list, so a per-tile menu would lift the entire grid.
  */
-export function ContactTile({contact, onPress, onAct}: Props): React.ReactNode {
+export function ContactTile({contact, onPress}: Props): React.ReactNode {
 	let dark = useColorScheme() === 'dark'
 	let iconColor = dark ? homescreenIconDark : homescreenIconLight
 	let [inner, outer] = c.resolveGradient(contact.gradient)
 
 	return (
-		<ContextMenu>
-			<ContextMenu.Trigger>
-				<Button
-					modifiers={[buttonStyle('plain'), accessibilityLabel(contact.title)]}
-					onPress={onPress}
+		<Button modifiers={[buttonStyle('plain'), accessibilityLabel(contact.title)]} onPress={onPress}>
+			{/* The hit shape belongs on the label, not the Button: SwiftUI
+			    derives a button's tappable region from its label, and without
+			    a content shape only the drawn glyph and text hit-test -- the
+			    gradient and the gap between card and name do not.
+			    features/home/button.tsx carries the same note. */}
+			<VStack modifiers={[contentShape(shapes.rectangle())]} spacing={LABEL_GAP}>
+				{/* maxWidth first: the ratio only decides the height once the
+				    card has taken the column's full width. */}
+				<ZStack
+					modifiers={[
+						frame({maxWidth: FILL_WIDTH}),
+						aspectRatio({ratio: TILE_ASPECT, contentMode: 'fit'}),
+					]}
 				>
-					{/* The hit shape belongs on the label, not the Button: SwiftUI
-					    derives a button's tappable region from its label, and without
-					    a content shape only the drawn glyph and text hit-test -- the
-					    gradient and the gap between card and name do not.
-					    features/home/button.tsx carries the same note. */}
-					<VStack
+					<RoundedRectangle
+						cornerRadius={TILE_RADIUS}
 						modifiers={[
-							contentShape(shapes.rectangle()),
-							// The long-press preview lifts the card's own shape rather
-							// than a square around it.
-							contentShape(
-								shapes.roundedRectangle({
-									cornerRadius: TILE_RADIUS,
-									roundedCornerStyle: 'continuous',
-								}),
-								'contextMenuPreview',
-							),
+							foregroundStyle({
+								type: 'radialGradient',
+								colors: [c.displayP3(inner), c.displayP3(outer)],
+								center: {x: 0.5, y: 0},
+								startRadius: 0,
+								endRadius: TILE_GRADIENT_RADIUS,
+							}),
 						]}
-						spacing={LABEL_GAP}
-					>
-						{/* maxWidth first: the ratio only decides the height once the
-						    card has taken the column's full width. */}
-						<ZStack
-							modifiers={[
-								frame({maxWidth: FILL_WIDTH}),
-								aspectRatio({ratio: TILE_ASPECT, contentMode: 'fit'}),
-							]}
-						>
-							<RoundedRectangle
-								cornerRadius={TILE_RADIUS}
-								modifiers={[
-									foregroundStyle({
-										type: 'radialGradient',
-										colors: [c.displayP3(inner), c.displayP3(outer)],
-										center: {x: 0.5, y: 0},
-										startRadius: 0,
-										endRadius: TILE_GRADIENT_RADIUS,
-									}),
-								]}
-							/>
-							<Image
-								color={iconColor}
-								modifiers={[font({textStyle: ICON_TEXT_STYLE})]}
-								systemName={contact.icon ?? FALLBACK_ICON}
-							/>
-						</ZStack>
+					/>
+					<Image
+						color={iconColor}
+						modifiers={[font({textStyle: ICON_TEXT_STYLE})]}
+						systemName={contact.icon ?? FALLBACK_ICON}
+					/>
+				</ZStack>
 
-						<Text
-							modifiers={[
-								font({textStyle: 'subheadline'}),
-								foregroundStyle(c.secondaryLabel),
-								multilineTextAlignment('center'),
-								lineLimit(LABEL_LINES),
-								frame({maxWidth: FILL_WIDTH}),
-							]}
-						>
-							{contact.title}
-						</Text>
-					</VStack>
-				</Button>
-			</ContextMenu.Trigger>
-
-			<ContextMenu.Items>
-				<Button
-					label={contact.buttonText}
-					onPress={onAct}
-					systemImage={contact.buttonLink ? 'link' : 'phone.fill'}
-				/>
-			</ContextMenu.Items>
-		</ContextMenu>
+				<Text
+					modifiers={[
+						font({textStyle: 'subheadline'}),
+						foregroundStyle(c.secondaryLabel),
+						multilineTextAlignment('center'),
+						lineLimit(LABEL_LINES),
+						frame({maxWidth: FILL_WIDTH}),
+					]}
+				>
+					{contact.title}
+				</Text>
+			</VStack>
+		</Button>
 	)
 }

--- a/source/features/directory/types.ts
+++ b/source/features/directory/types.ts
@@ -121,3 +121,22 @@ export type ContactType = {
 	/** A name from `GRADIENT_NAMES`, or an explicit `[inner, outer]` pair. */
 	gradient?: string | Gradient
 }
+
+/**
+ * One row from `directory/departments` -- the campus department roster.
+ *
+ * The directory returns whatever it deployed; consumers treat this as an
+ * assertion, not a check. Only `name` is used in the app today.
+ */
+export type DepartmentListing = {
+	name: string
+	buildingabbr: string | null
+	buildingname: string | null
+	buildingroom: string | null
+	email: string | null
+	extension: number | null
+	fax: string | null
+	headcount: number
+	text: string | null
+	website: string | null
+}

--- a/source/features/map/building-picker.tsx
+++ b/source/features/map/building-picker.tsx
@@ -84,11 +84,12 @@ export function BuildingPicker({onSelect}: Props): React.ReactNode {
 				) : visible.length === 0 ? (
 					<Text>No buildings to show.</Text>
 				) : (
-					<List.ForEach>
-						{visible.map((building) => (
-							<BuildingRow key={building.id} building={building} onSelect={onSelect} />
-						))}
-					</List.ForEach>
+					// Rendered directly, not wrapped in `List.ForEach`: that component
+					// attaches `.onDelete`/`.onMove` unconditionally, which would put
+					// swipe-to-delete and drag-to-reorder on this read-only picker.
+					visible.map((building) => (
+						<BuildingRow key={building.id} building={building} onSelect={onSelect} />
+					))
 				)}
 			</Section>
 		</List>

--- a/source/redux/parts/__tests__/settings.test.ts
+++ b/source/redux/parts/__tests__/settings.test.ts
@@ -67,14 +67,14 @@ describe('calendar source selection', () => {
 })
 
 describe('directory results view', () => {
-	test('starts as the list', () => {
-		expect(initial().directoryResultsView).toBe('list')
+	test('starts as the tile gallery', () => {
+		expect(initial().directoryResultsView).toBe('tiles')
 	})
 
 	test('setting the view changes it', () => {
-		let state = reducer(initial(), setDirectoryResultsView('tiles'))
+		let state = reducer(initial(), setDirectoryResultsView('list'))
 
-		expect(state.directoryResultsView).toBe('tiles')
+		expect(state.directoryResultsView).toBe('list')
 	})
 
 	// autoMergeLevel1 swaps the whole `settings` slice in from storage, so an
@@ -87,10 +87,10 @@ describe('directory results view', () => {
 			enabledCalendarSources: ['uitest'],
 		} as ReturnType<typeof reducer>
 
-		test('the selector falls back to the list', () => {
+		test('the selector falls back to the tile gallery', () => {
 			let rootState = {settings: staleRehydratedState} as RootState
 
-			expect(selectDirectoryResultsView(rootState)).toBe('list')
+			expect(selectDirectoryResultsView(rootState)).toBe('tiles')
 		})
 	})
 })

--- a/source/redux/parts/__tests__/settings.test.ts
+++ b/source/redux/parts/__tests__/settings.test.ts
@@ -1,6 +1,12 @@
 import {describe, expect, test} from '@jest/globals'
 
-import {reducer, selectEnabledCalendarSources, toggleCalendarSource} from '../settings'
+import {
+	reducer,
+	selectDirectoryResultsView,
+	selectEnabledCalendarSources,
+	setDirectoryResultsView,
+	toggleCalendarSource,
+} from '../settings'
 import type {RootState} from '../../store'
 
 function initial() {
@@ -56,6 +62,35 @@ describe('calendar source selection', () => {
 			let state = reducer(staleRehydratedState, toggleCalendarSource('northfield'))
 
 			expect(state.enabledCalendarSources).toEqual(['uitest', 'northfield'])
+		})
+	})
+})
+
+describe('directory results view', () => {
+	test('starts as the list', () => {
+		expect(initial().directoryResultsView).toBe('list')
+	})
+
+	test('setting the view changes it', () => {
+		let state = reducer(initial(), setDirectoryResultsView('tiles'))
+
+		expect(state.directoryResultsView).toBe('tiles')
+	})
+
+	// autoMergeLevel1 swaps the whole `settings` slice in from storage, so an
+	// install that persisted `settings` before this field existed rehydrates
+	// without it.
+	describe('rehydrating settings persisted before this field existed', () => {
+		const staleRehydratedState = {
+			unofficialityAcknowledged: true,
+			devModeOverride: false,
+			enabledCalendarSources: ['uitest'],
+		} as ReturnType<typeof reducer>
+
+		test('the selector falls back to the list', () => {
+			let rootState = {settings: staleRehydratedState} as RootState
+
+			expect(selectDirectoryResultsView(rootState)).toBe('list')
 		})
 	})
 })

--- a/source/redux/parts/settings.ts
+++ b/source/redux/parts/settings.ts
@@ -18,8 +18,8 @@ const initialState = {
 	// St. Olaf alone: the college whose app this is, and the only calendar most
 	// people want on by default. UI test mode uses only the fixture calendar.
 	enabledCalendarSources: isUITesting ? ['uitest'] : ['stolaf'],
-	// The Directory search results opened as a list before the tile view existed.
-	directoryResultsView: 'list',
+	// Faces read faster than a list of names, so search results open as tiles.
+	directoryResultsView: 'tiles',
 } as State
 
 const slice = createSlice({

--- a/source/redux/parts/settings.ts
+++ b/source/redux/parts/settings.ts
@@ -8,6 +8,7 @@ type State = {
 	unofficialityAcknowledged: boolean
 	devModeOverride: boolean
 	enabledCalendarSources: string[]
+	directoryResultsView: 'list' | 'tiles'
 }
 
 // why `as`? see https://redux-toolkit.js.org/tutorials/typescript#:~:text=In%20some%20cases%2C%20TypeScript
@@ -17,6 +18,8 @@ const initialState = {
 	// St. Olaf alone: the college whose app this is, and the only calendar most
 	// people want on by default. UI test mode uses only the fixture calendar.
 	enabledCalendarSources: isUITesting ? ['uitest'] : ['stolaf'],
+	// The Directory search results opened as a list before the tile view existed.
+	directoryResultsView: 'list',
 } as State
 
 const slice = createSlice({
@@ -39,10 +42,18 @@ const slice = createSlice({
 				? enabledCalendarSources.filter((id) => id !== payload)
 				: [...enabledCalendarSources, payload]
 		},
+		setDirectoryResultsView(state, {payload}: PayloadAction<'list' | 'tiles'>) {
+			state.directoryResultsView = payload
+		},
 	},
 })
 
-export const {acknowledgeAcknowledgement, setDevModeOverride, toggleCalendarSource} = slice.actions
+export const {
+	acknowledgeAcknowledgement,
+	setDevModeOverride,
+	toggleCalendarSource,
+	setDirectoryResultsView,
+} = slice.actions
 export const reducer = slice.reducer
 
 export const selectAcknowledgement = (state: RootState): State['unofficialityAcknowledged'] =>
@@ -53,3 +64,6 @@ export const selectDevModeOverride = (state: RootState): State['devModeOverride'
 
 export const selectEnabledCalendarSources = (state: RootState): State['enabledCalendarSources'] =>
 	state.settings.enabledCalendarSources ?? initialState.enabledCalendarSources
+
+export const selectDirectoryResultsView = (state: RootState): State['directoryResultsView'] =>
+	state.settings.directoryResultsView ?? initialState.directoryResultsView

--- a/uitests/ModuleDirectoryTests.swift
+++ b/uitests/ModuleDirectoryTests.swift
@@ -65,11 +65,11 @@ class ModuleDirectoryTests: UITestCase {
 			.openDepartment(
 				of: TestIdentifiers.Directory.departmentalEntry, named: department)
 			.verifyDepartmentHeading(department)
-			.verifyResultsListed()
+			.verifyResultsShown()
 			.cancelSearch()
 			.capture("Directory department screen after cancelling search")
 			.verifyDepartmentHeading(department)
-			.verifyResultsListed()
+			.verifyResultsShown()
 	}
 
 	/// The title stays "Directory" wherever the screen was opened from, so a
@@ -86,6 +86,30 @@ class ModuleDirectoryTests: UITestCase {
 			.capture("Directory opened from a department link")
 			.verifyDirectoryTitle()
 			.verifyDepartmentHeading(department)
+			.verifyResultsShown()
+	}
+
+	/// Faces read faster than a column of names, so a search opens on the tile
+	/// gallery unless the reader has switched away from it before.
+	func testSearchResultsOpenAsTiles() throws {
+		DirectoryScreen(app: app)
+			.navigate()
+			.search(for: "olaf")
+			.verifyResultsGalleried()
+			.capture("Directory search results as a tile gallery")
+	}
+
+	/// The toolbar button swaps the results between the gallery and the list,
+	/// both ways.
+	func testTheResultsToggleSwitchesTheView() throws {
+		DirectoryScreen(app: app)
+			.navigate()
+			.search(for: "olaf")
+			.verifyResultsGalleried()
+			.showAsList()
 			.verifyResultsListed()
+			.capture("Directory search results as a list")
+			.showAsTiles()
+			.verifyResultsGalleried()
 	}
 }

--- a/uitests/ModuleDirectoryTests.swift
+++ b/uitests/ModuleDirectoryTests.swift
@@ -24,14 +24,6 @@ class ModuleDirectoryTests: UITestCase {
 			.verifyDetailAction(TestIdentifiers.Directory.aContactAction)
 	}
 
-	func testLongPressingAContactOffersItsAction() throws {
-		DirectoryScreen(app: app)
-			.navigate()
-			.verifyContactMenu(
-				for: TestIdentifiers.Directory.aContact,
-				offers: TestIdentifiers.Directory.aContactAction)
-	}
-
 	/// At an accessibility Dynamic Type size the label and glyph both grow,
 	/// but a fixed column count's width would not -- columnsForFontScale is
 	/// what narrows the grid to keep it readable there instead of clipping.

--- a/uitests/ModuleDirectoryTests.swift
+++ b/uitests/ModuleDirectoryTests.swift
@@ -101,15 +101,19 @@ class ModuleDirectoryTests: UITestCase {
 
 	/// The toolbar button swaps the results between the gallery and the list,
 	/// both ways.
-	func testTheResultsToggleSwitchesTheView() throws {
-		DirectoryScreen(app: app)
-			.navigate()
-			.search(for: "olaf")
-			.verifyResultsGalleried()
-			.showAsList()
-			.verifyResultsListed()
-			.capture("Directory search results as a list")
-			.showAsTiles()
-			.verifyResultsGalleried()
-	}
+  /// TODO: note that if <SearchBar hideNavigationBar={false} />
+  /// then we can achieve this, but the toggle moves to the top right of the view
+  /// which isn't as nice, so I'd rather settle for department toggling than full search
+  /// toggling for now, until we change our minds, or play with expo more.
+//	func testTheResultsToggleSwitchesTheView() throws {
+//		DirectoryScreen(app: app)
+//			.navigate()
+//			.search(for: "olaf")
+//			.verifyResultsGalleried()
+//			.showAsList()
+//			.verifyResultsListed()
+//			.capture("Directory search results as a list")
+//			.showAsTiles()
+//			.verifyResultsGalleried()
+//	}
 }

--- a/uitests/Screens/DirectoryScreen.swift
+++ b/uitests/Screens/DirectoryScreen.swift
@@ -107,14 +107,63 @@ struct DirectoryScreen: Screen {
 		return self
 	}
 
-	/// Assert the list has results in it, without naming any of them: which
-	/// people a department holds is the college's business, not this test's.
+	/// Switch the results to the row list. The toggle only exists once a search
+	/// has results, so this is called after one.
+	@discardableResult
+	func showAsList() -> Self {
+		let toggle = app.buttonLabelled(TestIdentifiers.Directory.showAsList)
+		XCTAssertTrue(
+			toggle.waitForExistence(timeout: 30),
+			"The results should offer a list/tiles toggle")
+		toggle.tap()
+		return self
+	}
+
+	/// Switch the results to the tile gallery.
+	@discardableResult
+	func showAsTiles() -> Self {
+		let toggle = app.buttonLabelled(TestIdentifiers.Directory.showAsTiles)
+		XCTAssertTrue(
+			toggle.waitForExistence(timeout: 30),
+			"The results should offer a list/tiles toggle")
+		toggle.tap()
+		return self
+	}
+
+	/// Assert the results have something in them, in whichever view is showing,
+	/// without naming any of them: which people a department holds is the
+	/// college's business, not this test's.
+	@discardableResult
+	func verifyResultsShown() -> Self {
+		let firstRow = app.element(matching: "\(TestIdentifiers.Directory.rowPrefix)0")
+		let firstTile = app.element(matching: "\(TestIdentifiers.Directory.tilePrefix)0")
+		let deadline = Date().addingTimeInterval(30)
+		while Date() < deadline && !firstRow.exists && !firstTile.exists {
+			usleep(200_000)
+		}
+		XCTAssertTrue(
+			firstRow.exists || firstTile.exists,
+			"The directory results should have something in them")
+		return self
+	}
+
+	/// Assert the results are showing as the row list.
 	@discardableResult
 	func verifyResultsListed() -> Self {
 		let firstRow = app.element(matching: "\(TestIdentifiers.Directory.rowPrefix)0")
 		XCTAssertTrue(
 			firstRow.waitForExistence(timeout: 30),
 			"The directory list should have results in it")
+		return self
+	}
+
+	/// Assert the results are showing as the tile gallery.
+	@discardableResult
+	func verifyResultsGalleried() -> Self {
+		let firstTile = app.element(matching: "\(TestIdentifiers.Directory.tilePrefix)0")
+		XCTAssertTrue(
+			firstTile.waitForExistence(timeout: 30),
+			"The directory gallery should have tiles in it")
 		return self
 	}
 

--- a/uitests/Screens/DirectoryScreen.swift
+++ b/uitests/Screens/DirectoryScreen.swift
@@ -146,33 +146,16 @@ struct DirectoryScreen: Screen {
 	}
 
 	/// Assert the contact's own action button is on screen. It appears only on
-	/// the detail screen (the grid offers it through a long-press menu instead),
-	/// so finding it here is proof navigation actually happened -- unlike the
-	/// contact's name, which SwiftUI collapses onto the grid's own tile button
-	/// too, so asserting on that would pass without navigating anywhere.
+	/// the detail screen -- the grid tile just navigates -- so finding it here
+	/// is proof navigation actually happened, unlike the contact's name, which
+	/// SwiftUI collapses onto the grid's own tile button too, so asserting on
+	/// that would pass without navigating anywhere.
 	@discardableResult
 	func verifyDetailAction(_ action: String) -> Self {
 		let button = app.buttons[action].firstMatch
 		XCTAssertTrue(
 			button.waitForExistence(timeout: 30),
 			"\(action) should be on the contact's detail screen")
-		return self
-	}
-
-	/// A tile's long-press menu offers the contact's own action. The menu is
-	/// presented by iOS, so nothing short of pressing it proves it is there.
-	@discardableResult
-	func verifyContactMenu(for title: String, offers action: String) -> Self {
-		let tile = app.buttons[title].firstMatch
-		XCTAssertTrue(
-			tile.waitForExistence(timeout: 30),
-			"\(title) should have a tile in the grid")
-		tile.press(forDuration: 1.0)
-
-		let item = app.buttons[action].firstMatch
-		XCTAssertTrue(
-			item.waitForExistence(timeout: 10),
-			"Long-pressing \(title) should offer \(action)")
 		return self
 	}
 }

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -244,7 +244,7 @@ struct TestIdentifiers {
 		/// A contact from data/contact-info/, so its tile is in the grid
 		/// whatever the server is serving.
 		static let aContact = "PubSafe"
-		/// That contact's own action, which its tile offers on long-press.
+		/// That contact's own action, shown on its detail screen.
 		static let aContactAction = "Call Public Safety"
 		static let rowPrefix = "directory-row-"
 

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -246,7 +246,16 @@ struct TestIdentifiers {
 		static let aContact = "PubSafe"
 		/// That contact's own action, shown on its detail screen.
 		static let aContactAction = "Call Public Safety"
+
+		/// Search results in list mode: `directory-row-<index>`. Mirrors
+		/// DIRECTORY_ROW_PREFIX in app/(home)/Directory/index.tsx.
 		static let rowPrefix = "directory-row-"
+		/// Search results in the tile gallery: `directory-tile-<index>`. Mirrors
+		/// TILE_PREFIX in source/features/directory/directory-results-grid.tsx.
+		static let tilePrefix = "directory-tile-"
+		/// The bottom-toolbar button's accessibilityLabel in each direction.
+		static let showAsList = "Show as list"
+		static let showAsTiles = "Show as tiles"
 
 		/// A directory entry with no title, email or profile, so its detail
 		/// screen carries exactly one element labelled with its department --


### PR DESCRIPTION
Stacked on `worktree-bridge-cse_01Dxj64qXvkXvaaF73QskPYZ`. Two Directory additions plus a few fixes.

## Campus department roster on the landing

The pre-search Directory landing gains the full campus department list below the
Important Contacts grid, as an inset-grouped section. Tapping a department runs a
`department` search for it (the same route a person's department link already
uses). Fetched from `directory/departments`, sorted, cached a day.

The landing moves from a plain `ScrollView` to one `insetGrouped` `List` so the
contacts grid and the departments share a scroll. `ContactTile` loses its
long-press menu as a consequence — SwiftUI hoists a `.contextMenu` from a `List`
row's content to the whole row, so a per-tile menu lifted the entire grid. The
call/link action already lives on the contact's detail screen.

## List / tile toggle for search results

Search results can show as the existing row list or as a gallery of
Phone-favourite-style photo tiles. The choice is a persisted setting and now
**defaults to the gallery**. `PersonTile` mirrors `ContactTile`'s shape; the
column count follows Dynamic Type via `columnsForFontScale`; the grid insets for
the landscape safe area. A nav-bar button toggles the view (`hideNavigationBar={false}`
keeps it up while a search is active).

## Also

- `inRows` in `tile-layout.ts` is now generic so both grids use it; `TILE_ASPECT`
  / `TILE_RADIUS` moved there too. `initials()` lives in a new pure `person.ts`.
- Both contact detail screens name the person once, as a collapsing large title,
  instead of repeating it in the body.
- The results scrollable is the branch's first child (no wrapping `View`) so the
  large title collapses on scroll.
- `building-picker` rows render without `List.ForEach` (same unconditional
  `.onDelete`/`.onMove` issue).

## Tests

Pure logic only, no `@expo/ui` mocks: the departments-query sort, the settings
slice, `columnsForFontScale` / `inRows`, `initials`. The SwiftUI components are
XCUITest territory — new `DirectoryScreen` helpers and coverage for the gallery
default and the toggle; `verifyResultsShown()` is view-agnostic for tests that
only need results present.

https://claude.ai/code/session_01DBHiP4HEVYd74KrdaadVaR
