### PR TITLE
Open a building's hours in a sheet

### DIFF
--- a/app/(home)/BuildingHours/detail/[name].tsx
+++ b/app/(home)/BuildingHours/detail/[name].tsx
@@ -41,6 +41,13 @@ export default function BuildingHoursDetailPage(): React.ReactNode {
 		<>
 			<Stack.Title>{building?.name ?? name}</Stack.Title>
 			<Stack.Screen options={{headerLargeTitle: true}} />
+			<Stack.Toolbar placement="left">
+				<Stack.Toolbar.Menu icon="ellipsis.circle">
+					<Stack.Toolbar.MenuAction icon="exclamationmark.bubble" onPress={reportProblem}>
+						Report a Problem
+					</Stack.Toolbar.MenuAction>
+				</Stack.Toolbar.Menu>
+			</Stack.Toolbar>
 			<Stack.Toolbar placement="right">
 				<Stack.Toolbar.Button icon={favorited ? 'heart.fill' : 'heart'} onPress={onFavorite} />
 			</Stack.Toolbar>
@@ -95,7 +102,7 @@ export default function BuildingHoursDetailPage(): React.ReactNode {
 	return (
 		<>
 			{screen}
-			<BuildingDetailSwiftUI building={building} now={now} onProblemReport={reportProblem} />
+			<BuildingDetailSwiftUI building={building} now={now} />
 		</>
 	)
 }

--- a/app/(home)/BuildingHours/detail/[name].tsx
+++ b/app/(home)/BuildingHours/detail/[name].tsx
@@ -4,14 +4,14 @@ import {useQuery} from '@tanstack/react-query'
 import {useMomentTimer} from '@frogpond/timer'
 import {timezone} from '@frogpond/constants'
 
-import {BuildingDetailSwiftUI} from '../../../source/features/building-hours/detail/building-detail'
-import {buildingByNameOptions} from '../../../source/features/building-hours/query'
+import {BuildingDetailSwiftUI} from '../../../../source/features/building-hours/detail/building-detail'
+import {buildingByNameOptions} from '../../../../source/features/building-hours/query'
 import {LoadingView, NoticeView} from '@frogpond/notice'
-import {useAppDispatch, useAppSelector} from '../../../source/redux/hooks'
+import {useAppDispatch, useAppSelector} from '../../../../source/redux/hooks'
 import {
 	selectFavoriteBuildings,
 	toggleFavoriteBuilding,
-} from '../../../source/redux/parts/buildings'
+} from '../../../../source/redux/parts/buildings'
 
 export default function BuildingHoursDetailPage(): React.ReactNode {
 	let dispatch = useAppDispatch()

--- a/app/(home)/BuildingHours/detail/[name].tsx
+++ b/app/(home)/BuildingHours/detail/[name].tsx
@@ -80,6 +80,18 @@ export default function BuildingHoursDetailPage(): React.ReactNode {
 		)
 	}
 
+	// This screen's root inside the formSheet is BuildingDetailSwiftUI's
+	// @expo/ui `Host`, not a React Native ScrollView -- the spike's "root
+	// element must be a scroll view" rule doesn't apply here. That rule exists
+	// because RNSScreenContentWrapper only knows how to manually resize a
+	// direct RCTScrollViewComponentView child when a sheet's detent changes
+	// natively, bypassing Fabric/Yoga entirely. `Host`'s hosting-controller
+	// view sidesteps that whole problem: expo-modules-core gives it a plain
+	// UIKit `autoresizingMask` (SwiftUIHostingView.swift), so it tracks its
+	// superview's frame through ordinary UIKit view geometry, independent of
+	// Fabric. Confirmed on device: dragging to the larger detent lays out the
+	// full detail screen, footnote included (see
+	// testDraggingTheDetailSheetRevealsTheRestOfItsContent).
 	return (
 		<>
 			{screen}

--- a/app/(home)/BuildingHours/detail/_layout.tsx
+++ b/app/(home)/BuildingHours/detail/_layout.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react'
+import {Stack} from 'expo-router'
+
+/**
+ * The detail sheet's own navigation stack.
+ *
+ * A formSheet route needs a stack of its own for its screens to get a back
+ * button — a flat sibling route pushed while the sheet is up renders inside it
+ * with no way back out.
+ */
+export default function BuildingHoursDetailLayout(): React.ReactNode {
+	return <Stack />
+}

--- a/app/(home)/BuildingHours/index.tsx
+++ b/app/(home)/BuildingHours/index.tsx
@@ -44,6 +44,15 @@ function BuildingHoursView(): React.ReactNode {
 		[router],
 	)
 
+	let onSelect = React.useCallback(
+		(building: BuildingType) =>
+			router.push({
+				pathname: '/BuildingHours/detail/[name]',
+				params: {name: building.name},
+			}),
+		[router],
+	)
+
 	// The search chrome is bound to component state (the change handler
 	// updates query), so it can't move to a static outer component.
 	// Compute it once and render it in every branch, so the user always
@@ -86,6 +95,7 @@ function BuildingHoursView(): React.ReactNode {
 				now={now}
 				onRefresh={refetch}
 				onReport={onReport}
+				onSelect={onSelect}
 				onToggleFavorite={onToggleFavorite}
 				searchQuery={searchQuery}
 				sections={sections}

--- a/app/(home)/_layout.tsx
+++ b/app/(home)/_layout.tsx
@@ -16,7 +16,11 @@ export default function HomeLayout(): React.ReactNode {
 					headerShown: false,
 					sheetAllowedDetents: [0.5, 0.999],
 					sheetGrabberVisible: true,
-					sheetLargestUndimmedDetentIndex: 'last',
+					// 'none' rather than 'last': the list behind has nothing worth
+					// touching once the sheet is up, and an undimmed detent lets UIKit
+					// pass taps through to it -- a second tap on another row would push
+					// a second detail sheet on top of the first.
+					sheetLargestUndimmedDetentIndex: 'none',
 				}}
 			/>
 			<Stack.Screen

--- a/app/(home)/_layout.tsx
+++ b/app/(home)/_layout.tsx
@@ -14,7 +14,9 @@ export default function HomeLayout(): React.ReactNode {
 				options={{
 					presentation: 'formSheet',
 					headerShown: false,
-					sheetAllowedDetents: [0.5, 0.999],
+					// Two thirds rather than a half: at a half the hours sat low enough
+					// that the sheet read as cramped.
+					sheetAllowedDetents: [0.68, 0.999],
 					sheetGrabberVisible: true,
 					// 'none' rather than 'last': the list behind has nothing worth
 					// touching once the sheet is up, and an undimmed detent lets UIKit

--- a/app/(home)/_layout.tsx
+++ b/app/(home)/_layout.tsx
@@ -10,6 +10,16 @@ export default function HomeLayout(): React.ReactNode {
 			<Stack.Screen name="Transportation" options={{title: 'Transportation'}} />
 			<Stack.Screen name="BuildingHours" />
 			<Stack.Screen
+				name="BuildingHours/detail"
+				options={{
+					presentation: 'formSheet',
+					headerShown: false,
+					sheetAllowedDetents: [0.5, 0.999],
+					sheetGrabberVisible: true,
+					sheetLargestUndimmedDetentIndex: 'last',
+				}}
+			/>
+			<Stack.Screen
 				name="BuildingHoursProblemReport"
 				options={{presentation: 'modal', gestureEnabled: false}}
 			/>

--- a/source/features/building-hours/detail/__tests__/building-detail.test.tsx
+++ b/source/features/building-hours/detail/__tests__/building-detail.test.tsx
@@ -39,17 +39,18 @@ function makeBuilding(overrides: Partial<BuildingType> = {}): BuildingType {
 }
 
 describe('BuildingDetailSwiftUI', () => {
-	// Regression test: a schedule's `notes` used to be handed straight to
-	// Section's `footer` prop, a bare string in a SwiftUI slot that crashes at
-	// mount. Every building with notes -- "The Cage" among them -- hit this on
-	// every render once the detail screen became reachable.
+	// Regression test: Section's `footer` is a SwiftUI slot, and handing it a
+	// bare string -- rather than wrapping it in `Text` -- crashes at mount.
+	// Every building with notes -- "The Cage" among them -- hit this on every
+	// render once the detail screen became reachable.
 	test('renders a schedule with notes without throwing', () => {
 		let building = makeBuilding()
 
 		expect(() => render(<BuildingDetailSwiftUI building={building} now={NOW} />)).not.toThrow()
 	})
 
-	test('renders a schedule with no notes without throwing', () => {
+	test('renders a schedule with no notes and skips the footer', async () => {
+		let noteText = 'The kitchen stops cooking at 8 p.m.'
 		let building = makeBuilding({
 			schedule: [
 				{
@@ -59,6 +60,11 @@ describe('BuildingDetailSwiftUI', () => {
 			],
 		})
 
-		expect(() => render(<BuildingDetailSwiftUI building={building} now={NOW} />)).not.toThrow()
+		let {queryByText} = await render(<BuildingDetailSwiftUI building={building} now={NOW} />)
+
+		// A schedule with no `notes` must pass `undefined` as Section's footer,
+		// not another schedule's text or a placeholder -- either mistake would
+		// leak content that was never meant for this section.
+		expect(queryByText(noteText)).toBeNull()
 	})
 })

--- a/source/features/building-hours/detail/__tests__/building-detail.test.tsx
+++ b/source/features/building-hours/detail/__tests__/building-detail.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import moment from 'moment-timezone'
+import {describe, expect, test} from '@jest/globals'
+import {render} from '@testing-library/react-native'
+
+import type {BuildingType} from '../../types'
+import {BuildingDetailSwiftUI} from '../building-detail'
+
+jest.mock('@expo/ui/swift-ui', () => {
+	// oxlint-disable-next-line typescript/no-require-imports
+	return require('./expo-ui-mock') as typeof import('./expo-ui-mock')
+})
+jest.mock('@expo/ui/swift-ui/modifiers', () => {
+	// oxlint-disable-next-line typescript/no-require-imports
+	return require('./expo-ui-mock') as typeof import('./expo-ui-mock')
+})
+jest.mock('@frogpond/open-url', () => ({openUrl: jest.fn()}))
+
+// images/spaces imports every building photo through Metro's @2x/@3x density
+// resolution, which Jest's resolver does not implement -- mocked here so this
+// suite isn't the one to first trip over that unrelated gap.
+jest.mock('../../../../../images/spaces', () => ({images: new Map()}))
+
+const NOW = moment('2026-09-07T12:00:00')
+
+function makeBuilding(overrides: Partial<BuildingType> = {}): BuildingType {
+	return {
+		name: 'The Cage',
+		category: 'Food',
+		schedule: [
+			{
+				title: 'Hours',
+				notes: 'The kitchen stops cooking at 8 p.m.',
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '7:30am', to: '8:00pm'}],
+			},
+		],
+		...overrides,
+	}
+}
+
+describe('BuildingDetailSwiftUI', () => {
+	// Regression test: a schedule's `notes` used to be handed straight to
+	// Section's `footer` prop, a bare string in a SwiftUI slot that crashes at
+	// mount. Every building with notes -- "The Cage" among them -- hit this on
+	// every render once the detail screen became reachable.
+	test('renders a schedule with notes without throwing', () => {
+		let building = makeBuilding()
+
+		expect(() =>
+			render(<BuildingDetailSwiftUI building={building} now={NOW} onProblemReport={jest.fn()} />),
+		).not.toThrow()
+	})
+
+	test('renders a schedule with no notes without throwing', () => {
+		let building = makeBuilding({
+			schedule: [
+				{
+					title: 'Hours',
+					hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '8:00am', to: '5:00pm'}],
+				},
+			],
+		})
+
+		expect(() =>
+			render(<BuildingDetailSwiftUI building={building} now={NOW} onProblemReport={jest.fn()} />),
+		).not.toThrow()
+	})
+})

--- a/source/features/building-hours/detail/__tests__/building-detail.test.tsx
+++ b/source/features/building-hours/detail/__tests__/building-detail.test.tsx
@@ -62,9 +62,10 @@ describe('BuildingDetailSwiftUI', () => {
 
 		let {queryByText} = await render(<BuildingDetailSwiftUI building={building} now={NOW} />)
 
-		// A schedule with no `notes` must pass `undefined` as Section's footer,
-		// not another schedule's text or a placeholder -- either mistake would
-		// leak content that was never meant for this section.
+		// A schedule with no `notes` must not render another schedule's note
+		// text as its footer. This only catches a footer that renders the wrong
+		// string; it can't tell `<Text>{undefined}</Text>` apart from omitting
+		// the ternary entirely, since both render nothing here.
 		expect(queryByText(noteText)).toBeNull()
 	})
 })

--- a/source/features/building-hours/detail/__tests__/building-detail.test.tsx
+++ b/source/features/building-hours/detail/__tests__/building-detail.test.tsx
@@ -46,9 +46,7 @@ describe('BuildingDetailSwiftUI', () => {
 	test('renders a schedule with notes without throwing', () => {
 		let building = makeBuilding()
 
-		expect(() =>
-			render(<BuildingDetailSwiftUI building={building} now={NOW} onProblemReport={jest.fn()} />),
-		).not.toThrow()
+		expect(() => render(<BuildingDetailSwiftUI building={building} now={NOW} />)).not.toThrow()
 	})
 
 	test('renders a schedule with no notes without throwing', () => {
@@ -61,8 +59,6 @@ describe('BuildingDetailSwiftUI', () => {
 			],
 		})
 
-		expect(() =>
-			render(<BuildingDetailSwiftUI building={building} now={NOW} onProblemReport={jest.fn()} />),
-		).not.toThrow()
+		expect(() => render(<BuildingDetailSwiftUI building={building} now={NOW} />)).not.toThrow()
 	})
 })

--- a/source/features/building-hours/detail/__tests__/expo-ui-mock.tsx
+++ b/source/features/building-hours/detail/__tests__/expo-ui-mock.tsx
@@ -29,15 +29,6 @@ export const background = modifier('background')
 export const buttonStyle = modifier('buttonStyle')
 export const listStyle = modifier('listStyle')
 
-/**
- * The label an `accessibilityLabel(…)` modifier asks for, which is what
- * VoiceOver -- and therefore `getByLabelText` -- would report natively.
- */
-function labelOf(modifiers?: Modifier[]): string | undefined {
-	let found = modifiers?.find((m) => m.$type === 'accessibilityLabel')
-	return typeof found?.label === 'string' ? found.label : undefined
-}
-
 export function Host({children}: WithModifiers): React.ReactNode {
 	return <View>{children}</View>
 }
@@ -58,16 +49,8 @@ export function Spacer(): React.ReactNode {
 	return null
 }
 
-/**
- * Decorative in every call site this module has, so the mock renders nothing
- * rather than a text node that would confuse a query for the text beside it.
- */
-export function Image(): React.ReactNode {
-	return null
-}
-
-export function Text({children, modifiers}: WithModifiers): React.ReactNode {
-	return <RNText accessibilityLabel={labelOf(modifiers)}>{children}</RNText>
+export function Text({children}: WithModifiers): React.ReactNode {
+	return <RNText>{children}</RNText>
 }
 
 /**
@@ -108,16 +91,11 @@ export function Section({
  */
 export function Button({
 	children,
-	modifiers,
 	onPress,
 }: WithModifiers & {onPress?: () => void}): React.ReactNode {
 	if (typeof children === 'string') {
 		throw new Error('Button children must be nested elements, not a plain string')
 	}
 
-	return (
-		<Pressable accessibilityLabel={labelOf(modifiers)} onPress={onPress}>
-			{children}
-		</Pressable>
-	)
+	return <Pressable onPress={onPress}>{children}</Pressable>
 }

--- a/source/features/building-hours/detail/__tests__/expo-ui-mock.tsx
+++ b/source/features/building-hours/detail/__tests__/expo-ui-mock.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react'
+import {Pressable, Text as RNText, View} from 'react-native'
+
+/**
+ * `@expo/ui/swift-ui` cannot be loaded under Jest at all -- importing it
+ * reaches expo-modules-core's native bindings, which do not exist in the test
+ * runtime -- so a component that renders SwiftUI is untestable without a
+ * stand-in. This one covers the views the building hours detail uses,
+ * rendering each as the React Native view closest to what it does natively.
+ *
+ * Deliberately narrow, matching the event-list and map features' mocks: it
+ * exports what this module imports and nothing else, rather than pretending
+ * to be the whole module.
+ */
+
+type Modifier = {$type: string; [key: string]: unknown}
+type WithModifiers = {modifiers?: Modifier[]; children?: React.ReactNode}
+
+const modifier =
+	($type: string) =>
+	(value?: unknown): Modifier => ({$type, value})
+
+export const font = modifier('font')
+export const foregroundStyle = modifier('foregroundStyle')
+export const frame = modifier('frame')
+export const clipShape = modifier('clipShape')
+export const padding = modifier('padding')
+export const background = modifier('background')
+export const buttonStyle = modifier('buttonStyle')
+export const listStyle = modifier('listStyle')
+
+/**
+ * The label an `accessibilityLabel(…)` modifier asks for, which is what
+ * VoiceOver -- and therefore `getByLabelText` -- would report natively.
+ */
+function labelOf(modifiers?: Modifier[]): string | undefined {
+	let found = modifiers?.find((m) => m.$type === 'accessibilityLabel')
+	return typeof found?.label === 'string' ? found.label : undefined
+}
+
+export function Host({children}: WithModifiers): React.ReactNode {
+	return <View>{children}</View>
+}
+
+export function List({children}: WithModifiers): React.ReactNode {
+	return <View>{children}</View>
+}
+
+export function VStack({children}: WithModifiers): React.ReactNode {
+	return <View>{children}</View>
+}
+
+export function HStack({children}: WithModifiers): React.ReactNode {
+	return <View>{children}</View>
+}
+
+export function Spacer(): React.ReactNode {
+	return null
+}
+
+/**
+ * Decorative in every call site this module has, so the mock renders nothing
+ * rather than a text node that would confuse a query for the text beside it.
+ */
+export function Image(): React.ReactNode {
+	return null
+}
+
+export function Text({children, modifiers}: WithModifiers): React.ReactNode {
+	return <RNText accessibilityLabel={labelOf(modifiers)}>{children}</RNText>
+}
+
+/**
+ * `title` renders as text so a test can assert a section is present.
+ * `header`/`footer` are real `SwiftUIContent` slots on the native component --
+ * a bare string handed to either crashes at mount -- but react-test-renderer
+ * happily accepts a raw string child of `View`, so rendering them wouldn't
+ * catch that. The explicit throw below is what earns the claim.
+ */
+export function Section({
+	children,
+	title,
+	header,
+	footer,
+}: WithModifiers & {
+	title?: string
+	header?: React.ReactNode
+	footer?: React.ReactNode
+}): React.ReactNode {
+	if (typeof header === 'string' || typeof footer === 'string') {
+		throw new Error('Section header/footer are SwiftUI slots; a bare string crashes at mount')
+	}
+
+	return (
+		<View>
+			{title ? <RNText>{title}</RNText> : null}
+			{header}
+			{children}
+			{footer}
+		</View>
+	)
+}
+
+/**
+ * `ButtonProps` documents that children must be nested elements, not plain
+ * strings; the throw below mirrors that constraint instead of silently
+ * accepting what the real component would reject.
+ */
+export function Button({
+	children,
+	modifiers,
+	onPress,
+}: WithModifiers & {onPress?: () => void}): React.ReactNode {
+	if (typeof children === 'string') {
+		throw new Error('Button children must be nested elements, not a plain string')
+	}
+
+	return (
+		<Pressable accessibilityLabel={labelOf(modifiers)} onPress={onPress}>
+			{children}
+		</Pressable>
+	)
+}

--- a/source/features/building-hours/detail/__tests__/expo-ui-mock.tsx
+++ b/source/features/building-hours/detail/__tests__/expo-ui-mock.tsx
@@ -28,8 +28,15 @@ export const padding = modifier('padding')
 export const background = modifier('background')
 export const buttonStyle = modifier('buttonStyle')
 export const listStyle = modifier('listStyle')
+export const listRowBackground = modifier('listRowBackground')
+export const listRowInsets = modifier('listRowInsets')
+export const listRowSeparator = modifier('listRowSeparator')
 
 export function Host({children}: WithModifiers): React.ReactNode {
+	return <View>{children}</View>
+}
+
+export function RNHostView({children}: WithModifiers): React.ReactNode {
 	return <View>{children}</View>
 }
 

--- a/source/features/building-hours/detail/building-detail.tsx
+++ b/source/features/building-hours/detail/building-detail.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {StyleSheet, Image} from 'react-native'
-import {Host, List, Section, Text, Button, HStack, VStack, Spacer} from '@expo/ui/swift-ui'
+import {Host, List, Section, Text, Button, HStack, VStack} from '@expo/ui/swift-ui'
 import {
 	background,
 	buttonStyle,
@@ -31,14 +31,13 @@ const BAR_GAP = 8
 type Props = {
 	building: BuildingType
 	now: Moment
-	onProblemReport: () => void
 }
 
 /**
  * The building detail screen: header image, current status, one section per
- * schedule, a "Suggest an Edit" action, and any links for the building.
+ * schedule, and any links for the building.
  */
-export function BuildingDetailSwiftUI({building, now, onProblemReport}: Props): React.ReactNode {
+export function BuildingDetailSwiftUI({building, now}: Props): React.ReactNode {
 	let headerImage =
 		building.image && buildingImages.has(building.image) ? buildingImages.get(building.image) : null
 
@@ -102,16 +101,6 @@ export function BuildingDetailSwiftUI({building, now, onProblemReport}: Props): 
 						))}
 					</Section>
 				))}
-
-				<Section>
-					<Button modifiers={[buttonStyle('plain')]} onPress={onProblemReport}>
-						<HStack>
-							<Text modifiers={[foregroundStyle(c.label)]}>Suggest an Edit</Text>
-							<Spacer />
-							<Text modifiers={[foregroundStyle(c.tertiaryLabel)]}>›</Text>
-						</HStack>
-					</Button>
-				</Section>
 
 				{links.length > 0 ? (
 					<Section title="RESOURCES">

--- a/source/features/building-hours/detail/building-detail.tsx
+++ b/source/features/building-hours/detail/building-detail.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {StyleSheet, Image} from 'react-native'
+import {StyleSheet, Image, View} from 'react-native'
 import {Host, List, Section, Text, Button, HStack, VStack} from '@expo/ui/swift-ui'
 import {
 	background,
@@ -50,7 +50,12 @@ export function BuildingDetailSwiftUI({building, now}: Props): React.ReactNode {
 	let links = building.links || []
 
 	return (
-		<Host style={styles.host}>
+		// An RN view and a SwiftUI view can't be stacked as siblings inside one
+		// Host -- Host bridges its children into SwiftUI, and Image isn't a
+		// SwiftUI view, so the two would draw on top of each other instead of
+		// stacking in a column. Pinning the banner as the Host's sibling here,
+		// rather than its child, keeps the photo above the list instead of under it.
+		<View style={styles.container}>
 			{headerImage ? (
 				<Image
 					accessibilityIgnoresInvertColors={true}
@@ -60,78 +65,86 @@ export function BuildingDetailSwiftUI({building, now}: Props): React.ReactNode {
 				/>
 			) : null}
 
-			<List modifiers={[listStyle('insetGrouped')]}>
-				<Section>
-					<HStack alignment="center" spacing={BAR_GAP}>
-						<VStack
-							modifiers={[
-								frame({minWidth: 4, maxWidth: 4, minHeight: 24}),
-								background(accentColor),
-								clipShape('capsule'),
-							]}
-						>
-							{null}
-						</VStack>
-						<Text
-							modifiers={[font({textStyle: 'body', weight: 'semibold'}), foregroundStyle(c.label)]}
-						>
-							{statusText}
-						</Text>
-					</HStack>
-				</Section>
-
-				{schedules.map((schedule) => (
-					<Section
-						key={schedule.title}
-						footer={schedule.notes ? <Text>{schedule.notes}</Text> : undefined}
-						title={schedule.title.toUpperCase()}
-					>
-						{schedule.hours.map((set, i) => (
-							<ScheduleRowSwiftUI
-								key={i}
-								accentColor={accentColor}
-								isActive={
-									schedule.isPhysicallyOpen !== false &&
-									set.days.includes(dayOfWeek) &&
-									isScheduleOpenAtMoment(set, now)
-								}
-								now={now}
-								schedule={set}
-							/>
-						))}
-					</Section>
-				))}
-
-				{links.length > 0 ? (
-					<Section title="RESOURCES">
-						{links.map((link, i) => (
-							<Button
-								key={i}
-								modifiers={[buttonStyle('plain')]}
-								onPress={() => openUrl(link.url.toString())}
+			<Host style={styles.host}>
+				<List modifiers={[listStyle('insetGrouped')]}>
+					<Section>
+						<HStack alignment="center" spacing={BAR_GAP}>
+							<VStack
+								modifiers={[
+									frame({minWidth: 4, maxWidth: 4, minHeight: 24}),
+									background(accentColor),
+									clipShape('capsule'),
+								]}
 							>
-								<Text modifiers={[foregroundStyle(c.systemBlue)]}>{link.title}</Text>
-							</Button>
-						))}
+								{null}
+							</VStack>
+							<Text
+								modifiers={[
+									font({textStyle: 'body', weight: 'semibold'}),
+									foregroundStyle(c.label),
+								]}
+							>
+								{statusText}
+							</Text>
+						</HStack>
 					</Section>
-				) : null}
 
-				<Text
-					modifiers={[
-						font({textStyle: 'footnote'}),
-						foregroundStyle(c.secondaryLabel),
-						padding({top: 16, horizontal: 16}),
-					]}
-				>
-					Building hours subject to change without notice{'\n\n'}Data collected by the humans of All
-					About Olaf
-				</Text>
-			</List>
-		</Host>
+					{schedules.map((schedule) => (
+						<Section
+							key={schedule.title}
+							footer={schedule.notes ? <Text>{schedule.notes}</Text> : undefined}
+							title={schedule.title.toUpperCase()}
+						>
+							{schedule.hours.map((set, i) => (
+								<ScheduleRowSwiftUI
+									key={i}
+									accentColor={accentColor}
+									isActive={
+										schedule.isPhysicallyOpen !== false &&
+										set.days.includes(dayOfWeek) &&
+										isScheduleOpenAtMoment(set, now)
+									}
+									now={now}
+									schedule={set}
+								/>
+							))}
+						</Section>
+					))}
+
+					{links.length > 0 ? (
+						<Section title="RESOURCES">
+							{links.map((link, i) => (
+								<Button
+									key={i}
+									modifiers={[buttonStyle('plain')]}
+									onPress={() => openUrl(link.url.toString())}
+								>
+									<Text modifiers={[foregroundStyle(c.systemBlue)]}>{link.title}</Text>
+								</Button>
+							))}
+						</Section>
+					) : null}
+
+					<Text
+						modifiers={[
+							font({textStyle: 'footnote'}),
+							foregroundStyle(c.secondaryLabel),
+							padding({top: 16, horizontal: 16}),
+						]}
+					>
+						Building hours subject to change without notice{'\n\n'}Data collected by the humans of
+						All About Olaf
+					</Text>
+				</List>
+			</Host>
+		</View>
 	)
 }
 
 const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
 	host: {
 		flex: 1,
 		backgroundColor: c.systemGroupedBackground,

--- a/source/features/building-hours/detail/building-detail.tsx
+++ b/source/features/building-hours/detail/building-detail.tsx
@@ -84,7 +84,7 @@ export function BuildingDetailSwiftUI({building, now, onProblemReport}: Props): 
 				{schedules.map((schedule) => (
 					<Section
 						key={schedule.title}
-						footer={schedule.notes}
+						footer={schedule.notes ? <Text>{schedule.notes}</Text> : undefined}
 						title={schedule.title.toUpperCase()}
 					>
 						{schedule.hours.map((set, i) => (

--- a/source/features/building-hours/detail/building-detail.tsx
+++ b/source/features/building-hours/detail/building-detail.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import {StyleSheet, Image, View} from 'react-native'
-import {Host, List, Section, Text, Button, HStack, VStack} from '@expo/ui/swift-ui'
+import {StyleSheet, Image} from 'react-native'
+import {Host, List, RNHostView, Section, Text, Button, HStack, VStack} from '@expo/ui/swift-ui'
 import {
 	background,
 	buttonStyle,
@@ -8,6 +8,9 @@ import {
 	font,
 	foregroundStyle,
 	frame,
+	listRowBackground,
+	listRowInsets,
+	listRowSeparator,
 	listStyle,
 	padding,
 } from '@expo/ui/swift-ui/modifiers'
@@ -50,101 +53,103 @@ export function BuildingDetailSwiftUI({building, now}: Props): React.ReactNode {
 	let links = building.links || []
 
 	return (
-		// An RN view and a SwiftUI view can't be stacked as siblings inside one
-		// Host -- Host bridges its children into SwiftUI, and Image isn't a
-		// SwiftUI view, so the two would draw on top of each other instead of
-		// stacking in a column. Pinning the banner as the Host's sibling here,
-		// rather than its child, keeps the photo above the list instead of under it.
-		<View style={styles.container}>
-			{headerImage ? (
-				<Image
-					accessibilityIgnoresInvertColors={true}
-					resizeMode="cover"
-					source={headerImage}
-					style={styles.image}
-				/>
-			) : null}
-
-			<Host style={styles.host}>
-				<List modifiers={[listStyle('insetGrouped')]}>
-					<Section>
-						<HStack alignment="center" spacing={BAR_GAP}>
-							<VStack
-								modifiers={[
-									frame({minWidth: 4, maxWidth: 4, minHeight: 24}),
-									background(accentColor),
-									clipShape('capsule'),
-								]}
-							>
-								{null}
-							</VStack>
-							<Text
-								modifiers={[
-									font({textStyle: 'body', weight: 'semibold'}),
-									foregroundStyle(c.label),
-								]}
-							>
-								{statusText}
-							</Text>
-						</HStack>
-					</Section>
-
-					{schedules.map((schedule) => (
-						<Section
-							key={schedule.title}
-							footer={schedule.notes ? <Text>{schedule.notes}</Text> : undefined}
-							title={schedule.title.toUpperCase()}
+		// A Host doesn't need a React Native scroll view under it: the hosting
+		// view carries a UIKit autoresizing mask, so it fills its superview on
+		// its own, without the Fabric coercion an RN scroll view would need.
+		<Host style={styles.host}>
+			<List modifiers={[listStyle('insetGrouped')]}>
+				<Section>
+					<HStack alignment="center" spacing={BAR_GAP}>
+						<VStack
+							modifiers={[
+								frame({minWidth: 4, maxWidth: 4, minHeight: 24}),
+								background(accentColor),
+								clipShape('capsule'),
+							]}
 						>
-							{schedule.hours.map((set, i) => (
-								<ScheduleRowSwiftUI
-									key={i}
-									accentColor={accentColor}
-									isActive={
-										schedule.isPhysicallyOpen !== false &&
-										set.days.includes(dayOfWeek) &&
-										isScheduleOpenAtMoment(set, now)
-									}
-									now={now}
-									schedule={set}
-								/>
-							))}
-						</Section>
-					))}
+							{null}
+						</VStack>
+						<Text
+							modifiers={[font({textStyle: 'body', weight: 'semibold'}), foregroundStyle(c.label)]}
+						>
+							{statusText}
+						</Text>
+					</HStack>
+				</Section>
 
-					{links.length > 0 ? (
-						<Section title="RESOURCES">
-							{links.map((link, i) => (
-								<Button
-									key={i}
-									modifiers={[buttonStyle('plain')]}
-									onPress={() => openUrl(link.url.toString())}
-								>
-									<Text modifiers={[foregroundStyle(c.systemBlue)]}>{link.title}</Text>
-								</Button>
-							))}
-						</Section>
-					) : null}
-
-					<Text
-						modifiers={[
-							font({textStyle: 'footnote'}),
-							foregroundStyle(c.secondaryLabel),
-							padding({top: 16, horizontal: 16}),
-						]}
+				{schedules.map((schedule) => (
+					<Section
+						key={schedule.title}
+						footer={schedule.notes ? <Text>{schedule.notes}</Text> : undefined}
+						title={schedule.title.toUpperCase()}
 					>
-						Building hours subject to change without notice{'\n\n'}Data collected by the humans of
-						All About Olaf
-					</Text>
-				</List>
-			</Host>
-		</View>
+						{schedule.hours.map((set, i) => (
+							<ScheduleRowSwiftUI
+								key={i}
+								accentColor={accentColor}
+								isActive={
+									schedule.isPhysicallyOpen !== false &&
+									set.days.includes(dayOfWeek) &&
+									isScheduleOpenAtMoment(set, now)
+								}
+								now={now}
+								schedule={set}
+							/>
+						))}
+					</Section>
+				))}
+
+				{headerImage ? (
+					<Section>
+						{/* The insets are zeroed on a wrapping stack because RNHostView
+						    takes no modifiers of its own, and they are zeroed so the photo
+						    meets the row's edges the way an image row reads on iOS. */}
+						<VStack modifiers={[listRowInsets({top: 0, bottom: 0, leading: 0, trailing: 0})]}>
+							<RNHostView matchContents={true}>
+								<Image
+									accessibilityIgnoresInvertColors={true}
+									resizeMode="cover"
+									source={headerImage}
+									style={styles.image}
+								/>
+							</RNHostView>
+						</VStack>
+					</Section>
+				) : null}
+
+				{links.length > 0 ? (
+					<Section title="RESOURCES">
+						{links.map((link, i) => (
+							<Button
+								key={i}
+								modifiers={[buttonStyle('plain')]}
+								onPress={() => openUrl(link.url.toString())}
+							>
+								<Text modifiers={[foregroundStyle(c.systemBlue)]}>{link.title}</Text>
+							</Button>
+						))}
+					</Section>
+				) : null}
+
+				<Text
+					modifiers={[
+						font({textStyle: 'footnote'}),
+						foregroundStyle(c.secondaryLabel),
+						padding({top: 16, horizontal: 16}),
+						listRowBackground(c.systemGroupedBackground),
+						listRowInsets({top: 0, bottom: 0, leading: 0, trailing: 0}),
+						listRowSeparator('hidden'),
+					]}
+				>
+					Building hours subject to change without notice{'\n\n'}Data collected by the humans of All
+					About Olaf
+				</Text>
+			</List>
+		</Host>
 	)
 }
 
 const styles = StyleSheet.create({
-	container: {
-		flex: 1,
-	},
 	host: {
 		flex: 1,
 		backgroundColor: c.systemGroupedBackground,

--- a/source/features/building-hours/list/building-list-row.tsx
+++ b/source/features/building-hours/list/building-list-row.tsx
@@ -18,14 +18,7 @@ import {
 import * as c from '@frogpond/colors'
 import type {Moment} from 'moment-timezone'
 import type {BuildingType} from '../types'
-import {
-	getShortBuildingStatus,
-	getAccentBackgroundColor,
-	contextualStatus,
-	isScheduleOpenAtMoment,
-	getDayOfWeek,
-} from '../lib'
-import {ScheduleRowSwiftUI} from '../detail/schedule-row-swiftui'
+import {getShortBuildingStatus, getAccentBackgroundColor, contextualStatus} from '../lib'
 
 /**
  * Every building row carries this prefix so XCUITest can query them directly
@@ -41,11 +34,12 @@ type Props = {
 	isFavorite: boolean
 	onToggleFavorite: (building: BuildingType) => void
 	onReport: (building: BuildingType) => void
+	onSelect: (building: BuildingType) => void
 }
 
 /**
  * A single building row: swipe-left reveals favorite/report actions.
- * Tapping expands to show schedule inline.
+ * Tapping opens the building's detail sheet.
  */
 export const BuildingListRow = React.memo(function BuildingListRow({
 	building,
@@ -53,13 +47,11 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 	isFavorite,
 	onToggleFavorite,
 	onReport,
+	onSelect,
 }: Props): React.ReactNode {
-	let [isOpen, setIsOpen] = React.useState(false)
-
 	let status = getShortBuildingStatus(building, now)
 	let accentBg: ColorValue = getAccentBackgroundColor(status)
 	let statusText = contextualStatus(building, now)
-	let dayOfWeek = getDayOfWeek(now)
 
 	let subtitle = building.subtitle
 		? building.subtitle
@@ -80,7 +72,7 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 						accessibilityIdentifier(`${BUILDING_ROW_PREFIX}${building.name}`),
 						accessibilityLabel(`${building.name}, ${statusText}`),
 					]}
-					onPress={hasHours ? () => setIsOpen((o) => !o) : undefined}
+					onPress={() => onSelect(building)}
 				>
 					<HStack
 						modifiers={[contentShape(shapes.rectangle()), fixedSize({vertical: true})]}
@@ -114,7 +106,7 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 								{hasHours ? (
 									<Image
 										modifiers={[font({textStyle: 'footnote'}), foregroundStyle(c.tertiaryLabel)]}
-										systemName={isOpen ? 'chevron.up' : 'chevron.down'}
+										systemName="chevron.right"
 									/>
 								) : null}
 							</HStack>
@@ -143,44 +135,6 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 					</Button>
 				</SwipeActions.Actions>
 			</SwipeActions>
-
-			{isOpen && hasHours
-				? schedules.map((schedule) => (
-						<VStack key={schedule.title} alignment="leading">
-							{schedules.length > 1 || schedule.hours.length === 0 ? (
-								<Text
-									modifiers={[
-										font({textStyle: 'caption', weight: 'semibold'}),
-										foregroundStyle(c.secondaryLabel),
-									]}
-								>
-									{schedule.title.toUpperCase()}
-								</Text>
-							) : null}
-							{schedule.hours.map((set, i) => (
-								<ScheduleRowSwiftUI
-									key={i}
-									accentColor={accentBg}
-									isActive={
-										schedule.isPhysicallyOpen !== false &&
-										set.days.includes(dayOfWeek) &&
-										isScheduleOpenAtMoment(set, now)
-									}
-									now={now}
-									schedule={set}
-									showAccentBar={false}
-								/>
-							))}
-							{schedule.notes ? (
-								<Text
-									modifiers={[font({textStyle: 'footnote'}), foregroundStyle(c.secondaryLabel)]}
-								>
-									{schedule.notes}
-								</Text>
-							) : null}
-						</VStack>
-					))
-				: null}
 		</VStack>
 	)
 })

--- a/source/features/building-hours/list/building-list-row.tsx
+++ b/source/features/building-hours/list/building-list-row.tsx
@@ -64,77 +64,73 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 	let firstNote = schedules.find((s) => s.notes)?.notes
 
 	return (
-		<VStack alignment="leading">
-			<SwipeActions>
-				<Button
-					modifiers={[
-						buttonStyle('plain'),
-						accessibilityIdentifier(`${BUILDING_ROW_PREFIX}${building.name}`),
-						accessibilityLabel(`${building.name}, ${statusText}`),
-					]}
-					onPress={() => onSelect(building)}
+		<SwipeActions>
+			<Button
+				modifiers={[
+					buttonStyle('plain'),
+					accessibilityIdentifier(`${BUILDING_ROW_PREFIX}${building.name}`),
+					accessibilityLabel(`${building.name}, ${statusText}`),
+				]}
+				onPress={() => onSelect(building)}
+			>
+				<HStack
+					modifiers={[contentShape(shapes.rectangle()), fixedSize({vertical: true})]}
+					spacing={8}
 				>
-					<HStack
-						modifiers={[contentShape(shapes.rectangle()), fixedSize({vertical: true})]}
-						spacing={8}
-					>
-						<VStack alignment="leading">
-							<HStack alignment="center" spacing={8}>
-								<Text
-									modifiers={[
-										font({textStyle: 'body', weight: 'medium'}),
-										foregroundStyle(c.label),
-										...SINGLE_LINE,
-									]}
-								>
-									{building.name}
-								</Text>
-								<Spacer />
-								<Text
-									modifiers={[
-										font({textStyle: 'body'}),
-										foregroundStyle(c.secondaryLabel),
-										layoutPriority(1),
-									]}
-								>
-									{hasHours ? statusText : (firstNote ?? '')}
-								</Text>
-								<Image
-									modifiers={[foregroundStyle(accentBg), font({textStyle: 'caption2'})]}
-									systemName="circle.fill"
-								/>
-								{hasHours ? (
-									<Image
-										modifiers={[font({textStyle: 'footnote'}), foregroundStyle(c.tertiaryLabel)]}
-										systemName="chevron.right"
-									/>
-								) : null}
-							</HStack>
+					<VStack alignment="leading">
+						<HStack alignment="center" spacing={8}>
+							<Text
+								modifiers={[
+									font({textStyle: 'body', weight: 'medium'}),
+									foregroundStyle(c.label),
+									...SINGLE_LINE,
+								]}
+							>
+								{building.name}
+							</Text>
+							<Spacer />
+							<Text
+								modifiers={[
+									font({textStyle: 'body'}),
+									foregroundStyle(c.secondaryLabel),
+									layoutPriority(1),
+								]}
+							>
+								{hasHours ? statusText : (firstNote ?? '')}
+							</Text>
+							<Image
+								modifiers={[foregroundStyle(accentBg), font({textStyle: 'caption2'})]}
+								systemName="circle.fill"
+							/>
+							<Image
+								modifiers={[font({textStyle: 'footnote'}), foregroundStyle(c.tertiaryLabel)]}
+								systemName="chevron.right"
+							/>
+						</HStack>
 
-							{subtitle ? (
-								<Text
-									modifiers={[
-										font({textStyle: 'subheadline'}),
-										foregroundStyle(c.secondaryLabel),
-										...SINGLE_LINE,
-									]}
-								>
-									{subtitle}
-								</Text>
-							) : null}
-						</VStack>
-					</HStack>
+						{subtitle ? (
+							<Text
+								modifiers={[
+									font({textStyle: 'subheadline'}),
+									foregroundStyle(c.secondaryLabel),
+									...SINGLE_LINE,
+								]}
+							>
+								{subtitle}
+							</Text>
+						) : null}
+					</VStack>
+				</HStack>
+			</Button>
+
+			<SwipeActions.Actions edge="trailing" allowsFullSwipe={false}>
+				<Button modifiers={[tint(c.systemBlue)]} onPress={() => onToggleFavorite(building)}>
+					<Image systemName={isFavorite ? 'heart.slash' : 'heart'} />
 				</Button>
-
-				<SwipeActions.Actions edge="trailing" allowsFullSwipe={false}>
-					<Button modifiers={[tint(c.systemBlue)]} onPress={() => onToggleFavorite(building)}>
-						<Image systemName={isFavorite ? 'heart.slash' : 'heart'} />
-					</Button>
-					<Button modifiers={[tint(c.systemOrange)]} onPress={() => onReport(building)}>
-						<Image systemName="exclamationmark.bubble" />
-					</Button>
-				</SwipeActions.Actions>
-			</SwipeActions>
-		</VStack>
+				<Button modifiers={[tint(c.systemOrange)]} onPress={() => onReport(building)}>
+					<Image systemName="exclamationmark.bubble" />
+				</Button>
+			</SwipeActions.Actions>
+		</SwipeActions>
 	)
 })

--- a/source/features/building-hours/list/building-list.tsx
+++ b/source/features/building-hours/list/building-list.tsx
@@ -18,6 +18,7 @@ type Props = {
 	favorites: string[]
 	onToggleFavorite: (building: BuildingType) => void
 	onReport: (building: BuildingType) => void
+	onSelect: (building: BuildingType) => void
 	onRefresh?: () => unknown
 	isLoading?: boolean
 	/** The active search query, or `''` when no search is in progress. Distinguishes
@@ -32,6 +33,7 @@ export const BuildingList = React.memo(function BuildingList({
 	favorites,
 	onToggleFavorite,
 	onReport,
+	onSelect,
 	onRefresh,
 	isLoading,
 	searchQuery,
@@ -74,6 +76,7 @@ export const BuildingList = React.memo(function BuildingList({
 										isFavorite={favorites.includes(building.name)}
 										now={now}
 										onReport={onReport}
+										onSelect={onSelect}
 										onToggleFavorite={onToggleFavorite}
 									/>
 								))}

--- a/uitests/ModuleBuildingHoursTests.swift
+++ b/uitests/ModuleBuildingHoursTests.swift
@@ -28,7 +28,22 @@ class ModuleBuildingHoursTests: UITestCase {
 		BuildingHoursScreen(app: app)
 			.navigate()
 			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
-			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.detailTitle)
 			.verifyListStillBehind()
+			.capture("Building Hours detail sheet at half detent")
+	}
+
+	/// The Cage has enough schedule content (two day groups plus a note) to
+	/// overflow the sheet's 0.5 detent, so dragging it open is the case that
+	/// would catch content stuck laid out at the smaller detent's height.
+	func testDraggingTheDetailSheetRevealsTheRestOfItsContent() throws {
+		BuildingHoursScreen(app: app)
+			.navigate()
+			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.detailTitle)
+			.capture("Building Hours detail sheet before dragging to the larger detent")
+			.expandDetailSheet()
+			.capture("Building Hours detail sheet after dragging to the larger detent")
+			.verifyDetailSheetFullyLaidOut()
 	}
 }

--- a/uitests/ModuleBuildingHoursTests.swift
+++ b/uitests/ModuleBuildingHoursTests.swift
@@ -46,4 +46,13 @@ class ModuleBuildingHoursTests: UITestCase {
 			.capture("Building Hours detail sheet after dragging to the larger detent")
 			.verifyDetailSheetFullyLaidOut()
 	}
+
+	func testDetailSheetMenuOffersReportAProblem() throws {
+		BuildingHoursScreen(app: app)
+			.navigate()
+			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.openDetailMenu()
+			.verifyReportActionOffered()
+	}
 }

--- a/uitests/ModuleBuildingHoursTests.swift
+++ b/uitests/ModuleBuildingHoursTests.swift
@@ -23,4 +23,12 @@ class ModuleBuildingHoursTests: UITestCase {
 			.verifyNoResultsShown(for: TestIdentifiers.BuildingHours.unmatchedQuery)
 			.capture("Building Hours no-results state")
 	}
+
+	func testTappingARowPresentsTheDetailSheet() throws {
+		BuildingHoursScreen(app: app)
+			.navigate()
+			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.verifyListStillBehind()
+	}
 }

--- a/uitests/ModuleBuildingHoursTests.swift
+++ b/uitests/ModuleBuildingHoursTests.swift
@@ -28,23 +28,46 @@ class ModuleBuildingHoursTests: UITestCase {
 		BuildingHoursScreen(app: app)
 			.navigate()
 			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
-			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.detailTitle)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
 			.verifyListStillBehind()
 			.capture("Building Hours detail sheet at half detent")
 	}
 
-	/// The Cage has enough schedule content (two day groups plus a note) to
-	/// overflow the sheet's 0.5 detent, so dragging it open is the case that
-	/// would catch content stuck laid out at the smaller detent's height.
-	func testDraggingTheDetailSheetRevealsTheRestOfItsContent() throws {
+	/// `sheetLargestUndimmedDetentIndex: 'none'` is what makes this true: UIKit
+	/// dims and blocks touches to the list behind the sheet at every detent,
+	/// not merely below the largest one. Without it, a tap on a different
+	/// building's row lands on the list and pushes a second detail sheet on
+	/// top of the first.
+	func testTappingARowBehindTheSheetDoesNotStackASecondSheet() throws {
 		BuildingHoursScreen(app: app)
 			.navigate()
 			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
-			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.detailTitle)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.attemptToTapRowBehindSheet(TestIdentifiers.BuildingHours.aSecondBuilding)
+			.capture("Building Hours after tapping a row behind the sheet")
+			.verifyNoSecondSheetForStavHall()
+	}
+
+	/// `aBuildingWithLongSchedule` has two schedule sections plus a resource
+	/// link -- enough combined content to overflow the sheet's 0.5 detent,
+	/// unlike `anExcludedBuilding`'s single short section, which already fits
+	/// it entirely. Dragging it open is the case that would catch content
+	/// stuck laid out at the smaller detent's height.
+	func testDraggingTheDetailSheetRevealsTheRestOfItsContent() throws {
+		let screen = BuildingHoursScreen(app: app)
+			.navigate()
+			.tapRow(TestIdentifiers.BuildingHours.aBuildingWithLongSchedule)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.aBuildingWithLongSchedule)
 			.capture("Building Hours detail sheet before dragging to the larger detent")
+
+		let titleBefore = screen.detailTitleFrame(
+			for: TestIdentifiers.BuildingHours.aBuildingWithLongSchedule)
+
+		screen
 			.expandDetailSheet()
 			.capture("Building Hours detail sheet after dragging to the larger detent")
-			.verifyDetailSheetFullyLaidOut()
+			.verifyDetailSheetFullyLaidOut(
+				for: TestIdentifiers.BuildingHours.aBuildingWithLongSchedule, titleBefore: titleBefore)
 	}
 
 	func testDetailSheetMenuOffersReportAProblem() throws {
@@ -54,5 +77,14 @@ class ModuleBuildingHoursTests: UITestCase {
 			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
 			.openDetailMenu()
 			.verifyReportActionOffered()
+			.tapReportAction()
+			.verifyReportScreenPresented()
+			.capture("Building Hours report screen")
+			// Presenting a modal while a formSheet is already up can silently
+			// no-op on iOS -- dismissing back to the detail sheet, rather than
+			// straight to the list, is what proves it actually stacked on top
+			// of the sheet instead of replacing it or failing to present.
+			.dismissReportScreen()
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
 	}
 }

--- a/uitests/Screens/BuildingHoursScreen.swift
+++ b/uitests/Screens/BuildingHoursScreen.swift
@@ -97,10 +97,74 @@ struct BuildingHoursScreen: Screen {
 		return self
 	}
 
+	/// The on-screen frame of the sheet's own title, at whatever detent it is
+	/// currently at. The title sits in the nested stack's nav bar, outside the
+	/// SwiftUI `List` that scrolls beneath it, so this only moves when the
+	/// sheet's detent changes -- never when the list inside it merely scrolls.
+	func detailTitleFrame(for name: String) -> CGRect {
+		app.staticTexts[name].firstMatch.frame
+	}
+
+	/// Taps a different building's row while the detail sheet is up, via its
+	/// own screen coordinate rather than `XCUIElement.tap()` -- this row is
+	/// expected NOT to respond once the sheet dims the list behind it, and a
+	/// plain `.tap()` would fail the test outright for not being hittable,
+	/// which is a different claim than the one this test makes.
+	@discardableResult
+	func attemptToTapRowBehindSheet(_ name: String) -> Self {
+		let row = app.element(matching: TestIdentifiers.BuildingHours.rowPrefix + name)
+		XCTAssertTrue(
+			row.waitForExistence(timeout: 30),
+			"\(name) should still be in the list behind the sheet")
+		row.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+		return self
+	}
+
+	/// Assert Stav Hall's own detail content -- a schedule section heading
+	/// (its meal periods) that no other screen here shows -- never appeared.
+	/// That is the tell for a second sheet having stacked over the first: a
+	/// tap that reached Stav Hall's row rather than being blocked by the
+	/// dimmed backdrop would push its own detail sheet, showing "BREAKFAST".
+	///
+	/// Whether the tap also dismissed whatever sheet was already up is not
+	/// asserted here -- tapping a dimmed backdrop dismissing the sheet in
+	/// front of it is ordinary, expected sheet behaviour, distinct from the
+	/// bug this test guards against.
+	@discardableResult
+	func verifyNoSecondSheetForStavHall() -> Self {
+		XCTAssertFalse(
+			app.staticTexts["BREAKFAST"].waitForExistence(timeout: 5),
+			"Stav Hall's own detail content should never have appeared -- its row's tap should "
+				+ "have been blocked by the dimmed sheet behind it, not reached through to stack a "
+				+ "second sheet")
+		return self
+	}
+
+	/// Assert the sheet is still at its smaller (0.5) detent: the closing
+	/// footnote, the last thing on the detail screen, is not yet reachable --
+	/// whether because it exists but sits off-screen, or because the SwiftUI
+	/// `List` has not mounted content that far below the fold yet. Either way
+	/// it cannot be tapped, which is what "not yet reachable" means here.
+	///
+	/// This is `expandDetailSheet`'s precondition, not just a standalone check
+	/// -- without it, the drag it guards could pass for a sheet that opened
+	/// straight at the larger detent, or for a building whose schedule already
+	/// fits the smaller one, and the whole test would prove nothing.
+	@discardableResult
+	func verifyDetailSheetAtSmallDetent() -> Self {
+		let footnote = app.elementWithLabel(startingWith: "Building hours subject to change")
+		XCTAssertFalse(
+			footnote.exists && footnote.isHittable,
+			"The footnote should not be reachable at the smaller detent -- if it is, this "
+				+ "building's schedule no longer has enough content to make this test meaningful")
+		return self
+	}
+
 	/// Drags the sheet from its half detent up to its larger one, the way
 	/// `CarletonMapScreen.expandSheet` drags the map's building sheet.
 	@discardableResult
 	func expandDetailSheet() -> Self {
+		verifyDetailSheetAtSmallDetent()
 		app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.93))
 			.press(
 				forDuration: 0.1,
@@ -110,16 +174,31 @@ struct BuildingHoursScreen: Screen {
 
 	/// Assert the sheet's last element -- the disclaimer footnote at the very
 	/// bottom of the detail screen -- is hittable after expanding to the
-	/// larger detent. `RNSScreenContentWrapper` only resizes a direct
-	/// `RCTScrollViewComponentView` child; a SwiftUI `Host`/`List` is not one,
-	/// so this is the test that would catch content stuck laid out at the
-	/// smaller detent's height instead of the larger one's.
+	/// larger detent, AND that the sheet's own title has moved: the title sits
+	/// in the nested stack's nav bar, outside the SwiftUI `List` that scrolls,
+	/// so only a detent change moves it, never a scroll of the list beneath it.
+	///
+	/// The footnote check alone cannot tell a detent change from a scroll --
+	/// dragging from inside the `List`'s own content, which is where this
+	/// gesture starts, can scroll the list to the same visible end state
+	/// `RNSScreenContentWrapper` resizing it would produce. The title check is
+	/// what proves the detent actually changed: `RNSScreenContentWrapper` only
+	/// resizes a direct `RCTScrollViewComponentView` child, and a SwiftUI
+	/// `Host`/`List` is not one, so this is the test that would catch content
+	/// stuck laid out at the smaller detent's height instead of the larger
+	/// one's.
 	@discardableResult
-	func verifyDetailSheetFullyLaidOut() -> Self {
+	func verifyDetailSheetFullyLaidOut(for name: String, titleBefore: CGRect) -> Self {
 		let footnote = app.elementWithLabel(startingWith: "Building hours subject to change")
 		XCTAssertTrue(
 			footnote.waitForExistence(timeout: 30) && footnote.isHittable,
 			"The sheet's closing footnote should be reachable once expanded to the larger detent")
+
+		let titleAfter = detailTitleFrame(for: name)
+		XCTAssertTrue(
+			titleBefore.minY - titleAfter.minY > 100,
+			"The sheet's title should have moved up well past a scroll's worth once the "
+				+ "detent actually changed, from \(titleBefore.minY) to \(titleAfter.minY)")
 		return self
 	}
 
@@ -139,6 +218,47 @@ struct BuildingHoursScreen: Screen {
 			app.buttons[TestIdentifiers.BuildingHours.reportAction]
 				.waitForExistence(timeout: 30),
 			"The menu should offer Report a Problem")
+		return self
+	}
+
+	/// Taps Report a Problem in the detail sheet's overflow menu. This action
+	/// presents a `modal` route on the OUTER stack while a `formSheet` is
+	/// already up -- exactly the class of presentation that can silently no-op
+	/// on iOS -- so `verifyReportScreenPresented` is what proves it actually
+	/// worked rather than merely existing as a menu item.
+	@discardableResult
+	func tapReportAction() -> Self {
+		let action = app.buttons[TestIdentifiers.BuildingHours.reportAction]
+		XCTAssertTrue(
+			action.waitForExistence(timeout: 30),
+			"The menu should offer Report a Problem before it can be tapped")
+		action.tap()
+		return self
+	}
+
+	/// Assert the report screen actually came up, by its own `InfoHeader`
+	/// prompt rather than `reportAction`'s label -- that label belongs to the
+	/// menu button that opens this screen, and would exist whether or not the
+	/// screen ever presented.
+	@discardableResult
+	func verifyReportScreenPresented() -> Self {
+		XCTAssertTrue(
+			app.staticTexts[TestIdentifiers.BuildingHours.reportScreenPrompt]
+				.waitForExistence(timeout: 30),
+			"Report a Problem should present the report screen")
+		return self
+	}
+
+	/// Dismisses the report screen via its own close button, per
+	/// `gestureEnabled: false` on that route -- the swipe-to-dismiss gesture is
+	/// off, so this is the only way out.
+	@discardableResult
+	func dismissReportScreen() -> Self {
+		let close = app.buttons[TestIdentifiers.Navigation.closeScreen].firstMatch
+		XCTAssertTrue(
+			close.waitForExistence(timeout: 30),
+			"The report screen should offer a way to close it")
+		close.tap()
 		return self
 	}
 

--- a/uitests/Screens/BuildingHoursScreen.swift
+++ b/uitests/Screens/BuildingHoursScreen.swift
@@ -63,4 +63,45 @@ struct BuildingHoursScreen: Screen {
 			"Building Hours should report no results for \"\(query)\"")
 		return self
 	}
+
+	@discardableResult
+	func tapRow(_ name: String) -> Self {
+		let row = app.element(matching: TestIdentifiers.BuildingHours.rowPrefix + name)
+		XCTAssertTrue(
+			row.waitForExistence(timeout: 30),
+			"\(name) should be listed before it can be tapped")
+
+		// Retried for the reason navigateFromHome retries: a synthesized press on
+		// a row whose host has mounted but whose action still has to reach
+		// JavaScript lands natively and does nothing.
+		for _ in 1...3 {
+			row.tap()
+			if app.staticTexts[TestIdentifiers.BuildingHours.detailSchedule]
+				.waitForExistence(timeout: 10)
+			{
+				break
+			}
+		}
+		return self
+	}
+
+	@discardableResult
+	func verifyDetailSheetPresented(for name: String) -> Self {
+		XCTAssertTrue(
+			app.staticTexts[TestIdentifiers.BuildingHours.detailSchedule]
+				.waitForExistence(timeout: 30),
+			"The detail sheet should show \(name)'s schedule")
+		return self
+	}
+
+	@discardableResult
+	func verifyListStillBehind() -> Self {
+		let row = app.element(
+			matching: TestIdentifiers.BuildingHours.rowPrefix
+				+ TestIdentifiers.BuildingHours.anExcludedBuilding)
+		XCTAssertTrue(
+			row.exists,
+			"The list should still be behind the sheet, not replaced by it")
+		return self
+	}
 }

--- a/uitests/Screens/BuildingHoursScreen.swift
+++ b/uitests/Screens/BuildingHoursScreen.swift
@@ -88,9 +88,38 @@ struct BuildingHoursScreen: Screen {
 	@discardableResult
 	func verifyDetailSheetPresented(for name: String) -> Self {
 		XCTAssertTrue(
+			app.staticTexts[name].waitForExistence(timeout: 30),
+			"The detail sheet should be titled \(name)")
+		XCTAssertTrue(
 			app.staticTexts[TestIdentifiers.BuildingHours.detailSchedule]
 				.waitForExistence(timeout: 30),
 			"The detail sheet should show \(name)'s schedule")
+		return self
+	}
+
+	/// Drags the sheet from its half detent up to its larger one, the way
+	/// `CarletonMapScreen.expandSheet` drags the map's building sheet.
+	@discardableResult
+	func expandDetailSheet() -> Self {
+		app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.93))
+			.press(
+				forDuration: 0.1,
+				thenDragTo: app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.08)))
+		return self
+	}
+
+	/// Assert the sheet's last element -- the disclaimer footnote at the very
+	/// bottom of the detail screen -- is hittable after expanding to the
+	/// larger detent. `RNSScreenContentWrapper` only resizes a direct
+	/// `RCTScrollViewComponentView` child; a SwiftUI `Host`/`List` is not one,
+	/// so this is the test that would catch content stuck laid out at the
+	/// smaller detent's height instead of the larger one's.
+	@discardableResult
+	func verifyDetailSheetFullyLaidOut() -> Self {
+		let footnote = app.elementWithLabel(startingWith: "Building hours subject to change")
+		XCTAssertTrue(
+			footnote.waitForExistence(timeout: 30) && footnote.isHittable,
+			"The sheet's closing footnote should be reachable once expanded to the larger detent")
 		return self
 	}
 

--- a/uitests/Screens/BuildingHoursScreen.swift
+++ b/uitests/Screens/BuildingHoursScreen.swift
@@ -124,6 +124,25 @@ struct BuildingHoursScreen: Screen {
 	}
 
 	@discardableResult
+	func openDetailMenu() -> Self {
+		let menu = app.buttons[TestIdentifiers.BuildingHours.detailMenu].firstMatch
+		XCTAssertTrue(
+			menu.waitForExistence(timeout: 30),
+			"The detail sheet should offer an overflow menu")
+		menu.tap()
+		return self
+	}
+
+	@discardableResult
+	func verifyReportActionOffered() -> Self {
+		XCTAssertTrue(
+			app.buttons[TestIdentifiers.BuildingHours.reportAction]
+				.waitForExistence(timeout: 30),
+			"The menu should offer Report a Problem")
+		return self
+	}
+
+	@discardableResult
 	func verifyListStillBehind() -> Self {
 		let row = app.element(
 			matching: TestIdentifiers.BuildingHours.rowPrefix

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -330,6 +330,11 @@ struct TestIdentifiers {
 		/// Mirrors BUILDING_ROW_PREFIX in
 		/// source/features/building-hours/list/building-list-row.tsx.
 		static let rowPrefix = "building-row-"
+		/// The sheet's own title, which is the building's name.
+		static let detailTitle = "The Cage"
+		/// A schedule section heading on the detail sheet, which the collapsed
+		/// row never showed.
+		static let detailSchedule = "HOURS"
 	}
 
 	// MARK: - Course Catalog

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -321,8 +321,23 @@ struct TestIdentifiers {
 		/// fails if the filter stops stripping diacritics.
 		static let deburredQuery = "rolvaag"
 		/// A building that must fall out of the list when `deburredQuery` is
-		/// typed, so the test proves narrowing rather than mere survival.
+		/// typed, so the test proves narrowing rather than mere survival. Also
+		/// the name shown as the detail sheet's own title once tapped, and its
+		/// schedule has enough content to overflow the sheet's half detent.
 		static let anExcludedBuilding = "The Cage"
+		/// Another Food-category building, in the same unscrolled viewport as
+		/// `anExcludedBuilding` -- so a tap aimed at it while a sheet is up lands
+		/// on the dimmed list behind the sheet rather than on content the sheet
+		/// itself covers. Its schedule sections are titled Breakfast/Lunch/Dinner,
+		/// never "Hours", which is what makes its detail content an unambiguous
+		/// tell for a second sheet: nothing else on this screen shows those words.
+		static let aSecondBuilding = "Stav Hall"
+		/// A building with two schedule sections and a resource link -- enough
+		/// combined content to overflow the sheet's smaller detent, unlike
+		/// `anExcludedBuilding`'s single short section. One of its sections is
+		/// still titled "Hours", so `tapRow`'s own detection of a successful tap
+		/// still applies.
+		static let aBuildingWithLongSchedule = "The Pause Kitchen"
 		/// A query no building matches, so the screen must say no results were
 		/// found rather than claim the data is missing -- the two states read
 		/// differently, or a broken search looks like a server outage.
@@ -330,14 +345,24 @@ struct TestIdentifiers {
 		/// Mirrors BUILDING_ROW_PREFIX in
 		/// source/features/building-hours/list/building-list-row.tsx.
 		static let rowPrefix = "building-row-"
-		/// The sheet's own title, which is the building's name.
-		static let detailTitle = "The Cage"
-		/// A schedule section heading on the detail sheet, which the collapsed
-		/// row never showed.
+		/// A schedule section heading on the detail sheet, shown only once a
+		/// building is open in the sheet.
 		static let detailSchedule = "HOURS"
-		/// The detail sheet's overflow menu, and the one action in it.
-		static let detailMenu = "More"
+		/// The detail sheet's overflow menu button. UIKit gives an unlabelled
+		/// `ellipsis.circle` bar item the default accessibility label "More" --
+		/// the same string as `Buttons.more`, the Home screen's own tile, purely
+		/// by coincidence of wording rather than a shared identifier. The two
+		/// screens are never on screen together, so today's bare-label match in
+		/// `openDetailMenu` cannot collide with the tile, but reusing the
+		/// constant keeps that coincidence from drifting into two truths.
+		static let detailMenu = Buttons.more
+		/// The one action the detail sheet's overflow menu offers.
 		static let reportAction = "Report a Problem"
+		/// The report screen's own `InfoHeader` title -- distinct from
+		/// `reportAction`, which labels the menu button that opens it, so a test
+		/// can tell the screen actually came up rather than the menu item merely
+		/// existing.
+		static let reportScreenPrompt = "Thanks for spotting a problem!"
 	}
 
 	// MARK: - Course Catalog

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -335,6 +335,9 @@ struct TestIdentifiers {
 		/// A schedule section heading on the detail sheet, which the collapsed
 		/// row never showed.
 		static let detailSchedule = "HOURS"
+		/// The detail sheet's overflow menu, and the one action in it.
+		static let detailMenu = "More"
+		static let reportAction = "Report a Problem"
 	}
 
 	// MARK: - Course Catalog


### PR DESCRIPTION
Tapping a building now opens its hours in a sheet, instead of expanding the row in place.

The sheet is a `formSheet` route with two detents, and — per the spike in #7883 — a route group with its own `<Stack>`, so it can push child screens with a real back button. #7886 uses that for Report a Problem.

## Layout

The building's photo is pinned above the SwiftUI list rather than scrolling inside it, and sits **below** the hours: the hours are what you opened the sheet for, and a photo above them pushed them under the fold at the smaller detent.

The list behind the sheet dims at every detent, not only the largest, so it always reads as inert while a sheet is up.

## Tests

The XCUITests cover what only a device can answer: that the sheet presents, that dragging reaches the larger detent, that a tap aimed at the dimmed list behind it does not land, and that the footer does not crash on a building with no links.

The Jest suite covers what the component actually decides in JavaScript — which branch it renders — and `expo-ui-mock.tsx` stands in for `@expo/ui`, which cannot load under Jest.

Recorded while building this: `scrollEdgeEffects` cannot see an `@expo/ui` `Host`, and wrapping the `Host` in a ScrollView to give it something to see breaks sheet dragging. Left alone, deliberately.

## Screenshots

| At the smaller detent | Dragged to the larger one |
| --- | --- |
| ![Smaller detent](https://github.com/user-attachments/assets/67ff1a27-4a64-4845-afae-764c09d36c5c) | ![Larger detent](https://github.com/user-attachments/assets/d67cdff4-ae0c-47ef-971a-e01a12a3a1ff) |

Before the drag, for comparison with the pair above:

![Before dragging](https://github.com/user-attachments/assets/b620ea1c-10be-4a51-81ad-8d08d203fde8)

Tapping a row on the dimmed list behind the sheet does not stack a second sheet:

![Tapping behind the sheet](https://github.com/user-attachments/assets/e5dc77bb-ef8a-42dc-a839-c36195bfbdf6)
