### PR TITLE
Match the map sheet to Apple Maps

### DIFF
--- a/.claude/skills/run-on-simulator/SKILL.md
+++ b/.claude/skills/run-on-simulator/SKILL.md
@@ -98,12 +98,12 @@ a server is only half the job:
 | --- | --- |
 | `npx expo run:ios --port $PORT` | baked in at build time; the log then reads `Waiting on http://localhost:$PORT` |
 | `simctl openurl …expo-development-client/?url=…` | carried in the URL, percent-encoded (step 4 below) |
-| XCUITest | **it does not** — always 8081, see below |
+| XCUITest | `TEST_RUNNER_AAO_JS_LOCATION=localhost:$PORT` on the `xcodebuild test` command; `UITestCase` turns it into `-RCT_jsLocation` |
+| `simctl launch <UDID> <bundle id> -RCT_jsLocation localhost:$PORT` | a launch argument React Native reads before it guesses 8081 |
 
-**XCUITest cannot be pointed at your port.** `RCT_METRO_PORT` is a compile-time
-macro and this project ships React core precompiled, so a UITest build fetches
-from `localhost:8081` whoever owns it. Do not try to solve that with a port;
-embed the bundle instead — `run-uitests` has the recipe.
+`RCT_METRO_PORT` is only the compile-time default the guess falls back to; a
+launch argument overrides it at run time, and `--reset-state` does not clear
+it. `run-uitests` has the details and the embed-the-bundle alternative.
 
 If the app comes up on a red `No script URL provided` screen, or shows a screen
 that does not match your edits, suspect the port before you suspect your code.

--- a/.claude/skills/run-uitests/SKILL.md
+++ b/.claude/skills/run-uitests/SKILL.md
@@ -26,14 +26,14 @@ SKIP_BUNDLING=true CODE_SIGNING_DISABLED=true xcodebuild build-for-testing \
 xcrun simctl list devices available | grep iPhone   # pick a UDID
 xcrun simctl boot $UDID; xcrun simctl bootstatus $UDID -b
 
-# 3. Serve the JavaScript on 8081. The port is NOT negotiable here — see
-#    "Metro's port is baked in" below. In a lone worktree, this is enough.
-npx expo start --port 8081 &
-until curl -sf http://localhost:8081/status | grep -q running; do sleep 1; done
+# 3. Serve the JavaScript. Any free port; 8091 here because another checkout
+#    may own 8081 — see "Sharing a machine with other checkouts" below.
+npx expo start --port 8091 &
+until curl -sf http://localhost:8091/status | grep -q running; do sleep 1; done
 
 # 4. Run one test, or a suite, or the lot.
 rm -rf /tmp/results.xcresult
-xcodebuild test-without-building \
+TEST_RUNNER_AAO_JS_LOCATION=localhost:8091 xcodebuild test-without-building \
   -xctestrun $(find ios/build/Build/Products -name '*.xctestrun' -print -quit) \
   -destination "platform=iOS Simulator,id=<UDID>" \
   -only-testing:AllAboutOlafUITests/ModuleDirectoryTests/testSomething \
@@ -44,34 +44,33 @@ Pipe step 4 through `grep -E "^Test Case|error:|XCTAssert|Executed|\*\*"`.
 Unfiltered xcodebuild output is thousands of lines, most of it exported build
 settings, and it will bury the one assertion message you ran the test for.
 
-## Metro's port is baked in — embed the bundle instead
+## Sharing a machine with other checkouts
 
-**A UITest build always fetches JS from `localhost:8081`, and you cannot talk it
-out of that at run time.** `RCT_METRO_PORT` is a *compile-time* macro defaulting
-to 8081 (`node_modules/react-native/React/Base/RCTDefines.h:112`), and
-`ios/Podfile.properties.json` sets `EXPO_USE_PRECOMPILED_MODULES`, so
-`RCTBundleURLProvider` arrives precompiled — passing the macro to `xcodebuild`
-recompiles nothing. `UITestCase.setUp` also launches with `--reset-state`, and
-`AppDelegate` answers that by wiping the persistent defaults domain, taking any
-`RCT_jsLocation` override with it.
+A Debug build with no bundle inside asks `localhost:8081` for its JavaScript,
+and takes whatever answers. With parallel worktrees, that is whichever checkout
+started Metro first: the build succeeds, the tests run, and none of the JS is
+yours. Two ways out, and both are proven rather than assumed.
 
-So with parallel worktrees, the run-on-simulator advice to take your own port
-does **not** carry over: your tests will silently load whichever checkout owns
-8081. The build succeeds, the tests run, the screenshots look plausible, and
-none of it is your code.
+**Tell the app where your Metro is.** `-RCT_jsLocation host:port` is a launch
+argument React Native reads through `NSUserDefaults` before it guesses 8081
+(`RCTBundleURLProvider.mm`, `jsLocation`). `UITestCase` appends it whenever the
+test runner is started with `TEST_RUNNER_AAO_JS_LOCATION=host:port`, which is
+what step 4 does. It survives `--reset-state`: that flag removes the
+persistent defaults domain, and launch arguments live in the argument domain,
+which it does not touch. Verified on the simulator by reading the app's
+network log: every launch fetched `http://localhost:8091/index.bundle` and
+never asked 8081. It is not compiled in -- `RCT_METRO_PORT` is only the
+default the guess falls back to.
 
-The fix is to stop using Metro. `AppDelegate.bundleURL()` prefers an embedded
-bundle even in DEBUG, precisely so UITest runs can pin their JS:
+If the flag names a Metro that is not answering, the app falls back to guessing
+8081 again, so the `until` loop in step 3 is not optional. Neither is a clean
+cache after a `pnpm install` that purged `node_modules`: a Metro started before
+the purge serves "Unable to resolve" for every module until restarted with
+`--clear`.
 
-```swift
-#if DEBUG
-  if let bundled = Bundle.main.url(forResource: "main", withExtension: "jsbundle") {
-    return bundled
-  }
-  return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
-```
-
-Between step 1 and step 4, put this worktree's JS inside the `.app`:
+**Or embed the bundle and use no Metro at all.** `AppDelegate.bundleURL()`
+prefers a `main.jsbundle` inside the `.app` even in DEBUG, which is how CI
+runs. Between step 1 and step 4:
 
 ```bash
 mise run bundle:ios     # writes ios/AllAboutOlaf/main.jsbundle from THIS checkout
@@ -82,22 +81,14 @@ rm -rf "$APP/assets" && cp -R ios/assets "$APP/"
 ls "$APP/main.jsbundle"   # confirm before trusting any run
 ```
 
-(`mise run embed-jsbundle:ios` does this for `Debug-iphoneos`; the simulator
-needs the `Debug-iphonesimulator` path above.) Then skip step 3 entirely — no
-Metro, no port, and the JS provably came from this checkout. It is also what CI
-does, so a local pass and a CI pass mean the same thing.
+Then skip step 3. The cost: `bundle:ios` is a production-mode bundle, so no dev
+menu, redboxes become plain crashes, and every JS edit needs a re-bundle and
+re-copy rather than a re-run. Take this route when a run must match CI
+exactly; take the flag when you are iterating.
 
-Two consequences:
-
-- `bundle:ios` runs `expo export:embed --dev false`, so it is a production-mode
-  bundle: no dev menu, no fast refresh, redboxes become plain crashes.
-- **JS edits stop hot-reloading.** The red-green loop below still works, but each
-  iteration needs a re-bundle and re-copy, not just a re-run. Nothing is talking
-  to Metro any more, so a Metro reload changes nothing.
-
-Symptom that you skipped this: the UI hierarchy in the `.xcresult` shows a
-screen you do not recognise — an older layout, or elements your identifiers do
-not match. Dump the hierarchy before assuming your selectors are wrong.
+Symptom that neither happened: the UI hierarchy in the `.xcresult` shows a
+screen you do not recognise -- an older layout, or elements your identifiers
+do not match. Dump the hierarchy before assuming your selectors are wrong.
 
 ## Pin the destination
 

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -77,16 +77,13 @@ const FOOTPRINT_OPACITY = 0
 /// `SHEET_COLLAPSED_HEIGHT * scale` and this is not the height it takes on
 /// screen.
 ///
-/// It matches the picker's header block, `16 + 44 + 16` (see `SEARCH_MARGIN`
-/// in `building-picker.tsx`), which at this stop is all the picker draws. A
-/// shorter stop cannot hold the block, and SwiftUI centres content too tall
-/// for the box it is presented in rather than clipping its bottom, so the
-/// field's top edge is what a shorter stop cuts off; a taller one gives the
-/// slack to the list, and the space below the field grows.
-///
-/// Found by sweeping and looking at the captures, since none of that shows up
-/// in a frame, and solved for one simulator. See "Sizing the collapsed detent"
-/// in `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md`.
+/// It is the picker's header block, `16 + 44 + 16` (see `SEARCH_MARGIN` in
+/// `building-picker.tsx`), which at this stop is all the picker draws, so it
+/// holds on any device. A shorter stop cannot hold the block, and SwiftUI
+/// centres content too tall for the box it is presented in rather than
+/// clipping its bottom, so the field's top edge is what a shorter stop cuts
+/// off; a taller one gives the slack to the list, and the space below the
+/// field grows. `testSheetOpensOnItsCollapsedStop` checks the field is whole.
 const SHEET_COLLAPSED_HEIGHT = 76
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
 

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -31,6 +31,12 @@ import {BuildingPicker} from '../../../source/features/map/building-picker'
 import {SHEET_RESTING_FRACTION} from '../../../source/lib/constants'
 import {sheetHeightFor} from '../../../source/features/map/lib/sheet-height'
 import {toBuildingFootprints} from '../../../source/features/map/lib/building-footprints'
+import {
+	nextSheetDetent,
+	type SheetDetent,
+	type SheetEvent,
+	type SheetState,
+} from '../../../source/features/map/lib/sheet-moves'
 import {mapDataOptions} from '../../../source/features/map/query'
 import type {Coordinate, Point} from '../../../source/features/map/types'
 import {mapStyleUrl} from '../../../source/features/map/urls'
@@ -65,19 +71,36 @@ const MARKER_HIT_SLOP = (MIN_TOUCH_TARGET - MARKER_SIZE) / 2
 /// that drops a layer from the tree.
 const FOOTPRINT_OPACITY = 0
 
-/// Apple Maps' three stops, and the sheet never dismisses: the search field
-/// alone, half the screen, and `large`.
-/// Leaves 34pt above the search field and 20pt below it. Not symmetric, and
-/// not freely tunable: the gap below only grows by moving the sheet up, and by
-/// the time it matches the 34pt above, the category tabs below have risen into
-/// view. Symmetry here needs the tabs section's margins moved too.
-const SHEET_COLLAPSED_HEIGHT = 100
+/// Apple Maps' collapsed stop is its 44pt search field with 16pt above and
+/// below, and the grabber inside the top margin. The picker lays the field out
+/// with exactly those margins, so the two must move together.
+const SHEET_COLLAPSED_HEIGHT = 76
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
 
 /// A fraction rather than UIKit's own `medium`, which is exactly a half and
 /// leaves the list feeling cut off at the point most people stop dragging.
 const MIDDLE_DETENT: PresentationDetent = {fraction: SHEET_RESTING_FRACTION}
 const SHEET_DETENTS: PresentationDetent[] = [COLLAPSED_DETENT, MIDDLE_DETENT, 'large']
+
+/// The rules speak in names; the modifier speaks in detents. The rules' middle
+/// stop is `MIDDLE_DETENT`, not UIKit's `medium`.
+const DETENT_FOR: Record<SheetDetent, PresentationDetent> = {
+	collapsed: COLLAPSED_DETENT,
+	medium: MIDDLE_DETENT,
+	large: 'large',
+}
+
+/// Structural like `sheetHeightFor`, since a detent handed back by the sheet
+/// is not promised to be the object that went in.
+function nameOf(detent: PresentationDetent): SheetDetent {
+	if (detent === 'large') {
+		return 'large'
+	}
+	if (detent === 'medium' || 'fraction' in detent) {
+		return 'medium'
+	}
+	return 'collapsed'
+}
 
 export default function MapPage(): React.ReactNode {
 	// `/Map` has served Carleton alone since before it read the route, so a
@@ -102,27 +125,11 @@ export default function MapPage(): React.ReactNode {
 	let {height: windowHeight} = useWindowDimensions()
 	let insets = useSafeAreaInsets()
 	let [sheetPresented, setSheetPresented] = React.useState(true)
-	// Which stop the sheet rests at. Driven by selecting a building, and by the
-	// user dragging it, which is why it is state rather than derived.
-	let [detent, setDetent] = React.useState<PresentationDetent>(COLLAPSED_DETENT)
-	// Bumped only when we move the sheet ourselves, and used to key the Group.
-	// See `moveSheet`.
-	let [sheetNonce, setSheetNonce] = React.useState(0)
-
-	/// Moves the sheet, which takes more than setting the detent.
-	///
-	/// `presentationDetents`' `selection` is honoured when the SwiftUI view is
-	/// first built -- it seeds an `@State` -- but not when it changes after:
-	/// the new value never reaches the modifier instance, so its `onChange`
-	/// never fires. Remounting the Group rebuilds the modifier and the seed
-	/// path runs again with the value we want.
-	///
-	/// Keyed on a nonce rather than on the detent itself, because the detent
-	/// also changes when the user drags the sheet, and remounting then would
-	/// throw away their search text and scroll position mid-gesture.
-	let moveSheet = React.useCallback((to: PresentationDetent) => {
-		setDetent(to)
-		setSheetNonce((n) => n + 1)
+	// Where the sheet rests, and where a search focus lifted it from. Every
+	// move goes through `nextSheetDetent`, including the user's own drags.
+	let [sheet, setSheet] = React.useState<SheetState>({current: 'collapsed', previous: null})
+	let dispatchSheet = React.useCallback((event: SheetEvent) => {
+		setSheet((state) => nextSheetDetent(event, state))
 	}, [])
 
 	// The sheet has no dismissed state. `interactiveDismissDisabled` should keep
@@ -144,7 +151,7 @@ export default function MapPage(): React.ReactNode {
 	// camera has to keep clear.
 	// A fraction is measured against the window less the top inset, so the
 	// camera is padded against the same thing rather than the whole window.
-	let sheetHeight = sheetHeightFor(detent, windowHeight - insets.top)
+	let sheetHeight = sheetHeightFor(DETENT_FOR[sheet.current], windowHeight - insets.top)
 
 	let footprints = React.useMemo(() => toBuildingFootprints(buildings), [buildings])
 
@@ -162,11 +169,9 @@ export default function MapPage(): React.ReactNode {
 			// One sheet, whose contents swap. Tapping a second building while the
 			// card is up is a state change, not a presentation.
 			setSelectedBuildingId(id)
-			// Apple Maps raises its sheet to half height when you pick a place,
-			// which is also the stop the camera pads for.
-			moveSheet(MIDDLE_DETENT)
+			dispatchSheet({type: 'footprint-tapped'})
 		},
-		[moveSheet],
+		[dispatchSheet],
 	)
 
 	let selectedBuilding = React.useMemo(
@@ -255,7 +260,6 @@ export default function MapPage(): React.ReactNode {
 			<Host pointerEvents="none" style={StyleSheet.absoluteFill}>
 				<BottomSheet isPresented={sheetPresented} onIsPresentedChange={setSheetPresented}>
 					<Group
-						key={sheetNonce}
 						modifiers={[
 							// The sheet's own chrome is a translucent material, and the
 							// map read straight through the list. A PlatformColor rather
@@ -263,8 +267,8 @@ export default function MapPage(): React.ReactNode {
 							// still follows the system appearance.
 							background(c.systemGroupedBackground),
 							presentationDetents(SHEET_DETENTS, {
-								selection: detent,
-								onSelectionChange: setDetent,
+								selection: DETENT_FOR[sheet.current],
+								onSelectionChange: (to) => dispatchSheet({type: 'dragged', to: nameOf(to)}),
 							}),
 							presentationDragIndicator('visible'),
 							// The map behind the sheet stays live at every stop, which is
@@ -278,21 +282,20 @@ export default function MapPage(): React.ReactNode {
 						{selectedBuildingId ? (
 							<BuildingInfo
 								building={selectedBuilding}
-								onClose={() => {
-									setSelectedBuildingId(null)
-									moveSheet(COLLAPSED_DETENT)
-								}}
+								onClose={() => setSelectedBuildingId(null)}
 							/>
 						) : (
 							<BuildingPicker
 								campus={campus}
-								// oxlint-disable-next-line typescript/no-empty-function
-								onSearchCancel={() => {}}
-								// oxlint-disable-next-line typescript/no-empty-function
-								onSearchFocusChange={() => {}}
+								onSearchCancel={() => dispatchSheet({type: 'search-cancelled'})}
+								onSearchFocusChange={(focused, hasText) =>
+									dispatchSheet(
+										focused ? {type: 'search-focused'} : {type: 'search-blurred', hasText},
+									)
+								}
 								onSelect={(id) => {
 									setSelectedBuildingId(id)
-									moveSheet(MIDDLE_DETENT)
+									dispatchSheet({type: 'row-tapped'})
 								}}
 							/>
 						)}

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -76,11 +76,11 @@ const FOOTPRINT_OPACITY = 0
 /// a detent's role among the sheet's detents, not to this detent's own
 /// height, so this constant is a SCREEN-space number, unrelated in value to
 /// the picker's own layout margins even though both describe the same
-/// field. 53 is what measuring the field's on-screen margins on an iPhone
+/// field. 37 is what measuring the field's on-screen margins on an iPhone
 /// 17 Pro simulator converges to; see
 /// `.superpowers/sdd/2026-09-07-map-sheet-search-bar/task-8-report.md` for
 /// the measurements and whether that holds at another window size.
-const SHEET_COLLAPSED_HEIGHT = 53
+const SHEET_COLLAPSED_HEIGHT = 37
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
 
 /// A fraction rather than UIKit's own `medium`, which is exactly a half and

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -73,13 +73,15 @@ const FOOTPRINT_OPACITY = 0
 
 /// Apple Maps' collapsed stop lays its field out at 16 + 44 + 16 = 76pt in
 /// LAYOUT space. UIKit shrinks whatever a sheet presents by a scale tied to
-/// a detent's role among the sheet's detents, not to this detent's own
-/// height, so this constant is a SCREEN-space number, unrelated in value to
-/// the picker's own layout margins even though both describe the same
-/// field. 37 is what measuring the field's on-screen margins on an iPhone
-/// 17 Pro simulator converges to; see
+/// a detent's role among the sheet's detents, and that same shrink pins the
+/// sheet's own on-screen height near Maps' small-detent height (about
+/// 65.41pt on this simulator) no matter what this constant requests -- so,
+/// despite its name, this is NOT the sheet's rendered height. It is the
+/// particular request that puts the field's position inside that fixed
+/// on-screen sheet at symmetric margins: 37 is what measuring those margins
+/// on an iPhone 17 Pro simulator converges to; see
 /// `.superpowers/sdd/2026-09-07-map-sheet-search-bar/task-8-report.md` for
-/// the measurements and whether that holds at another window size.
+/// the arithmetic and whether that holds at another window size.
 const SHEET_COLLAPSED_HEIGHT = 37
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
 

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -72,20 +72,22 @@ const MARKER_HIT_SLOP = (MIN_TOUCH_TARGET - MARKER_SIZE) / 2
 const FOOTPRINT_OPACITY = 0
 
 /// The collapsed detent, requested in the sheet content's own layout space.
-/// UIKit shrinks whatever a sheet presents by a scale tied to the detent's
-/// role among the sheet's detents -- 0.860697 on an iPhone 17 Pro simulator --
-/// so the stop renders at `SHEET_COLLAPSED_HEIGHT * scale` and this is not the
-/// height it takes on screen.
+/// UIKit shrinks whatever a sheet presents by a scale tied to the detent --
+/// 0.86 at this one on an iPhone 17 Pro simulator -- so the stop renders at
+/// `SHEET_COLLAPSED_HEIGHT * scale` and this is not the height it takes on
+/// screen.
 ///
-/// **This value does not yet buy the collapsed stop the design asks for.** The
-/// picker's content is taller than the stop and SwiftUI centres what overflows,
-/// so the stop shows the middle of that content rather than its top: at 37 the
-/// search field is sliced across the top by 19.9pt. Every value swept between
-/// 37 and 110 trades that slice against a strip of category segments below the
-/// field, and no value avoids both. See "Sizing the collapsed detent" in
-/// `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md` for the
-/// measurements and what the stop would have to hold instead.
-const SHEET_COLLAPSED_HEIGHT = 37
+/// It matches the picker's header block, `16 + 44 + 16` (see `SEARCH_MARGIN`
+/// in `building-picker.tsx`), which at this stop is all the picker draws. A
+/// shorter stop cannot hold the block, and SwiftUI centres content too tall
+/// for the box it is presented in rather than clipping its bottom, so the
+/// field's top edge is what a shorter stop cuts off; a taller one gives the
+/// slack to the list, and the space below the field grows.
+///
+/// Found by sweeping and looking at the captures, since none of that shows up
+/// in a frame, and solved for one simulator. See "Sizing the collapsed detent"
+/// in `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md`.
+const SHEET_COLLAPSED_HEIGHT = 76
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
 
 /// A fraction rather than UIKit's own `medium`, which is exactly a half and
@@ -298,6 +300,7 @@ export default function MapPage(): React.ReactNode {
 						) : (
 							<BuildingPicker
 								campus={campus}
+								compact={sheet.current === 'collapsed'}
 								onSearchCancel={() => dispatchSheet({type: 'search-cancelled'})}
 								onSearchFocusChange={(focused, hasText) =>
 									dispatchSheet(

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -71,18 +71,20 @@ const MARKER_HIT_SLOP = (MIN_TOUCH_TARGET - MARKER_SIZE) / 2
 /// that drops a layer from the tree.
 const FOOTPRINT_OPACITY = 0
 
-/// Apple Maps' collapsed stop lays its field out at 16 + 44 + 16 = 76pt in
-/// LAYOUT space. UIKit shrinks whatever a sheet presents by a scale tied to
-/// a detent's role among the sheet's detents, and that same shrink pins the
-/// sheet's own on-screen height near Maps' small-detent height (about
-/// 65.41pt on this simulator) no matter what this constant requests -- so,
-/// despite its name, this is NOT the sheet's rendered height. It is the
-/// particular request that puts the field's position inside that fixed
-/// on-screen sheet at symmetric margins: 37 is what measuring those margins
-/// on an iPhone 17 Pro simulator converges to; see "Sizing the collapsed
-/// detent" in
-/// `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md` for
-/// the arithmetic and whether that holds at another window size.
+/// The collapsed detent, requested in the sheet content's own layout space.
+/// UIKit shrinks whatever a sheet presents by a scale tied to the detent's
+/// role among the sheet's detents -- 0.860697 on an iPhone 17 Pro simulator --
+/// so the stop renders at `SHEET_COLLAPSED_HEIGHT * scale` and this is not the
+/// height it takes on screen.
+///
+/// **This value does not yet buy the collapsed stop the design asks for.** The
+/// picker's content is taller than the stop and SwiftUI centres what overflows,
+/// so the stop shows the middle of that content rather than its top: at 37 the
+/// search field is sliced across the top by 19.9pt. Every value swept between
+/// 37 and 110 trades that slice against a strip of category segments below the
+/// field, and no value avoids both. See "Sizing the collapsed detent" in
+/// `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md` for the
+/// measurements and what the stop would have to hold instead.
 const SHEET_COLLAPSED_HEIGHT = 37
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
 

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -286,6 +286,10 @@ export default function MapPage(): React.ReactNode {
 						) : (
 							<BuildingPicker
 								campus={campus}
+								// oxlint-disable-next-line typescript/no-empty-function
+								onSearchCancel={() => {}}
+								// oxlint-disable-next-line typescript/no-empty-function
+								onSearchFocusChange={() => {}}
 								onSelect={(id) => {
 									setSelectedBuildingId(id)
 									moveSheet(MIDDLE_DETENT)

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -79,8 +79,9 @@ const FOOTPRINT_OPACITY = 0
 /// despite its name, this is NOT the sheet's rendered height. It is the
 /// particular request that puts the field's position inside that fixed
 /// on-screen sheet at symmetric margins: 37 is what measuring those margins
-/// on an iPhone 17 Pro simulator converges to; see
-/// `.superpowers/sdd/2026-09-07-map-sheet-search-bar/task-8-report.md` for
+/// on an iPhone 17 Pro simulator converges to; see "Sizing the collapsed
+/// detent" in
+/// `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md` for
 /// the arithmetic and whether that holds at another window size.
 const SHEET_COLLAPSED_HEIGHT = 37
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -71,10 +71,16 @@ const MARKER_HIT_SLOP = (MIN_TOUCH_TARGET - MARKER_SIZE) / 2
 /// that drops a layer from the tree.
 const FOOTPRINT_OPACITY = 0
 
-/// Apple Maps' collapsed stop is its 44pt search field with 16pt above and
-/// below, and the grabber inside the top margin. The picker lays the field out
-/// with exactly those margins, so the two must move together.
-const SHEET_COLLAPSED_HEIGHT = 76
+/// Apple Maps' collapsed stop lays its field out at 16 + 44 + 16 = 76pt in
+/// LAYOUT space. UIKit shrinks whatever a sheet presents by a scale tied to
+/// a detent's role among the sheet's detents, not to this detent's own
+/// height, so this constant is a SCREEN-space number, unrelated in value to
+/// the picker's own layout margins even though both describe the same
+/// field. 53 is what measuring the field's on-screen margins on an iPhone
+/// 17 Pro simulator converges to; see
+/// `.superpowers/sdd/2026-09-07-map-sheet-search-bar/task-8-report.md` for
+/// the measurements and whether that holds at another window size.
+const SHEET_COLLAPSED_HEIGHT = 53
 const COLLAPSED_DETENT: PresentationDetent = {height: SHEET_COLLAPSED_HEIGHT}
 
 /// A fraction rather than UIKit's own `medium`, which is exactly a half and

--- a/app/(home)/Map/index.tsx
+++ b/app/(home)/Map/index.tsx
@@ -71,6 +71,10 @@ const MARKER_HIT_SLOP = (MIN_TOUCH_TARGET - MARKER_SIZE) / 2
 /// that drops a layer from the tree.
 const FOOTPRINT_OPACITY = 0
 
+/// Under the header, clear of the sheet at every stop but `large`, which
+/// covers the whole map anyway.
+const ATTRIBUTION_POSITION = {top: 8, right: 8}
+
 /// The collapsed detent, requested in the sheet content's own layout space.
 /// UIKit shrinks whatever a sheet presents by a scale tied to the detent --
 /// 0.86 at this one on an iPhone 17 Pro simulator -- so the stop renders at
@@ -220,7 +224,15 @@ export default function MapPage(): React.ReactNode {
 	return (
 		<View style={StyleSheet.absoluteFill}>
 			<Stack.Title>{CAMPUS_TITLE[campus]}</Stack.Title>
-			<Map logo={false} mapStyle={mapStyleUrl(campus)} style={StyleSheet.absoluteFill}>
+			{/* The attribution button carries the OpenStreetMap credit the tiles'
+			    licence requires, so it stays; it moves to the top corner because
+			    the sheet's floating collapsed stop sat on top of it at the bottom. */}
+			<Map
+				attributionPosition={ATTRIBUTION_POSITION}
+				logo={false}
+				mapStyle={mapStyleUrl(campus)}
+				style={StyleSheet.absoluteFill}
+			>
 				<Camera
 					ref={cameraRef}
 					initialViewState={{center: CAMPUS_CENTER[campus], zoom: DEFAULT_ZOOM}}

--- a/modules/campus-search-bar/expo-module.config.json
+++ b/modules/campus-search-bar/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["CampusSearchBarModule"]
+  }
+}

--- a/modules/campus-search-bar/index.tsx
+++ b/modules/campus-search-bar/index.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react'
+import type {NativeSyntheticEvent} from 'react-native'
+import {requireNativeView} from 'expo'
+
+export type CampusSearchBarProps = {
+	placeholder: string
+	text: string
+	onTextChange: (text: string) => void
+	onFocusChange: (focused: boolean) => void
+	onCancel: () => void
+	testID?: string
+}
+
+type NativeProps = {
+	placeholder: string
+	text: string
+	testID?: string
+	onTextChange: (event: NativeSyntheticEvent<{value: string}>) => void
+	onFocusChange: (event: NativeSyntheticEvent<{value: boolean}>) => void
+	onCancel: () => void
+}
+
+const CampusSearchBarNativeView: React.ComponentType<NativeProps> = requireNativeView(
+	'CampusSearchBar',
+	'CampusSearchBarView',
+)
+
+/// UIKit's search bar as SwiftUI content, for sheets built with `@expo/ui`.
+/// Renders only inside a `Host`: it is a SwiftUI view, not a React Native one.
+export function CampusSearchBar({
+	onTextChange,
+	onFocusChange,
+	onCancel,
+	...rest
+}: CampusSearchBarProps): React.ReactNode {
+	return (
+		<CampusSearchBarNativeView
+			{...rest}
+			onCancel={onCancel}
+			onFocusChange={(event) => onFocusChange(event.nativeEvent.value)}
+			onTextChange={(event) => onTextChange(event.nativeEvent.value)}
+		/>
+	)
+}

--- a/modules/campus-search-bar/index.tsx
+++ b/modules/campus-search-bar/index.tsx
@@ -2,9 +2,10 @@ import * as React from 'react'
 import type {NativeSyntheticEvent} from 'react-native'
 import {requireNativeView} from 'expo'
 
+/// No `text` prop: the bar owns its text and reports changes. Cancel clears
+/// it natively and reports the empty string before `onCancel`.
 export type CampusSearchBarProps = {
 	placeholder: string
-	text: string
 	onTextChange: (text: string) => void
 	onFocusChange: (focused: boolean) => void
 	onCancel: () => void
@@ -13,7 +14,6 @@ export type CampusSearchBarProps = {
 
 type NativeProps = {
 	placeholder: string
-	text: string
 	testID?: string
 	onTextChange: (event: NativeSyntheticEvent<{value: string}>) => void
 	onFocusChange: (event: NativeSyntheticEvent<{value: boolean}>) => void

--- a/modules/campus-search-bar/ios/CampusSearchBar.podspec
+++ b/modules/campus-search-bar/ios/CampusSearchBar.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name           = 'CampusSearchBar'
+  s.version        = '1.0.0'
+  s.summary        = 'A UISearchBar for SwiftUI content hosted by @expo/ui'
+  s.description    = 'Expo module exposing UIKit\'s search bar as a SwiftUI view, so a sheet built with @expo/ui gets the system search field and its Cancel button'
+  s.authors        = { 'StoDevX' => 'allaboutolaf@frogpond.tech' }
+  s.license        = { type: 'MIT' }
+  s.homepage       = 'https://github.com/StoDevX/AAO-React-Native'
+  s.platforms      = { :ios => '15.1' }
+  s.source         = { git: 'https://github.com/StoDevX/AAO-React-Native.git', tag: s.version.to_s }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.source_files = '**/*.swift'
+end

--- a/modules/campus-search-bar/ios/CampusSearchBarModule.swift
+++ b/modules/campus-search-bar/ios/CampusSearchBarModule.swift
@@ -1,0 +1,9 @@
+import ExpoModulesCore
+
+public class CampusSearchBarModule: Module {
+	public func definition() -> ModuleDefinition {
+		Name("CampusSearchBar")
+
+		View(CampusSearchBarView.self)
+	}
+}

--- a/modules/campus-search-bar/ios/CampusSearchBarView.swift
+++ b/modules/campus-search-bar/ios/CampusSearchBarView.swift
@@ -3,7 +3,9 @@ import SwiftUI
 import UIKit
 
 /// Apple Maps' search field is 44pt tall. UIKit's default is shorter, so the
-/// height is pinned rather than inherited.
+/// height is pinned rather than inherited. The picker's margins, the
+/// collapsed detent's height, and `CarletonMapScreen.swift`'s scale
+/// derivation are all sized against this constant.
 private let fieldHeight: CGFloat = 44
 
 final class CampusSearchBarProps: ExpoSwiftUI.ViewProps {
@@ -62,6 +64,11 @@ private struct SearchBar: UIViewRepresentable {
 	func updateUIView(_ bar: UISearchBar, context: Context) {
 		context.coordinator.props = props
 		bar.placeholder = props.placeholder
+		// Set on both the bar and its text field, not tidied down to one: a test
+		// needs the bar's own identifier to scope a query for its Cancel button
+		// (`app.otherElements[id].buttons[...]`) and the text field's identifier
+		// to find the field itself (`app.searchFields[id]`) -- two different
+		// XCUITest element types, each keyed off this same testID.
 		bar.accessibilityIdentifier = props.testID
 		bar.searchTextField.accessibilityIdentifier = props.testID
 		// `props.text` can be an echo of a keystroke this coordinator already

--- a/modules/campus-search-bar/ios/CampusSearchBarView.swift
+++ b/modules/campus-search-bar/ios/CampusSearchBarView.swift
@@ -49,7 +49,13 @@ private struct SearchBar: UIViewRepresentable {
 		// Zero: the sheet content supplies the 16pt margins, so the bar must
 		// not add its own.
 		bar.directionalLayoutMargins = .zero
-		bar.searchTextField.heightAnchor.constraint(equalToConstant: fieldHeight).isActive = true
+		// Required would fight UISearchBar's own (private, undocumented) layout
+		// of the text field within the bar; 999 lets that layout win instead of
+		// throwing constraint-conflict warnings, at the cost of possibly falling
+		// short of 44pt — Task 5 measures the resulting height.
+		let textFieldHeight = bar.searchTextField.heightAnchor.constraint(equalToConstant: fieldHeight)
+		textFieldHeight.priority = UILayoutPriority(999)
+		textFieldHeight.isActive = true
 		return bar
 	}
 
@@ -58,7 +64,11 @@ private struct SearchBar: UIViewRepresentable {
 		bar.placeholder = props.placeholder
 		bar.accessibilityIdentifier = props.testID
 		bar.searchTextField.accessibilityIdentifier = props.testID
-		if bar.text != props.text {
+		// `props.text` after a keystroke is just JS echoing what the user typed,
+		// arriving one round-trip late. Writing it back would overwrite whatever
+		// the user has typed since, so only text JS actually originated (a value
+		// this coordinator did not just send) is allowed to move the caret.
+		if props.text != context.coordinator.lastSentText, bar.text != props.text {
 			bar.text = props.text
 		}
 		context.coordinator.updateCancelButton(on: bar, animated: false)
@@ -66,19 +76,26 @@ private struct SearchBar: UIViewRepresentable {
 
 	final class Coordinator: NSObject, UISearchBarDelegate {
 		var props: CampusSearchBarProps
+		/// The last value this coordinator sent to JS via `onTextChange`, so
+		/// `updateUIView` can tell "JS echoing what the user just typed" apart
+		/// from "JS actually changed the text" and only act on the latter.
+		var lastSentText: String?
 
 		init(props: CampusSearchBarProps) {
 			self.props = props
 		}
 
 		/// Cancel is there whenever there is something to cancel: an active
-		/// edit, or text left in the field after tapping away.
+		/// edit, or text left in the field after tapping away. `UISearchBar`
+		/// itself never becomes first responder — it forwards focus to its
+		/// inner text field — so that field is what must be asked.
 		func updateCancelButton(on bar: UISearchBar, animated: Bool) {
 			let hasText = !(bar.text ?? "").isEmpty
-			bar.setShowsCancelButton(bar.isFirstResponder || hasText, animated: animated)
+			bar.setShowsCancelButton(bar.searchTextField.isFirstResponder || hasText, animated: animated)
 		}
 
 		func searchBar(_ bar: UISearchBar, textDidChange text: String) {
+			lastSentText = text
 			props.onTextChange(["value": text])
 			updateCancelButton(on: bar, animated: true)
 		}
@@ -101,6 +118,7 @@ private struct SearchBar: UIViewRepresentable {
 			bar.text = ""
 			bar.resignFirstResponder()
 			bar.setShowsCancelButton(false, animated: true)
+			lastSentText = ""
 			props.onTextChange(["value": ""])
 			props.onCancel()
 		}

--- a/modules/campus-search-bar/ios/CampusSearchBarView.swift
+++ b/modules/campus-search-bar/ios/CampusSearchBarView.swift
@@ -1,0 +1,108 @@
+import ExpoModulesCore
+import SwiftUI
+import UIKit
+
+/// Apple Maps' search field is 44pt tall. UIKit's default is shorter, so the
+/// height is pinned rather than inherited.
+private let fieldHeight: CGFloat = 44
+
+final class CampusSearchBarProps: ExpoSwiftUI.ViewProps {
+	@Field var placeholder: String = ""
+	@Field var text: String = ""
+	@Field var testID: String?
+	var onTextChange = EventDispatcher()
+	var onFocusChange = EventDispatcher()
+	var onCancel = EventDispatcher()
+}
+
+/// The SwiftUI face of the module: what `@expo/ui`'s `Host` mounts as a child.
+struct CampusSearchBarView: ExpoSwiftUI.View {
+	@ObservedObject var props: CampusSearchBarProps
+
+	init(props: CampusSearchBarProps) {
+		self.props = props
+	}
+
+	var body: some View {
+		SearchBar(props: props)
+			.frame(height: fieldHeight)
+	}
+}
+
+/// UIKit's search bar, because it is the field Apple Maps draws and it owns
+/// the Cancel button's appearance and animation.
+private struct SearchBar: UIViewRepresentable {
+	@ObservedObject var props: CampusSearchBarProps
+
+	func makeCoordinator() -> Coordinator {
+		Coordinator(props: props)
+	}
+
+	func makeUIView(context: Context) -> UISearchBar {
+		let bar = UISearchBar()
+		bar.delegate = context.coordinator
+		// `.minimal` drops the bar's own background so the sheet's material
+		// shows through, leaving only the field itself, as in Maps.
+		bar.searchBarStyle = .minimal
+		bar.autocorrectionType = .no
+		bar.returnKeyType = .search
+		// Zero: the sheet content supplies the 16pt margins, so the bar must
+		// not add its own.
+		bar.directionalLayoutMargins = .zero
+		bar.searchTextField.heightAnchor.constraint(equalToConstant: fieldHeight).isActive = true
+		return bar
+	}
+
+	func updateUIView(_ bar: UISearchBar, context: Context) {
+		context.coordinator.props = props
+		bar.placeholder = props.placeholder
+		bar.accessibilityIdentifier = props.testID
+		bar.searchTextField.accessibilityIdentifier = props.testID
+		if bar.text != props.text {
+			bar.text = props.text
+		}
+		context.coordinator.updateCancelButton(on: bar, animated: false)
+	}
+
+	final class Coordinator: NSObject, UISearchBarDelegate {
+		var props: CampusSearchBarProps
+
+		init(props: CampusSearchBarProps) {
+			self.props = props
+		}
+
+		/// Cancel is there whenever there is something to cancel: an active
+		/// edit, or text left in the field after tapping away.
+		func updateCancelButton(on bar: UISearchBar, animated: Bool) {
+			let hasText = !(bar.text ?? "").isEmpty
+			bar.setShowsCancelButton(bar.isFirstResponder || hasText, animated: animated)
+		}
+
+		func searchBar(_ bar: UISearchBar, textDidChange text: String) {
+			props.onTextChange(["value": text])
+			updateCancelButton(on: bar, animated: true)
+		}
+
+		func searchBarTextDidBeginEditing(_ bar: UISearchBar) {
+			updateCancelButton(on: bar, animated: true)
+			props.onFocusChange(["value": true])
+		}
+
+		func searchBarTextDidEndEditing(_ bar: UISearchBar) {
+			updateCancelButton(on: bar, animated: true)
+			props.onFocusChange(["value": false])
+		}
+
+		func searchBarSearchButtonClicked(_ bar: UISearchBar) {
+			bar.resignFirstResponder()
+		}
+
+		func searchBarCancelButtonClicked(_ bar: UISearchBar) {
+			bar.text = ""
+			bar.resignFirstResponder()
+			bar.setShowsCancelButton(false, animated: true)
+			props.onTextChange(["value": ""])
+			props.onCancel()
+		}
+	}
+}

--- a/modules/campus-search-bar/ios/CampusSearchBarView.swift
+++ b/modules/campus-search-bar/ios/CampusSearchBarView.swift
@@ -64,25 +64,45 @@ private struct SearchBar: UIViewRepresentable {
 		bar.placeholder = props.placeholder
 		bar.accessibilityIdentifier = props.testID
 		bar.searchTextField.accessibilityIdentifier = props.testID
-		// `props.text` after a keystroke is just JS echoing what the user typed,
-		// arriving one round-trip late. Writing it back would overwrite whatever
-		// the user has typed since, so only text JS actually originated (a value
-		// this coordinator did not just send) is allowed to move the caret.
-		if props.text != context.coordinator.lastSentText, bar.text != props.text {
-			bar.text = props.text
+		// `props.text` can be an echo of a keystroke this coordinator already
+		// sent, arriving late. If it matches a still-pending sent value, drop
+		// that value (and anything queued before it, now unreachable) and leave
+		// the field alone; otherwise it is a genuine JS-originated change — a
+		// paste, a cleared search, a tapped suggestion — and must be written,
+		// which also means anything still in flight is now stale and moot.
+		if let echoedIndex = context.coordinator.pendingSent.firstIndex(of: props.text) {
+			context.coordinator.pendingSent.removeFirst(echoedIndex + 1)
+		} else {
+			if bar.text != props.text {
+				bar.text = props.text
+			}
+			context.coordinator.pendingSent.removeAll()
 		}
 		context.coordinator.updateCancelButton(on: bar, animated: false)
 	}
 
 	final class Coordinator: NSObject, UISearchBarDelegate {
 		var props: CampusSearchBarProps
-		/// The last value this coordinator sent to JS via `onTextChange`, so
-		/// `updateUIView` can tell "JS echoing what the user just typed" apart
-		/// from "JS actually changed the text" and only act on the latter.
-		var lastSentText: String?
+		/// Values sent to JS via `onTextChange` that have not yet come back
+		/// through `props.text`, oldest first. A single remembered value is not
+		/// enough: two keystrokes sent before either echoes back need their own
+		/// slots, or the second keystroke's echo is mistaken for the first's and
+		/// the first is dropped. Capped so a JS side that never echoes — a bug
+		/// on that end — cannot grow this without bound.
+		var pendingSent: [String] = []
 
 		init(props: CampusSearchBarProps) {
 			self.props = props
+		}
+
+		/// Queues a value this coordinator is about to report to JS, so its
+		/// eventual echo through `props.text` can be told apart from a change
+		/// JS made on its own.
+		func recordSent(_ text: String) {
+			pendingSent.append(text)
+			if pendingSent.count > 32 {
+				pendingSent.removeFirst()
+			}
 		}
 
 		/// Cancel is there whenever there is something to cancel: an active
@@ -95,7 +115,7 @@ private struct SearchBar: UIViewRepresentable {
 		}
 
 		func searchBar(_ bar: UISearchBar, textDidChange text: String) {
-			lastSentText = text
+			recordSent(text)
 			props.onTextChange(["value": text])
 			updateCancelButton(on: bar, animated: true)
 		}
@@ -118,7 +138,7 @@ private struct SearchBar: UIViewRepresentable {
 			bar.text = ""
 			bar.resignFirstResponder()
 			bar.setShowsCancelButton(false, animated: true)
-			lastSentText = ""
+			recordSent("")
 			props.onTextChange(["value": ""])
 			props.onCancel()
 		}

--- a/modules/campus-search-bar/ios/CampusSearchBarView.swift
+++ b/modules/campus-search-bar/ios/CampusSearchBarView.swift
@@ -8,9 +8,13 @@ import UIKit
 /// derivation are all sized against this constant.
 private let fieldHeight: CGFloat = 44
 
+/// The bar owns its text. JavaScript hears every change through
+/// `onTextChange` and never writes text back: the one change it could want,
+/// clearing on Cancel, the bar does itself before reporting it. A `text` prop
+/// would make every keystroke a round trip whose echo has to be told apart
+/// from a real write, and nothing here needs that.
 final class CampusSearchBarProps: ExpoSwiftUI.ViewProps {
 	@Field var placeholder: String = ""
-	@Field var text: String = ""
 	@Field var testID: String?
 	var onTextChange = EventDispatcher()
 	var onFocusChange = EventDispatcher()
@@ -48,8 +52,10 @@ private struct SearchBar: UIViewRepresentable {
 		bar.searchBarStyle = .minimal
 		bar.autocorrectionType = .no
 		bar.returnKeyType = .search
-		// Zero: the sheet content supplies the 16pt margins, so the bar must
-		// not add its own.
+		// The bar still insets its text field about 8pt from each side on top
+		// of this; the picker's horizontal padding is trimmed by that much so
+		// the field's visible margin matches Maps'. See
+		// `SEARCH_BAR_HORIZONTAL_PADDING` in `building-picker.tsx`.
 		bar.directionalLayoutMargins = .zero
 		// Required would fight UISearchBar's own (private, undocumented) layout
 		// of the text field within the bar; 999 lets that layout win instead of
@@ -71,45 +77,14 @@ private struct SearchBar: UIViewRepresentable {
 		// XCUITest element types, each keyed off this same testID.
 		bar.accessibilityIdentifier = props.testID
 		bar.searchTextField.accessibilityIdentifier = props.testID
-		// `props.text` can be an echo of a keystroke this coordinator already
-		// sent, arriving late. If it matches a still-pending sent value, drop
-		// that value (and anything queued before it, now unreachable) and leave
-		// the field alone; otherwise it is a genuine JS-originated change — a
-		// paste, a cleared search, a tapped suggestion — and must be written,
-		// which also means anything still in flight is now stale and moot.
-		if let echoedIndex = context.coordinator.pendingSent.firstIndex(of: props.text) {
-			context.coordinator.pendingSent.removeFirst(echoedIndex + 1)
-		} else {
-			if bar.text != props.text {
-				bar.text = props.text
-			}
-			context.coordinator.pendingSent.removeAll()
-		}
 		context.coordinator.updateCancelButton(on: bar, animated: false)
 	}
 
 	final class Coordinator: NSObject, UISearchBarDelegate {
 		var props: CampusSearchBarProps
-		/// Values sent to JS via `onTextChange` that have not yet come back
-		/// through `props.text`, oldest first. A single remembered value is not
-		/// enough: two keystrokes sent before either echoes back need their own
-		/// slots, or the second keystroke's echo is mistaken for the first's and
-		/// the first is dropped. Capped so a JS side that never echoes — a bug
-		/// on that end — cannot grow this without bound.
-		var pendingSent: [String] = []
 
 		init(props: CampusSearchBarProps) {
 			self.props = props
-		}
-
-		/// Queues a value this coordinator is about to report to JS, so its
-		/// eventual echo through `props.text` can be told apart from a change
-		/// JS made on its own.
-		func recordSent(_ text: String) {
-			pendingSent.append(text)
-			if pendingSent.count > 32 {
-				pendingSent.removeFirst()
-			}
 		}
 
 		/// Cancel is there whenever there is something to cancel: an active
@@ -122,7 +97,6 @@ private struct SearchBar: UIViewRepresentable {
 		}
 
 		func searchBar(_ bar: UISearchBar, textDidChange text: String) {
-			recordSent(text)
 			props.onTextChange(["value": text])
 			updateCancelButton(on: bar, animated: true)
 		}
@@ -145,7 +119,6 @@ private struct SearchBar: UIViewRepresentable {
 			bar.text = ""
 			bar.resignFirstResponder()
 			bar.setShowsCancelButton(false, animated: true)
-			recordSent("")
 			props.onTextChange(["value": ""])
 			props.onCancel()
 		}

--- a/modules/campus-search-bar/ios/CampusSearchBarView.swift
+++ b/modules/campus-search-bar/ios/CampusSearchBarView.swift
@@ -54,7 +54,7 @@ private struct SearchBar: UIViewRepresentable {
 		// Required would fight UISearchBar's own (private, undocumented) layout
 		// of the text field within the bar; 999 lets that layout win instead of
 		// throwing constraint-conflict warnings, at the cost of possibly falling
-		// short of 44pt — Task 5 measures the resulting height.
+		// short of 44pt — testTheSearchFieldIsAppleMapsHeight verifies the resulting height.
 		let textFieldHeight = bar.searchTextField.heightAnchor.constraint(equalToConstant: fieldHeight)
 		textFieldHeight.priority = UILayoutPriority(999)
 		textFieldHeight.isActive = true

--- a/modules/campus-search-bar/package.json
+++ b/modules/campus-search-bar/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@frogpond/campus-search-bar",
+  "version": "1.0.0",
+  "main": "index.tsx",
+  "types": "index.tsx"
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@frogpond/app-theme": "workspace:*",
     "@frogpond/badge": "workspace:*",
     "@frogpond/button": "workspace:*",
+    "@frogpond/campus-search-bar": "workspace:*",
     "@frogpond/ccc-calendar": "workspace:*",
     "@frogpond/ccc-jobs": "workspace:*",
     "@frogpond/colors": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@frogpond/button':
         specifier: workspace:*
         version: link:modules/button
+      '@frogpond/campus-search-bar':
+        specifier: workspace:*
+        version: link:modules/campus-search-bar
       '@frogpond/ccc-calendar':
         specifier: workspace:*
         version: link:modules/ccc-calendar
@@ -525,6 +528,8 @@ importers:
       react-native-typography:
         specifier: 1.4.1
         version: 1.4.1(react-native@0.86.2)(react@19.2.8)
+
+  modules/campus-search-bar: {}
 
   modules/ccc-calendar:
     dependencies:
@@ -6418,7 +6423,7 @@ snapshots:
       metro-resolver: 0.84.5
       metro-runtime: 0.84.5
       metro-source-map: 0.84.5(supports-color@8.1.1)
-      metro-symbolicate: 0.84.5
+      metro-symbolicate: 0.84.5(supports-color@8.1.1)
       metro-transform-plugins: 0.84.5(supports-color@8.1.1)
       metro-transform-worker: 0.84.5(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -9401,7 +9406,7 @@ snapshots:
       '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
-      metro-symbolicate: 0.84.5
+      metro-symbolicate: 0.84.5(supports-color@8.1.1)
       nullthrows: 1.1.1
       ob1: 0.84.5
       source-map: 0.5.7
@@ -9409,7 +9414,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-symbolicate@0.84.5:
+  metro-symbolicate@0.84.5(supports-color@8.1.1):
     dependencies:
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -9417,6 +9422,8 @@ snapshots:
       nullthrows: 1.1.1
       source-map: 0.5.7
       vlq: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   metro-transform-plugins@0.84.5(supports-color@8.1.1):
     dependencies:
@@ -9479,7 +9486,7 @@ snapshots:
       metro-resolver: 0.84.5
       metro-runtime: 0.84.5
       metro-source-map: 0.84.5(supports-color@8.1.1)
-      metro-symbolicate: 0.84.5
+      metro-symbolicate: 0.84.5(supports-color@8.1.1)
       metro-transform-plugins: 0.84.5(supports-color@8.1.1)
       metro-transform-worker: 0.84.5(supports-color@8.1.1)
       mime-types: 3.0.2

--- a/source/features/map/__tests__/building-picker.test.tsx
+++ b/source/features/map/__tests__/building-picker.test.tsx
@@ -14,6 +14,10 @@ jest.mock('@expo/ui/swift-ui/modifiers', () => {
 	// oxlint-disable-next-line typescript/no-require-imports
 	return require('../../../testing/expo-ui-mock') as typeof import('../../../testing/expo-ui-mock')
 })
+jest.mock('@frogpond/campus-search-bar', () => {
+	// oxlint-disable-next-line typescript/no-require-imports
+	return require('./campus-search-bar-mock') as typeof import('./campus-search-bar-mock')
+})
 
 const fixtures = [
 	makeBuilding({id: 'a', name: 'Alpha Hall', categories: ['building']}),
@@ -36,7 +40,11 @@ afterEach(() => {
 	trackedQueryClients.length = 0
 })
 
-async function renderPicker(onSelect = jest.fn()) {
+async function renderPicker(
+	onSelect = jest.fn(),
+	onSearchFocusChange = jest.fn(),
+	onSearchCancel = jest.fn(),
+) {
 	let client = new QueryClient({defaultOptions: {queries: {retry: false}}})
 	trackedQueryClients.push(client)
 	// Seeding the cache rather than mocking the query module keeps the
@@ -44,10 +52,15 @@ async function renderPicker(onSelect = jest.fn()) {
 	client.setQueryData(keys.all('carleton'), fixtures)
 	await render(
 		<QueryClientProvider client={client}>
-			<BuildingPicker campus="carleton" onSelect={onSelect} />
+			<BuildingPicker
+				campus="carleton"
+				onSearchCancel={onSearchCancel}
+				onSearchFocusChange={onSearchFocusChange}
+				onSelect={onSelect}
+			/>
 		</QueryClientProvider>,
 	)
-	return onSelect
+	return {onSelect, onSearchFocusChange, onSearchCancel}
 }
 
 describe('BuildingPicker', () => {
@@ -80,5 +93,36 @@ describe('BuildingPicker', () => {
 		await waitFor(() => {
 			expect(screen.getByText('Gamma Field')).toBeTruthy()
 		})
+	})
+
+	it('reports focus changes on the search field to the screen', async () => {
+		let {onSearchFocusChange} = await renderPicker()
+		let field = screen.getByLabelText('Search for a place')
+		await fireEvent(field, 'focus')
+		expect(onSearchFocusChange).toHaveBeenLastCalledWith(true, false)
+		await fireEvent(field, 'blur')
+		expect(onSearchFocusChange).toHaveBeenLastCalledWith(false, false)
+	})
+
+	it('tells the screen a blurred field still holds a query', async () => {
+		let {onSearchFocusChange} = await renderPicker()
+		let field = screen.getByLabelText('Search for a place')
+		await fireEvent.changeText(field, 'gamma')
+		await fireEvent(field, 'blur')
+		expect(onSearchFocusChange).toHaveBeenLastCalledWith(false, true)
+	})
+
+	it('clears the query and shows the categories again when the search is cancelled', async () => {
+		let {onSearchCancel} = await renderPicker()
+		await fireEvent.changeText(screen.getByLabelText('Search for a place'), 'gamma')
+		await waitFor(() => {
+			expect(screen.queryByText('Outdoors')).toBeNull()
+		})
+		await fireEvent.press(screen.getByText('Cancel'))
+		expect(onSearchCancel).toHaveBeenCalledTimes(1)
+		await waitFor(() => {
+			expect(screen.getByText('Outdoors')).toBeTruthy()
+		})
+		expect(screen.getByText('Alpha Hall')).toBeTruthy()
 	})
 })

--- a/source/features/map/__tests__/building-picker.test.tsx
+++ b/source/features/map/__tests__/building-picker.test.tsx
@@ -3,6 +3,7 @@ import {fireEvent, render, screen, waitFor} from '@testing-library/react-native'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 
 import {BuildingPicker} from '../building-picker'
+import {CATEGORY_LABELS} from '../category-picker'
 import {keys} from '../query'
 import {makeBuilding} from './fixtures'
 
@@ -40,11 +41,12 @@ afterEach(() => {
 	trackedQueryClients.length = 0
 })
 
-async function renderPicker(
+async function renderPicker({
+	compact = false,
 	onSelect = jest.fn(),
 	onSearchFocusChange = jest.fn(),
 	onSearchCancel = jest.fn(),
-) {
+} = {}) {
 	let client = new QueryClient({defaultOptions: {queries: {retry: false}}})
 	trackedQueryClients.push(client)
 	// Seeding the cache rather than mocking the query module keeps the
@@ -54,6 +56,7 @@ async function renderPicker(
 		<QueryClientProvider client={client}>
 			<BuildingPicker
 				campus="carleton"
+				compact={compact}
 				onSearchCancel={onSearchCancel}
 				onSearchFocusChange={onSearchFocusChange}
 				onSelect={onSelect}
@@ -69,6 +72,21 @@ describe('BuildingPicker', () => {
 		expect(screen.getByText('Alpha Hall')).toBeTruthy()
 		expect(screen.queryByText('Beta Lot')).toBeNull()
 		expect(screen.queryByText('Gamma Field')).toBeNull()
+	})
+
+	it('draws the search field alone when the sheet has room for nothing else', async () => {
+		await renderPicker({compact: true})
+		expect(screen.getByLabelText('Search for a place')).toBeTruthy()
+		for (let label of CATEGORY_LABELS) {
+			expect(screen.queryByText(label)).toBeNull()
+		}
+	})
+
+	it('draws the categories once the sheet has room for them', async () => {
+		await renderPicker({compact: false})
+		for (let label of CATEGORY_LABELS) {
+			expect(screen.getByText(label)).toBeTruthy()
+		}
 	})
 
 	it('switches the visible list when a different category is chosen', async () => {

--- a/source/features/map/__tests__/campus-search-bar-mock.tsx
+++ b/source/features/map/__tests__/campus-search-bar-mock.tsx
@@ -7,6 +7,10 @@ import type {CampusSearchBarProps} from '@frogpond/campus-search-bar'
 /// not exist under Jest, so the picker's tests render this instead. A text
 /// input for the field and a pressable for Cancel are enough to drive the
 /// branches the picker decides in JavaScript.
+///
+/// Cancel renders unconditionally here, where the real bar hides it until the
+/// field is focused or holds text -- so a Jest test is never evidence about
+/// whether Cancel is visible, only about what happens when it is pressed.
 export function CampusSearchBar({
 	onCancel,
 	onFocusChange,

--- a/source/features/map/__tests__/campus-search-bar-mock.tsx
+++ b/source/features/map/__tests__/campus-search-bar-mock.tsx
@@ -11,13 +11,13 @@ import type {CampusSearchBarProps} from '@frogpond/campus-search-bar'
 /// Cancel renders unconditionally here, where the real bar hides it until the
 /// field is focused or holds text -- so a Jest test is never evidence about
 /// whether Cancel is visible, only about what happens when it is pressed.
+/// Like the real bar, the input owns its text: nothing writes it from JS.
 export function CampusSearchBar({
 	onCancel,
 	onFocusChange,
 	onTextChange,
 	placeholder,
 	testID,
-	text,
 }: CampusSearchBarProps): React.ReactNode {
 	return (
 		<View>
@@ -27,7 +27,6 @@ export function CampusSearchBar({
 				onChangeText={onTextChange}
 				onFocus={() => onFocusChange(true)}
 				placeholder={placeholder}
-				value={text}
 			/>
 			<Pressable accessibilityRole="button" onPress={onCancel}>
 				<Text>Cancel</Text>

--- a/source/features/map/__tests__/campus-search-bar-mock.tsx
+++ b/source/features/map/__tests__/campus-search-bar-mock.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import {Pressable, Text, TextInput, View} from 'react-native'
+
+import type {CampusSearchBarProps} from '@frogpond/campus-search-bar'
+
+/// The module reaches expo-modules-core's native view registry, which does
+/// not exist under Jest, so the picker's tests render this instead. A text
+/// input for the field and a pressable for Cancel are enough to drive the
+/// branches the picker decides in JavaScript.
+export function CampusSearchBar({
+	onCancel,
+	onFocusChange,
+	onTextChange,
+	placeholder,
+	testID,
+	text,
+}: CampusSearchBarProps): React.ReactNode {
+	return (
+		<View>
+			<TextInput
+				accessibilityLabel={testID ?? placeholder}
+				onBlur={() => onFocusChange(false)}
+				onChangeText={onTextChange}
+				onFocus={() => onFocusChange(true)}
+				placeholder={placeholder}
+				value={text}
+			/>
+			<Pressable accessibilityRole="button" onPress={onCancel}>
+				<Text>Cancel</Text>
+			</Pressable>
+		</View>
+	)
+}

--- a/source/features/map/building-info.tsx
+++ b/source/features/map/building-info.tsx
@@ -27,6 +27,12 @@ import {buildingPhotoUrl} from './urls'
 /// Matches the glyph Apple uses to close a sheet.
 const CLOSE_GLYPH_SIZE = 26
 
+/// The card's own dismiss button. The search bar's Cancel carries the same
+/// "Close" accessibility label, so a screen-wide query for that label could
+/// answer for either; this testID scopes a test to the card alone. Matches
+/// `TestIdentifiers.CarletonMap.cardCloseButton` in `TestIdentifiers.swift`.
+const CARD_CLOSE_BUTTON_ID = 'card-close-button'
+
 type Props = {
 	building: Feature<Building> | undefined
 	onClose: () => void
@@ -40,7 +46,11 @@ export function BuildingInfo({building, onClose}: Props): React.ReactNode {
 			<List>
 				<Section>
 					<Text>Building not found.</Text>
-					<Button modifiers={[accessibilityLabel('Close'), buttonStyle('plain')]} onPress={onClose}>
+					<Button
+						modifiers={[accessibilityLabel('Close'), buttonStyle('plain')]}
+						onPress={onClose}
+						testID={CARD_CLOSE_BUTTON_ID}
+					>
 						{/* The filled xmark Apple's sheets close with now, rather than a
 						    text button. */}
 						<Image
@@ -87,7 +97,11 @@ export function BuildingInfo({building, onClose}: Props): React.ReactNode {
 						) : null}
 					</VStack>
 					<Spacer />
-					<Button modifiers={[accessibilityLabel('Close'), buttonStyle('plain')]} onPress={onClose}>
+					<Button
+						modifiers={[accessibilityLabel('Close'), buttonStyle('plain')]}
+						onPress={onClose}
+						testID={CARD_CLOSE_BUTTON_ID}
+					>
 						{/* The filled xmark Apple's sheets close with now, rather than a
 						    text button. */}
 						<Image

--- a/source/features/map/building-picker.tsx
+++ b/source/features/map/building-picker.tsx
@@ -1,24 +1,15 @@
 import * as React from 'react'
+import {Button, HStack, Image, List, Section, Spacer, Text, VStack} from '@expo/ui/swift-ui'
 import {
-	Button,
-	HStack,
-	Image,
-	List,
-	Section,
-	Spacer,
-	Text,
-	TextField,
-	VStack,
-} from '@expo/ui/swift-ui'
-import {
-	autocorrectionDisabled,
 	buttonStyle,
 	contentShape,
 	font,
 	foregroundStyle,
+	padding,
 	shapes,
 } from '@expo/ui/swift-ui/modifiers'
 import {useQuery} from '@tanstack/react-query'
+import {CampusSearchBar} from '@frogpond/campus-search-bar'
 import {useDebounce} from '@frogpond/use-debounce'
 import fuzzyfind from 'fuzzyfind'
 
@@ -30,14 +21,36 @@ import type {Building, Feature} from './types'
 /// Matches the debounce every other search screen in the app uses.
 const SEARCH_DEBOUNCE_MS = 200
 
+/// Apple Maps' collapsed sheet is its search field with 16pt on every side,
+/// and the grabber sits inside the top 16. The sheet's collapsed detent is
+/// sized to exactly this, so these three numbers move together.
+const SEARCH_MARGIN = 16
+const SEARCH_PLACEHOLDER = 'Search for a place'
+
 type Props = {
 	campus: Campus
 	onSelect: (id: string) => void
+	/// Focus is what raises the sheet, and losing it may lower it -- but only
+	/// when the field is empty, since a typed query still needs the room to
+	/// show its results. The screen that owns the sheet decides; the picker
+	/// only reports what happened.
+	onSearchFocusChange: (focused: boolean, hasText: boolean) => void
+	onSearchCancel: () => void
 }
 
 /// The picker's contents, as SwiftUI. The sheet that presents them, and the
 /// `Host` they render into, both belong to the map screen.
-export function BuildingPicker({campus, onSelect}: Props): React.ReactNode {
+///
+/// A VStack rather than a List with the field inside it: a grouped List adds
+/// its own section insets around anything it holds, which is what made the
+/// old field's margins uneven and untunable. Out here the field's margins are
+/// the padding modifier and nothing else.
+export function BuildingPicker({
+	campus,
+	onSelect,
+	onSearchFocusChange,
+	onSearchCancel,
+}: Props): React.ReactNode {
 	let [category, setCategory] = React.useState<CategoryLabel>('Buildings')
 	let [typedQuery, setTypedQuery] = React.useState('')
 	let query = useDebounce(typedQuery.trim(), SEARCH_DEBOUNCE_MS)
@@ -57,44 +70,58 @@ export function BuildingPicker({campus, onSelect}: Props): React.ReactNode {
 		return buildings.filter((b) => b.properties.categories?.includes(key))
 	}, [buildings, category, query])
 
-	return (
-		<List>
-			<Section>
-				<TextField
-					modifiers={[autocorrectionDisabled(true)]}
-					onTextChange={setTypedQuery}
-					placeholder="Search for a place"
-				/>
-			</Section>
+	let cancelSearch = React.useCallback(() => {
+		setTypedQuery('')
+		onSearchCancel()
+	}, [onSearchCancel])
 
+	return (
+		<VStack spacing={0}>
+			{/* CampusSearchBar takes no modifiers, so its margins live on the
+			    stack around it. */}
+			<VStack modifiers={[padding({horizontal: SEARCH_MARGIN, vertical: SEARCH_MARGIN})]}>
+				<CampusSearchBar
+					onCancel={cancelSearch}
+					onFocusChange={(focused) => onSearchFocusChange(focused, typedQuery.trim() !== '')}
+					onTextChange={setTypedQuery}
+					placeholder={SEARCH_PLACEHOLDER}
+					testID={SEARCH_PLACEHOLDER}
+					text={typedQuery}
+				/>
+			</VStack>
+
+			{/* Pinned under the field rather than scrolling with the list, so
+			    the header reads as one block: grabber, field, segments. */}
 			{query ? null : (
-				<Section>
+				<VStack modifiers={[padding({horizontal: SEARCH_MARGIN, bottom: 8})]}>
 					<CategoryPicker onChange={setCategory} selected={category} />
-				</Section>
+				</VStack>
 			)}
 
-			<Section>
-				{isError ? (
-					<Button onPress={() => void refetch()}>
-						<VStack alignment="leading" spacing={2}>
-							<Text>{`A problem occured while loading: ${error}`}</Text>
-							<Text>Tap to try again.</Text>
-						</VStack>
-					</Button>
-				) : isLoading ? (
-					<Text>Loading…</Text>
-				) : visible.length === 0 ? (
-					<Text>No buildings to show.</Text>
-				) : (
-					// Rendered directly, not wrapped in `List.ForEach`: that component
-					// attaches `.onDelete`/`.onMove` unconditionally, which would put
-					// swipe-to-delete and drag-to-reorder on this read-only picker.
-					visible.map((building) => (
-						<BuildingRow key={building.id} building={building} onSelect={onSelect} />
-					))
-				)}
-			</Section>
-		</List>
+			<List>
+				<Section>
+					{isError ? (
+						<Button onPress={() => void refetch()}>
+							<VStack alignment="leading" spacing={2}>
+								<Text>{`A problem occured while loading: ${error}`}</Text>
+								<Text>Tap to try again.</Text>
+							</VStack>
+						</Button>
+					) : isLoading ? (
+						<Text>Loading…</Text>
+					) : visible.length === 0 ? (
+						<Text>No buildings to show.</Text>
+					) : (
+						// Rendered directly, not wrapped in `List.ForEach`: that component
+						// attaches `.onDelete`/`.onMove` unconditionally, which would put
+						// swipe-to-delete and drag-to-reorder on this read-only picker.
+						visible.map((building) => (
+							<BuildingRow key={building.id} building={building} onSelect={onSelect} />
+						))
+					)}
+				</Section>
+			</List>
+		</VStack>
 	)
 }
 

--- a/source/features/map/building-picker.tsx
+++ b/source/features/map/building-picker.tsx
@@ -21,13 +21,14 @@ import type {Building, Feature} from './types'
 /// Matches the debounce every other search screen in the app uses.
 const SEARCH_DEBOUNCE_MS = 200
 
-/// The picker lays the search bar out with this margin above and below it, in
-/// LAYOUT space. `UISearchBar` is 64pt tall and centres its 44pt text field in
-/// itself, so the space around the visible field is this plus the bar's own
-/// 10pt -- 26pt, where Apple Maps has 16. The sheet's collapsed detent
-/// (`SHEET_COLLAPSED_HEIGHT` in `Map/index.tsx`) is a SCREEN-space number
-/// UIKit's presentation shrink sits between, not a multiple of this one; see
-/// that constant's own comment for the numbers.
+/// The margin above and below the search field, in LAYOUT space, and the
+/// margin the field visibly gets: `CampusSearchBarView` pins the bar to a 44pt
+/// slot, and although `UISearchBar` draws 64pt tall -- its 44pt text field
+/// centred, 10pt of its own chrome above and below -- that overflow takes no
+/// layout space and the bar's `.minimal` style paints none of it. So the
+/// picker's header block is `16 + 44 + 16 = 76`pt, which is what the sheet's
+/// collapsed stop is sized to hold; see `SHEET_COLLAPSED_HEIGHT` in
+/// `Map/index.tsx`.
 const SEARCH_MARGIN = 16
 const SEARCH_PLACEHOLDER = 'Search for a place'
 
@@ -43,6 +44,13 @@ const SEARCH_BAR_HORIZONTAL_PADDING = SEARCH_MARGIN - 8
 
 type Props = {
 	campus: Campus
+	/// True when the sheet is at a stop with room for the search field and
+	/// nothing else. Drawing the category segments there would not merely hide
+	/// them: a `VStack` taller than the stop it is presented in is centred in
+	/// it rather than clipped at the bottom, so the segments would take the
+	/// top of the field off with them. The list stays, and compresses to
+	/// nothing.
+	compact: boolean
 	onSelect: (id: string) => void
 	/// Focus is what raises the sheet, and losing it may lower it -- but only
 	/// when the field is empty, since a typed query still needs the room to
@@ -61,6 +69,7 @@ type Props = {
 /// the padding modifier and nothing else.
 export function BuildingPicker({
 	campus,
+	compact,
 	onSelect,
 	onSearchFocusChange,
 	onSearchCancel,
@@ -108,7 +117,7 @@ export function BuildingPicker({
 
 			{/* Pinned under the field rather than scrolling with the list, so
 			    the header reads as one block: grabber, field, segments. */}
-			{query ? null : (
+			{compact || query ? null : (
 				<VStack modifiers={[padding({horizontal: SEARCH_MARGIN, bottom: 8})]}>
 					<CategoryPicker onChange={setCategory} selected={category} />
 				</VStack>

--- a/source/features/map/building-picker.tsx
+++ b/source/features/map/building-picker.tsx
@@ -21,9 +21,10 @@ import type {Building, Feature} from './types'
 /// Matches the debounce every other search screen in the app uses.
 const SEARCH_DEBOUNCE_MS = 200
 
-/// The picker lays the field out with this margin above and below it, in
-/// LAYOUT space -- Apple Maps' own 16pt on every side, with the grabber
-/// inside the top margin. The sheet's collapsed detent
+/// The picker lays the search bar out with this margin above and below it, in
+/// LAYOUT space. `UISearchBar` is 64pt tall and centres its 44pt text field in
+/// itself, so the space around the visible field is this plus the bar's own
+/// 10pt -- 26pt, where Apple Maps has 16. The sheet's collapsed detent
 /// (`SHEET_COLLAPSED_HEIGHT` in `Map/index.tsx`) is a SCREEN-space number
 /// UIKit's presentation shrink sits between, not a multiple of this one; see
 /// that constant's own comment for the numbers.

--- a/source/features/map/building-picker.tsx
+++ b/source/features/map/building-picker.tsx
@@ -27,6 +27,14 @@ const SEARCH_DEBOUNCE_MS = 200
 const SEARCH_MARGIN = 16
 const SEARCH_PLACEHOLDER = 'Search for a place'
 
+/// `UISearchBar` insets its own text field about 8pt from the edges it is
+/// given, on top of whatever padding wraps it -- measured by comparing the
+/// field's on-screen x to Apple Maps' at the same scale (Task 8's report has
+/// the numbers). Trimming the wrapper's horizontal padding by that 8 is what
+/// keeps the field's visible margin at `SEARCH_MARGIN`, which the collapsed
+/// detent is sized against; `SEARCH_MARGIN` itself stays untouched.
+const SEARCH_BAR_HORIZONTAL_PADDING = SEARCH_MARGIN - 8
+
 type Props = {
 	campus: Campus
 	onSelect: (id: string) => void
@@ -79,7 +87,9 @@ export function BuildingPicker({
 		<VStack spacing={0}>
 			{/* CampusSearchBar takes no modifiers, so its margins live on the
 			    stack around it. */}
-			<VStack modifiers={[padding({horizontal: SEARCH_MARGIN, vertical: SEARCH_MARGIN})]}>
+			<VStack
+				modifiers={[padding({horizontal: SEARCH_BAR_HORIZONTAL_PADDING, vertical: SEARCH_MARGIN})]}
+			>
 				<CampusSearchBar
 					onCancel={cancelSearch}
 					onFocusChange={(focused) => onSearchFocusChange(focused, typedQuery.trim() !== '')}

--- a/source/features/map/building-picker.tsx
+++ b/source/features/map/building-picker.tsx
@@ -32,8 +32,10 @@ const SEARCH_PLACEHOLDER = 'Search for a place'
 
 /// `UISearchBar` insets its own text field about 8pt from the edges it is
 /// given, on top of whatever padding wraps it -- measured by comparing the
-/// field's on-screen x to Apple Maps' at the same scale (Task 8's report has
-/// the numbers). Trimming the wrapper's horizontal padding by that 8 is what
+/// field's on-screen x to Apple Maps' at the same scale (see "Sizing the
+/// collapsed detent" in
+/// `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md` for the
+/// numbers). Trimming the wrapper's horizontal padding by that 8 is what
 /// keeps the field's visible margin at `SEARCH_MARGIN`, which the collapsed
 /// detent is sized against; `SEARCH_MARGIN` itself stays untouched.
 const SEARCH_BAR_HORIZONTAL_PADDING = SEARCH_MARGIN - 8

--- a/source/features/map/building-picker.tsx
+++ b/source/features/map/building-picker.tsx
@@ -111,7 +111,6 @@ export function BuildingPicker({
 					onTextChange={setTypedQuery}
 					placeholder={SEARCH_PLACEHOLDER}
 					testID={SEARCH_PLACEHOLDER}
-					text={typedQuery}
 				/>
 			</VStack>
 

--- a/source/features/map/building-picker.tsx
+++ b/source/features/map/building-picker.tsx
@@ -21,9 +21,12 @@ import type {Building, Feature} from './types'
 /// Matches the debounce every other search screen in the app uses.
 const SEARCH_DEBOUNCE_MS = 200
 
-/// Apple Maps' collapsed sheet is its search field with 16pt on every side,
-/// and the grabber sits inside the top 16. The sheet's collapsed detent is
-/// sized to exactly this, so these three numbers move together.
+/// The picker lays the field out with this margin above and below it, in
+/// LAYOUT space -- Apple Maps' own 16pt on every side, with the grabber
+/// inside the top margin. The sheet's collapsed detent
+/// (`SHEET_COLLAPSED_HEIGHT` in `Map/index.tsx`) is a SCREEN-space number
+/// UIKit's presentation shrink sits between, not a multiple of this one; see
+/// that constant's own comment for the numbers.
 const SEARCH_MARGIN = 16
 const SEARCH_PLACEHOLDER = 'Search for a place'
 

--- a/source/features/map/lib/__tests__/sheet-moves.test.ts
+++ b/source/features/map/lib/__tests__/sheet-moves.test.ts
@@ -1,0 +1,95 @@
+import {nextSheetDetent, type SheetState} from '../sheet-moves'
+
+const at = (
+	current: SheetState['current'],
+	previous: SheetState['previous'] = null,
+): SheetState => ({
+	current,
+	previous,
+})
+
+describe('nextSheetDetent', () => {
+	describe('focusing the search bar', () => {
+		it.each(['collapsed', 'medium', 'large'] as const)(
+			'raises the sheet to large from %s and remembers where it was',
+			(from) => {
+				expect(nextSheetDetent({type: 'search-focused'}, at(from))).toEqual({
+					current: 'large',
+					previous: from,
+				})
+			},
+		)
+	})
+
+	describe('cancelling the search', () => {
+		it('returns the sheet to the remembered stop', () => {
+			expect(nextSheetDetent({type: 'search-cancelled'}, at('large', 'collapsed'))).toEqual({
+				current: 'collapsed',
+				previous: null,
+			})
+		})
+
+		it('leaves the sheet alone when nothing is remembered', () => {
+			expect(nextSheetDetent({type: 'search-cancelled'}, at('large'))).toEqual(at('large'))
+		})
+
+		it('does not move a sheet the user has since dragged elsewhere', () => {
+			expect(nextSheetDetent({type: 'search-cancelled'}, at('medium', 'collapsed'))).toEqual(
+				at('medium'),
+			)
+		})
+	})
+
+	describe('losing focus without cancelling', () => {
+		it('returns the sheet when the field was left empty', () => {
+			expect(
+				nextSheetDetent({type: 'search-blurred', hasText: false}, at('large', 'collapsed')),
+			).toEqual(at('collapsed'))
+		})
+
+		it('leaves a typed query on screen, and can still be cancelled later', () => {
+			expect(
+				nextSheetDetent({type: 'search-blurred', hasText: true}, at('large', 'collapsed')),
+			).toEqual(at('large', 'collapsed'))
+		})
+
+		it('does not move a sheet the user has since dragged elsewhere', () => {
+			expect(
+				nextSheetDetent({type: 'search-blurred', hasText: false}, at('medium', 'collapsed')),
+			).toEqual(at('medium', 'collapsed'))
+		})
+	})
+
+	describe('tapping a row', () => {
+		it('drops a large sheet to medium so the map shows', () => {
+			expect(nextSheetDetent({type: 'row-tapped'}, at('large'))).toEqual(at('medium'))
+		})
+
+		it('leaves a medium sheet where it is', () => {
+			expect(nextSheetDetent({type: 'row-tapped'}, at('medium'))).toEqual(at('medium'))
+		})
+
+		it('forgets a pending return, since the search is over', () => {
+			expect(nextSheetDetent({type: 'row-tapped'}, at('large', 'collapsed'))).toEqual(at('medium'))
+		})
+	})
+
+	describe('tapping a footprint on the map', () => {
+		it('raises a collapsed sheet to medium so the card fits', () => {
+			expect(nextSheetDetent({type: 'footprint-tapped'}, at('collapsed'))).toEqual(at('medium'))
+		})
+
+		it.each(['medium', 'large'] as const)('leaves a %s sheet alone', (from) => {
+			expect(nextSheetDetent({type: 'footprint-tapped'}, at(from))).toEqual(at(from))
+		})
+	})
+
+	describe('dragging', () => {
+		it('records the stop and keeps a pending return', () => {
+			expect(nextSheetDetent({type: 'dragged', to: 'medium'}, at('large', 'collapsed'))).toEqual({
+				current: 'medium',
+				previous: 'collapsed',
+			})
+		})
+	})
+})

--- a/source/features/map/lib/__tests__/sheet-moves.test.ts
+++ b/source/features/map/lib/__tests__/sheet-moves.test.ts
@@ -69,6 +69,10 @@ describe('nextSheetDetent', () => {
 			expect(nextSheetDetent({type: 'row-tapped'}, at('medium'))).toEqual(at('medium'))
 		})
 
+		it('leaves a collapsed sheet where it is', () => {
+			expect(nextSheetDetent({type: 'row-tapped'}, at('collapsed'))).toEqual(at('collapsed'))
+		})
+
 		it('forgets a pending return, since the search is over', () => {
 			expect(nextSheetDetent({type: 'row-tapped'}, at('large', 'collapsed'))).toEqual(at('medium'))
 		})

--- a/source/features/map/lib/__tests__/sheet-moves.test.ts
+++ b/source/features/map/lib/__tests__/sheet-moves.test.ts
@@ -10,7 +10,7 @@ const at = (
 
 describe('nextSheetDetent', () => {
 	describe('focusing the search bar', () => {
-		it.each(['collapsed', 'medium', 'large'] as const)(
+		it.each(['collapsed', 'medium'] as const)(
 			'raises the sheet to large from %s and remembers where it was',
 			(from) => {
 				expect(nextSheetDetent({type: 'search-focused'}, at(from))).toEqual({
@@ -19,6 +19,20 @@ describe('nextSheetDetent', () => {
 				})
 			},
 		)
+
+		it('leaves nothing to return to when focused while already at large', () => {
+			expect(nextSheetDetent({type: 'search-focused'}, at('large'))).toEqual({
+				current: 'large',
+				previous: null,
+			})
+		})
+
+		it('re-focusing keeps the stop the search began from', () => {
+			expect(nextSheetDetent({type: 'search-focused'}, at('large', 'collapsed'))).toEqual({
+				current: 'large',
+				previous: 'collapsed',
+			})
+		})
 	})
 
 	describe('cancelling the search', () => {

--- a/source/features/map/lib/sheet-moves.ts
+++ b/source/features/map/lib/sheet-moves.ts
@@ -1,0 +1,52 @@
+/// The sheet's three stops, named for what they are rather than by height so
+/// the rules read the way the design describes them.
+export type SheetDetent = 'collapsed' | 'medium' | 'large'
+
+export type SheetEvent =
+	| {type: 'search-focused'}
+	| {type: 'search-cancelled'}
+	| {type: 'search-blurred'; hasText: boolean}
+	| {type: 'row-tapped'}
+	| {type: 'footprint-tapped'}
+	| {type: 'dragged'; to: SheetDetent}
+
+/// `previous` is the stop a search focus raised the sheet from, so cancelling
+/// can put it back. Null when no return is pending.
+export type SheetState = {current: SheetDetent; previous: SheetDetent | null}
+
+/// Decides where the sheet goes after something happens to it.
+///
+/// The sheet moves only when its current stop cannot show the result of what
+/// the user just did: a search needs the full list, a card needs more than the
+/// collapsed strip, and a row tapped from the full list hides the map the row
+/// is about. Everything else leaves the sheet where the user put it.
+export function nextSheetDetent(event: SheetEvent, state: SheetState): SheetState {
+	switch (event.type) {
+		case 'search-focused':
+			return {current: 'large', previous: state.current}
+		case 'search-cancelled':
+			// A drag after the focus means the user chose a stop themselves;
+			// returning would override that choice.
+			if (state.previous !== null && state.current === 'large') {
+				return {current: state.previous, previous: null}
+			}
+			return {current: state.current, previous: null}
+		case 'search-blurred':
+			// Tapping away from a typed query leaves the results readable at
+			// `large`; only an empty field means the search is over.
+			if (!event.hasText && state.current === 'large' && state.previous !== null) {
+				return {current: state.previous, previous: null}
+			}
+			return state
+		case 'row-tapped':
+			return {current: state.current === 'large' ? 'medium' : state.current, previous: null}
+		case 'footprint-tapped':
+			return {current: state.current === 'collapsed' ? 'medium' : state.current, previous: null}
+		case 'dragged':
+			return {current: event.to, previous: state.previous}
+		default: {
+			const never: never = event
+			return never
+		}
+	}
+}

--- a/source/features/map/lib/sheet-moves.ts
+++ b/source/features/map/lib/sheet-moves.ts
@@ -23,7 +23,10 @@ export type SheetState = {current: SheetDetent; previous: SheetDetent | null}
 export function nextSheetDetent(event: SheetEvent, state: SheetState): SheetState {
 	switch (event.type) {
 		case 'search-focused':
-			return {current: 'large', previous: state.current}
+			return {
+				current: 'large',
+				previous: state.current === 'large' ? state.previous : state.current,
+			}
 		case 'search-cancelled':
 			// A drag after the focus means the user chose a stop themselves;
 			// returning would override that choice.

--- a/source/features/map/lib/sheet-moves.ts
+++ b/source/features/map/lib/sheet-moves.ts
@@ -48,8 +48,8 @@ export function nextSheetDetent(event: SheetEvent, state: SheetState): SheetStat
 		case 'dragged':
 			return {current: event.to, previous: state.previous}
 		default: {
-			const never: never = event
-			return never
+			let _exhaustive: never = event
+			throw new Error(`Unhandled sheet event: ${JSON.stringify(_exhaustive)}`)
 		}
 	}
 }

--- a/uitests/CLAUDE.md
+++ b/uitests/CLAUDE.md
@@ -53,8 +53,11 @@ earlier one will match both.
 **A `Stack.SearchBar` is `app.searchFields.firstMatch`**, wherever the screen
 puts it — the bottom-toolbar placement most screens use here is reached the same
 way as a header one. `searchField.value as? String` returns the placeholder, not
-`nil`, when the field is empty. The SwiftUI `TextField` on the Carleton map is
-the exception: that one is `app.textFields[...]`.
+`nil`, when the field is empty. The Carleton map's field is a `UISearchBar`
+inside an `@expo/ui` sheet, so it is `app.searchFields[...]` too. Its cancel
+button carries no identifier and, on iOS 26, the label `Close` — which the
+building card's own dismiss button also has — so query it inside the bar rather
+than across the whole screen.
 
 **Retry a dropped tap; do not lengthen the timeout.** A row is hittable as soon
 as its host mounts, but its action has to reach JavaScript — a tap synthesized

--- a/uitests/ModuleCarletonMapTests.swift
+++ b/uitests/ModuleCarletonMapTests.swift
@@ -57,15 +57,19 @@ class ModuleCarletonMapTests: UITestCase {
 
 	/// The bar reports each keystroke to JavaScript and takes the echo back as
 	/// a prop, which is a round trip with a race in it. Typing a whole name is
-	/// what shows whether a character was lost on the way.
+	/// what shows whether a character was lost on the way: the field is read
+	/// back, and a building the query cannot match has to leave the list, which
+	/// is the half that can only happen if the text arrived in JavaScript.
 	func testTypingIntoSearchKeepsEveryCharacter() throws {
 		CarletonMapScreen(app: app)
 			.navigate()
 			.checkSheetPresented()
 			.focusSearch()
+			.capture("Carleton map list before a query is typed")
+			.verifyListed(TestIdentifiers.CarletonMap.anotherBuilding)
 			.typeIntoSearch(TestIdentifiers.CarletonMap.aBuilding)
 			.capture("Carleton map sheet with a typed query")
-			.verifySearchFound(TestIdentifiers.CarletonMap.aBuilding)
+			.verifyFilteredOut(TestIdentifiers.CarletonMap.anotherBuilding)
 	}
 
 	func testTappingARowFromTheFullSheetDropsItToMedium() throws {
@@ -78,13 +82,8 @@ class ModuleCarletonMapTests: UITestCase {
 		screen
 			.selectBuilding(named: TestIdentifiers.CarletonMap.aBuilding)
 			.capture("Carleton map card after a row tap from large")
-		// The picker is gone once the card is up, so the card's own top edge
-		// stands in for the field's.
-		let cardTop = screen.closeButtonTop()
-		XCTAssertTrue(
-			cardTop - largeTop > 100,
-			"A row tapped from the full sheet should drop it to medium; the content's top went from \(largeTop) to \(cardTop)")
-		screen.verifyCardAtMedium()
+			.verifyCardDroppedFrom(largeTop)
+			.verifyCardAtMedium()
 	}
 
 	func testTappingAFootprintWhileCollapsedRaisesTheCardToMedium() throws {

--- a/uitests/ModuleCarletonMapTests.swift
+++ b/uitests/ModuleCarletonMapTests.swift
@@ -9,7 +9,6 @@ class ModuleCarletonMapTests: UITestCase {
 
 	/// The whole path a user takes: open the map, reach into the sheet, and
 	/// come out with a building's card.
-	///
 	func testSelectingABuildingShowsItsCard() throws {
 		CarletonMapScreen(app: app)
 			.navigate()
@@ -18,5 +17,83 @@ class ModuleCarletonMapTests: UITestCase {
 			.selectBuilding(named: TestIdentifiers.CarletonMap.aBuilding)
 			.checkBuildingCardPresented()
 			.capture("Carleton map sheet at its middle detent, showing a building's card")
+	}
+
+	/// The sheet opens on its smallest stop, at the foot of the screen. Whether
+	/// that stop holds the field and nothing else is a question for the capture:
+	/// see `verifyCollapsed` for why no assertion can answer it.
+	func testSheetOpensOnItsCollapsedStop() throws {
+		CarletonMapScreen(app: app)
+			.navigate()
+			.checkSheetPresented()
+			.capture("Carleton map sheet collapsed")
+			.verifyCollapsed()
+	}
+
+	/// The module pins the field at 44pt with a constraint UIKit is free to
+	/// overrule silently, so the height is worth a test of its own.
+	func testTheSearchFieldIsAppleMapsHeight() throws {
+		CarletonMapScreen(app: app)
+			.navigate()
+			.checkSheetPresented()
+			.expandSheet()
+			.verifySearchFieldHeight()
+	}
+
+	func testFocusingSearchRaisesTheSheetAndCancelReturnsIt() throws {
+		let screen = CarletonMapScreen(app: app)
+			.navigate()
+			.checkSheetPresented()
+		let collapsedTop = screen.searchFieldTop()
+
+		screen
+			.focusSearch()
+			.capture("Carleton map sheet raised by search focus")
+			.verifySheetMoved(from: collapsedTop, direction: "up", "Focusing search should raise the sheet to large")
+			.cancelSearch()
+			.capture("Carleton map sheet after cancelling search")
+			.verifySheetReturned(to: collapsedTop)
+	}
+
+	/// The bar reports each keystroke to JavaScript and takes the echo back as
+	/// a prop, which is a round trip with a race in it. Typing a whole name is
+	/// what shows whether a character was lost on the way.
+	func testTypingIntoSearchKeepsEveryCharacter() throws {
+		CarletonMapScreen(app: app)
+			.navigate()
+			.checkSheetPresented()
+			.focusSearch()
+			.typeIntoSearch(TestIdentifiers.CarletonMap.aBuilding)
+			.capture("Carleton map sheet with a typed query")
+			.verifySearchFound(TestIdentifiers.CarletonMap.aBuilding)
+	}
+
+	func testTappingARowFromTheFullSheetDropsItToMedium() throws {
+		let screen = CarletonMapScreen(app: app)
+			.navigate()
+			.checkSheetPresented()
+			.expandSheet()
+		let largeTop = screen.searchFieldTop()
+
+		screen
+			.selectBuilding(named: TestIdentifiers.CarletonMap.aBuilding)
+			.capture("Carleton map card after a row tap from large")
+		// The picker is gone once the card is up, so the card's own top edge
+		// stands in for the field's.
+		let cardTop = screen.closeButtonTop()
+		XCTAssertTrue(
+			cardTop - largeTop > 100,
+			"A row tapped from the full sheet should drop it to medium; the content's top went from \(largeTop) to \(cardTop)")
+		screen.verifyCardAtMedium()
+	}
+
+	func testTappingAFootprintWhileCollapsedRaisesTheCardToMedium() throws {
+		CarletonMapScreen(app: app)
+			.navigate()
+			.checkSheetPresented()
+			.verifyCollapsed()
+			.tapAFootprint()
+			.capture("Carleton map card after a footprint tap from collapsed")
+			.verifyCardAtMedium()
 	}
 }

--- a/uitests/ModuleCarletonMapTests.swift
+++ b/uitests/ModuleCarletonMapTests.swift
@@ -86,6 +86,16 @@ class ModuleCarletonMapTests: UITestCase {
 			.verifyCardAtMedium()
 	}
 
+	/// UIKit shrinks the presented sheet by a scale that depends on the
+	/// detent, so the collapsed content's margins have to be checked in
+	/// screen space rather than assumed from the layout numbers that went in.
+	func testCollapsedSheetHasSymmetricMargins() throws {
+		CarletonMapScreen(app: app)
+			.navigate()
+			.checkSheetPresented()
+			.verifyCollapsedMarginsSymmetric()
+	}
+
 	func testTappingAFootprintWhileCollapsedRaisesTheCardToMedium() throws {
 		CarletonMapScreen(app: app)
 			.navigate()

--- a/uitests/ModuleCarletonMapTests.swift
+++ b/uitests/ModuleCarletonMapTests.swift
@@ -29,6 +29,7 @@ class ModuleCarletonMapTests: UITestCase {
 			.capture("Carleton map sheet collapsed")
 			.verifyCollapsed()
 			.verifyFieldWithinSheet()
+			.verifyAttributionClearOfSheet()
 	}
 
 	/// The module pins the field at 44pt with a constraint UIKit is free to

--- a/uitests/ModuleCarletonMapTests.swift
+++ b/uitests/ModuleCarletonMapTests.swift
@@ -19,15 +19,16 @@ class ModuleCarletonMapTests: UITestCase {
 			.capture("Carleton map sheet at its middle detent, showing a building's card")
 	}
 
-	/// The sheet opens on its smallest stop, at the foot of the screen. Whether
-	/// that stop holds the field and nothing else is a question for the capture:
-	/// see `verifyCollapsed` for why no assertion can answer it.
+	/// The sheet opens on its smallest stop, at the foot of the screen, holding
+	/// the whole search field. That the field is the only thing on the stop is
+	/// still a question for the capture.
 	func testSheetOpensOnItsCollapsedStop() throws {
 		CarletonMapScreen(app: app)
 			.navigate()
 			.checkSheetPresented()
 			.capture("Carleton map sheet collapsed")
 			.verifyCollapsed()
+			.verifyFieldWithinSheet()
 	}
 
 	/// The module pins the field at 44pt with a constraint UIKit is free to
@@ -94,6 +95,7 @@ class ModuleCarletonMapTests: UITestCase {
 			.navigate()
 			.checkSheetPresented()
 			.verifyCollapsedMarginsSymmetric()
+			.verifyFieldWithinSheet()
 	}
 
 	func testTappingAFootprintWhileCollapsedRaisesTheCardToMedium() throws {

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -261,6 +261,24 @@ struct CarletonMapScreen: Screen {
 		return self
 	}
 
+	/// The attribution button sits over the map, and the collapsed sheet
+	/// floats over the bottom of it, so the two have to be kept apart: the
+	/// button's whole frame above the sheet's top edge, and still tappable.
+	@discardableResult
+	func verifyAttributionClearOfSheet() -> Self {
+		let button = app.buttons[TestIdentifiers.CarletonMap.attribution].firstMatch
+		XCTAssertTrue(
+			button.waitForExistence(timeout: 30) && button.isHittable,
+			"The map's attribution button should be on screen and tappable")
+		let sheet = sheetFrame()
+		XCTContext.runActivity(named: "attribution \(button.frame) sheet \(sheet)") { _ in }
+		XCTAssertTrue(
+			button.frame.maxY < sheet.minY,
+			"The attribution button should sit clear of the sheet, not under it: "
+				+ "button \(button.frame), sheet \(sheet)")
+		return self
+	}
+
 	/// A move is a change of at least a hundred points: the collapsed stop
 	/// renders at about 65pt, medium at half the screen, and large at nearly
 	/// all of it, so anything smaller is a scroll or a wobble, not a detent

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -73,10 +73,10 @@ struct CarletonMapScreen: Screen {
 	/// out as a quietly short field rather than a console warning. Measuring is
 	/// the only thing that would notice.
 	///
-	/// Measured at a full-width stop. A floating sheet draws its content scaled
-	/// to the inset it floats in, so every frame read at the collapsed stop is
-	/// smaller than the layout that produced it, and 44pt would be the wrong
-	/// number to expect there.
+	/// Measured at a full-width stop. Something applies a 0.8607 scale to the
+	/// collapsed sheet's content -- what applies it has not been identified --
+	/// so every frame read there is smaller than the layout that produced it,
+	/// and 44pt would be the wrong number to expect.
 	@discardableResult
 	func verifySearchFieldHeight() -> Self {
 		let height = searchField.frame.height
@@ -104,7 +104,7 @@ struct CarletonMapScreen: Screen {
 		searchField.tap()
 		XCTAssertTrue(
 			cancelButton.waitForExistence(timeout: 10),
-			"Focusing the search field should show its Cancel button")
+			"Focusing the search field should show its cancel button, which iOS labels Close")
 		return self
 	}
 
@@ -131,13 +131,24 @@ struct CarletonMapScreen: Screen {
 		return self
 	}
 
-	/// The list is what the query is for, so a filtered row proves the text
-	/// reached JavaScript rather than only the field.
+	/// Reads a row off the unfiltered list, so that its absence later means the
+	/// filter dropped it rather than that it was never there.
 	@discardableResult
-	func verifySearchFound(_ name: String) -> Self {
+	func verifyListed(_ name: String) -> Self {
 		XCTAssertTrue(
 			app.buttons[name].firstMatch.waitForExistence(timeout: 30),
-			"Searching should narrow the list to \(name)")
+			"The expanded sheet should list \(name) before anything is typed")
+		return self
+	}
+
+	/// A row the query cannot match has to leave the list, which is what shows
+	/// the typed text reached JavaScript. A row that still matches would stay
+	/// put whether the filter ran or not, so it proves nothing.
+	@discardableResult
+	func verifyFilteredOut(_ name: String) -> Self {
+		XCTAssertTrue(
+			app.buttons[name].firstMatch.waitForNonExistence(timeout: 30),
+			"Searching should drop \(name) from the list")
 		return self
 	}
 
@@ -145,11 +156,11 @@ struct CarletonMapScreen: Screen {
 	/// which is what tells it apart from medium and large.
 	///
 	/// That the field is the *only* thing on it is not asserted, because it
-	/// cannot be from here. A sheet clips what it draws but not what it
-	/// hit-tests, so the category segments beneath the field answer
+	/// cannot be from here. The category segments beneath the field answer
 	/// `isHittable` at every collapsed height tried -- 44, 60, 76 and 160 --
-	/// while the screen visibly changes between them. The capture is what that
-	/// half has to be judged on.
+	/// while the screen visibly changes between them, so the hit test is not
+	/// measuring what the sheet shows. The capture is what that half has to be
+	/// judged on.
 	@discardableResult
 	func verifyCollapsed() -> Self {
 		XCTAssertTrue(searchField.isHittable, "The search field should be reachable while collapsed")
@@ -247,6 +258,17 @@ struct CarletonMapScreen: Screen {
 	/// the way the field is the picker's.
 	func closeButtonTop() -> CGFloat {
 		closeButton.frame.minY
+	}
+
+	/// The picker is gone once the card is up, so the card's own top edge stands
+	/// in for the field's. Same hundred-point rule as `verifySheetMoved`.
+	@discardableResult
+	func verifyCardDroppedFrom(_ before: CGFloat) -> Self {
+		let after = closeButtonTop()
+		XCTAssertTrue(
+			after - before > 100,
+			"A row tapped from the full sheet should drop it to medium; the content's top went from \(before) to \(after)")
+		return self
 	}
 
 	/// The medium stop is half the window. A card whose top is in the middle

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -280,9 +280,9 @@ struct CarletonMapScreen: Screen {
 	}
 
 	/// A move is a change of at least a hundred points: the collapsed stop
-	/// renders at about 65pt, medium at half the screen, and large at nearly
-	/// all of it, so anything smaller is a scroll or a wobble, not a detent
-	/// change.
+	/// renders at about 65pt, the middle stop at `SHEET_RESTING_FRACTION` of
+	/// the screen, and large at nearly all of it, so anything smaller is a
+	/// scroll or a wobble, not a detent change.
 	@discardableResult
 	func verifySheetMoved(from before: CGFloat, direction: String, _ message: String) -> Self {
 		let after = searchFieldTop()
@@ -378,15 +378,17 @@ struct CarletonMapScreen: Screen {
 		return self
 	}
 
-	/// The medium stop is half the window. A card whose top is in the middle
-	/// third of the screen is at it; one hugging the bottom is still collapsed.
+	/// The middle stop is `SHEET_RESTING_FRACTION` (0.68) of the window, so the
+	/// card's top lands about a third of the way down. A top in the band from
+	/// a fifth to a half of the screen is at it: higher is `large`, lower is
+	/// still collapsed.
 	@discardableResult
 	func verifyCardAtMedium() -> Self {
 		let top = closeButtonTop()
 		let height = app.windows.firstMatch.frame.height
 		XCTAssertTrue(
-			top > height * 0.33 && top < height * 0.66,
-			"A footprint tapped while collapsed should raise the card to medium; its top is at \(top) of \(height)")
+			top > height * 0.2 && top < height * 0.5,
+			"The card should be at the middle stop; its top is at \(top) of \(height)")
 		return self
 	}
 }

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -337,19 +337,59 @@ struct CarletonMapScreen: Screen {
 		return self
 	}
 
-	/// Taps the map itself, in the strip above the collapsed sheet. The
-	/// initial camera frames campus, so the screen's centre lands on a
-	/// footprint; which one does not matter, only that a card opens.
+	/// The map view. MapLibre publishes a single element for the whole map and
+	/// nothing per building -- a hierarchy dump from a failing run shows one
+	/// `Other` labelled "Map", valued `Zoom 16x.`, and no footprints -- so a
+	/// test cannot ask for a building. It can ask where the map is.
+	private var mapView: XCUIElement {
+		app.otherElements[TestIdentifiers.CarletonMap.map].firstMatch
+	}
+
+	/// Points within the map's own bounds, tried in turn until one lands on a
+	/// building.
+	///
+	/// Normalised against the map rather than the screen, so they mean what
+	/// they say: the map occupies the space between the navigation bar and the
+	/// collapsed sheet, and a screen-relative offset moves off it whenever
+	/// either changes height.
+	///
+	/// The map's centre is not among them on its own, because it is not a
+	/// building: on a hosted runner the initial camera puts Gould Lane there,
+	/// and the road between two footprints is what the tap hit. Which building
+	/// answers does not matter -- the test is about what a footprint tap does
+	/// to the sheet -- but some building has to.
+	private static let footprintProbes: [CGVector] = [
+		CGVector(dx: 0.50, dy: 0.45),
+		CGVector(dx: 0.30, dy: 0.52),
+		CGVector(dx: 0.70, dy: 0.48),
+		CGVector(dx: 0.45, dy: 0.62),
+		CGVector(dx: 0.62, dy: 0.67),
+		CGVector(dx: 0.28, dy: 0.70),
+	]
+
+	/// Taps the map until a building card opens.
+	///
+	/// Retrying one coordinate, which this did before, cannot succeed where the
+	/// first tap found no building: the camera has not moved, so every attempt
+	/// hits the same patch of ground. Each attempt here tries somewhere else.
 	@discardableResult
 	func tapAFootprint() -> Self {
-		for attempt in 1...3 {
-			app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+		XCTAssertTrue(
+			mapView.waitForExistence(timeout: 30),
+			"The map should be on screen before anything tries to tap it")
+
+		for (index, probe) in Self.footprintProbes.enumerated() {
+			mapView.coordinate(withNormalizedOffset: probe).tap()
 			if closeButton.waitForExistence(timeout: 10) {
 				return self
 			}
-			XCTContext.runActivity(named: "Tap \(attempt) on the map opened no card; retrying") { _ in }
+			XCTContext.runActivity(
+				named: "Tap \(index + 1) at \(probe) opened no card; trying elsewhere"
+			) { _ in }
 		}
-		XCTFail("Tapping the map never opened a building card")
+
+		XCTFail(
+			"None of \(Self.footprintProbes.count) points on the map opened a building card")
 		return self
 	}
 

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -71,11 +71,10 @@ struct CarletonMapScreen: Screen {
 		searchField.frame.minY
 	}
 
-	/// Apple Maps' field is 44pt, and the collapsed detent is that plus 16pt
-	/// above and below. The bar pins the height at priority 999 so UIKit's own
-	/// layout of the text field wins any conflict, which means a conflict comes
-	/// out as a quietly short field rather than a console warning. Measuring is
-	/// the only thing that would notice.
+	/// Apple Maps' field is 44pt. The bar pins the height at priority 999 so
+	/// UIKit's own layout of the text field wins any conflict, which means a
+	/// conflict comes out as a quietly short field rather than a console
+	/// warning. Measuring is the only thing that would notice.
 	///
 	/// Measured at a full-width stop. UIKit applies a detent-dependent shrink to
 	/// any presented sheet's content -- Apple Maps' own small-detent drop shadow
@@ -180,9 +179,25 @@ struct CarletonMapScreen: Screen {
 	}
 
 	/// UIKit shrinks a presented sheet by a detent-dependent scale, so the
-	/// design's 16 + 44 + 16 = 76pt of layout content lands on screen smaller
-	/// than it was laid out. The field's own frame is what the scale and the
-	/// margins around it come back as, once that shrink has already happened.
+	/// design's layout content lands on screen smaller than it was laid out.
+	/// The field's own frame is what the scale and the margins around it come
+	/// back as, once that shrink has already happened.
+	///
+	/// **This cannot see the field being clipped.** XCUITest reports an
+	/// element's frame whether or not an ancestor draws over it or cuts it off,
+	/// so a stop too short to hold the field passes here: at the collapsed
+	/// height the app ships, the field's own frame starts 19.9pt above the
+	/// sheet's top edge and the capture shows its top sliced away, while this
+	/// assertion is green. Whether the stop holds the field whole, and holds
+	/// nothing else, is judged on the screenshot.
+	///
+	/// The sheet's own box is queryable -- an `otherElement` whose frame is
+	/// what the sheet shows, the smaller of the two that contain the
+	/// `Sheet Grabber` button -- so comparing the field's frame against it
+	/// would catch the clipping directly. That check belongs here as soon as
+	/// the collapsed stop has content it can contain; see "Sizing the collapsed
+	/// detent" in
+	/// `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md`.
 	@discardableResult
 	func verifyCollapsedMarginsSymmetric() -> Self {
 		let field = searchField.frame

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -17,8 +17,12 @@ struct CarletonMapScreen: Screen {
 			.buttons[TestIdentifiers.CarletonMap.cancel].firstMatch
 	}
 
+	/// Its own `testID` rather than a label query: the search bar's Cancel
+	/// carries the same "Close" label, and the picker is still mounted while
+	/// this is waited on, so a label-only query could be satisfied by the
+	/// wrong element.
 	private var closeButton: XCUIElement {
-		app.buttons[TestIdentifiers.CarletonMap.close].firstMatch
+		app.buttons[TestIdentifiers.CarletonMap.cardCloseButton].firstMatch
 	}
 
 	/// The map has no home tile of its own -- both campuses' Campus screens

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -182,9 +182,13 @@ struct CarletonMapScreen: Screen {
 		let field = searchField.frame
 		let window = app.windows.firstMatch.frame
 		let scale = field.height / 44
-		// Maps insets all four sides of the sheet equally, so the field's own
-		// left inset gives the scaled inset directly.
-		let inset = field.origin.x - 16 * scale
+		// The floating sheet's inset comes from the shrink alone -- a scaled
+		// box centred in the window leaves (1 - scale) of the width split
+		// evenly on both sides -- not from wherever the field itself sits.
+		// `UISearchBar` insets its own text field further in than Maps' field
+		// sits, so deriving the inset from the field's x would fold that extra
+		// margin into "inset" and hide it there instead of in bottomMargin.
+		let inset = window.width * (1 - scale) / 2
 		let sheetBottom = window.height - inset
 		let bottomMargin = sheetBottom - (field.origin.y + field.height)
 		let topMargin = 16 * scale

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -77,10 +77,12 @@ struct CarletonMapScreen: Screen {
 	/// out as a quietly short field rather than a console warning. Measuring is
 	/// the only thing that would notice.
 	///
-	/// Measured at a full-width stop. Something applies a 0.8607 scale to the
-	/// collapsed sheet's content -- what applies it has not been identified --
-	/// so every frame read there is smaller than the layout that produced it,
-	/// and 44pt would be the wrong number to expect.
+	/// Measured at a full-width stop. UIKit applies a detent-dependent shrink to
+	/// any presented sheet's content -- Apple Maps' own small-detent drop shadow
+	/// carries the same 0.8607 scale -- so a frame read at a smaller detent is
+	/// smaller than the layout that produced it, and 44pt would be the wrong
+	/// number to expect there. See "Sizing the collapsed detent" in
+	/// `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md`.
 	@discardableResult
 	func verifySearchFieldHeight() -> Self {
 		let height = searchField.frame.height
@@ -207,9 +209,10 @@ struct CarletonMapScreen: Screen {
 		return self
 	}
 
-	/// A move is a change of at least a hundred points: the stops are 76pt,
-	/// half the screen, and nearly all of it, so anything smaller is a scroll
-	/// or a wobble, not a detent change.
+	/// A move is a change of at least a hundred points: the collapsed stop
+	/// renders at about 65pt, medium at half the screen, and large at nearly
+	/// all of it, so anything smaller is a scroll or a wobble, not a detent
+	/// change.
 	@discardableResult
 	func verifySheetMoved(from before: CGFloat, direction: String, _ message: String) -> Self {
 		let after = searchFieldTop()

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -9,6 +9,35 @@ struct CarletonMapScreen: Screen {
 		app.searchFields[TestIdentifiers.CarletonMap.search].firstMatch
 	}
 
+	/// The box the sheet actually draws, which is what its content is clipped
+	/// to. `app.sheets` is empty for this presentation: UIKit exposes the sheet
+	/// as an `otherElement` holding the grabber button, and the window-sized
+	/// host holds that button too, so the shortest of the elements holding it
+	/// is the sheet.
+	///
+	/// Descendants rather than frames decide this. The grabber's own frame is
+	/// padded out for hit testing and reaches above the sheet's top edge, so
+	/// asking which frames contain it finds the sheet nowhere.
+	///
+	/// Fails rather than falling back to the window if nothing answers. A box
+	/// the whole screen tall contains anything, so a fallback would turn
+	/// `verifyFieldWithinSheet` green on a query that had stopped working.
+	private func sheetFrame() -> CGRect {
+		let window = app.windows.firstMatch.frame
+		let candidates = app.otherElements
+			.containing(NSPredicate(format: "label == %@", TestIdentifiers.CarletonMap.sheetGrabber))
+			.allElementsBoundByIndex
+			.map(\.frame)
+			.filter { $0.height < window.height }
+		guard let sheet = candidates.min(by: { $0.height < $1.height }) else {
+			XCTFail(
+				"The presented sheet's own box should be findable as the shortest element "
+					+ "holding the \(TestIdentifiers.CarletonMap.sheetGrabber)")
+			return .null
+		}
+		return sheet
+	}
+
 	/// Scoped to the search bar rather than the whole screen: the building
 	/// card's own dismiss button carries the same label, so an unscoped query
 	/// could answer for either.
@@ -160,12 +189,9 @@ struct CarletonMapScreen: Screen {
 	/// The collapsed stop rests at the foot of the screen with the field on it,
 	/// which is what tells it apart from medium and large.
 	///
-	/// That the field is the *only* thing on it is not asserted, because it
-	/// cannot be from here. The category segments beneath the field answer
-	/// `isHittable` at every collapsed height tried -- 44, 60, 76 and 160 --
-	/// while the screen visibly changes between them, so the hit test is not
-	/// measuring what the sheet shows. The capture is what that half has to be
-	/// judged on.
+	/// How much of the field the stop shows is `verifyFieldWithinSheet`'s
+	/// question, not this one: `isHittable` answers true for content the sheet
+	/// clips away, so it measures reachability rather than what is drawn.
 	@discardableResult
 	func verifyCollapsed() -> Self {
 		XCTAssertTrue(searchField.isHittable, "The search field should be reachable while collapsed")
@@ -183,21 +209,11 @@ struct CarletonMapScreen: Screen {
 	/// The field's own frame is what the scale and the margins around it come
 	/// back as, once that shrink has already happened.
 	///
-	/// **This cannot see the field being clipped.** XCUITest reports an
-	/// element's frame whether or not an ancestor draws over it or cuts it off,
-	/// so a stop too short to hold the field passes here: at the collapsed
-	/// height the app ships, the field's own frame starts 19.9pt above the
-	/// sheet's top edge and the capture shows its top sliced away, while this
-	/// assertion is green. Whether the stop holds the field whole, and holds
-	/// nothing else, is judged on the screenshot.
-	///
-	/// The sheet's own box is queryable -- an `otherElement` whose frame is
-	/// what the sheet shows, the smaller of the two that contain the
-	/// `Sheet Grabber` button -- so comparing the field's frame against it
-	/// would catch the clipping directly. That check belongs here as soon as
-	/// the collapsed stop has content it can contain; see "Sizing the collapsed
-	/// detent" in
-	/// `docs/superpowers/specs/2026-09-07-map-sheet-search-bar-design.md`.
+	/// **This cannot see the field being clipped**, because XCUITest reports an
+	/// element's frame whether or not an ancestor cuts it off: a stop too short
+	/// to hold the field leaves the margins around it symmetric and this
+	/// assertion green. `verifyFieldWithinSheet` is the one that catches that,
+	/// and the two belong together.
 	@discardableResult
 	func verifyCollapsedMarginsSymmetric() -> Self {
 		let field = searchField.frame
@@ -221,6 +237,27 @@ struct CarletonMapScreen: Screen {
 			bottomMargin, topMargin, accuracy: 1,
 			"The collapsed sheet should leave the same margin below the field as "
 				+ "above it: top \(topMargin), bottom \(bottomMargin)")
+		return self
+	}
+
+	/// The stop has to *hold* the field, not merely position it well. A `VStack`
+	/// taller than the stop it is presented in is centred in it rather than
+	/// clipped at the bottom, so a stop that cannot fit the picker's header
+	/// block slices the field's top edge off -- which
+	/// `verifyCollapsedMarginsSymmetric` reads as symmetric and passes.
+	///
+	/// Measured against the sheet's own box rather than the window's: the sheet
+	/// floats clear of the screen's edges, so the window would call a field
+	/// hanging off the sheet contained.
+	@discardableResult
+	func verifyFieldWithinSheet() -> Self {
+		let field = searchField.frame
+		let sheet = sheetFrame()
+		XCTContext.runActivity(named: "field \(field) in sheet \(sheet)") { _ in }
+		XCTAssertTrue(
+			field.minY >= sheet.minY && field.maxY <= sheet.maxY,
+			"The collapsed sheet should hold the whole search field, not clip it: "
+				+ "field \(field), sheet \(sheet)")
 		return self
 	}
 

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -173,6 +173,32 @@ struct CarletonMapScreen: Screen {
 		return self
 	}
 
+	/// UIKit shrinks a presented sheet by a detent-dependent scale, so the
+	/// design's 16 + 44 + 16 = 76pt of layout content lands on screen smaller
+	/// than it was laid out. The field's own frame is what the scale and the
+	/// margins around it come back as, once that shrink has already happened.
+	@discardableResult
+	func verifyCollapsedMarginsSymmetric() -> Self {
+		let field = searchField.frame
+		let window = app.windows.firstMatch.frame
+		let scale = field.height / 44
+		// Maps insets all four sides of the sheet equally, so the field's own
+		// left inset gives the scaled inset directly.
+		let inset = field.origin.x - 16 * scale
+		let sheetBottom = window.height - inset
+		let bottomMargin = sheetBottom - (field.origin.y + field.height)
+		let topMargin = 16 * scale
+		XCTContext.runActivity(
+			named: "scale \(scale), inset \(inset), sheetBottom \(sheetBottom), "
+				+ "topMargin \(topMargin), bottomMargin \(bottomMargin)"
+		) { _ in }
+		XCTAssertEqual(
+			bottomMargin, topMargin, accuracy: 1,
+			"The collapsed sheet should leave the same margin below the field as "
+				+ "above it: top \(topMargin), bottom \(bottomMargin)")
+		return self
+	}
+
 	/// A move is a change of at least a hundred points: the stops are 76pt,
 	/// half the screen, and nearly all of it, so anything smaller is a scroll
 	/// or a wobble, not a detent change.

--- a/uitests/Screens/CarletonMapScreen.swift
+++ b/uitests/Screens/CarletonMapScreen.swift
@@ -3,10 +3,22 @@ import XCTest
 struct CarletonMapScreen: Screen {
 	let app: XCUIApplication
 
-	/// The picker sheet's search field, which is the sheet's only content at
-	/// the collapsed detent it opens at.
+	/// The picker sheet's search field: a UISearchBar's text field, which is
+	/// the sheet's only content at the collapsed detent it opens at.
 	private var searchField: XCUIElement {
-		app.textFields[TestIdentifiers.CarletonMap.search].firstMatch
+		app.searchFields[TestIdentifiers.CarletonMap.search].firstMatch
+	}
+
+	/// Scoped to the search bar rather than the whole screen: the building
+	/// card's own dismiss button carries the same label, so an unscoped query
+	/// could answer for either.
+	private var cancelButton: XCUIElement {
+		app.otherElements[TestIdentifiers.CarletonMap.search]
+			.buttons[TestIdentifiers.CarletonMap.cancel].firstMatch
+	}
+
+	private var closeButton: XCUIElement {
+		app.buttons[TestIdentifiers.CarletonMap.close].firstMatch
 	}
 
 	/// The map has no home tile of its own -- both campuses' Campus screens
@@ -49,6 +61,32 @@ struct CarletonMapScreen: Screen {
 		return self
 	}
 
+	/// Where the field's top edge sits on screen. Only a detent change moves
+	/// it: it is pinned above the list, so a scroll never does.
+	func searchFieldTop() -> CGFloat {
+		searchField.frame.minY
+	}
+
+	/// Apple Maps' field is 44pt, and the collapsed detent is that plus 16pt
+	/// above and below. The bar pins the height at priority 999 so UIKit's own
+	/// layout of the text field wins any conflict, which means a conflict comes
+	/// out as a quietly short field rather than a console warning. Measuring is
+	/// the only thing that would notice.
+	///
+	/// Measured at a full-width stop. A floating sheet draws its content scaled
+	/// to the inset it floats in, so every frame read at the collapsed stop is
+	/// smaller than the layout that produced it, and 44pt would be the wrong
+	/// number to expect there.
+	@discardableResult
+	func verifySearchFieldHeight() -> Self {
+		let height = searchField.frame.height
+		XCTContext.runActivity(named: "The search field measures \(height)pt tall") { _ in }
+		XCTAssertEqual(
+			height, 44, accuracy: 1,
+			"The search field should be Apple Maps' 44pt, not \(height)")
+		return self
+	}
+
 	/// Drags the sheet from its collapsed detent up to full height, where the
 	/// building list is.
 	@discardableResult
@@ -61,13 +99,97 @@ struct CarletonMapScreen: Screen {
 		return self
 	}
 
+	@discardableResult
+	func focusSearch() -> Self {
+		searchField.tap()
+		XCTAssertTrue(
+			cancelButton.waitForExistence(timeout: 10),
+			"Focusing the search field should show its Cancel button")
+		return self
+	}
+
+	@discardableResult
+	func cancelSearch() -> Self {
+		cancelButton.tap()
+		XCTAssertTrue(
+			cancelButton.waitForNonExistence(timeout: 10),
+			"Cancel should hide itself once there is nothing to cancel")
+		return self
+	}
+
+	/// Types into the focused field one character at a time, the way a person
+	/// does, and reads the whole string back. The bar reports each keystroke to
+	/// JavaScript and takes the echo back as a prop, so a character lost to
+	/// that round trip would show up here and nowhere else.
+	@discardableResult
+	func typeIntoSearch(_ text: String) -> Self {
+		searchField.typeText(text)
+		let arrived = searchField.value as? String
+		XCTAssertEqual(
+			arrived, text,
+			"Every character typed should survive the round trip to JavaScript")
+		return self
+	}
+
+	/// The list is what the query is for, so a filtered row proves the text
+	/// reached JavaScript rather than only the field.
+	@discardableResult
+	func verifySearchFound(_ name: String) -> Self {
+		XCTAssertTrue(
+			app.buttons[name].firstMatch.waitForExistence(timeout: 30),
+			"Searching should narrow the list to \(name)")
+		return self
+	}
+
+	/// The collapsed stop rests at the foot of the screen with the field on it,
+	/// which is what tells it apart from medium and large.
+	///
+	/// That the field is the *only* thing on it is not asserted, because it
+	/// cannot be from here. A sheet clips what it draws but not what it
+	/// hit-tests, so the category segments beneath the field answer
+	/// `isHittable` at every collapsed height tried -- 44, 60, 76 and 160 --
+	/// while the screen visibly changes between them. The capture is what that
+	/// half has to be judged on.
+	@discardableResult
+	func verifyCollapsed() -> Self {
+		XCTAssertTrue(searchField.isHittable, "The search field should be reachable while collapsed")
+		let top = searchFieldTop()
+		let windowHeight = app.windows.firstMatch.frame.height
+		XCTAssertTrue(
+			top > windowHeight * 0.8,
+			"The collapsed sheet should rest at the foot of the screen; the field's top is at \(top) of \(windowHeight)")
+		XCTAssertFalse(cancelButton.exists, "An empty, unfocused field has nothing to cancel")
+		return self
+	}
+
+	/// A move is a change of at least a hundred points: the stops are 76pt,
+	/// half the screen, and nearly all of it, so anything smaller is a scroll
+	/// or a wobble, not a detent change.
+	@discardableResult
+	func verifySheetMoved(from before: CGFloat, direction: String, _ message: String) -> Self {
+		let after = searchFieldTop()
+		let moved = direction == "up" ? before - after : after - before
+		XCTAssertTrue(
+			moved > 100,
+			"\(message): the field's top went from \(before) to \(after)")
+		return self
+	}
+
+	@discardableResult
+	func verifySheetReturned(to before: CGFloat) -> Self {
+		let after = searchFieldTop()
+		XCTAssertTrue(
+			abs(after - before) < 2,
+			"Cancel should put the sheet back where it was, at \(before), not \(after)")
+		return self
+	}
+
 	/// Taps a named row rather than the first button on screen, which is the
 	/// navigation bar's rather than the list's.
 	///
 	/// Retried, for the reason `navigateFromHome` retries: a synthesized press
 	/// on a row whose host has mounted but whose action still has to reach
-	/// JavaScript lands natively and does nothing. The row is found, the event
-	/// is delivered, and the sheet stays on the list. Waiting longer does not
+	/// JavaScript lands natively and does nothing. Waiting longer does not
 	/// help a dropped tap; tapping again does.
 	/// Matched on the label's prefix, not the whole label: a building carrying
 	/// an abbreviation reads as "Buntrock Commons, BC", so an exact match finds
@@ -79,14 +201,13 @@ struct CarletonMapScreen: Screen {
 			row.waitForExistence(timeout: 30),
 			"The expanded sheet should list \(name)")
 
-		let close = app.buttons[TestIdentifiers.CarletonMap.close].firstMatch
 		for attempt in 1...3 {
 			// The row's centre on purpose. It falls on the Spacer between the
 			// name and the chevron, which is outside what a SwiftUI button's
 			// label draws -- the row carries a contentShape so the whole of it
 			// responds, and tapping over the name would pass either way.
 			row.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
-			if close.waitForExistence(timeout: 10) {
+			if closeButton.waitForExistence(timeout: 10) {
 				return self
 			}
 			XCTContext.runActivity(
@@ -98,12 +219,45 @@ struct CarletonMapScreen: Screen {
 		return self
 	}
 
+	/// Taps the map itself, in the strip above the collapsed sheet. The
+	/// initial camera frames campus, so the screen's centre lands on a
+	/// footprint; which one does not matter, only that a card opens.
+	@discardableResult
+	func tapAFootprint() -> Self {
+		for attempt in 1...3 {
+			app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+			if closeButton.waitForExistence(timeout: 10) {
+				return self
+			}
+			XCTContext.runActivity(named: "Tap \(attempt) on the map opened no card; retrying") { _ in }
+		}
+		XCTFail("Tapping the map never opened a building card")
+		return self
+	}
+
 	@discardableResult
 	func checkBuildingCardPresented() -> Self {
-		let close = app.buttons[TestIdentifiers.CarletonMap.close].firstMatch
 		XCTAssertTrue(
-			close.waitForExistence(timeout: 30),
+			closeButton.waitForExistence(timeout: 30),
 			"Selecting a building should show its card, which offers a way out")
+		return self
+	}
+
+	/// The card's close button is the card's top edge for measuring purposes,
+	/// the way the field is the picker's.
+	func closeButtonTop() -> CGFloat {
+		closeButton.frame.minY
+	}
+
+	/// The medium stop is half the window. A card whose top is in the middle
+	/// third of the screen is at it; one hugging the bottom is still collapsed.
+	@discardableResult
+	func verifyCardAtMedium() -> Self {
+		let top = closeButtonTop()
+		let height = app.windows.firstMatch.frame.height
+		XCTAssertTrue(
+			top > height * 0.33 && top < height * 0.66,
+			"A footprint tapped while collapsed should raise the card to medium; its top is at \(top) of \(height)")
 		return self
 	}
 }

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -113,6 +113,9 @@ struct TestIdentifiers {
 		/// query runs, so a label-only query could answer for either. Matches
 		/// `CARD_CLOSE_BUTTON_ID` in `source/features/map/building-info.tsx`.
 		static let cardCloseButton = "card-close-button"
+		/// MapLibre's attribution button, found by the label it gives itself. It
+		/// carries the OpenStreetMap credit, so it has to stay reachable.
+		static let attribution = "About this map"
 		/// UIKit's own drag indicator on the presented sheet, found by label --
 		/// it carries no identifier. Its element is the sheet's child, which is
 		/// how the sheet's own box is found.

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -104,6 +104,10 @@ struct TestIdentifiers {
 		/// UIKit puts the identifier on the text field, so this is a
 		/// `searchFields` query.
 		static let search = "Search for a place"
+		/// The map view itself. MapLibre publishes one element for the whole map --
+		/// labelled "Map", valued with the zoom -- and nothing per building, so
+		/// this is the only handle a test has on where the map is on screen.
+		static let map = "Map"
 		/// UIKit's own dismiss button on the search bar, found by label. iOS 26
 		/// draws it as a circular glyph beside the field and labels it "Close".
 		static let cancel = "Close"

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -100,9 +100,14 @@ struct TestIdentifiers {
 	// it is the shared map screen's own identifiers, not Carleton-specific ones.
 
 	enum CarletonMap {
-		/// The sheet's search field. Its placeholder is its accessibility label,
-		/// which is what a SwiftUI TextField reports when it has no other.
+		/// The sheet's search field. The bar's testID is its placeholder, and
+		/// UIKit puts the identifier on the text field, so this is a
+		/// `searchFields` query.
 		static let search = "Search for a place"
+		/// UIKit's own dismiss button on the search bar, found by label. iOS 26
+		/// draws it as a circular glyph beside the field and labels it "Close"
+		/// rather than "Cancel", which is the label a `UISearchBar` used to carry.
+		static let cancel = "Close"
 		static let close = "Close"
 		/// A building near the top of the alphabetical list, so the expanded
 		/// sheet shows it without scrolling.

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -108,7 +108,12 @@ struct TestIdentifiers {
 		/// draws it as a circular glyph beside the field and labels it "Close"
 		/// rather than "Cancel", which is the label a `UISearchBar` used to carry.
 		static let cancel = "Close"
-		static let close = "Close"
+		/// The building card's own dismiss button, a `testID` rather than a
+		/// label -- it shares the "Close" label with the search bar's Cancel
+		/// (`cancel`, above), and the picker is still mounted while the card's
+		/// query runs, so a label-only query could answer for either. Matches
+		/// `CARD_CLOSE_BUTTON_ID` in `source/features/map/building-info.tsx`.
+		static let cardCloseButton = "card-close-button"
 		/// A building near the top of the alphabetical list, so the expanded
 		/// sheet shows it without scrolling.
 		static let aBuilding = "Allen House"

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -116,6 +116,12 @@ struct TestIdentifiers {
 		/// -- absent from Carleton's map data, so selecting it is what would
 		/// fail if the map's campus parameter were ignored.
 		static let aStolafBuilding = "Buntrock Commons"
+		/// A second building, high enough in the list to be on screen even with
+		/// the keyboard up, and not a match for `aBuilding` under the picker's
+		/// subsequence search -- so typing that query has to drop it. Carleton can
+		/// rename either of these; a failure here is worth checking against the
+		/// list before it is blamed on the filter.
+		static let anotherBuilding = "216 College Street"
 	}
 
 	// MARK: - SIS

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -105,8 +105,7 @@ struct TestIdentifiers {
 		/// `searchFields` query.
 		static let search = "Search for a place"
 		/// UIKit's own dismiss button on the search bar, found by label. iOS 26
-		/// draws it as a circular glyph beside the field and labels it "Close"
-		/// rather than "Cancel", which is the label a `UISearchBar` used to carry.
+		/// draws it as a circular glyph beside the field and labels it "Close".
 		static let cancel = "Close"
 		/// The building card's own dismiss button, a `testID` rather than a
 		/// label -- it shares the "Close" label with the search bar's Cancel

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -114,6 +114,10 @@ struct TestIdentifiers {
 		/// query runs, so a label-only query could answer for either. Matches
 		/// `CARD_CLOSE_BUTTON_ID` in `source/features/map/building-info.tsx`.
 		static let cardCloseButton = "card-close-button"
+		/// UIKit's own drag indicator on the presented sheet, found by label --
+		/// it carries no identifier. Its element is the sheet's child, which is
+		/// how the sheet's own box is found.
+		static let sheetGrabber = "Sheet Grabber"
 		/// A building near the top of the alphabetical list, so the expanded
 		/// sheet shows it without scrolling.
 		static let aBuilding = "Allen House"

--- a/uitests/UITestCase.swift
+++ b/uitests/UITestCase.swift
@@ -43,7 +43,19 @@ class UITestCase: XCTestCase {
 		// depend on what ran before it -- testLongPressNoticeTogglesDevMode
 		// inverts if dev mode is already on, and failed only in long runs.
 		app.launchArguments.append(TestIdentifiers.LaunchArguments.resetState)
+		appendJsLocationIfProvided()
 		app.launch()
+	}
+
+	/// Points the app at a Metro other than the default localhost:8081, when
+	/// the test runner was started with `TEST_RUNNER_AAO_JS_LOCATION=host:port`.
+	/// `-RCT_jsLocation` is read by React Native as a command-line default;
+	/// without it, a Metro that some other checkout left on 8081 would serve
+	/// this app someone else's JavaScript.
+	func appendJsLocationIfProvided() {
+		if let location = ProcessInfo.processInfo.environment["AAO_JS_LOCATION"] {
+			app.launchArguments.append(contentsOf: ["-RCT_jsLocation", location])
+		}
 	}
 
 	/// Terminate and relaunch the app with `--reset-state` to clear persisted
@@ -54,6 +66,7 @@ class UITestCase: XCTestCase {
 			TestIdentifiers.LaunchArguments.uiTesting,
 			TestIdentifiers.LaunchArguments.resetState,
 		]
+		appendJsLocationIfProvided()
 		app.launch()
 	}
 
@@ -69,6 +82,7 @@ class UITestCase: XCTestCase {
 			TestIdentifiers.LaunchArguments.resetState,
 			"-UIPreferredContentSizeCategoryName", category,
 		]
+		appendJsLocationIfProvided()
 		app.launch()
 	}
 }

--- a/uitests/XCUITestHelpers.swift
+++ b/uitests/XCUITestHelpers.swift
@@ -26,9 +26,13 @@ extension XCUIApplication {
 				TestIdentifiers.Menus.foodRowPrefix, label))
 	}
 
-	/// Find a button by the label UIKit gave it. Buttons the system builds --
-	/// a search bar's cancel button, say -- carry no accessibility identifier,
-	/// so the usual subscript, which matches identifiers, never finds them.
+	/// Find a button by the label UIKit gave it, matching on the label alone.
+	///
+	/// The plain subscript is not confined to identifiers: it answers with a
+	/// system button that has only a label, which is how `CarletonMapScreen`
+	/// reaches the search bar's Close button. What it will not do is tell the
+	/// two attributes apart, so use this wherever a label is the only thing
+	/// that should count.
 	func buttonLabelled(_ label: String) -> XCUIElement {
 		buttons.matching(NSPredicate(format: "label == %@", label)).firstMatch
 	}


### PR DESCRIPTION
<!-- Description left for @hawkrives to write. -->

## Screenshots

Captured from `ModuleCarletonMapTests` on an iPhone 17 Pro simulator, iOS 26.5.

&nbsp; | &nbsp;
--- | ---
**Collapsed stop** | **Raised by search focus**
<img alt=sheet-collapsed src=https://github.com/user-attachments/assets/4a98fa6a-ac23-40cd-93da-dd12eb4c3f87 width=380> | <img alt=sheet-raised-by-search-focus src=https://github.com/user-attachments/assets/644f8253-7649-4ee4-b45f-25505ef9a1d9 width=380>
**A typed query** |  **After cancelling the search** | 
<img alt=sheet-with-a-typed-query src=https://github.com/user-attachments/assets/34877ec6-18f9-47bc-8f02-12239e10795f width=380> | <img alt=sheet-after-cancelling-search src=https://github.com/user-attachments/assets/7d5591c2-24bb-4b54-b84e-2d095e141a80 width=380>
**The list before a query is typed** | **Building card after a row tap from `large`** | 
<img alt=list-before-a-query-is-typed src=https://github.com/user-attachments/assets/ed2d246d-2eda-4e4b-84aa-7b75e66e4cc9 width=380> | <img alt=card-after-a-row-tap-from-large src=https://github.com/user-attachments/assets/dc1691da-a361-4745-830b-d61cd3a5430d width=380>
**Building card after a footprint tap from collapsed** | |
<img alt=card-after-a-footprint-tap-from-collapsed src=https://github.com/user-attachments/assets/9e3d3d31-3b37-488c-a443-769f9b480d6e width=380> |


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMn6ZCYjq9XFdJ1mxkDEHC
