### PR TITLE
Key the toolchain cache on mise.lock, not mise.toml

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        # Keyed on mise.lock rather than mise.toml -- see the note in check.yml.
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
       - run: pnpm install --frozen-lockfile
       - run: mise run validate-data
       - run: mise run bundle-data
@@ -34,6 +37,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
       - run: sudo xcode-select -s /Applications/Xcode_26.4.app
       - run: git fetch --prune --unshallow
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,18 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        # Keyed on mise.lock alone. mise.toml also carries every task definition,
+        # so editing a script invalidated a toolchain cache that had not changed --
+        # three versions of this file across one stack of pull requests meant three
+        # copies of the same tools. The lock pins the versions and per-platform
+        # checksums, which is what `mise install` actually reads.
+        #
+        # A lock that disagrees with mise.toml still fails the job rather than
+        # passing on a stale cache: mise-action installs with `--locked` whenever a
+        # lock file is present, and that refuses any tool or version the lock does
+        # not name. The install runs on every job, cache hit or not.
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
       - run: pnpm install --frozen-lockfile
       - run: mise run bundle-data
       - run: hk check
@@ -35,6 +47,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
       - run: pnpm install --frozen-lockfile
       - run: mise run format:check
 
@@ -44,6 +58,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
       - run: pnpm install --frozen-lockfile
       - run: mise run bundle-data
       - run: mise run lint
@@ -54,6 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
       - run: pnpm install --frozen-lockfile
       - name: Run tests
         run: mise run test -- --coverage
@@ -66,6 +84,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
       - run: pnpm install --frozen-lockfile
       - run: mise run bundle-data
       - run: mise run tsc
@@ -76,7 +96,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
       - run: pnpm install --frozen-lockfile
+      # The toolchain cache is keyed on mise.lock, so a lock that has drifted
+      # from mise.toml would restore a cache satisfying neither. Checked here
+      # rather than left to the install: every job would fail on it, but this
+      # one says which invariant broke.
+      - run: mise run validate-mise-lock
       - run: mise run validate-data
       # A module that imports a @frogpond package without declaring it still
       # resolves, via the root node_modules hoist, until it doesn't.
@@ -118,6 +145,8 @@ jobs:
             jsbundle/e=${{ env.cache_epoch }}/host=ubuntu@24.04/target=ios/ref=master/hash=${{ hashFiles('mise.toml', 'package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml', 'tsconfig.json', 'babel.config.js', 'index.js', 'data/**', 'images/**', 'modules/**/*.ts', 'modules/**/*.tsx', 'source/**/*.ts', 'source/**/*.tsx', 'app/**/*.ts', 'app/**/*.tsx') }}
 
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
         if: steps.jsbundle-cache.outputs.cache-matched-key == ''
 
       - name: Install pnpm dependencies
@@ -203,6 +232,8 @@ jobs:
         run: sudo xcode-select -s /Applications/${{ env.xcode_version }}.app
 
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
 
       - name: Install pnpm dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,7 +23,9 @@ jobs:
 
       - name: Install mise
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        # Keyed on mise.lock rather than mise.toml -- see the note in check.yml.
         with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
           experimental: true
 
       - name: Set up development environment

--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -19,6 +19,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
+        # Keyed on mise.lock rather than mise.toml -- see the note in check.yml.
+        with:
+          cache_key: mise-v2-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('mise.lock') }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/mise.toml
+++ b/mise.toml
@@ -210,6 +210,15 @@ run = "node scripts/validate-single-copy.mjs"
 description = "Check that pnpm-lock.yaml matches the package.json files"
 run = "pnpm install --frozen-lockfile --lockfile-only --trust-lockfile"
 
+# CI keys its toolchain cache on mise.lock alone, so a lock that has drifted
+# from mise.toml would otherwise restore a cache that satisfies neither. The
+# dry run resolves every tool against the lock without installing anything:
+# it exits 1 for a tool the lock does not name, or a version it names
+# differently, and 0 when they agree -- whether or not the tools are present.
+[tasks."validate-mise-lock"]
+description = "Check that mise.lock matches mise.toml"
+run = "mise install --locked --dry-run"
+
 [tasks."compress-data"]
 description = "Compress data files"
 run = "gzip --keep docs/*.json"
@@ -245,5 +254,6 @@ depends = [
 	"test",
 	"validate-deps",
 	"validate-lockfile",
+	"validate-mise-lock",
 	"validate-single-copy",
 ]


### PR DESCRIPTION
The mise cache key hashes every config file, and `mise.toml` holds task definitions as well as `[tools]`. So editing a script invalidates a toolchain cache that has not changed.

The current stack of nine pull requests shows the cost. Three versions of `mise.toml` exist across it, differing only by task edits — a `depends = ["bundle-data"]` line and one new `[tasks."validate-building-keys"]` block. Neither touches a tool. But they produce three cache keys, and with two runner platforms and per-branch cache scoping that became **ten entries totalling 1.9 GB** of a 10 GB repository budget, holding byte-identical toolchains.

That mattered because the budget is shared: over the limit, GitHub evicts least-recently-used, and what got evicted were the `ios-app` and `jsbundle` caches the UITest shards restore with `fail-on-cache-miss: true`. Several shards went red having never run a test.

`mise.lock` pins each tool's resolved version and per-platform checksums, and mise-action passes `--locked` whenever a lock file is present — so the lock, not the toml, is what installation actually reads. Every branch in that stack has an identical `mise.lock`.

## Drift still fails

Keying on the lock means a `mise.toml` that disagrees with it no longer changes the key, so this adds an explicit check rather than leaving it implicit:

```
[tasks."validate-mise-lock"]
run = "mise install --locked --dry-run"
```

Measured on this machine:

| state | exit |
| --- | --- |
| lock matches toml | 0 |
| `node` pinned to a version the lock does not name | 1 |
| a tool in `[tools]` absent from the lock | 1 |

It resolves without installing, so it is not confused by a cold cache — unlike `--dry-run-code`, which exits 1 merely because tools are not yet present.

This runs in the Data job beside the other lockfile checks, and is in `agent:pre-commit`. It is a second line rather than the only one: mise-action installs with `--locked` on every job, and `miseInstall()` runs unconditionally after the cache restore — verified in the pinned action's `dist/index.js`, where the sequence is `restoreMiseCache()` → `testMise()` → `miseInstall()`. A mismatch cannot ride through on a cache hit.

## Notes

- Key is `mise-v2-…` so the two schemes are distinguishable in `gh cache list`. Existing `mise-v1-…` entries will not match and will age out.
- Applied to all twelve `mise-action` usages across four workflows; the rationale is written out once in `check.yml`, with pointers elsewhere.
- Expected steady state: two entries (one per platform) on `master`, which pull requests restore and do not re-save, versus ten today.