### PR TITLE
Let the cache cleanup survive a cache deleted underneath it

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -15,6 +15,13 @@ on:
 
 # actions: write to delete cache entries; pull-requests: read so `gh pr view`
 # can tell which PR refs are still open.
+# Five triggers feed this, and nothing stopped two runs overlapping. Both list
+# the same caches, then each deletes what the other already took. Queued rather
+# than cancelled: a cancelled cleanup is one that did not happen.
+concurrency:
+  group: cache-cleanup
+  cancel-in-progress: false
+
 permissions:
   actions: write
   contents: read
@@ -33,7 +40,8 @@ jobs:
         run: |
           gh cache list --ref "${{ github.ref }}" --limit 500 --json 'ref' -q '.[].ref' | while read ref; do
             echo "Deleting caches for ref: $ref"
-            gh cache delete --all --succeed-on-no-caches --ref "$ref"
+            gh cache delete --all --succeed-on-no-caches --ref "$ref" \
+              || echo "::warning::Could not delete caches for $ref -- a concurrent run may have taken them already"
           done
 
       - name: Clean up caches for the just-deleted branch
@@ -43,7 +51,8 @@ jobs:
           DELETED_REF: refs/heads/${{ github.event.ref }}
         run: |
           echo "Deleting caches for ref: $DELETED_REF"
-          gh cache delete --all --succeed-on-no-caches --ref "$DELETED_REF"
+          gh cache delete --all --succeed-on-no-caches --ref "$DELETED_REF" \
+            || echo "::warning::Could not delete caches for $DELETED_REF -- a concurrent run may have taken them already"
 
       - name: Delete PR caches for all branches without open PRs
         if: github.event_name != 'delete'
@@ -57,7 +66,8 @@ jobs:
               state="$(gh pr view "$pr" --json state -q .state 2>/dev/null)"
               case "$state" in MERGED|CLOSED)
                 echo "Deleting caches for PR ref: refs/pull/$pr/merge"
-                gh cache delete --all --succeed-on-no-caches --ref "refs/pull/$pr/merge";;
+                gh cache delete --all --succeed-on-no-caches --ref "refs/pull/$pr/merge" \
+                  || echo "::warning::Could not delete caches for refs/pull/$pr/merge -- a concurrent run may have taken them already";;
               esac
             done
 
@@ -73,6 +83,7 @@ jobs:
               branch="${ref#refs/heads/}"
               if ! gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${branch}" >/dev/null 2>&1; then
                 echo "Deleting caches for stale merge-queue ref: $ref"
-                gh cache delete --all --succeed-on-no-caches --ref "$ref"
+                gh cache delete --all --succeed-on-no-caches --ref "$ref" \
+                  || echo "::warning::Could not delete caches for $ref -- a concurrent run may have taken them already"
               fi
             done


### PR DESCRIPTION
The cleanup job failed on #7902 with:

```
Deleting caches for PR ref: refs/pull/7902/merge
X Could not find a cache matching 7480372105 (with ref refs/pull/7902/merge)
##[error]Process completed with exit code 1
```

Nothing was wrong with what it decided to do — #7902 really had merged, so deleting its caches was correct. It failed on *how*: the step lists caches and then deletes them, and something removed one in between. `gh cache delete` exits non-zero for a cache it cannot find, the step runs under `bash -e`, and one lost race kills the loop before it reaches the refs after it.

`--succeed-on-no-caches` does not cover this. Per `gh cache delete --help` it returns 0 when *no caches are found for the ref*, which is a different case from an entry disappearing partway through.

## Two changes

**A delete that loses the race warns instead of failing.** The entry is gone either way, which is what the step wanted. A real problem — a bad token, a rate limit — still surfaces, as a warning on every ref rather than a silent skip.

**The workflow gets a concurrency group.** Five triggers feed it: a closed pull request, a deleted branch, a push to master, a six-hourly schedule, and manual dispatch. There was nothing to stop two of them overlapping, and two runs enumerating the same caches will each try to remove what the other already took. `cancel-in-progress: false`, deliberately — a cancelled cleanup is one that did not happen.

## Checked

The guard was run under `bash -e` against a stub that fails the way `gh` does, to confirm the loop continues rather than exiting at the first failure:

```
Deleting caches for ref: a
X Could not find a cache matching 123
::warning::Could not delete caches for a -- a concurrent run may have taken them already
... b, c ...
loop completed all three
EXIT: 0
```

The race was real rather than theoretical here: I was purging ccache entries by hand at the time, to get the repository back under its 10 GB budget. But manual deletion is not needed to trigger it — the schedule alone overlaps the other four triggers.