### PR TITLE
Push Report a Problem into the sheet's own stack

### DIFF
--- a/.claude/skills/add-screen/index.md
+++ b/.claude/skills/add-screen/index.md
@@ -98,7 +98,7 @@ is required, not stylistic, when flattening the loader into the screen would
 change behaviour: a `useState` initialiser seeded from loaded data (React
 only evaluates it on first mount), or the screen's own ungated `useQuery`
 calls that must not fire until the loader's data resolves. See
-`app/(home)/BuildingHoursProblemReport.tsx` for the reference three-component
+`app/(home)/BuildingHours/detail/report.tsx` for the reference three-component
 shape, and `app/(settings)/Credits.tsx` for the simple chrome-plus-body shape.
 
 **Nothing may be added to `app/` that is not a route.** Every `.ts`/`.tsx`
@@ -180,8 +180,11 @@ Any `.navigate(literal)` call site needs
 ## Common Patterns and Best Practices
 
 ### Screen Naming Conventions
-- Route files are PascalCase, matching the screen title (`Credits.tsx`,
-  `BuildingHoursProblemReport.tsx`)
+- A standalone route file is PascalCase, matching the screen title
+  (`Credits.tsx`). A route nested inside a feature's own directory takes the
+  file-system name of its segment instead — lowercase for a fixed segment
+  (`detail/report.tsx`), bracketed for a dynamic one (`detail/[name].tsx`) —
+  the same convention expo-router itself uses for the segment.
 - Support files under `source/features/` are kebab-case
 - Component names inside a route file follow the `ScreenNamePage` /
   `ScreenNameView` / `ScreenNameLoader` convention from Step 2
@@ -240,7 +243,7 @@ If you encounter issues:
 See existing routes for reference implementations:
 - `app/(settings)/Credits.tsx` — simple chrome-plus-body screen, no data loading
 - `app/(home)/Contacts/index.tsx` — chrome plus an inner `…View` with a query
-- `app/(home)/BuildingHoursProblemReport.tsx` — the full three-component shape (chrome, loader, view)
+- `app/(home)/BuildingHours/detail/report.tsx` — the full three-component shape (chrome, loader, view)
 - `source/features/home/` — the home screen's support components
 - `source/features/menus/` — a feature with several routes sharing support code
 - `source/features/settings/` — a feature with many sub-screens

--- a/app/(home)/BuildingHours/detail/[name].tsx
+++ b/app/(home)/BuildingHours/detail/[name].tsx
@@ -42,14 +42,18 @@ export default function BuildingHoursDetailPage(): React.ReactNode {
 			<Stack.Title>{building?.name ?? name}</Stack.Title>
 			<Stack.Screen options={{headerLargeTitle: true}} />
 			<Stack.Toolbar placement="left">
-				<Stack.Toolbar.Menu icon="ellipsis.circle">
+				<Stack.Toolbar.Menu accessibilityLabel="More" icon="ellipsis.circle">
 					<Stack.Toolbar.MenuAction icon="exclamationmark.bubble" onPress={reportProblem}>
 						Report a Problem
 					</Stack.Toolbar.MenuAction>
 				</Stack.Toolbar.Menu>
 			</Stack.Toolbar>
 			<Stack.Toolbar placement="right">
-				<Stack.Toolbar.Button icon={favorited ? 'heart.fill' : 'heart'} onPress={onFavorite} />
+				<Stack.Toolbar.Button
+					accessibilityLabel={favorited ? 'Remove from Favorites' : 'Add to Favorites'}
+					icon={favorited ? 'heart.fill' : 'heart'}
+					onPress={onFavorite}
+				/>
 			</Stack.Toolbar>
 		</>
 	)

--- a/app/(home)/BuildingHours/detail/[name].tsx
+++ b/app/(home)/BuildingHours/detail/[name].tsx
@@ -29,7 +29,7 @@ export default function BuildingHoursDetailPage(): React.ReactNode {
 	let reportProblem = React.useCallback(
 		() =>
 			router.push({
-				pathname: '/BuildingHoursProblemReport',
+				pathname: '/BuildingHours/detail/report',
 				params: {name},
 			}),
 		[name, router],

--- a/app/(home)/BuildingHours/detail/report.tsx
+++ b/app/(home)/BuildingHours/detail/report.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {Stack, useLocalSearchParams, useNavigation, useRouter} from 'expo-router'
+import {usePreventRemove} from 'expo-router/react-navigation'
 import {useQuery} from '@tanstack/react-query'
 import {Alert, ScrollView, View} from 'react-native'
 import moment from 'moment-timezone'
@@ -41,37 +42,33 @@ function useBuildingEditor(initialBuilding: BuildingType) {
 	let [submitted, setSubmitted] = React.useState(false)
 
 	/**
-	 * Checks for unsaved edits before this screen leaves the stack.
+	 * Checks for unsaved edits before this screen leaves the stack, whether
+	 * from its own back button or from the detail sheet itself being dragged
+	 * down or dismissed by its backdrop. The edge-swipe gesture is not a path
+	 * out here -- it is turned off below, on the same route -- so it needs no
+	 * guarding.
 	 *
-	 * `beforeRemove` intercepts a pop however it was triggered -- the back
-	 * button or the edge-swipe gesture -- since this screen is pushed rather
-	 * than presented as a modal.
+	 * A plain `beforeRemove` listener only ever sees a pop of this screen; it
+	 * has no way to tell UIKit to refuse a dismissal of the *sheet*, a level
+	 * up. `usePreventRemove` additionally registers this screen's route with
+	 * the navigator's `PreventRemoveProvider`, which bubbles the block up to
+	 * the formSheet's own route so a native sheet dismissal is refused too.
 	 * https://reactnavigation.org/docs/preventing-going-back
 	 */
-	React.useEffect(
-		() =>
-			navigation.addListener('beforeRemove', (event) => {
-				if (!hasUnsavedChanges || submitted) {
-					return
-				}
-
-				event.preventDefault()
-
-				Alert.alert(
-					'Discard changes?',
-					'You have made unsaved changes. Are you sure you want to discard them?',
-					[
-						{text: 'Edit', style: 'cancel', onPress: noop},
-						{
-							text: 'Discard',
-							style: 'destructive',
-							onPress: () => navigation.dispatch(event.data.action),
-						},
-					],
-				)
-			}),
-		[navigation, hasUnsavedChanges, submitted],
-	)
+	usePreventRemove(hasUnsavedChanges && !submitted, ({data}) => {
+		Alert.alert(
+			'Discard changes?',
+			'You have made unsaved changes. Are you sure you want to discard them?',
+			[
+				{text: 'Edit', style: 'cancel', onPress: noop},
+				{
+					text: 'Discard',
+					style: 'destructive',
+					onPress: () => navigation.dispatch(data.action),
+				},
+			],
+		)
+	})
 
 	let dispatchAction = React.useCallback(
 		(action: BuildingAction) => dispatch(applyBuildingAction(action)),
@@ -313,12 +310,15 @@ export default function BuildingHoursProblemReportPage(): React.ReactNode {
 	return (
 		<>
 			<Stack.Title>Report a Problem</Stack.Title>
-			{/* The default native back button pops before `beforeRemove` gets a
-			 * say, which can leave the unsaved-changes guard unable to cancel
-			 * the pop it just intercepted. A JS-driven `goBack()` call, same as
-			 * the guard's own re-dispatch on Discard, keeps the two in sync. */}
+			{/* The edge-swipe gesture pops natively, ahead of anything in JS,
+			 * so the unsaved-changes guard above can't refuse it in time --
+			 * turned off here rather than guarded. */}
 			<Stack.Screen options={{gestureEnabled: false}} />
 			<Stack.Toolbar placement="left">
+				{/* The default native back button has the same problem: it pops
+				 * before `beforeRemove` gets a say. A JS-driven `goBack()` call,
+				 * the same dispatch the guard's own Discard button uses, keeps
+				 * the pop and the guard in sync. */}
 				<Stack.Toolbar.Button
 					accessibilityLabel="Back"
 					icon="chevron.left"

--- a/app/(home)/BuildingHours/detail/report.tsx
+++ b/app/(home)/BuildingHours/detail/report.tsx
@@ -9,7 +9,7 @@ import noop from 'lodash/noop'
 import {timezone} from '@frogpond/constants'
 import {InfoHeader} from '@frogpond/info-header'
 import {TableView, Section, Cell} from '@frogpond/tableview'
-import {CellTextField, CellToggle, DeleteButtonCell, ButtonCell} from '@frogpond/tableview/cells'
+import {CellTextField, CellToggle, DeleteButtonCell} from '@frogpond/tableview/cells'
 
 import {buildingByNameOptions} from '../../../../source/features/building-hours/query'
 import type {
@@ -116,6 +116,18 @@ let BuildingHoursProblemReportView = ({initialBuilding}: Props): React.ReactNode
 
 	return (
 		<ScrollView contentInsetAdjustmentBehavior="automatic">
+			{/* In the header rather than at the foot of the form: this screen
+			 * exists to send the report, and every schedule a venue has pushes a
+			 * cell at the bottom further down a sheet that shows about half a
+			 * screen. Here it is reachable at any detent, whatever the venue. */}
+			<Stack.Toolbar placement="right">
+				<Stack.Toolbar.Button
+					accessibilityLabel="Submit Report"
+					icon="paperplane.fill"
+					onPress={submit}
+				/>
+			</Stack.Toolbar>
+
 			<InfoHeader
 				message="If you could change what is incorrect and share it with us we&rsquo;d greatly appreciate it."
 				title="Thanks for spotting a problem!"
@@ -145,10 +157,6 @@ let BuildingHoursProblemReportView = ({initialBuilding}: Props): React.ReactNode
 						onPress={() => dispatch({type: 'ADD_SCHEDULE'})}
 						title="Add New Schedule"
 					/>
-				</Section>
-
-				<Section footer="Thanks for reporting!">
-					<ButtonCell accessoryIcon="paperplane.fill" onPress={submit} title="Submit Report" />
 				</Section>
 			</TableView>
 		</ScrollView>

--- a/app/(home)/BuildingHours/detail/report.tsx
+++ b/app/(home)/BuildingHours/detail/report.tsx
@@ -310,15 +310,13 @@ export default function BuildingHoursProblemReportPage(): React.ReactNode {
 	return (
 		<>
 			<Stack.Title>Report a Problem</Stack.Title>
-			{/* The edge-swipe gesture pops natively, ahead of anything in JS,
-			 * so the unsaved-changes guard above can't refuse it in time --
-			 * turned off here rather than guarded. */}
+			{/* On device, the edge-swipe gesture did not reliably surface the
+			 * unsaved-changes alert -- turned off here rather than guarded. */}
 			<Stack.Screen options={{gestureEnabled: false}} />
 			<Stack.Toolbar placement="left">
-				{/* The default native back button has the same problem: it pops
-				 * before `beforeRemove` gets a say. A JS-driven `goBack()` call,
-				 * the same dispatch the guard's own Discard button uses, keeps
-				 * the pop and the guard in sync. */}
+				{/* The default native back button had the same problem on device.
+				 * A JS-driven `goBack()` call, the same dispatch the guard's own
+				 * Discard button uses, keeps the pop and the guard in sync. */}
 				<Stack.Toolbar.Button
 					accessibilityLabel="Back"
 					icon="chevron.left"

--- a/app/(home)/BuildingHours/detail/report.tsx
+++ b/app/(home)/BuildingHours/detail/report.tsx
@@ -10,15 +10,15 @@ import {InfoHeader} from '@frogpond/info-header'
 import {TableView, Section, Cell} from '@frogpond/tableview'
 import {CellTextField, CellToggle, DeleteButtonCell, ButtonCell} from '@frogpond/tableview/cells'
 
-import {buildingByNameOptions} from '../../source/features/building-hours/query'
+import {buildingByNameOptions} from '../../../../source/features/building-hours/query'
 import type {
 	BuildingType,
 	NamedBuildingScheduleType,
 	SingleBuildingScheduleType,
-} from '../../source/features/building-hours/types'
-import {summarizeDays, formatBuildingTimes} from '../../source/features/building-hours/lib'
-import {submitReport} from '../../source/features/building-hours/report/submit'
-import type {BuildingAction} from '../../source/features/building-hours/report/building-reducer'
+} from '../../../../source/features/building-hours/types'
+import {summarizeDays, formatBuildingTimes} from '../../../../source/features/building-hours/lib'
+import {submitReport} from '../../../../source/features/building-hours/report/submit'
+import type {BuildingAction} from '../../../../source/features/building-hours/report/building-reducer'
 import {
 	applyBuildingAction,
 	clearReport,
@@ -27,7 +27,7 @@ import {
 	startReport,
 	useAppDispatch,
 	useAppSelector,
-} from '../../source/redux'
+} from '../../../../source/redux'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 
 function useBuildingEditor(initialBuilding: BuildingType) {
@@ -41,10 +41,11 @@ function useBuildingEditor(initialBuilding: BuildingType) {
 	let [submitted, setSubmitted] = React.useState(false)
 
 	/**
-	 * checking for unsaved edits
+	 * Checks for unsaved edits before this screen leaves the stack.
 	 *
-	 * noting that we also have `gestureEnabled` set to false in the navigation options
-	 * (ios only) to prevent dismissing the modal without prompting.
+	 * `beforeRemove` intercepts a pop however it was triggered -- the back
+	 * button or the edge-swipe gesture -- since this screen is pushed rather
+	 * than presented as a modal.
 	 * https://reactnavigation.org/docs/preventing-going-back
 	 */
 	React.useEffect(
@@ -312,10 +313,15 @@ export default function BuildingHoursProblemReportPage(): React.ReactNode {
 	return (
 		<>
 			<Stack.Title>Report a Problem</Stack.Title>
-			<Stack.Toolbar placement="right">
+			{/* The default native back button pops before `beforeRemove` gets a
+			 * say, which can leave the unsaved-changes guard unable to cancel
+			 * the pop it just intercepted. A JS-driven `goBack()` call, same as
+			 * the guard's own re-dispatch on Discard, keeps the two in sync. */}
+			<Stack.Screen options={{gestureEnabled: false}} />
+			<Stack.Toolbar placement="left">
 				<Stack.Toolbar.Button
-					accessibilityLabel="Close Screen"
-					icon="xmark"
+					accessibilityLabel="Back"
+					icon="chevron.left"
 					onPress={() => navigation.goBack()}
 				/>
 			</Stack.Toolbar>

--- a/app/(home)/BuildingHours/index.tsx
+++ b/app/(home)/BuildingHours/index.tsx
@@ -35,15 +35,6 @@ function BuildingHoursView(): React.ReactNode {
 		[dispatch],
 	)
 
-	let onReport = React.useCallback(
-		(building: BuildingType) =>
-			router.push({
-				pathname: '/BuildingHoursProblemReport',
-				params: {name: building.name},
-			}),
-		[router],
-	)
-
 	let onSelect = React.useCallback(
 		(building: BuildingType) =>
 			router.push({
@@ -94,7 +85,6 @@ function BuildingHoursView(): React.ReactNode {
 				isLoading={isLoading}
 				now={now}
 				onRefresh={refetch}
-				onReport={onReport}
 				onSelect={onSelect}
 				onToggleFavorite={onToggleFavorite}
 				searchQuery={searchQuery}

--- a/app/(home)/_layout.tsx
+++ b/app/(home)/_layout.tsx
@@ -25,10 +25,6 @@ export default function HomeLayout(): React.ReactNode {
 					sheetLargestUndimmedDetentIndex: 'none',
 				}}
 			/>
-			<Stack.Screen
-				name="BuildingHoursProblemReport"
-				options={{presentation: 'modal', gestureEnabled: false}}
-			/>
 			<Stack.Screen name="BuildingHoursScheduleEditor" options={{presentation: 'modal'}} />
 			<Stack.Screen name="Communities" />
 			<Stack.Screen name="Map" options={{title: 'Carleton Map'}} />

--- a/source/features/building-hours/detail/__tests__/building-detail.test.tsx
+++ b/source/features/building-hours/detail/__tests__/building-detail.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import moment from 'moment-timezone'
-import {describe, expect, test} from '@jest/globals'
+import {afterEach, describe, expect, test} from '@jest/globals'
 import {render} from '@testing-library/react-native'
 
 import type {BuildingType} from '../../types'
 import {BuildingDetailSwiftUI} from '../building-detail'
+import {images as buildingImages} from '../../../../../images/spaces'
 
 jest.mock('@expo/ui/swift-ui', () => {
 	// oxlint-disable-next-line typescript/no-require-imports
@@ -18,7 +19,9 @@ jest.mock('@frogpond/open-url', () => ({openUrl: jest.fn()}))
 
 // images/spaces imports every building photo through Metro's @2x/@3x density
 // resolution, which Jest's resolver does not implement -- mocked here so this
-// suite isn't the one to first trip over that unrelated gap.
+// suite isn't the one to first trip over that unrelated gap. The mocked Map is
+// mutable, so tests that need a resolvable photo populate it directly rather
+// than re-mocking the module.
 jest.mock('../../../../../images/spaces', () => ({images: new Map()}))
 
 const NOW = moment('2026-09-07T12:00:00')
@@ -67,5 +70,26 @@ describe('BuildingDetailSwiftUI', () => {
 		// string; it can't tell `<Text>{undefined}</Text>` apart from omitting
 		// the ternary entirely, since both render nothing here.
 		expect(queryByText(noteText)).toBeNull()
+	})
+
+	afterEach(() => {
+		buildingImages.clear()
+	})
+
+	test('renders the building photo when the building has one', async () => {
+		buildingImages.set('cage', {uri: 'cage.jpg', width: 100, height: 100, scale: 1})
+		let building = makeBuilding({image: 'cage'})
+
+		let {getByTestId} = await render(<BuildingDetailSwiftUI building={building} now={NOW} />)
+
+		expect(getByTestId('building-photo')).toBeTruthy()
+	})
+
+	test('renders no photo when the building has none', async () => {
+		let building = makeBuilding({image: undefined})
+
+		let {queryByTestId} = await render(<BuildingDetailSwiftUI building={building} now={NOW} />)
+
+		expect(queryByTestId('building-photo')).toBeNull()
 	})
 })

--- a/source/features/building-hours/detail/building-detail.tsx
+++ b/source/features/building-hours/detail/building-detail.tsx
@@ -37,11 +37,11 @@ type Props = {
 }
 
 /**
- * The building detail screen: header image, current status, one section per
- * schedule, and any links for the building.
+ * The building detail screen: current status, one section per schedule, the
+ * building's photo, and any links for the building.
  */
 export function BuildingDetailSwiftUI({building, now}: Props): React.ReactNode {
-	let headerImage =
+	let buildingPhoto =
 		building.image && buildingImages.has(building.image) ? buildingImages.get(building.image) : null
 
 	let status = getShortBuildingStatus(building, now)
@@ -99,7 +99,7 @@ export function BuildingDetailSwiftUI({building, now}: Props): React.ReactNode {
 					</Section>
 				))}
 
-				{headerImage ? (
+				{buildingPhoto ? (
 					<Section>
 						{/* The insets are zeroed on a wrapping stack because RNHostView
 						    takes no modifiers of its own, and they are zeroed so the photo
@@ -109,8 +109,9 @@ export function BuildingDetailSwiftUI({building, now}: Props): React.ReactNode {
 								<Image
 									accessibilityIgnoresInvertColors={true}
 									resizeMode="cover"
-									source={headerImage}
+									source={buildingPhoto}
 									style={styles.image}
+									testID="building-photo"
 								/>
 							</RNHostView>
 						</VStack>

--- a/source/features/building-hours/list/building-list-row.tsx
+++ b/source/features/building-hours/list/building-list-row.tsx
@@ -121,8 +121,19 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 				</HStack>
 			</Button>
 
-			<SwipeActions.Actions edge="trailing" allowsFullSwipe={false}>
-				<Button modifiers={[tint(c.systemBlue)]} onPress={() => onToggleFavorite(building)}>
+			{/* A full swipe now triggers this directly: with only one action left,
+			 * and a reversible one, that is the ordinary iOS pattern (Mail's
+			 * single-action swipe behaves the same way), not the two-action
+			 * "swipe reveals both, full swipe does neither" balance the report
+			 * action used to need. */}
+			<SwipeActions.Actions edge="trailing" allowsFullSwipe={true}>
+				<Button
+					modifiers={[
+						tint(c.systemBlue),
+						accessibilityLabel(isFavorite ? 'Remove from Favorites' : 'Add to Favorites'),
+					]}
+					onPress={() => onToggleFavorite(building)}
+				>
 					<Image systemName={isFavorite ? 'heart.slash' : 'heart'} />
 				</Button>
 			</SwipeActions.Actions>

--- a/source/features/building-hours/list/building-list-row.tsx
+++ b/source/features/building-hours/list/building-list-row.tsx
@@ -33,12 +33,11 @@ type Props = {
 	now: Moment
 	isFavorite: boolean
 	onToggleFavorite: (building: BuildingType) => void
-	onReport: (building: BuildingType) => void
 	onSelect: (building: BuildingType) => void
 }
 
 /**
- * A single building row: swipe-left reveals favorite/report actions.
+ * A single building row: swipe-left reveals the favorite action.
  * Tapping opens the building's detail sheet.
  */
 export const BuildingListRow = React.memo(function BuildingListRow({
@@ -46,7 +45,6 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 	now,
 	isFavorite,
 	onToggleFavorite,
-	onReport,
 	onSelect,
 }: Props): React.ReactNode {
 	let status = getShortBuildingStatus(building, now)
@@ -126,9 +124,6 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 			<SwipeActions.Actions edge="trailing" allowsFullSwipe={false}>
 				<Button modifiers={[tint(c.systemBlue)]} onPress={() => onToggleFavorite(building)}>
 					<Image systemName={isFavorite ? 'heart.slash' : 'heart'} />
-				</Button>
-				<Button modifiers={[tint(c.systemOrange)]} onPress={() => onReport(building)}>
-					<Image systemName="exclamationmark.bubble" />
 				</Button>
 			</SwipeActions.Actions>
 		</SwipeActions>

--- a/source/features/building-hours/list/building-list-row.tsx
+++ b/source/features/building-hours/list/building-list-row.tsx
@@ -121,11 +121,9 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 				</HStack>
 			</Button>
 
-			{/* A full swipe now triggers this directly: with only one action left,
-			 * and a reversible one, that is the ordinary iOS pattern (Mail's
-			 * single-action swipe behaves the same way), not the two-action
-			 * "swipe reveals both, full swipe does neither" balance the report
-			 * action used to need. */}
+			{/* One action, and a reversible one, so a full swipe triggers it
+			 * directly -- the ordinary iOS pattern, the same way Mail's
+			 * single-action swipe behaves. */}
 			<SwipeActions.Actions edge="trailing" allowsFullSwipe={true}>
 				<Button
 					modifiers={[

--- a/source/features/building-hours/list/building-list.tsx
+++ b/source/features/building-hours/list/building-list.tsx
@@ -17,7 +17,6 @@ type Props = {
 	now: Moment
 	favorites: string[]
 	onToggleFavorite: (building: BuildingType) => void
-	onReport: (building: BuildingType) => void
 	onSelect: (building: BuildingType) => void
 	onRefresh?: () => unknown
 	isLoading?: boolean
@@ -32,7 +31,6 @@ export const BuildingList = React.memo(function BuildingList({
 	now,
 	favorites,
 	onToggleFavorite,
-	onReport,
 	onSelect,
 	onRefresh,
 	isLoading,
@@ -75,7 +73,6 @@ export const BuildingList = React.memo(function BuildingList({
 										building={building}
 										isFavorite={favorites.includes(building.name)}
 										now={now}
-										onReport={onReport}
 										onSelect={onSelect}
 										onToggleFavorite={onToggleFavorite}
 									/>

--- a/uitests/ModuleBuildingHoursTests.swift
+++ b/uitests/ModuleBuildingHoursTests.swift
@@ -79,6 +79,7 @@ class ModuleBuildingHoursTests: UITestCase {
 			.verifyReportActionOffered()
 			.tapReportAction()
 			.verifyReportScreenPresented()
+			.verifyReportPushedIntoSheet()
 			.capture("Building Hours report screen")
 			// Presenting a modal while a formSheet is already up can silently
 			// no-op on iOS -- dismissing back to the detail sheet, rather than

--- a/uitests/ModuleBuildingHoursTests.swift
+++ b/uitests/ModuleBuildingHoursTests.swift
@@ -30,7 +30,7 @@ class ModuleBuildingHoursTests: UITestCase {
 			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
 			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
 			.verifyListStillBehind()
-			.capture("Building Hours detail sheet at half detent")
+			.capture("Building Hours detail sheet at the smaller detent")
 	}
 
 	/// `sheetLargestUndimmedDetentIndex: 'none'` is what makes this true: UIKit
@@ -49,7 +49,7 @@ class ModuleBuildingHoursTests: UITestCase {
 	}
 
 	/// `aBuildingWithLongSchedule` has two schedule sections plus a resource
-	/// link -- enough combined content to overflow the sheet's 0.5 detent,
+	/// link -- enough combined content to overflow the sheet's smaller detent,
 	/// unlike `anExcludedBuilding`'s single short section, which already fits
 	/// it entirely. Dragging it open is the case that would catch content
 	/// stuck laid out at the smaller detent's height.
@@ -86,6 +86,28 @@ class ModuleBuildingHoursTests: UITestCase {
 			// stack instead of replacing it.
 			.dismissReportScreen()
 			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+	}
+
+	/// The detail sheet offers no close control of its own -- only an overflow
+	/// menu and a favourite button -- so drag and backdrop are its only exits.
+	/// `preventNativeDismiss` on the report route makes this worth proving
+	/// directly: a `preventedRoutes` entry that outlived the report screen
+	/// would trap the user in a sheet nothing could close. This goes back with
+	/// no edits (so no alert should appear) and then drags the sheet itself
+	/// closed, confirming the exit still works once the report route is gone.
+	func testDismissingTheDetailSheetAfterVisitingReportWithNoEditsWorks() throws {
+		BuildingHoursScreen(app: app)
+			.navigate()
+			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.openDetailMenu()
+			.tapReportAction()
+			.verifyReportScreenPresented()
+			.dismissReportScreen()
+			.verifyNoDiscardChangesAlertPresented()
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.attemptToDragSheetClosed()
+			.verifyDetailSheetGone(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
 	}
 
 	/// The report screen's unsaved-changes guard has to survive every way out,
@@ -129,7 +151,7 @@ class ModuleBuildingHoursTests: UITestCase {
 			.attemptToTapDimmedBackdrop()
 			.verifyDiscardChangesAlertPresented()
 			.chooseToDiscardChanges()
-			.verifyReportScreenGone()
+			.verifyReportScreenGone(buildingName: TestIdentifiers.BuildingHours.anExcludedBuilding)
 	}
 
 	/// `BuildingHoursScheduleEditor` still presents as a `modal` on the OUTER

--- a/uitests/ModuleBuildingHoursTests.swift
+++ b/uitests/ModuleBuildingHoursTests.swift
@@ -81,11 +81,73 @@ class ModuleBuildingHoursTests: UITestCase {
 			.verifyReportScreenPresented()
 			.verifyReportPushedIntoSheet()
 			.capture("Building Hours report screen")
-			// Presenting a modal while a formSheet is already up can silently
-			// no-op on iOS -- dismissing back to the detail sheet, rather than
-			// straight to the list, is what proves it actually stacked on top
-			// of the sheet instead of replacing it or failing to present.
+			// Dismissing back to the detail sheet, rather than straight to the
+			// list, is what proves the report pushed into the sheet's own
+			// stack instead of replacing it.
 			.dismissReportScreen()
 			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+	}
+
+	/// The report screen's unsaved-changes guard has to survive every way out,
+	/// not just the ones a plain `beforeRemove` listener can see. Dragging the
+	/// sheet down or tapping its dimmed backdrop asks UIKit to dismiss the
+	/// *formSheet* natively -- a level up from the report screen's own pushed
+	/// stack -- which `beforeRemove` alone cannot refuse. This is the scenario
+	/// that motivated moving the guard to `usePreventRemove`.
+	func testUnsavedChangesGuardSurvivesEveryWayToLeave() throws {
+		let screen = BuildingHoursScreen(app: app)
+			.navigate()
+			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.openDetailMenu()
+			.tapReportAction()
+			.verifyReportScreenPresented()
+			.makeUnsavedEditOnReportScreen()
+
+		// The back button: cancelling keeps the edit and the report screen up.
+		screen
+			.dismissReportScreen()
+			.verifyDiscardChangesAlertPresented()
+			.chooseToKeepEditing()
+			.verifyReportScreenPresented()
+
+		// Dragging the sheet closed attempts a native dismissal of the whole
+		// formSheet, not just a pop of the report screen -- the path the
+		// Critical this test guards against found unguarded.
+		screen
+			.attemptToDragSheetClosed()
+			.verifyDiscardChangesAlertPresented()
+			.capture("Building Hours guard blocks a sheet drag")
+			.chooseToKeepEditing()
+			.verifyReportScreenPresented()
+
+		// The dimmed backdrop is the sheet's other native dismissal path.
+		// Confirming the discard this time proves the guard's "let it go"
+		// branch still actually lets the sheet close, rather than the guard
+		// having accidentally made the sheet undismissable outright.
+		screen
+			.attemptToTapDimmedBackdrop()
+			.verifyDiscardChangesAlertPresented()
+			.chooseToDiscardChanges()
+			.verifyReportScreenGone()
+	}
+
+	/// `BuildingHoursScheduleEditor` still presents as a `modal` on the OUTER
+	/// stack, pushed from the report screen two levels inside the formSheet.
+	/// A modal presented while a formSheet is already up is exactly the class
+	/// of presentation this task moved Report a Problem off of because it can
+	/// silently no-op on iOS -- this asserts whether the editor actually comes
+	/// up from its new, deeper starting point.
+	func testScheduleEditorPresentsFromWithinTheReportScreen() throws {
+		BuildingHoursScreen(app: app)
+			.navigate()
+			.tapRow(TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.verifyDetailSheetPresented(for: TestIdentifiers.BuildingHours.anExcludedBuilding)
+			.openDetailMenu()
+			.tapReportAction()
+			.verifyReportScreenPresented()
+			.openScheduleEditorFromReportScreen()
+			.capture("Building Hours schedule editor opened from the report screen")
+			.verifyScheduleEditorPresented()
 	}
 }

--- a/uitests/ModuleBuildingHoursTests.swift
+++ b/uitests/ModuleBuildingHoursTests.swift
@@ -80,6 +80,7 @@ class ModuleBuildingHoursTests: UITestCase {
 			.tapReportAction()
 			.verifyReportScreenPresented()
 			.verifyReportPushedIntoSheet()
+			.verifySubmitReportReachable()
 			.capture("Building Hours report screen")
 			// Dismissing back to the detail sheet, rather than straight to the
 			// list, is what proves the report pushed into the sheet's own

--- a/uitests/Screens/BuildingHoursScreen.swift
+++ b/uitests/Screens/BuildingHoursScreen.swift
@@ -140,7 +140,7 @@ struct BuildingHoursScreen: Screen {
 		return self
 	}
 
-	/// Assert the sheet is still at its smaller (0.5) detent: the closing
+	/// Assert the sheet is still at its smaller detent: the closing
 	/// footnote, the last thing on the detail screen, is not yet reachable --
 	/// whether because it exists but sits off-screen, or because the SwiftUI
 	/// `List` has not mounted content that far below the fold yet. Either way
@@ -160,7 +160,7 @@ struct BuildingHoursScreen: Screen {
 		return self
 	}
 
-	/// Drags the sheet from its half detent up to its larger one, the way
+	/// Drags the sheet from its smaller detent up to its larger one, the way
 	/// `CarletonMapScreen.expandSheet` drags the map's building sheet.
 	@discardableResult
 	func expandDetailSheet() -> Self {
@@ -251,10 +251,9 @@ struct BuildingHoursScreen: Screen {
 	/// presenting as a modal over it. Queried by the back button's own label
 	/// rather than `element(boundBy: 0)` -- the list's nav bar is still in the
 	/// hierarchy behind the sheet, so an unscoped positional query can match
-	/// the wrong bar's button. Also assert the list is still visible behind
-	/// the sheet, which is the "still a sheet, not a modal that replaced it"
-	/// half of the discriminator: a modal presented on the outer stack would
-	/// cover the list entirely.
+	/// the wrong bar's button. The back button carrying the sheet's own label
+	/// is the actual discriminator: a modal presented on the outer stack would
+	/// not carry a back button that pops into the sheet's nested stack.
 	@discardableResult
 	func verifyReportPushedIntoSheet() -> Self {
 		XCTAssertTrue(
@@ -267,7 +266,6 @@ struct BuildingHoursScreen: Screen {
 			back.exists && back.isHittable,
 			"The report should push into the sheet's stack, so it carries a back button")
 
-		verifyListStillBehind()
 		return self
 	}
 
@@ -343,13 +341,22 @@ struct BuildingHoursScreen: Screen {
 
 	/// Assert the report screen -- and, since a discarded sheet dismissal
 	/// closes the whole formSheet rather than just popping the report screen,
-	/// the sheet itself -- is gone.
+	/// the sheet itself -- is gone. Checking only `reportScreenPrompt` would
+	/// pass equally for a plain pop back to the building detail screen, with
+	/// the sheet still up behind it -- so this also asserts the sheet's own
+	/// title is gone, which only a real dismissal of the formSheet produces.
+	/// Scoped to `navigationBars` rather than a bare `staticTexts` lookup: the
+	/// building's name is also a list row's own label, which never goes away.
 	@discardableResult
-	func verifyReportScreenGone() -> Self {
+	func verifyReportScreenGone(buildingName: String) -> Self {
 		XCTAssertTrue(
 			app.staticTexts[TestIdentifiers.BuildingHours.reportScreenPrompt]
 				.waitForNonExistence(timeout: 15),
 			"Confirming the discard should have let the dismissal go through")
+		XCTAssertTrue(
+			app.navigationBars.staticTexts[buildingName].waitForNonExistence(timeout: 15),
+			"The sheet itself, titled \(buildingName), should have closed too, not just popped "
+				+ "back to it")
 		return self
 	}
 
@@ -386,6 +393,13 @@ struct BuildingHoursScreen: Screen {
 		return self
 	}
 
+	/// Distinguishes a sheet from a full-screen push: a pushed screen replaces
+	/// the list in the hierarchy, while a sheet leaves it present underneath.
+	/// `XCUIElement.exists` is true for a merely-covered element as much as a
+	/// visible one, so this does NOT tell a sheet apart from a modal that
+	/// covers the list -- react-native-screens' `modal` is a pageSheet that
+	/// also leaves the list in the hierarchy. Only meaningful where the
+	/// alternative under test is a full-screen push.
 	@discardableResult
 	func verifyListStillBehind() -> Self {
 		let row = app.element(
@@ -394,6 +408,18 @@ struct BuildingHoursScreen: Screen {
 		XCTAssertTrue(
 			row.exists,
 			"The list should still be behind the sheet, not replaced by it")
+		return self
+	}
+
+	/// Assert the detail sheet itself -- not just whatever screen was pushed
+	/// inside it -- has closed, by its own title going away. Scoped to
+	/// `navigationBars` rather than a bare `staticTexts` lookup: the building's
+	/// name is also a list row's own label, which never goes away.
+	@discardableResult
+	func verifyDetailSheetGone(for name: String) -> Self {
+		XCTAssertTrue(
+			app.navigationBars.staticTexts[name].waitForNonExistence(timeout: 15),
+			"The detail sheet, titled \(name), should have closed")
 		return self
 	}
 }

--- a/uitests/Screens/BuildingHoursScreen.swift
+++ b/uitests/Screens/BuildingHoursScreen.swift
@@ -249,16 +249,39 @@ struct BuildingHoursScreen: Screen {
 		return self
 	}
 
-	/// Dismisses the report screen via its own close button, per
-	/// `gestureEnabled: false` on that route -- the swipe-to-dismiss gesture is
-	/// off, so this is the only way out.
+	/// Assert the report screen pushed into the sheet's own stack rather than
+	/// presenting as a modal over it. `element(boundBy: 0)` alone cannot tell a
+	/// back chevron from a close button -- both are just "a button" in the nav
+	/// bar -- so this also asserts the close button used by the old modal
+	/// route is gone, which the push route's leading button positively is not.
+	@discardableResult
+	func verifyReportPushedIntoSheet() -> Self {
+		XCTAssertTrue(
+			app.staticTexts[TestIdentifiers.BuildingHours.reportScreenPrompt]
+				.waitForExistence(timeout: 30),
+			"The report screen should be up")
+
+		XCTAssertFalse(
+			app.buttons[TestIdentifiers.Navigation.closeScreen].exists,
+			"A pushed screen should not carry the modal's close button")
+
+		let back = app.navigationBars.buttons.element(boundBy: 0)
+		XCTAssertTrue(
+			back.exists && back.isHittable,
+			"The report should push into the sheet's stack, so it carries a back button")
+		return self
+	}
+
+	/// Dismisses the report screen via its navigation bar's leading button --
+	/// a back button, since the report is pushed into the sheet's own stack
+	/// rather than presented as a modal.
 	@discardableResult
 	func dismissReportScreen() -> Self {
-		let close = app.buttons[TestIdentifiers.Navigation.closeScreen].firstMatch
+		let back = app.navigationBars.buttons.element(boundBy: 0)
 		XCTAssertTrue(
-			close.waitForExistence(timeout: 30),
-			"The report screen should offer a way to close it")
-		close.tap()
+			back.waitForExistence(timeout: 30),
+			"The report screen should offer a way to go back")
+		back.tap()
 		return self
 	}
 

--- a/uitests/Screens/BuildingHoursScreen.swift
+++ b/uitests/Screens/BuildingHoursScreen.swift
@@ -221,11 +221,9 @@ struct BuildingHoursScreen: Screen {
 		return self
 	}
 
-	/// Taps Report a Problem in the detail sheet's overflow menu. This action
-	/// presents a `modal` route on the OUTER stack while a `formSheet` is
-	/// already up -- exactly the class of presentation that can silently no-op
-	/// on iOS -- so `verifyReportScreenPresented` is what proves it actually
-	/// worked rather than merely existing as a menu item.
+	/// Taps Report a Problem in the detail sheet's overflow menu.
+	/// `verifyReportScreenPresented` is what proves the push actually worked,
+	/// rather than the action merely existing as a menu item.
 	@discardableResult
 	func tapReportAction() -> Self {
 		let action = app.buttons[TestIdentifiers.BuildingHours.reportAction]
@@ -250,10 +248,13 @@ struct BuildingHoursScreen: Screen {
 	}
 
 	/// Assert the report screen pushed into the sheet's own stack rather than
-	/// presenting as a modal over it. `element(boundBy: 0)` alone cannot tell a
-	/// back chevron from a close button -- both are just "a button" in the nav
-	/// bar -- so this also asserts the close button used by the old modal
-	/// route is gone, which the push route's leading button positively is not.
+	/// presenting as a modal over it. Queried by the back button's own label
+	/// rather than `element(boundBy: 0)` -- the list's nav bar is still in the
+	/// hierarchy behind the sheet, so an unscoped positional query can match
+	/// the wrong bar's button. Also assert the list is still visible behind
+	/// the sheet, which is the "still a sheet, not a modal that replaced it"
+	/// half of the discriminator: a modal presented on the outer stack would
+	/// cover the list entirely.
 	@discardableResult
 	func verifyReportPushedIntoSheet() -> Self {
 		XCTAssertTrue(
@@ -261,27 +262,127 @@ struct BuildingHoursScreen: Screen {
 				.waitForExistence(timeout: 30),
 			"The report screen should be up")
 
-		XCTAssertFalse(
-			app.buttons[TestIdentifiers.Navigation.closeScreen].exists,
-			"A pushed screen should not carry the modal's close button")
-
-		let back = app.navigationBars.buttons.element(boundBy: 0)
+		let back = app.navigationBars.buttons[TestIdentifiers.Navigation.backButton]
 		XCTAssertTrue(
 			back.exists && back.isHittable,
 			"The report should push into the sheet's stack, so it carries a back button")
+
+		verifyListStillBehind()
 		return self
 	}
 
-	/// Dismisses the report screen via its navigation bar's leading button --
-	/// a back button, since the report is pushed into the sheet's own stack
-	/// rather than presented as a modal.
+	/// Dismisses the report screen via its own back button. Queried by label
+	/// rather than position -- see `verifyReportPushedIntoSheet`.
 	@discardableResult
 	func dismissReportScreen() -> Self {
-		let back = app.navigationBars.buttons.element(boundBy: 0)
+		let back = app.navigationBars.buttons[TestIdentifiers.Navigation.backButton]
 		XCTAssertTrue(
 			back.waitForExistence(timeout: 30),
 			"The report screen should offer a way to go back")
 		back.tap()
+		return self
+	}
+
+	/// Types a change into the report screen's Name field, the simplest way to
+	/// put the unsaved-changes guard into its "armed" state.
+	@discardableResult
+	func makeUnsavedEditOnReportScreen() -> Self {
+		let nameField = app.textFields.firstMatch
+		XCTAssertTrue(nameField.waitForExistence(timeout: 30), "The report screen should have a Name field")
+		nameField.tap()
+		nameField.typeText(" edited")
+		return self
+	}
+
+	private var discardChangesAlert: XCUIElement {
+		app.alerts["Discard changes?"]
+	}
+
+	@discardableResult
+	func verifyDiscardChangesAlertPresented() -> Self {
+		XCTAssertTrue(
+			discardChangesAlert.waitForExistence(timeout: 15),
+			"The unsaved-changes guard should have raised its alert")
+		return self
+	}
+
+	@discardableResult
+	func verifyNoDiscardChangesAlertPresented() -> Self {
+		XCTAssertFalse(
+			discardChangesAlert.waitForExistence(timeout: 5),
+			"No alert should appear -- this gesture should have been a no-op")
+		return self
+	}
+
+	/// Cancels the discard, staying on the screen with edits intact.
+	@discardableResult
+	func chooseToKeepEditing() -> Self {
+		discardChangesAlert.buttons["Edit"].tap()
+		return self
+	}
+
+	/// Confirms the discard, letting the pending navigation go through.
+	@discardableResult
+	func chooseToDiscardChanges() -> Self {
+		discardChangesAlert.buttons["Discard"].tap()
+		return self
+	}
+
+	/// Attempts to drag the detail sheet closed from inside the report screen,
+	/// the same drag `expandDetailSheet` uses to change detents, but downward
+	/// and past the bottom of the screen so it asks UIKit to dismiss the sheet
+	/// entirely rather than merely shrink it.
+	@discardableResult
+	func attemptToDragSheetClosed() -> Self {
+		app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.4))
+			.press(
+				forDuration: 0.1,
+				thenDragTo: app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 1.05)))
+		return self
+	}
+
+	/// Assert the report screen -- and, since a discarded sheet dismissal
+	/// closes the whole formSheet rather than just popping the report screen,
+	/// the sheet itself -- is gone.
+	@discardableResult
+	func verifyReportScreenGone() -> Self {
+		XCTAssertTrue(
+			app.staticTexts[TestIdentifiers.BuildingHours.reportScreenPrompt]
+				.waitForNonExistence(timeout: 15),
+			"Confirming the discard should have let the dismissal go through")
+		return self
+	}
+
+	/// Opens `BuildingHoursScheduleEditor` from one of the report screen's
+	/// editable hours rows -- "Weekdays" on `anExcludedBuilding`'s schedule.
+	/// The row is a single Pressable carrying a concatenated label (title and
+	/// detail together, e.g. "Weekdays, 7:30 AM — 8:00 PM"), not a standalone
+	/// "Weekdays" text, hence the prefix match.
+	@discardableResult
+	func openScheduleEditorFromReportScreen() -> Self {
+		let weekdaysRow = app.elementWithLabel(startingWith: "Weekdays")
+		XCTAssertTrue(
+			weekdaysRow.waitForExistence(timeout: 15),
+			"The report screen should list an editable Weekdays row")
+		weekdaysRow.tap()
+		return self
+	}
+
+	@discardableResult
+	func verifyScheduleEditorPresented() -> Self {
+		XCTAssertTrue(
+			app.staticTexts["Edit Schedule"].waitForExistence(timeout: 15),
+			"Tapping a schedule row should present the schedule editor")
+		return self
+	}
+
+	/// Taps the dimmed backdrop above the sheet -- the list behind it, which
+	/// `sheetLargestUndimmedDetentIndex: 'none'` keeps dimmed and untouchable
+	/// at every detent. A normal sheet dismisses on this tap; the guard should
+	/// refuse it the same as a drag.
+	@discardableResult
+	func attemptToTapDimmedBackdrop() -> Self {
+		app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1)).tap()
 		return self
 	}
 

--- a/uitests/Screens/BuildingHoursScreen.swift
+++ b/uitests/Screens/BuildingHoursScreen.swift
@@ -247,6 +247,28 @@ struct BuildingHoursScreen: Screen {
 		return self
 	}
 
+	/// Assert the report screen's submit control is on screen and can be tapped
+	/// the moment the screen appears.
+	///
+	/// `isHittable`, not `exists`: the control used to be the last cell of a
+	/// form whose length grows with every schedule a venue has, inside a sheet
+	/// that shows about half a screen -- so it existed in the hierarchy while
+	/// being off-screen for the venues that need it most. Sending the report
+	/// itself hands off to the system mail composer, which is outside the app
+	/// and outside what this can assert; that it can be reached at all is the
+	/// part that broke.
+	@discardableResult
+	func verifySubmitReportReachable() -> Self {
+		let submit = app.navigationBars.buttons[TestIdentifiers.BuildingHours.submitReportAction]
+		XCTAssertTrue(
+			submit.waitForExistence(timeout: 30),
+			"The report screen should offer Submit Report")
+		XCTAssertTrue(
+			submit.isHittable,
+			"Submit Report should be reachable without scrolling the form")
+		return self
+	}
+
 	/// Assert the report screen pushed into the sheet's own stack rather than
 	/// presenting as a modal over it. Queried by the back button's own label
 	/// rather than `element(boundBy: 0)` -- the list's nav bar is still in the

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -368,6 +368,8 @@ struct TestIdentifiers {
 		/// can tell the screen actually came up rather than the menu item merely
 		/// existing.
 		static let reportScreenPrompt = "Thanks for spotting a problem!"
+		/// The report screen's own submit control, in the navigation bar.
+		static let submitReportAction = "Submit Report"
 	}
 
 	// MARK: - Course Catalog

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -326,8 +326,10 @@ struct TestIdentifiers {
 		static let deburredQuery = "rolvaag"
 		/// A building that must fall out of the list when `deburredQuery` is
 		/// typed, so the test proves narrowing rather than mere survival. Also
-		/// the name shown as the detail sheet's own title once tapped, and its
-		/// schedule has enough content to overflow the sheet's half detent.
+		/// the name shown as the detail sheet's own title once tapped. Its
+		/// schedule is a single short section that already fits the sheet's
+		/// smaller detent -- see `aBuildingWithLongSchedule` for the one that
+		/// overflows it.
 		static let anExcludedBuilding = "The Cage"
 		/// Another Food-category building, in the same unscrolled viewport as
 		/// `anExcludedBuilding` -- so a tap aimed at it while a sheet is up lands
@@ -352,10 +354,9 @@ struct TestIdentifiers {
 		/// A schedule section heading on the detail sheet, shown only once a
 		/// building is open in the sheet.
 		static let detailSchedule = "HOURS"
-		/// The detail sheet's overflow menu button. UIKit gives an unlabelled
-		/// `ellipsis.circle` bar item the default accessibility label "More" --
-		/// the same string as `Buttons.more`, the Home screen's own tile, purely
-		/// by coincidence of wording rather than a shared identifier. The two
+		/// The detail sheet's overflow menu button, labelled "More" -- the same
+		/// string as `Buttons.more`, the Home screen's own tile, purely by
+		/// coincidence of wording rather than a shared identifier. The two
 		/// screens are never on screen together, so today's bare-label match in
 		/// `openDetailMenu` cannot collide with the tile, but reusing the
 		/// constant keeps that coincidence from drifting into two truths.

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -35,6 +35,10 @@ struct TestIdentifiers {
 	enum Navigation {
 		static let openSettings = "Open Settings"
 		static let closeScreen = "Close Screen"
+		/// Matches the report screen's own explicit back button, whose
+		/// accessibilityLabel is fixed rather than the previous screen's title,
+		/// so tests can assert on it regardless of which building is open.
+		static let backButton = "Back"
 	}
 
 	/// Labels UIKit gives a `Stack.SearchBar`'s own controls. In the bottom


### PR DESCRIPTION
Report a Problem was a route on the outer stack, so opening it from a building's detail sheet dismissed the sheet and pushed a full screen. It now lives inside the sheet's own stack — the sheet stays up, the report screen pushes into it with a back button.

That is the payoff from the spike in #7883: the sheet is a route group with its own `<Stack>`, so it can hold more than one screen.

## The data-loss hole this closed

The report screen has unsaved edits, and it guarded them with `navigation.addListener('beforeRemove')`. That covers the back button and it covers a swipe. It does **not** cover dragging the sheet away, because a native sheet dismissal never routes through that listener — only `usePreventRemove` populates `preventedRoutes`, which is what sets `preventNativeDismiss` on the native side.

So the screen could be dragged off with edits in it, silently. Swapped to `usePreventRemove`, and the XCUITest drags the sheet down with a dirty form and asserts the confirmation appears.

## Also here

The sheet's overflow menu and favourite button had no accessibility labels — added. And the detail screen's photo variable was named for where it came from rather than what it is.

## Screenshots

Report a Problem, pushed into the sheet's own stack with a back button rather than replacing it:

![Report screen](https://github.com/user-attachments/assets/169f0bec-8c55-4da7-8c03-e11dfb26b707)

The schedule editor presents from within that screen:

![Schedule editor](https://github.com/user-attachments/assets/b1bf904f-fa51-461b-a2bb-c36abbbf084c)

And the guard catches a **drag**, which the old `beforeRemove` listener never saw:

![Guard blocks a sheet drag](https://github.com/user-attachments/assets/eeb066f4-8205-4a51-a97a-d4c3de416e12)
