### PR TITLE
Write the ccache from master only

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -260,7 +260,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/Library/Caches/ccache
-          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}/run=${{ github.run_id }}-${{ github.run_attempt }}
+          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/run=${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
             ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/
             ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=master/
@@ -334,17 +334,26 @@ jobs:
         run: ccache --show-stats
 
       # Saved under a key no read will ever match, so every build writes a new
-      # entry and the prefixes above restore the newest. actions/cache declines
-      # to save when the restore hit its primary key, which suits a cache of
-      # build output but not this one: ccache grows with every compile, so a
-      # single matching key would freeze it at whatever it held first. Ours had
-      # frozen at 19kB, written before the compiler wrapper worked.
+      # entry and the prefixes above restore the newest. A key that could be hit
+      # cannot be written again, which suits a cache of build output but not
+      # this one: ccache grows with every compile, so a stable key would freeze
+      # it at whatever it held first. Ours had frozen at 19kB, written before
+      # the compiler wrapper worked.
+      #
+      # Only master writes. Every run saving its own copy meant a ~1 GB entry
+      # per branch per run, and the repository's 10 GB of cache is shared: over
+      # the limit GitHub evicts the least recently used, which took out the app
+      # and jsbundle caches the UITest shards restore with fail-on-cache-miss,
+      # so shards went red having never run a test. A pull request still reads
+      # master's cache through the ref=master prefix above, and ccache is
+      # content-addressed -- a neighbouring branch's objects answer its compiles
+      # just as well.
       - name: Save ccache
-        if: always()
+        if: always() && github.ref == 'refs/heads/master'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/Library/Caches/ccache
-          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/hash=${{ hashFiles('app.config.ts', 'plugins/**', 'uitests/**', 'images/**', 'pnpm-lock.yaml', 'mise.toml') }}/run=${{ github.run_id }}-${{ github.run_attempt }}
+          key: ccache/e=${{ env.cache_epoch }}/host=macOS@26/target=ios/xcode=${{ env.xcode_version }}/ref=${{ github.head_ref || github.ref_name }}/run=${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Save iOS app to cache
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
Every run saved its own ~1 GB compiler cache. With a stack of nine pull requests in flight that alone reached ~5 GB of the repository's 10 GB budget.

The budget is shared, and over the limit GitHub evicts the least recently used. What got evicted were the `ios-app` and `jsbundle` caches — which the UITest shards restore with `fail-on-cache-miss: true`. Several shards failed in under 30 seconds at "Load the cached iOS jsbundle", having never launched the app, and read as test failures. One `iOS Bundle` job was observed saving its cache successfully at 22:12 and the shard that needed it missing it an hour later.

## The change

Pull requests still **read** the cache — the `restore-keys` already fall through to `ref=master/` — they just stop writing one. ccache addresses each object by its preprocessed source, compiler and flags, so master's objects answer a branch's compiles; that is the same property the existing comment relies on for the hashless prefix restore.

What it gives up: a branch no longer inherits its **own** previous run, only master's. For work that touches native sources heavily, that is a real cost. It also saves each pull request the ~43s the save step takes.

Measured on two recent `Build for iOS` jobs:

| step | job 1 | job 2 |
| --- | --- | --- |
| restore ccache | 42s | 38s |
| compile | 6m04s | 7m15s |
| save ccache | 44s | 43s |

`check.yml` runs on `push: {branches: [master]}`, so master keeps refreshing its entry.

## Dropping `hash=`

The key was:

```
ccache/e=…/host=…/target=ios/xcode=…/ref=REF/hash=H/run=RUN-ATTEMPT
```

Both `restore-keys` stop at `ref=…/` — before `hash=` — so the hash never participated in a match. Editing `uitests/**` or `mise.toml` could not invalidate this cache, whatever the key implied. Removing it changes no behaviour; it removes a claim the config was not making good on.

`run=` stays, and is doing real work: a key that can be hit cannot be written again, so a stable key would freeze the cache at its first contents. That already happened once — the comment in the workflow records it frozen at 19 kB.

## Not addressed

Master still writes one entry per push and they accumulate until evicted. That is far cheaper than one per branch per run, but it is not bounded. If it becomes a problem, pruning older master ccache entries after a successful save would be the next step.