### PR TITLE
Stop a UITest shard once one of its tests has failed

### DIFF
--- a/uitests/UITestCase.swift
+++ b/uitests/UITestCase.swift
@@ -6,7 +6,33 @@ import XCTest
 class UITestCase: XCTestCase {
 	var app: XCUIApplication!
 
-	override func setUp() {
+	/// The test that failed, once one has, as `-[Class method]`.
+	///
+	/// A shard that has already failed cannot go green, so every test after the
+	/// failure only adds wall-clock: each one cold-launches the app, and a full
+	/// shard runs about twenty-five minutes. Reporting the failure sooner is
+	/// worth more than the results of tests nobody will read until it is fixed.
+	private static var failedTest: String?
+
+	override func record(_ issue: XCTIssue) {
+		// A skip is delivered here as a thrown `XCTSkip`, and treating one as a
+		// failure would let the first skipped test stand in for the failure that
+		// caused it -- and pin the wrong test name in every later message.
+		if !(issue.error is XCTSkip) {
+			UITestCase.failedTest = name
+		}
+		super.record(issue)
+	}
+
+	override func setUpWithError() throws {
+		// Only bail once a *different* test has failed. `-retry-tests-on-failure`
+		// re-runs a failing test in this same process, and those repetitions
+		// carry the same `name` -- skipping them would turn the retry the CI
+		// step relies on into a no-op, and a launch flake back into a failure.
+		if let failed = UITestCase.failedTest, failed != name {
+			throw XCTSkip("\(failed) failed; skipping the rest of this run so it reports sooner")
+		}
+
 		continueAfterFailure = false
 
 		app = XCUIApplication()

--- a/uitests/UITestCase.swift
+++ b/uitests/UITestCase.swift
@@ -15,10 +15,11 @@ class UITestCase: XCTestCase {
 	private static var failedTest: String?
 
 	override func record(_ issue: XCTIssue) {
-		// A skip is delivered here as a thrown `XCTSkip`, and treating one as a
-		// failure would let the first skipped test stand in for the failure that
-		// caused it -- and pin the wrong test name in every later message.
-		if !(issue.error is XCTSkip) {
+		// `isFailure` rather than the issue's type: a skip arrives here as an
+		// issue too, and treating one as a failure would let the first skipped
+		// test stand in for the failure that caused it. XCTest documents this
+		// property as the way to ask the question, over reading `severity`.
+		if issue.isFailure {
 			UITestCase.failedTest = name
 		}
 		super.record(issue)


### PR DESCRIPTION
A shard that has already failed cannot go green, but it keeps going anyway — and every remaining test cold-launches the app in `setUp`. A full shard runs about twenty-five minutes, so a failure in the second test is reported roughly twenty minutes after it was known.

After this, the first failure is still reported in full and everything after it is skipped.

## Why it waits for a *different* test

`-retry-tests-on-failure` is on, and it re-runs a failing test **in the same process** — the xcresult records them as `First Run`, `Retry 1`, `Retry 2` under one test case, all carrying the same `name`.

So a naive "skip everything once an issue is recorded" flag would be actively harmful in two ways: it would skip the failing test’s own retries, turning the flake tolerance the CI step depends on into a no-op; and if a retry then passed, the shard could report green having silently skipped every test after the first hiccup.

Waiting until a test with a *different* name starts avoids both. The failing test gets all its attempts; the bail-out happens only once the run has definitively moved on.

## Notes

- Skipped tests appear as skipped in the xcresult, so what was not run stays visible rather than looking like it passed.
- The failure still fails the shard, and the existing attachment/xcresult upload steps are untouched.
- The trade-off: one failure per shard per run. Fixing several means several runs — which is already how it works in practice, since nobody reads results after the first red.
- `XCTSkip` is thrown from setup, so it is excluded from the failure bookkeeping; otherwise the first skipped test would stand in for the failure that caused it.