### PR TITLE
Deploy the data with the Pages action, not a force-push

### DIFF
--- a/.github/workflows/deploy-data.yml
+++ b/.github/workflows/deploy-data.yml
@@ -3,16 +3,28 @@ name: Validate/Deploy Data
 on:
   push: {branches: [master]}
 
-# The final step force-pushes the bundled data to the gh-pages branch.
+# `pages: write` and `id-token: write` are what actions/deploy-pages needs to
+# claim a deployment; `contents: read` is all the rest of the job wants. The
+# previous version force-pushed a branch, so it held `contents: write` against
+# the whole repository to publish sixteen JSON files.
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time, and never cancel one that has started: a cancelled
+# deploy leaves the site serving whatever the last completed run published,
+# which for data the app fetches is worse than being a few minutes stale.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 env:
   MISE_RUBY_COMPILE: 'false'
 
 jobs:
-  validate-then-deploy:
-    name: Validate, then deploy data
+  build:
+    name: Validate and bundle the data
     runs-on: ubuntu-latest
     steps:
       - name: Check out the code
@@ -31,26 +43,25 @@ jobs:
           mise run validate-bus-data
           mise run validate-data
 
-      # Having validated the data, we now prepare a bundle.  This script creates
-      # files in a docs/ directory.
       - name: Bundle the data
         run: mise run bundle-data
 
-      # Notes: actions/checkout@v2 no longer fetches entire history nor enters
-      # detached HEAD state.  We really just need to check out an (orphaned)
-      # branch and then add, commit, and push the appropriate directory.
-      - name: Commit the data
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout --orphan "gh-pages-$GITHUB_SHA"
-          git --work-tree=docs add .
-          git commit -m "Automated data deployment at $(date -Is)"
-          git show --stat HEAD
+      # Uploads docs/ as the Pages artifact. The bundle is the whole site --
+      # sixteen JSON files and a stylesheet, no index -- so it needs no base
+      # path and no configure-pages step ahead of it.
+      - name: Upload the bundle as a Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs
 
-      # If the previous commit successfully happened, download the latest state
-      # of the remote branch gh-pages.
-      - name: Deploy the data
-        run: |
-          git fetch --prune --unshallow origin gh-pages
-          git push --force-with-lease origin "gh-pages-$GITHUB_SHA:gh-pages"
+  deploy:
+    name: Deploy the data to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy the artifact
+        id: deployment
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1


### PR DESCRIPTION
> [!IMPORTANT]
> **This needs a settings change to work.** The repository's Pages source is currently `build_type=legacy`, `source=gh-pages`. It has to be switched to **GitHub Actions** under Settings → Pages. Until that happens `deploy-pages` fails, and since the shipped app fetches `stolaf.dev/AAO-React-Native/a-to-z.json`, the data stops updating. Flip the setting, then merge.

Publishing sixteen JSON files should not require write access to the entire repository. The job held `contents: write`, checked out an orphan branch, committed `docs/` onto it and force-pushed over `gh-pages` on every push to master.

The Pages actions upload the bundle as an artifact and deploy that. The token drops to:

```yaml
permissions:
  contents: read
  pages: write
  id-token: write
```

## The address does not move

Worth stating plainly, because it is the thing that could bite. `stolaf.dev` is **not** configured on this repository — its own `cname` is `null`. It is the custom domain on `StoDevX/stodevx.github.io`, and GitHub serves project sites in the org beneath it, which is why this repo reports `html_url = http://stolaf.dev/AAO-React-Native/`.

So the domain is inherited and unaffected by how this repository publishes. I also checked `gh-pages` for a `CNAME` file to carry into the artifact — there is none; the branch holds only the sixteen data files.

## Details

- **Two jobs.** `build` validates and bundles, `deploy` publishes. That split is what the Pages actions expect, and it keeps the deployment environment off the job that runs project code.
- **`concurrency: {group: pages, cancel-in-progress: false}`.** One deployment at a time, and a started one is never cancelled — a half-published site is worse than one a few minutes stale, given the app reads these files.
- **No `configure-pages` step.** It exists to compute a base path for site generators; the bundle here *is* the whole site, sixteen JSON files and a stylesheet with no index, so there is nothing to configure.
- All three actions pinned to commit SHAs, as everything else in this repository is: `upload-pages-artifact` v5.0.0, `deploy-pages` v5.0.1.

## After merging

The `gh-pages` branch stops being written and becomes a historical artifact. Deleting it is a separate decision — worth keeping until a deployment has demonstrably succeeded through the new path.