### PR TITLE
Quarantine the cancelled-swipe-back Directory test

### DIFF
--- a/uitests/ModuleDirectoryTests.swift
+++ b/uitests/ModuleDirectoryTests.swift
@@ -43,6 +43,16 @@ class ModuleDirectoryTests: UITestCase {
 	/// the reader returns to a list of results with nothing on screen saying
 	/// what was searched for.
 	func testCancelledSwipeBackKeepsTheQuery() throws {
+		// Passes on a developer's machine in about eighteen seconds and fails on
+		// every hosted runner, including all three of the attempts
+		// `-retry-tests-on-failure` allows it. UIKit decides an interactive pop
+		// from how far the finger travelled and how fast, and `cancelSwipeBack`
+		// aims for a drag that is deliberately close to that threshold -- which a
+		// loaded runner resolves the other way. The behaviour it covers is real,
+		// so this is quarantined rather than deleted until the gesture can be
+		// driven at a speed the runner cannot misread.
+		try XCTSkipIf(true, "Gesture timing is not reproducible on a hosted runner")
+
 		DirectoryScreen(app: app)
 			.navigate()
 			.search(for: "olaf")


### PR DESCRIPTION
This test passes on a developer machine in about eighteen seconds and fails on every hosted runner — including all three attempts `-retry-tests-on-failure` gives it. It is not flaky in the usual sense; it is reliably wrong about one class of machine.

`cancelSwipeBack` drags most of the way across and lets go without completing, and UIKit decides an interactive pop from how far the finger travelled and how fast. The helper aims deliberately close to that threshold, and a loaded runner resolves the ambiguity the other way.

The behaviour it covers is real — the search field is the only thing holding the query, so an abandoned swipe back has to return it intact — so the test is skipped rather than deleted, with the reasoning recorded next to it. Unskipping it needs the gesture driven at a speed a slow runner cannot misread.

Evidence: `xcresult` from PR #7885 shard 2 shows `First Run / Retry 1 / Retry 2` all failed, and a local run of the same test on the same commit passed in 17.7s.