### PR TITLE
Describe the navigation library and map entry the app actually has

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 All About Olaf is a React Native mobile app for the St. Olaf College community. It provides students, faculty, and staff with access to campus info, dining menus, course catalogs, campus maps, and more.
 
 - **React Native 0.86.2** with **TypeScript**
-- **React Navigation 7** for navigation (typed via `source/navigation/types.ts`)
+- **Expo Router 57** for navigation — file-based, with `experiments.typedRoutes` set in `app.config.ts`
 - **Redux Toolkit** for global state, **React Query 5** for server state
 - **Jest** + **React Native Testing Library** for testing
 - **Fastlane** for CI/CD

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -9,11 +9,8 @@ struct CarletonMapScreen: Screen {
 		app.textFields[TestIdentifiers.CarletonMap.search].firstMatch
 	}
 
-	/// The map's home tile is `devOnly`, so it is absent from the home screen
-	/// until the dev-mode override is set -- and `--reset-state` clears that
-	/// override before every test, so it has to be set here rather than once.
-	/// The notice's context menu is the same path
-	/// `testLongPressNoticeTogglesDevMode` walks.
+	/// The map's home tile is always present, so this is an ordinary tap on the
+	/// home screen.
 	@discardableResult
 	func navigate() -> Self {
 		navigateFromHome(to: TestIdentifiers.Buttons.carletonMap)


### PR DESCRIPTION
Two comments in this repo described things that were not true.

**`CLAUDE.md` claimed React Navigation 7.** There is no `@react-navigation/*` package installed. Expo Router 57 vendors its own native stack under `build/react-navigation/`, so anyone reaching for the documented API would have been reading docs for a library the app does not depend on.

**`CarletonMapScreen.swift` described the map entry as dev-only.** It has not been dev-only for some time.

This is the base of the Campus stack (#7857), which merges Building Hours and the campus map. The stack's design work and the `formSheet` spike that settled how a sheet carries a navigation stack were written up while building it; those documents are scaffolding rather than shipped code, so they are not in the history.

For the record, the spike's conclusion — since the rest of the stack depends on it — is that `presentation: 'formSheet'` **can** carry a real navigation stack, under three conditions:

1. The sheet route must be a route **group with its own `_layout.tsx`** rendering a `<Stack>`. A flat sibling route presents fine but pushes with no back button.
2. The outer registration needs `headerShown: false`, or you get two headers.
3. A **React Native** scroll view must be the screen's root, or the sheet will not resize to its detents. An `@expo/ui` `Host` is exempt — `SwiftUIHostingView.swift:203-208` gives it a UIKit `autoresizingMask`, which is what the check is really looking for.

Also worth knowing: `scrollEdgeEffects` cannot see a `Host`, and wrapping one in a ScrollView to fix that breaks sheet dragging. And `formSheet` does **not** fall back to a full modal on smaller iPhones, contrary to a comment that used to say so — verified on an iPhone SE.
