### PR TITLE
Show a venue's building on its detail sheet

### DIFF
--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -70,7 +70,30 @@ const FOOTPRINT_OPACITY = 0
 /// view. Symmetry here needs the tabs section's margins moved too.
 const SHEET_COLLAPSED_HEIGHT = 100
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
-const SHEET_DETENTS: PresentationDetent[] = [COLLAPSED_DETENT, 'medium', 'large']
+
+/// Two thirds rather than UIKit's own `medium`, which is exactly a half and
+/// leaves the list feeling cut off at the point most people stop dragging.
+const MIDDLE_DETENT: PresentationDetent = {fraction: 0.67}
+const SHEET_DETENTS: PresentationDetent[] = [COLLAPSED_DETENT, MIDDLE_DETENT, 'large']
+
+/// How tall a detent actually is, which the camera needs so it can keep that
+/// much of the map clear.
+///
+/// Read structurally rather than by identity: the sheet hands its selection
+/// back through `onSelectionChange`, and nothing promises that is the same
+/// object we passed in.
+function sheetHeightFor(detent: PresentationDetent, windowHeight: number): number {
+	if (detent === 'large') {
+		return windowHeight
+	}
+	if (detent === 'medium') {
+		return windowHeight / 2
+	}
+	if ('fraction' in detent) {
+		return windowHeight * detent.fraction
+	}
+	return detent.height
+}
 
 export default function MapPage(): React.ReactNode {
 	// `/Map` has served Carleton alone since before it read the route, so a
@@ -134,12 +157,7 @@ export default function MapPage(): React.ReactNode {
 
 	// How much of the map the sheet is covering right now, which is what the
 	// camera has to keep clear.
-	let sheetHeight =
-		detent === 'medium'
-			? windowHeight / 2
-			: detent === 'large'
-				? windowHeight
-				: SHEET_COLLAPSED_HEIGHT
+	let sheetHeight = sheetHeightFor(detent, windowHeight)
 
 	let footprints = React.useMemo(() => toBuildingFootprints(buildings), [buildings])
 
@@ -159,7 +177,7 @@ export default function MapPage(): React.ReactNode {
 			setSelectedBuildingId(id)
 			// Apple Maps raises its sheet to half height when you pick a place,
 			// which is also the stop the camera pads for.
-			moveSheet('medium')
+			moveSheet(MIDDLE_DETENT)
 		},
 		[moveSheet],
 	)
@@ -283,7 +301,7 @@ export default function MapPage(): React.ReactNode {
 								campus={campus}
 								onSelect={(id) => {
 									setSelectedBuildingId(id)
-									moveSheet('medium')
+									moveSheet(MIDDLE_DETENT)
 								}}
 							/>
 						)}

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {StyleSheet, useWindowDimensions, View, type NativeSyntheticEvent} from 'react-native'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {BottomSheet, Group, Host} from '@expo/ui/swift-ui'
 import {
 	background,
@@ -28,6 +29,7 @@ import {parseCampus, type Campus} from '../../../source/features/building-hours/
 import {BuildingInfo} from '../../../source/features/map/building-info'
 import {BuildingPicker} from '../../../source/features/map/building-picker'
 import {SHEET_RESTING_FRACTION} from '../../../source/lib/constants'
+import {sheetHeightFor} from '../../../source/features/map/lib/sheet-height'
 import {toBuildingFootprints} from '../../../source/features/map/lib/building-footprints'
 import {mapDataOptions} from '../../../source/features/map/query'
 import type {Coordinate, Point} from '../../../source/features/map/types'
@@ -77,25 +79,6 @@ const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
 const MIDDLE_DETENT: PresentationDetent = {fraction: SHEET_RESTING_FRACTION}
 const SHEET_DETENTS: PresentationDetent[] = [COLLAPSED_DETENT, MIDDLE_DETENT, 'large']
 
-/// How tall a detent actually is, which the camera needs so it can keep that
-/// much of the map clear.
-///
-/// Read structurally rather than by identity: the sheet hands its selection
-/// back through `onSelectionChange`, and nothing promises that is the same
-/// object we passed in.
-function sheetHeightFor(detent: PresentationDetent, windowHeight: number): number {
-	if (detent === 'large') {
-		return windowHeight
-	}
-	if (detent === 'medium') {
-		return windowHeight / 2
-	}
-	if ('fraction' in detent) {
-		return windowHeight * detent.fraction
-	}
-	return detent.height
-}
-
 export default function MapPage(): React.ReactNode {
 	// `/Map` has served Carleton alone since before it read the route, so a
 	// missing param keeps that default rather than falling through to
@@ -117,6 +100,7 @@ export default function MapPage(): React.ReactNode {
 	let [selectedBuildingId, setSelectedBuildingId] = React.useState<string | null>(null)
 	let {data: buildings = [], error} = useQuery(mapDataOptions(campus))
 	let {height: windowHeight} = useWindowDimensions()
+	let insets = useSafeAreaInsets()
 	let [sheetPresented, setSheetPresented] = React.useState(true)
 	// Which stop the sheet rests at. Driven by selecting a building, and by the
 	// user dragging it, which is why it is state rather than derived.
@@ -158,7 +142,9 @@ export default function MapPage(): React.ReactNode {
 
 	// How much of the map the sheet is covering right now, which is what the
 	// camera has to keep clear.
-	let sheetHeight = sheetHeightFor(detent, windowHeight)
+	// A fraction is measured against the window less the top inset, so the
+	// camera is padded against the same thing rather than the whole window.
+	let sheetHeight = sheetHeightFor(detent, windowHeight - insets.top)
 
 	let footprints = React.useMemo(() => toBuildingFootprints(buildings), [buildings])
 

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -27,6 +27,7 @@ import {NoticeView} from '@frogpond/notice'
 import {parseCampus, type Campus} from '../../../source/features/building-hours/query'
 import {BuildingInfo} from '../../../source/features/map/building-info'
 import {BuildingPicker} from '../../../source/features/map/building-picker'
+import {SHEET_RESTING_FRACTION} from '../../../source/lib/constants'
 import {toBuildingFootprints} from '../../../source/features/map/lib/building-footprints'
 import {mapDataOptions} from '../../../source/features/map/query'
 import type {Coordinate, Point} from '../../../source/features/map/types'
@@ -71,9 +72,9 @@ const FOOTPRINT_OPACITY = 0
 const SHEET_COLLAPSED_HEIGHT = 100
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
 
-/// Two thirds rather than UIKit's own `medium`, which is exactly a half and
+/// A fraction rather than UIKit's own `medium`, which is exactly a half and
 /// leaves the list feeling cut off at the point most people stop dragging.
-const MIDDLE_DETENT: PresentationDetent = {fraction: 0.67}
+const MIDDLE_DETENT: PresentationDetent = {fraction: SHEET_RESTING_FRACTION}
 const SHEET_DETENTS: PresentationDetent[] = [COLLAPSED_DETENT, MIDDLE_DETENT, 'large']
 
 /// How tall a detent actually is, which the camera needs so it can keep that

--- a/app/(home)/_layout.tsx
+++ b/app/(home)/_layout.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import {Stack} from 'expo-router'
 
+import {SHEET_RESTING_FRACTION} from '../../source/lib/constants'
+
 export default function HomeLayout(): React.ReactNode {
 	return (
 		<Stack screenOptions={{headerBackButtonDisplayMode: 'minimal'}}>
@@ -14,9 +16,9 @@ export default function HomeLayout(): React.ReactNode {
 				options={{
 					presentation: 'formSheet',
 					headerShown: false,
-					// Two thirds rather than a half: at a half the hours sat low enough
-					// that the sheet read as cramped.
-					sheetAllowedDetents: [0.68, 0.999],
+					// Shared with the campus map's sheet so the two rest at the same
+					// height; at a half the hours sat low enough to read as cramped.
+					sheetAllowedDetents: [SHEET_RESTING_FRACTION, 0.999],
 					sheetGrabberVisible: true,
 					// 'none' rather than 'last': the list behind has nothing worth
 					// touching once the sheet is up, and an undimmed detent lets UIKit

--- a/data/_schemas/building-hours.yaml
+++ b/data/_schemas/building-hours.yaml
@@ -20,7 +20,14 @@ properties:
     items: {$ref: '#/definitions/schedule'}
   breakSchedule:
     type: object
-    propertyNames: {enum: [fall, thanksgiving, winter, interim, spring, easter, summer]}
+    # The break names from _schemas/breaks.yaml, plus `summer`. Constrained so a
+    # key mis-indented into this block -- `building:`, say -- is rejected rather
+    # than silently swallowed. `christmasfest` is listed though no building
+    # currently sets hours for it: it is a real St. Olaf break, and the schema
+    # should not be what stops someone recording that the library closes early
+    # for it.
+    propertyNames:
+      enum: [fall, thanksgiving, christmasfest, winter, interim, spring, easter, summer]
 
 definitions:
   links:

--- a/mise.toml
+++ b/mise.toml
@@ -164,6 +164,10 @@ run = "tsc --noEmit"
 
 [tasks.test]
 description = "Run Jest tests"
+# Same reason as tsc above: source/features/building-hours/query.ts imports
+# docs/building-hours.json, which bundle-data generates, so the suite cannot
+# run against a clean checkout without it.
+depends = ["bundle-data"]
 run = "jest"
 
 # --- Data ---

--- a/source/features/building-hours/detail/__tests__/building-cutout.test.tsx
+++ b/source/features/building-hours/detail/__tests__/building-cutout.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import {describe, expect, test} from '@jest/globals'
+import {render} from '@testing-library/react-native'
+
+import {BuildingCutout} from '../building-cutout'
+import {makeBuilding} from '../../../map/__tests__/fixtures'
+import type {Building, Feature, GeometryCollection} from '../../../map/types'
+
+jest.mock('@maplibre/maplibre-react-native', () => {
+	// oxlint-disable-next-line typescript/no-require-imports
+	return require('../../../../testing/maplibre-mock') as typeof import('../../../../testing/maplibre-mock')
+})
+jest.mock('@expo/ui/swift-ui', () => {
+	// oxlint-disable-next-line typescript/no-require-imports
+	return require('../../../../testing/expo-ui-mock') as typeof import('../../../../testing/expo-ui-mock')
+})
+
+function withGeometry(geometry: GeometryCollection): Feature<Building> {
+	return {...makeBuilding({id: 'toh', name: 'Tomson Hall'}), geometry}
+}
+
+describe('BuildingCutout', () => {
+	test('renders a labelled map for a feature with a real footprint', async () => {
+		let feature = withGeometry({
+			type: 'GeometryCollection',
+			geometries: [
+				{
+					type: 'Polygon',
+					coordinates: [
+						[
+							[-93.18, 44.46],
+							[-93.17, 44.46],
+							[-93.17, 44.47],
+							[-93.18, 44.47],
+						],
+					],
+				},
+			],
+		})
+
+		let {getByLabelText} = await render(<BuildingCutout campus="stolaf" feature={feature} />)
+
+		expect(getByLabelText('Map showing Tomson Hall')).toBeTruthy()
+	})
+
+	// The building-hours data can carry a `building` key that resolves to a
+	// feature with no coordinates at all (a records-only stub, say), so this
+	// has to render nothing rather than an unframeable map.
+	test('renders nothing for a feature with no coordinates', async () => {
+		let feature = withGeometry({type: 'GeometryCollection', geometries: []})
+
+		let {queryByLabelText} = await render(<BuildingCutout campus="stolaf" feature={feature} />)
+
+		expect(queryByLabelText('Map showing Tomson Hall')).toBeNull()
+	})
+})

--- a/source/features/building-hours/detail/__tests__/building-cutout.test.tsx
+++ b/source/features/building-hours/detail/__tests__/building-cutout.test.tsx
@@ -19,30 +19,10 @@ function withGeometry(geometry: GeometryCollection): Feature<Building> {
 	return {...makeBuilding({id: 'toh', name: 'Tomson Hall'}), geometry}
 }
 
+// The rendered case lives in `building-detail.test.tsx`, which asserts the same
+// label plus the join and the query wiring that put the feature here. These two
+// cover what only this component decides: when to draw nothing.
 describe('BuildingCutout', () => {
-	test('renders a labelled map for a feature with a real footprint', async () => {
-		let feature = withGeometry({
-			type: 'GeometryCollection',
-			geometries: [
-				{
-					type: 'Polygon',
-					coordinates: [
-						[
-							[-93.18, 44.46],
-							[-93.17, 44.46],
-							[-93.17, 44.47],
-							[-93.18, 44.47],
-						],
-					],
-				},
-			],
-		})
-
-		let {getByLabelText} = await render(<BuildingCutout campus="stolaf" feature={feature} />)
-
-		expect(getByLabelText('Map showing Tomson Hall')).toBeTruthy()
-	})
-
 	// Six St. Olaf venues -- The Cage, Stav Hall and the rest of Buntrock's
 	// dining rooms among them -- key to a point-of-interest record whose only
 	// geometry is a Point. There is no footprint to fill, outline or label, and

--- a/source/features/building-hours/detail/__tests__/building-cutout.test.tsx
+++ b/source/features/building-hours/detail/__tests__/building-cutout.test.tsx
@@ -43,6 +43,22 @@ describe('BuildingCutout', () => {
 		expect(getByLabelText('Map showing Tomson Hall')).toBeTruthy()
 	})
 
+	// Six St. Olaf venues -- The Cage, Stav Hall and the rest of Buntrock's
+	// dining rooms among them -- key to a point-of-interest record whose only
+	// geometry is a Point. There is no footprint to fill, outline or label, and
+	// framing on a zero-area box clamps MapLibre to maximum zoom: a blank tile
+	// with a name floating on it.
+	test('renders nothing for a feature whose only geometry is a Point', async () => {
+		let feature = withGeometry({
+			type: 'GeometryCollection',
+			geometries: [{type: 'Point', coordinates: [-93.1827, 44.4619]}],
+		})
+
+		let {queryByLabelText} = await render(<BuildingCutout campus="stolaf" feature={feature} />)
+
+		expect(queryByLabelText('Map showing Tomson Hall')).toBeNull()
+	})
+
 	// The building-hours data can carry a `building` key that resolves to a
 	// feature with no coordinates at all (a records-only stub, say), so this
 	// has to render nothing rather than an unframeable map.

--- a/source/features/building-hours/detail/__tests__/building-detail.test.tsx
+++ b/source/features/building-hours/detail/__tests__/building-detail.test.tsx
@@ -2,9 +2,14 @@ import React from 'react'
 import moment from 'moment-timezone'
 import {afterEach, describe, expect, test} from '@jest/globals'
 import {render} from '@testing-library/react-native'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 
 import type {BuildingType} from '../../types'
+import type {Campus} from '../../query'
 import {BuildingDetailSwiftUI} from '../building-detail'
+import {keys as mapKeys} from '../../../map/query'
+import {makeBuilding as makeFeature} from '../../../map/__tests__/fixtures'
+import type {Building, Feature} from '../../../map/types'
 import {images as buildingImages} from '../../../../../images/spaces'
 
 jest.mock('@expo/ui/swift-ui', () => {
@@ -14,6 +19,10 @@ jest.mock('@expo/ui/swift-ui', () => {
 jest.mock('@expo/ui/swift-ui/modifiers', () => {
 	// oxlint-disable-next-line typescript/no-require-imports
 	return require('./expo-ui-mock') as typeof import('./expo-ui-mock')
+})
+jest.mock('@maplibre/maplibre-react-native', () => {
+	// oxlint-disable-next-line typescript/no-require-imports
+	return require('../../../../testing/maplibre-mock') as typeof import('../../../../testing/maplibre-mock')
 })
 jest.mock('@frogpond/open-url', () => ({openUrl: jest.fn()}))
 
@@ -41,6 +50,44 @@ function makeBuilding(overrides: Partial<BuildingType> = {}): BuildingType {
 	}
 }
 
+// Every query left without observers gets a garbage-collection timeout, and
+// React Query's default is five minutes -- long enough to outlive the run and
+// leave the Jest worker to be force-killed rather than exiting on its own.
+// Testing Library registers its unmounting afterEach when it is imported, and
+// Jest runs afterEach hooks in registration order, so by the time this one
+// runs the components are gone and every gc timeout has been armed.
+const trackedQueryClients: QueryClient[] = []
+
+afterEach(() => {
+	for (let queryClient of trackedQueryClients) {
+		queryClient.clear()
+	}
+	trackedQueryClients.length = 0
+})
+
+/**
+ * Renders the detail screen behind a `QueryClientProvider`, since it reads
+ * the map's geojson through `useQuery` now -- seeding `mapFeatures` puts that
+ * query straight into a warm cache rather than a real fetch, matching how the
+ * sheet behaves once `/Map` has visited the same campus.
+ */
+function renderDetail(
+	building: BuildingType,
+	campus: Campus = 'stolaf',
+	mapFeatures?: Array<Feature<Building>>,
+) {
+	let client = new QueryClient({defaultOptions: {queries: {retry: false}}})
+	trackedQueryClients.push(client)
+	if (mapFeatures) {
+		client.setQueryData(mapKeys.all(campus), mapFeatures)
+	}
+	return render(
+		<QueryClientProvider client={client}>
+			<BuildingDetailSwiftUI building={building} campus={campus} now={NOW} />
+		</QueryClientProvider>,
+	)
+}
+
 describe('BuildingDetailSwiftUI', () => {
 	// Regression test: Section's `footer` is a SwiftUI slot, and handing it a
 	// bare string -- rather than wrapping it in `Text` -- crashes at mount.
@@ -49,9 +96,7 @@ describe('BuildingDetailSwiftUI', () => {
 	test('renders a schedule with notes without throwing', () => {
 		let building = makeBuilding()
 
-		expect(() =>
-			render(<BuildingDetailSwiftUI building={building} campus="stolaf" now={NOW} />),
-		).not.toThrow()
+		expect(() => renderDetail(building)).not.toThrow()
 	})
 
 	test('renders a schedule with no notes and skips the footer', async () => {
@@ -65,9 +110,7 @@ describe('BuildingDetailSwiftUI', () => {
 			],
 		})
 
-		let {queryByText} = await render(
-			<BuildingDetailSwiftUI building={building} campus="stolaf" now={NOW} />,
-		)
+		let {queryByText} = await renderDetail(building)
 
 		// A schedule with no `notes` must not render another schedule's note
 		// text as its footer. This only catches a footer that renders the wrong
@@ -84,9 +127,7 @@ describe('BuildingDetailSwiftUI', () => {
 		buildingImages.set('cage', {uri: 'cage.jpg', width: 100, height: 100, scale: 1})
 		let building = makeBuilding({image: 'cage'})
 
-		let {getByTestId} = await render(
-			<BuildingDetailSwiftUI building={building} campus="stolaf" now={NOW} />,
-		)
+		let {getByTestId} = await renderDetail(building)
 
 		expect(getByTestId('building-photo')).toBeTruthy()
 	})
@@ -94,9 +135,7 @@ describe('BuildingDetailSwiftUI', () => {
 	test('renders no photo when the building has none', async () => {
 		let building = makeBuilding({image: undefined})
 
-		let {queryByTestId} = await render(
-			<BuildingDetailSwiftUI building={building} campus="stolaf" now={NOW} />,
-		)
+		let {queryByTestId} = await renderDetail(building)
 
 		expect(queryByTestId('building-photo')).toBeNull()
 	})
@@ -110,10 +149,50 @@ describe('BuildingDetailSwiftUI', () => {
 		buildingImages.set('disco', {uri: 'disco.jpg', width: 100, height: 100, scale: 1})
 		let building = makeBuilding({name: 'Writing Center', image: 'disco'})
 
-		let {queryByTestId} = await render(
-			<BuildingDetailSwiftUI building={building} campus="carleton" now={NOW} />,
-		)
+		let {queryByTestId} = await renderDetail(building, 'carleton')
 
 		expect(queryByTestId('building-photo')).toBeNull()
+	})
+
+	// The whole point of `building` -- Task 1's join key -- is a cutout that
+	// frames the venue's own building, not some other one. Registrar is the
+	// fixture the plan calls for: its `building` id (`toh`) differs from its
+	// own name, so this only passes if the lookup actually joined on the key
+	// rather than coincidentally matching a feature named the same as the venue.
+	test('shows the cutout, labelled with the joined building, when the venue carries a building key', async () => {
+		let toh = makeFeature({id: 'toh', name: 'Tomson Hall'})
+		// `makeFeature` defaults to an empty GeometryCollection -- the cutout
+		// renders nothing without a real footprint to frame, so this needs one.
+		toh.geometry = {
+			type: 'GeometryCollection',
+			geometries: [
+				{
+					type: 'Polygon',
+					coordinates: [
+						[
+							[-93.18, 44.46],
+							[-93.17, 44.46],
+							[-93.17, 44.47],
+							[-93.18, 44.47],
+						],
+					],
+				},
+			],
+		}
+		let building = makeBuilding({name: 'Registrar', building: 'toh'})
+
+		let {getByLabelText} = await renderDetail(building, 'stolaf', [toh])
+
+		expect(getByLabelText('Map showing Tomson Hall')).toBeTruthy()
+	})
+
+	// Every Carleton venue, and any St. Olaf one not yet keyed to a building,
+	// is this case -- no cutout, no placeholder, no empty frame.
+	test('shows no cutout when the venue carries no building key', async () => {
+		let building = makeBuilding({name: 'Sayles Café', building: undefined})
+
+		let {queryByLabelText} = await renderDetail(building, 'carleton')
+
+		expect(queryByLabelText(/^Map showing/u)).toBeNull()
 	})
 })

--- a/source/features/building-hours/detail/building-cutout.tsx
+++ b/source/features/building-hours/detail/building-cutout.tsx
@@ -9,9 +9,12 @@ import type {Building, Feature} from '../../map/types'
 import {mapStyleUrl} from '../../map/urls'
 import type {Campus} from '../query'
 
+/** How tall the cutout draws. */
 const CUTOUT_HEIGHT = 160
-/// Both campuses' styles ship the same Noto Sans stacks, so one font name
-/// works against either glyph endpoint.
+/**
+ * Both campuses' styles ship the same Noto Sans stacks, so one font name works
+ * against either glyph endpoint.
+ */
 const LABEL_FONT = ['Noto Sans Medium']
 /** Points of breathing room around the framed building, so its footprint
  * doesn't run flush against the cutout's edges. */

--- a/source/features/building-hours/detail/building-cutout.tsx
+++ b/source/features/building-hours/detail/building-cutout.tsx
@@ -33,7 +33,12 @@ type Props = {
  * `featureBounds` signals by returning `undefined`.
  */
 export function BuildingCutout({campus, feature}: Props): React.ReactNode {
-	let bounds = featureBounds(feature)
+	// Framed on the same geometry the layers below draw, so the two cannot
+	// disagree. Callers are expected to have checked `hasFootprint` already --
+	// this guard is the belt to that braces, and keeps the component honest on
+	// its own.
+	let footprints = toBuildingFootprints([feature])
+	let bounds = footprints.features.length > 0 ? featureBounds(feature) : undefined
 	if (!bounds) {
 		return null
 	}
@@ -74,7 +79,7 @@ export function BuildingCutout({campus, feature}: Props): React.ReactNode {
 				    puts the subject beyond doubt: `text-allow-overlap` and
 				    `text-ignore-placement` keep the label from being dropped in
 				    favour of a neighbour's. */}
-				<GeoJSONSource data={toBuildingFootprints([feature])} id="cutout-building">
+				<GeoJSONSource data={footprints} id="cutout-building">
 					<Layer
 						id="cutout-building-fill"
 						paint={{'fill-color': c.gold, 'fill-opacity': 0.35}}

--- a/source/features/building-hours/detail/building-cutout.tsx
+++ b/source/features/building-hours/detail/building-cutout.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react'
+import {StyleSheet} from 'react-native'
+import {RNHostView} from '@expo/ui/swift-ui'
+import {Camera, GeoJSONSource, Layer, Map} from '@maplibre/maplibre-react-native'
+import * as c from '@frogpond/colors'
+import {toBuildingFootprints} from '../../map/lib/building-footprints'
+import {featureBounds} from '../../map/lib/feature-bounds'
+import type {Building, Feature} from '../../map/types'
+import {mapStyleUrl} from '../../map/urls'
+import type {Campus} from '../query'
+
+const CUTOUT_HEIGHT = 160
+/// Both campuses' styles ship the same Noto Sans stacks, so one font name
+/// works against either glyph endpoint.
+const LABEL_FONT = ['Noto Sans Medium']
+/** Points of breathing room around the framed building, so its footprint
+ * doesn't run flush against the cutout's edges. */
+const CUTOUT_PADDING = 32
+
+type Props = {
+	campus: Campus
+	feature: Feature<Building>
+}
+
+/**
+ * A small, non-interactive map framed on the venue's own building -- "where
+ * this is," not decoration. No logo, no attribution link, no user location,
+ * and every touch gesture is off: the sheet's own drag and the list's own
+ * scroll have to reach past it undisturbed, and there is nothing here for a
+ * tap to do.
+ *
+ * Renders `null` when the feature carries no coordinates at all, which
+ * `featureBounds` signals by returning `undefined`.
+ */
+export function BuildingCutout({campus, feature}: Props): React.ReactNode {
+	let bounds = featureBounds(feature)
+	if (!bounds) {
+		return null
+	}
+
+	return (
+		<RNHostView matchContents={true}>
+			<Map
+				accessibilityLabel={`Map showing ${feature.properties.name}`}
+				accessibilityRole="image"
+				attribution={false}
+				compass={false}
+				doubleTapHoldZoom={false}
+				doubleTapZoom={false}
+				dragPan={false}
+				logo={false}
+				mapStyle={mapStyleUrl(campus)}
+				scaleBar={false}
+				style={styles.map}
+				touchPitch={false}
+				touchRotate={false}
+				touchZoom={false}
+			>
+				<Camera
+					initialViewState={{
+						bounds,
+						padding: {
+							top: CUTOUT_PADDING,
+							right: CUTOUT_PADDING,
+							bottom: CUTOUT_PADDING,
+							left: CUTOUT_PADDING,
+						},
+					}}
+				/>
+
+				{/* The basemap names whichever buildings its own collision rules
+				    allow, which at this zoom is usually the neighbours and not the
+				    one being framed. Drawing this building's own outline and name
+				    puts the subject beyond doubt: `text-allow-overlap` and
+				    `text-ignore-placement` keep the label from being dropped in
+				    favour of a neighbour's. */}
+				<GeoJSONSource data={toBuildingFootprints([feature])} id="cutout-building">
+					<Layer
+						id="cutout-building-fill"
+						paint={{'fill-color': c.gold, 'fill-opacity': 0.35}}
+						type="fill"
+					/>
+					<Layer
+						id="cutout-building-outline"
+						paint={{'line-color': c.gold, 'line-width': 2}}
+						type="line"
+					/>
+					<Layer
+						id="cutout-building-label"
+						layout={{
+							'text-allow-overlap': true,
+							'text-field': ['get', 'name'],
+							'text-font': LABEL_FONT,
+							'text-ignore-placement': true,
+							'text-size': 13,
+						}}
+						// Literal colours, not PlatformColor: MapLibre's paint spec takes
+						// style-spec strings and cannot resolve a dynamic system colour.
+						// Both campuses' basemaps are light, so dark-on-white reads in
+						// either appearance.
+						paint={{
+							'text-color': 'rgb(28, 28, 30)',
+							'text-halo-color': 'rgb(255, 255, 255)',
+							'text-halo-width': 1.5,
+						}}
+						type="symbol"
+					/>
+				</GeoJSONSource>
+			</Map>
+		</RNHostView>
+	)
+}
+
+const styles = StyleSheet.create({
+	map: {
+		width: '100%',
+		height: CUTOUT_HEIGHT,
+	},
+})

--- a/source/features/building-hours/detail/building-detail.tsx
+++ b/source/features/building-hours/detail/building-detail.tsx
@@ -14,10 +14,14 @@ import {
 	listStyle,
 	padding,
 } from '@expo/ui/swift-ui/modifiers'
+import {useQuery} from '@tanstack/react-query'
 import * as c from '@frogpond/colors'
 import type {Moment} from 'moment-timezone'
+import {BuildingCutout} from './building-cutout'
+import {findBuildingFeature} from '../lib/find-building-feature'
 import type {BuildingType} from '../types'
 import type {Campus} from '../query'
+import {mapDataOptions} from '../../map/query'
 import {images as buildingImages} from '../../../../images/spaces'
 import {
 	getShortBuildingStatus,
@@ -59,6 +63,17 @@ export function BuildingDetailSwiftUI({building, now, campus}: Props): React.Rea
 
 	let schedules = building.schedule || []
 	let links = building.links || []
+
+	// Every Carleton venue, and any St. Olaf one not yet keyed to a building,
+	// carries no `building` id -- skip the fetch entirely rather than warm a
+	// cache no lookup will ever use. Where a key does exist, this query shares
+	// `mapDataOptions`' cache key with `/Map`, so the sheet usually hits a warm
+	// cache instead of a spinner.
+	let {data: mapFeatures} = useQuery({
+		...mapDataOptions(campus),
+		enabled: Boolean(building.building),
+	})
+	let feature = mapFeatures ? findBuildingFeature(mapFeatures, building) : undefined
 
 	return (
 		// A Host doesn't need a React Native scroll view under it: the hosting
@@ -106,6 +121,17 @@ export function BuildingDetailSwiftUI({building, now, campus}: Props): React.Rea
 						))}
 					</Section>
 				))}
+
+				{feature ? (
+					<Section>
+						{/* Zeroed the same way the photo below is: RNHostView takes no
+						    modifiers of its own, so the inset has to come from the
+						    wrapping stack. */}
+						<VStack modifiers={[listRowInsets({top: 0, bottom: 0, leading: 0, trailing: 0})]}>
+							<BuildingCutout campus={campus} feature={feature} />
+						</VStack>
+					</Section>
+				) : null}
 
 				{buildingPhoto ? (
 					<Section>

--- a/source/features/building-hours/detail/building-detail.tsx
+++ b/source/features/building-hours/detail/building-detail.tsx
@@ -18,6 +18,7 @@ import {useQuery} from '@tanstack/react-query'
 import * as c from '@frogpond/colors'
 import type {Moment} from 'moment-timezone'
 import {BuildingCutout} from './building-cutout'
+import {hasFootprint} from '../../map/lib/building-footprints'
 import {findBuildingFeature} from '../lib/find-building-feature'
 import type {BuildingType} from '../types'
 import type {Campus} from '../query'
@@ -73,7 +74,11 @@ export function BuildingDetailSwiftUI({building, now, campus}: Props): React.Rea
 		...mapDataOptions(campus),
 		enabled: Boolean(building.building),
 	})
-	let feature = mapFeatures ? findBuildingFeature(mapFeatures, building) : undefined
+	let joined = mapFeatures ? findBuildingFeature(mapFeatures, building) : undefined
+	// A venue can join to a record with no outline -- a point of interest rather
+	// than a building. There is nothing to frame, so the section goes too: an
+	// empty row reads as a broken image, not as an absent one.
+	let feature = joined && hasFootprint(joined) ? joined : undefined
 
 	return (
 		// A Host doesn't need a React Native scroll view under it: the hosting

--- a/source/features/building-hours/lib/__tests__/find-building-feature.test.ts
+++ b/source/features/building-hours/lib/__tests__/find-building-feature.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, test} from '@jest/globals'
+import {makeBuilding} from '../../../map/__tests__/fixtures'
+import {findBuildingFeature} from '../find-building-feature'
+import type {BuildingType} from '../../types'
+
+function makeVenue(overrides: Partial<BuildingType> & {name: string}): BuildingType {
+	return {category: 'Academia', schedule: [], ...overrides}
+}
+
+describe('findBuildingFeature', () => {
+	test('returns the feature whose id matches the venue key', () => {
+		let toh = makeBuilding({id: 'toh', name: 'Tomson Hall'})
+		let features = [makeBuilding({id: 'thecage', name: 'The Cage'}), toh]
+		let venue = makeVenue({name: 'Tomson Hall', building: 'toh'})
+
+		expect(findBuildingFeature(features, venue)).toBe(toh)
+	})
+
+	test('returns undefined when the venue carries no key', () => {
+		let features = [makeBuilding({id: 'toh', name: 'Tomson Hall'})]
+		let venue = makeVenue({name: 'A Carleton Venue'})
+
+		expect(findBuildingFeature(features, venue)).toBeUndefined()
+	})
+
+	test('returns undefined when the key matches no feature, without throwing', () => {
+		let features = [makeBuilding({id: 'toh', name: 'Tomson Hall'})]
+		let venue = makeVenue({name: 'Not Yet Mapped', building: 'nonexistent-id'})
+
+		expect(() => findBuildingFeature(features, venue)).not.toThrow()
+		expect(findBuildingFeature(features, venue)).toBeUndefined()
+	})
+
+	test('resolves several venues sharing one building to that one feature', () => {
+		let toh = makeBuilding({id: 'toh', name: 'Tomson Hall'})
+		let features = [toh]
+		let registrar = makeVenue({name: 'Registrar', building: 'toh'})
+		let financialAid = makeVenue({name: 'Financial Aid', building: 'toh'})
+		let healthServices = makeVenue({name: 'Health Services', building: 'toh'})
+
+		expect(findBuildingFeature(features, registrar)).toBe(toh)
+		expect(findBuildingFeature(features, financialAid)).toBe(toh)
+		expect(findBuildingFeature(features, healthServices)).toBe(toh)
+	})
+})

--- a/source/features/building-hours/lib/find-building-feature.ts
+++ b/source/features/building-hours/lib/find-building-feature.ts
@@ -1,0 +1,23 @@
+import type {Building, Feature} from '../../map/types'
+import type {BuildingType} from '../types'
+
+/**
+ * Finds the map feature a venue sits in, matching `venue.building` against
+ * `Feature.id` and nothing else. A venue with no key, or a key that matches no
+ * feature, returns `undefined` — that is the normal case for a whole campus
+ * (Carleton carries no keys) and must not throw.
+ *
+ * Matching stays id-only on purpose: falling back to the building's name once
+ * put the Skoglund Athletic Center in a car park named `lot-skoglund`, and
+ * matched the Flaten Art Museum to the Flaten Art Barn, a different building.
+ */
+export function findBuildingFeature(
+	features: Array<Feature<Building>>,
+	venue: BuildingType,
+): Feature<Building> | undefined {
+	if (!venue.building) {
+		return undefined
+	}
+
+	return features.find((feature) => feature.id === venue.building)
+}

--- a/source/features/building-hours/query.ts
+++ b/source/features/building-hours/query.ts
@@ -41,10 +41,7 @@ function fetchBuildings(campus: Campus) {
 		// reason nobody could act on. Carleton's data lives outside this
 		// repository, so it still comes over the wire.
 		if (isUITesting && campus === 'stolaf') {
-			// Through `unknown` because a link's `url` is a string in JSON and a
-			// `URL` in `BuildingType` -- the same gap the network path casts over
-			// one line below, since the server sends the same JSON.
-			return (bundledBuildings as unknown as {data: BuildingType[]}).data
+			return (bundledBuildings as {data: BuildingType[]}).data
 		}
 
 		let response = await clientFor(campus).get('spaces/hours', {signal}).json()

--- a/source/features/building-hours/query.ts
+++ b/source/features/building-hours/query.ts
@@ -1,7 +1,9 @@
 import {carletonClient, client} from '@frogpond/api'
+import {isUITesting} from '@frogpond/launch-arguments'
 import {queryOptions, useQuery, UseQueryResult} from '@tanstack/react-query'
 import {groupBy} from 'lodash'
 import {selectFavoriteBuildings, useAppSelector} from '../../redux'
+import bundledBuildings from '../../../docs/building-hours.json'
 import {BuildingType} from './types'
 
 /** The two campuses that serve building hours through this feature. */
@@ -32,6 +34,19 @@ function clientFor(campus: Campus): typeof client {
 
 function fetchBuildings(campus: Campus) {
 	return async ({signal}: {signal: AbortSignal}): Promise<BuildingType[]> => {
+		// UI tests assert against what a screen does with a venue, so they need
+		// the same venues every run, and they need this repository's copy rather
+		// than the deployed one -- a `building` key added here only reaches the
+		// server once it merges, and a test for it would fail in between for a
+		// reason nobody could act on. Carleton's data lives outside this
+		// repository, so it still comes over the wire.
+		if (isUITesting && campus === 'stolaf') {
+			// Through `unknown` because a link's `url` is a string in JSON and a
+			// `URL` in `BuildingType` -- the same gap the network path casts over
+			// one line below, since the server sends the same JSON.
+			return (bundledBuildings as unknown as {data: BuildingType[]}).data
+		}
+
 		let response = await clientFor(campus).get('spaces/hours', {signal}).json()
 		return (response as {data: BuildingType[]}).data
 	}

--- a/source/features/building-hours/types.ts
+++ b/source/features/building-hours/types.ts
@@ -26,7 +26,16 @@ export type NamedBuildingScheduleType = {
 	hours: SingleBuildingScheduleType[]
 }
 
-export type BreakScheduleContainerType = Record<BreakNameEnumType, NamedBuildingScheduleType[]>
+/**
+ * Break schedules, keyed by break.
+ *
+ * Partial because neither campus publishes every break: both servers send seven
+ * of the eight, omitting `christmasfest`. Requiring the full set made the type
+ * a claim about the data that was never true.
+ */
+export type BreakScheduleContainerType = Partial<
+	Record<BreakNameEnumType, NamedBuildingScheduleType[]>
+>
 
 export type BuildingLinkType = {
 	title: string

--- a/source/features/building-hours/types.ts
+++ b/source/features/building-hours/types.ts
@@ -37,6 +37,10 @@ export type BuildingType = {
 	name: string
 	subtitle?: string
 	abbreviation?: string
+	/** The map feature id this venue sits in, e.g. `toh` for Tomson Hall. Several
+	 * venues can share one id — Registrar and Financial Aid both live in Tomson
+	 * Hall. Carleton venues carry none; their hours live outside this repo. */
+	building?: string
 	isNotice?: boolean
 	noticeMessage?: string
 	image?: string

--- a/source/features/map/lib/__tests__/feature-bounds.test.ts
+++ b/source/features/map/lib/__tests__/feature-bounds.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, test} from '@jest/globals'
+import {featureBounds} from '../feature-bounds'
+import {makeBuilding} from '../../__tests__/fixtures'
+import type {Feature, Building, GeometryCollection} from '../../types'
+
+function withGeometry(geometry: GeometryCollection): Feature<Building> {
+	return {...makeBuilding({id: 'toh', name: 'Tomson Hall'}), geometry}
+}
+
+describe('featureBounds', () => {
+	test('bounds a single Polygon to its ring', () => {
+		let feature = withGeometry({
+			type: 'GeometryCollection',
+			geometries: [
+				{
+					type: 'Polygon',
+					coordinates: [
+						[
+							[-93.18, 44.46],
+							[-93.17, 44.46],
+							[-93.17, 44.47],
+							[-93.18, 44.47],
+							[-93.18, 44.46],
+						],
+					],
+				},
+			],
+		})
+
+		expect(featureBounds(feature)).toEqual([-93.18, 44.46, -93.17, 44.47])
+	})
+
+	test('bounds a MultiPolygon across all of its disjoint wings', () => {
+		let feature = withGeometry({
+			type: 'GeometryCollection',
+			geometries: [
+				{
+					type: 'MultiPolygon',
+					coordinates: [
+						[
+							[
+								[-93.2, 44.5],
+								[-93.19, 44.5],
+								[-93.19, 44.51],
+							],
+						],
+						[
+							[
+								[-93.15, 44.4],
+								[-93.14, 44.4],
+								[-93.14, 44.41],
+							],
+						],
+					],
+				},
+			],
+		})
+
+		expect(featureBounds(feature)).toEqual([-93.2, 44.4, -93.14, 44.51])
+	})
+
+	test('ignores Point geometry when a Polygon is also present', () => {
+		let feature = withGeometry({
+			type: 'GeometryCollection',
+			geometries: [
+				{type: 'Point', coordinates: [-93.175, 44.465]},
+				{
+					type: 'Polygon',
+					coordinates: [
+						[
+							[-93.18, 44.46],
+							[-93.17, 44.46],
+							[-93.17, 44.47],
+							[-93.18, 44.47],
+						],
+					],
+				},
+			],
+		})
+
+		expect(featureBounds(feature)).toEqual([-93.18, 44.46, -93.17, 44.47])
+	})
+
+	test('falls back to a Point when no polygon exists', () => {
+		let feature = withGeometry({
+			type: 'GeometryCollection',
+			geometries: [{type: 'Point', coordinates: [-93.175, 44.465]}],
+		})
+
+		expect(featureBounds(feature)).toEqual([-93.175, 44.465, -93.175, 44.465])
+	})
+
+	test('returns undefined for a feature with no geometry at all', () => {
+		let feature = withGeometry({type: 'GeometryCollection', geometries: []})
+
+		expect(featureBounds(feature)).toBeUndefined()
+	})
+})

--- a/source/features/map/lib/__tests__/feature-bounds.test.ts
+++ b/source/features/map/lib/__tests__/feature-bounds.test.ts
@@ -59,11 +59,14 @@ describe('featureBounds', () => {
 		expect(featureBounds(feature)).toEqual([-93.2, 44.4, -93.14, 44.51])
 	})
 
-	test('ignores Point geometry when a Polygon is also present', () => {
+	// The point is deliberately outside the footprint. Every St. Olaf feature
+	// currently carries one inside its own outline, which would leave the
+	// bounds identical either way and make this test unable to fail.
+	test('stretches to cover a Point lying outside the Polygon', () => {
 		let feature = withGeometry({
 			type: 'GeometryCollection',
 			geometries: [
-				{type: 'Point', coordinates: [-93.175, 44.465]},
+				{type: 'Point', coordinates: [-93.19, 44.455]},
 				{
 					type: 'Polygon',
 					coordinates: [
@@ -78,7 +81,7 @@ describe('featureBounds', () => {
 			],
 		})
 
-		expect(featureBounds(feature)).toEqual([-93.18, 44.46, -93.17, 44.47])
+		expect(featureBounds(feature)).toEqual([-93.19, 44.455, -93.17, 44.47])
 	})
 
 	test('falls back to a Point when no polygon exists', () => {

--- a/source/features/map/lib/__tests__/sheet-height.test.ts
+++ b/source/features/map/lib/__tests__/sheet-height.test.ts
@@ -1,0 +1,27 @@
+import {describe, expect, test} from '@jest/globals'
+import {sheetHeightFor} from '../sheet-height'
+
+// 800 stands in for the window less its top inset -- what UIKit measures a
+// fraction against.
+const AVAILABLE = 800
+
+describe('sheetHeightFor', () => {
+	test('gives the whole available height to the large detent', () => {
+		expect(sheetHeightFor('large', AVAILABLE)).toBe(800)
+	})
+
+	test('gives half to the system medium detent', () => {
+		expect(sheetHeightFor('medium', AVAILABLE)).toBe(400)
+	})
+
+	test('scales a fractional detent by the available height', () => {
+		expect(sheetHeightFor({fraction: 0.68}, AVAILABLE)).toBeCloseTo(544)
+	})
+
+	// A detent given in points is already a height, so the available height
+	// does not enter into it -- the collapsed stop is 100pt on every device.
+	test('takes a point detent at its word', () => {
+		expect(sheetHeightFor({height: 100}, AVAILABLE)).toBe(100)
+		expect(sheetHeightFor({height: 100}, 2000)).toBe(100)
+	})
+})

--- a/source/features/map/lib/building-footprints.ts
+++ b/source/features/map/lib/building-footprints.ts
@@ -71,3 +71,15 @@ export function toBuildingFootprints(
 
 	return {type: 'FeatureCollection', features}
 }
+
+/**
+ * Whether a feature has an outline a map can draw.
+ *
+ * Several St. Olaf venues key to a point-of-interest record whose only geometry
+ * is a Point -- Buntrock's dining rooms, the bookstore, admissions. There is
+ * nothing to fill, outline or label, so anything that would frame or highlight
+ * a building has to ask this first rather than discovering it halfway down.
+ */
+export function hasFootprint(building: Feature<Building>): boolean {
+	return toBuildingFootprints([building]).features.length > 0
+}

--- a/source/features/map/lib/feature-bounds.ts
+++ b/source/features/map/lib/feature-bounds.ts
@@ -1,0 +1,45 @@
+import type {LngLatBounds} from '@maplibre/maplibre-react-native'
+import type {Building, Coordinate, Feature} from '../types'
+
+/**
+ * The smallest box containing every coordinate in a feature's geometry, in
+ * the west/south/east/north order MapLibre's `Camera` bounds want.
+ *
+ * Framing the camera on this rather than a fixed zoom is what makes a small
+ * building and a sprawling one both fill the cutout sensibly: a large
+ * building's bounds are wide, so the camera backs off further to fit them.
+ *
+ * Returns `undefined` for a feature with no coordinates at all -- a
+ * points-only, geometry-free record has nothing to frame -- so a caller can
+ * skip drawing rather than pass MapLibre an empty box.
+ */
+export function featureBounds(feature: Feature<Building>): LngLatBounds | undefined {
+	let west = Infinity
+	let south = Infinity
+	let east = -Infinity
+	let north = -Infinity
+
+	let visit = (coordinate: Coordinate) => {
+		let [lng, lat] = coordinate
+		west = Math.min(west, lng)
+		south = Math.min(south, lat)
+		east = Math.max(east, lng)
+		north = Math.max(north, lat)
+	}
+
+	for (let geometry of feature.geometry.geometries) {
+		if (geometry.type === 'Point') {
+			visit(geometry.coordinates)
+		} else if (geometry.type === 'Polygon') {
+			geometry.coordinates.forEach((ring) => ring.forEach(visit))
+		} else if (geometry.type === 'MultiPolygon') {
+			geometry.coordinates.forEach((polygon) => polygon.forEach((ring) => ring.forEach(visit)))
+		}
+	}
+
+	if (!Number.isFinite(west) || !Number.isFinite(south)) {
+		return undefined
+	}
+
+	return [west, south, east, north]
+}

--- a/source/features/map/lib/feature-bounds.ts
+++ b/source/features/map/lib/feature-bounds.ts
@@ -9,9 +9,11 @@ import type {Building, Coordinate, Feature} from '../types'
  * building and a sprawling one both fill the cutout sensibly: a large
  * building's bounds are wide, so the camera backs off further to fit them.
  *
- * Returns `undefined` for a feature with no coordinates at all -- a
- * points-only, geometry-free record has nothing to frame -- so a caller can
- * skip drawing rather than pass MapLibre an empty box.
+ * Returns `undefined` only for a feature carrying no coordinates whatsoever.
+ * A points-only record yields a real but zero-area box, which MapLibre fits by
+ * clamping to maximum zoom -- a blank tile, not a building. A caller that needs
+ * something worth framing should ask whether there is a footprint first; see
+ * `BuildingCutout`.
  */
 export function featureBounds(feature: Feature<Building>): LngLatBounds | undefined {
 	let west = Infinity

--- a/source/features/map/lib/sheet-height.ts
+++ b/source/features/map/lib/sheet-height.ts
@@ -1,0 +1,27 @@
+import type {PresentationDetent} from '@expo/ui/swift-ui/modifiers'
+
+/**
+ * How tall a detent actually is, which the camera needs so it can keep that
+ * much of the map clear.
+ *
+ * Read structurally rather than by identity: the sheet hands its selection back
+ * through `onSelectionChange`, and nothing promises that is the same object we
+ * passed in -- the native side builds a fresh dictionary.
+ *
+ * `available` is the height a fraction is measured against, which UIKit calls
+ * the maximum detent value: the window less the top inset, not the window. A
+ * sheet can never cover the status bar, so measuring against the full window
+ * over-pads the camera by the inset's share of the fraction.
+ */
+export function sheetHeightFor(detent: PresentationDetent, available: number): number {
+	if (detent === 'large') {
+		return available
+	}
+	if (detent === 'medium') {
+		return available / 2
+	}
+	if ('fraction' in detent) {
+		return available * detent.fraction
+	}
+	return detent.height
+}

--- a/source/lib/constants.ts
+++ b/source/lib/constants.ts
@@ -5,3 +5,13 @@ export const DEFAULT_URL = 'https://stolaf.api.frogpond.tech/v1/'
 // so without it the last path segment is replaced rather than extended.
 export const CARLETON_DEFAULT_URL = 'https://carleton.api.frogpond.tech/v1/'
 export const SUPPORT_EMAIL = 'allaboutolaf@frogpond.tech'
+
+/**
+ * Where a sheet rests before anyone drags it, as a fraction of the height it
+ * is allowed.
+ *
+ * Shared so the building detail sheet and the campus map's sheet cannot drift
+ * apart: a half leaves both of them reading as cramped, and two sheets in one
+ * app resting at different heights reads as an accident.
+ */
+export const SHEET_RESTING_FRACTION = 0.68

--- a/source/lib/constants.ts
+++ b/source/lib/constants.ts
@@ -7,11 +7,14 @@ export const CARLETON_DEFAULT_URL = 'https://carleton.api.frogpond.tech/v1/'
 export const SUPPORT_EMAIL = 'allaboutolaf@frogpond.tech'
 
 /**
- * Where a sheet rests before anyone drags it, as a fraction of the height it
- * is allowed.
+ * A sheet's middle stop, as a fraction of the height it is allowed.
  *
- * Shared so the building detail sheet and the campus map's sheet cannot drift
- * apart: a half leaves both of them reading as cramped, and two sheets in one
- * app resting at different heights reads as an accident.
+ * The building detail sheet opens here; the map's sheet opens collapsed and
+ * comes here when a building is picked. Shared so the two cannot drift apart --
+ * they already had, by a point -- since two sheets in one app stopping at
+ * different heights reads as an accident rather than a decision.
+ *
+ * A fraction is measured against UIKit's maximum detent value, which is the
+ * window less its top inset, not the window.
  */
 export const SHEET_RESTING_FRACTION = 0.68

--- a/source/testing/maplibre-mock.tsx
+++ b/source/testing/maplibre-mock.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import {View, type ViewProps} from 'react-native'
+
+/// `@maplibre/maplibre-react-native` bridges to a native MapLibre view through
+/// a TurboModule, which does not exist in the Jest runtime -- importing the
+/// real module throws before a single test runs. This stand-in renders `Map`
+/// as a plain `View` carrying the props a test can assert on (its
+/// accessibility label, in particular), and skips `Camera` and `Layer`
+/// entirely: neither draws anything a Jest tree can observe.
+///
+/// Deliberately narrow: it covers what `BuildingCutout` imports and nothing
+/// else, rather than pretending to be the whole module.
+
+type MapProps = Pick<ViewProps, 'accessibilityLabel' | 'accessibilityRole' | 'style' | 'testID'> & {
+	children?: React.ReactNode
+}
+
+export function Map({children, ...viewProps}: MapProps): React.ReactNode {
+	return <View {...viewProps}>{children}</View>
+}
+
+export function Camera(): React.ReactNode {
+	return null
+}
+
+/// Renders its children so a test can still reach whatever the source wraps.
+/// The GeoJSON it carries is data, and belongs to `toBuildingFootprints`' own
+/// tests rather than to a render assertion here.
+export function GeoJSONSource({children}: {children?: React.ReactNode}): React.ReactNode {
+	return <>{children}</>
+}
+
+/// A layer's whole job is paint and layout the renderer applies. There is
+/// nothing here Jest could assert that would not just be reading back the
+/// props we passed.
+export function Layer(): React.ReactNode {
+	return null
+}

--- a/source/testing/maplibre-mock.tsx
+++ b/source/testing/maplibre-mock.tsx
@@ -23,11 +23,11 @@ export function Camera(): React.ReactNode {
 	return null
 }
 
-/// Renders its children so a test can still reach whatever the source wraps.
-/// The GeoJSON it carries is data, and belongs to `toBuildingFootprints`' own
-/// tests rather than to a render assertion here.
-export function GeoJSONSource({children}: {children?: React.ReactNode}): React.ReactNode {
-	return <>{children}</>
+/// Draws nothing, like the layers it wraps. The GeoJSON it carries is data,
+/// and belongs to `toBuildingFootprints`' own tests rather than to a render
+/// assertion here.
+export function GeoJSONSource(): React.ReactNode {
+	return null
 }
 
 /// A layer's whole job is paint and layout the renderer applies. There is

--- a/uitests/ModuleCampusTests.swift
+++ b/uitests/ModuleCampusTests.swift
@@ -113,6 +113,35 @@ class ModuleCampusTests: UITestCase {
 				for: TestIdentifiers.Campus.aBuildingWithLongSchedule, titleBefore: titleBefore)
 	}
 
+	/// Registrar's `building` key (`toh`) resolves to a feature named Tomson
+	/// Hall, not Registrar -- so this only passes if the cutout actually joined
+	/// on the key, rather than coincidentally matching a feature sharing the
+	/// venue's own name. See `TestIdentifiers.Campus.aBuildingWithCutout`.
+	func testDetailSheetShowsACutoutMapForAVenueWithABuildingKey() throws {
+		CampusScreen(app: app)
+			.navigate()
+			// Registrar's category sits well below the list's initial viewport,
+			// so it is searched into view rather than assumed reachable the way
+			// `anExcludedBuilding` and its Food-category neighbours are.
+			.search(for: TestIdentifiers.Campus.aBuildingWithCutout)
+			.tapRow(TestIdentifiers.Campus.aBuildingWithCutout)
+			.verifyDetailSheetTitled(TestIdentifiers.Campus.aBuildingWithCutout)
+			.verifyCutoutShown(for: TestIdentifiers.Campus.aBuildingWithCutoutFrames)
+			.capture("Campus detail sheet showing a building cutout")
+	}
+
+	/// Every Carleton venue carries no `building` key -- its hours data lives
+	/// outside this repo -- so the absence of a cutout has to read as
+	/// deliberate, not as a broken map that silently failed to draw.
+	func testDetailSheetShowsNoCutoutForACarletonVenue() throws {
+		CampusScreen(app: app)
+			.navigateToCarleton()
+			.tapRow(TestIdentifiers.Campus.carletonBuilding)
+			.verifyDetailSheetTitled(TestIdentifiers.Campus.carletonBuilding)
+			.verifyNoCutoutShown()
+			.capture("Campus detail sheet for a Carleton venue, with no cutout")
+	}
+
 	func testDetailSheetMenuOffersReportAProblem() throws {
 		CampusScreen(app: app)
 			.navigate()

--- a/uitests/ModuleCarletonMapTests.swift
+++ b/uitests/ModuleCarletonMapTests.swift
@@ -17,5 +17,6 @@ class ModuleCarletonMapTests: UITestCase {
 			.expandSheet()
 			.selectBuilding(named: TestIdentifiers.CarletonMap.aBuilding)
 			.checkBuildingCardPresented()
+			.capture("Carleton map sheet at its middle detent, showing a building's card")
 	}
 }

--- a/uitests/Screens/CampusScreen.swift
+++ b/uitests/Screens/CampusScreen.swift
@@ -492,11 +492,17 @@ struct CampusScreen: Screen {
 	/// for every Carleton venue, which carries no `building` key at all. Not
 	/// scoped to one building's label: no cutout should exist for any building
 	/// here, so this checks for the shared label prefix instead.
+	///
+	/// Checks `exists` outright rather than waiting one out. A missing key
+	/// disables the map query, so the sheet decides against a cutout from the
+	/// same venue data that gave it the title -- and callers assert that title
+	/// first. There is no later moment for a cutout to arrive in, so a wait
+	/// here would only spend its full timeout on every passing run.
 	@discardableResult
 	func verifyNoCutoutShown() -> Self {
 		let cutout = app.elementWithLabel(startingWith: TestIdentifiers.Campus.cutoutLabelPrefix)
 		XCTAssertFalse(
-			cutout.waitForExistence(timeout: 5),
+			cutout.exists,
 			"No cutout map should appear for a venue with no building key")
 		return self
 	}

--- a/uitests/Screens/CampusScreen.swift
+++ b/uitests/Screens/CampusScreen.swift
@@ -470,4 +470,34 @@ struct CampusScreen: Screen {
 			"The detail sheet, titled \(name), should have closed")
 		return self
 	}
+
+	/// Assert the detail sheet shows a cutout map framing `buildingName` --
+	/// `BuildingCutout`'s own accessibility label, not a testID, since the
+	/// element XCUITest gets back for a plain accessibility-labelled native
+	/// view carries no identifier. Scrolls first: short content (Registrar's,
+	/// say) can already show everything the smaller detent offers, but nothing
+	/// here assumes that -- the list is scrolled toward the cutout's expected
+	/// position the same way `scrollUntilExists` proves any lazily-built row.
+	@discardableResult
+	func verifyCutoutShown(for buildingName: String) -> Self {
+		let cutout = app.elementWithLabel(startingWith: TestIdentifiers.Campus.cutoutLabelPrefix + buildingName)
+		scrollUntilExists(cutout)
+		XCTAssertTrue(
+			cutout.waitForExistence(timeout: 30),
+			"The detail sheet should show a cutout map framing \(buildingName)")
+		return self
+	}
+
+	/// Assert no cutout map appears anywhere in the detail sheet -- the case
+	/// for every Carleton venue, which carries no `building` key at all. Not
+	/// scoped to one building's label: no cutout should exist for any building
+	/// here, so this checks for the shared label prefix instead.
+	@discardableResult
+	func verifyNoCutoutShown() -> Self {
+		let cutout = app.elementWithLabel(startingWith: TestIdentifiers.Campus.cutoutLabelPrefix)
+		XCTAssertFalse(
+			cutout.waitForExistence(timeout: 5),
+			"No cutout map should appear for a venue with no building key")
+		return self
+	}
 }

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -387,6 +387,20 @@ struct TestIdentifiers {
 		/// hand-hosted map screen stays where it is, so this is a navigation,
 		/// not a mode switch.
 		static let mapButton = "Map"
+
+		/// A St. Olaf venue whose `building` key (`toh`) resolves to a
+		/// differently-named feature -- Tomson Hall, not Registrar -- so a test
+		/// asserting the cutout frames `aBuildingWithCutoutFrames` only passes if
+		/// the join actually used the key. `The Cage`, whose key (`thecage`)
+		/// happens to share wording with its own name, would pass even with a
+		/// broken join that fell back to matching on name.
+		static let aBuildingWithCutout = "Registrar"
+		static let aBuildingWithCutoutFrames = "Tomson Hall"
+
+		/// The prefix `BuildingCutout` sets as its accessibility label, naming
+		/// the building it frames. Mirrors the template literal in
+		/// source/features/building-hours/detail/building-cutout.tsx.
+		static let cutoutLabelPrefix = "Map showing "
 	}
 
 	// MARK: - Course Catalog

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -324,8 +324,9 @@ struct TestIdentifiers {
 	// MARK: - Campus
 
 	enum Campus {
-		/// A building ccc-server serves from this repo's data, so it is in the
-		/// list whatever host the app is pointed at.
+		/// A St. Olaf venue. Under test the app reads St. Olaf's hours from this
+		/// repository's bundled copy rather than a server, so this is whatever
+		/// `data/building-hours/` says today.
 		static let aBuilding = "Rølvaag Library"
 		/// A query that matches `aBuilding` only through deburring, so the test
 		/// fails if the filter stops stripping diacritics.


### PR DESCRIPTION
A building's detail sheet now shows a small map framing the building it sits in, using the `building:` keys added in #7892.

## What it draws

`findBuildingFeature` joins the venue's key to a map feature; `featureBounds` frames it; `BuildingCutout` draws the footprint with a fill, an outline and the building's name.

The label paint uses literal colours rather than `PlatformColor` — MapLibre's paint spec cannot resolve a `PlatformColor`, and passing one produces no error, just no label.

## Two ways it drew nothing useful, both fixed

**A blank tan tile.** Six St. Olaf venues key to features that are a bare point with no footprint. A zero-area bounding box clamps to maximum zoom, so the cutout rendered an empty tile that looked like a broken map. `hasFootprint` now gates the section — no footprint, no cutout, and no empty card left behind either.

I got this wrong first time round: I verified the cutout against the Registrar, which is a Polygon, and generalised from it. The evidence was in a screenshot I had captured and not opened. `feature-bounds.test.ts` had also pinned the broken behaviour as correct.

The long-term fix is StoDevX/campus-map-data#10, which gives those point-only places a `parent` building to fall back to.

## Sheet height

Both sheets now stop at the same fraction, shared as `SHEET_RESTING_FRACTION`. They had already drifted apart by a point. The fraction is measured against the window **less its top inset**, which is what UIKit measures a detent against — the earlier arithmetic used the whole window and overshot by the status bar's height.

## Schema

`building:` is now constrained in `data/_schemas/building-hours.yaml`, which catches the key being mis-indented into a `breakSchedule` block. While constraining the break names I derived the enum from the data files and dropped `christmasfest` — a real St. Olaf break with no current entries — which would have made its hours impossible to record. It comes from `_schemas/breaks.yaml` now.

`BreakScheduleContainerType` is `Partial`: no feed has ever sent all eight breaks.

## Screenshots

The Registrar is in Tomson Hall, so its sheet frames Tomson Hall — labelled, with its neighbours for context:

![Cutout](https://github.com/user-attachments/assets/c4c3d685-6175-4029-9c87-5617024af1a9)

A Carleton venue carries no building key, so there is no cutout and no empty card left where one would have been:

![No cutout](https://github.com/user-attachments/assets/71114e4b-c0bc-4577-9d59-7f36ebb974b1)
