### PR TITLE
Trim the ccache to its configured size before saving it

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -268,6 +268,23 @@ jobs:
         if: always()
         run: ccache --show-stats
 
+      # ccache enforces max_size only while it writes, and a build that hits
+      # everything writes nothing -- so the limit never applies on exactly the
+      # runs it is working best on. A 100%-hit build measured the cache at
+      # 5.3 GB against the 2 GB configured above, 264% over, carried into every
+      # save and every restore.
+      #
+      # --cleanup applies the limit now. It evicts least-recently-used, and the
+      # objects this build just hit are the most recently used, so the working
+      # set is what survives; what goes is what no build has wanted in a while.
+      # Only master saves, so only master needs trimming, and the stats print
+      # again afterwards to show what it cost.
+      - name: Trim the ccache to its configured size
+        if: always() && github.ref == 'refs/heads/master'
+        run: |
+          ccache --cleanup
+          ccache --show-stats
+
       # Saved under a key no read will ever match, so every build writes a new
       # entry and the prefixes above restore the newest. A key that could be hit
       # cannot be written again, which suits a cache of build output but not


### PR DESCRIPTION
Stacked on #7907.

`ccache --set-config=max_size=2G` is set when ccache is installed, but ccache only enforces that limit **while it writes**. A build that hits everything writes nothing, so the limit goes unenforced on exactly the runs where the cache is working best.

A master build measured this directly:

```
Cacheable calls:   1386 / 1392 (99.57%)
  Hits:            1386 / 1386 (100.0%)
  Misses:             0 / 1386 ( 0.00%)
Local storage:
  Cache size (GB):  5.3 /  2.0 (263.8%)
```

Perfect hit rate, and **264% over the configured size**. That 5.3 GB is what every save uploads and every restore pulls down — roughly 971 MB compressed, ~30s each way, in a repository whose 10 GB cache budget has been overflowing all evening and evicting the app and jsbundle caches the UITest shards depend on.

## The change

`ccache --cleanup` after the build, before the save. It applies `max_size` at a point of our choosing rather than waiting for a write that may never come.

**Why this does not cost the hit rate:** `--cleanup` evicts least-recently-used, and the objects a build has just hit are its most recently used. The working set is what survives; what goes is what no build has wanted for a while. Only master saves (since #7903), so only master is trimmed.

The stats print again afterwards, so the next master build reports what the trim actually cost — this is deliberately observable rather than assumed.

## Considered and rejected

- **Trimming before the build.** Same eviction, but with no build having touched the cache yet, recency reflects the *previous* build rather than this one. Trimming after keeps the objects that just proved useful.
- **Raising `max_size` to match reality.** Honest about what is happening, but it makes the entry permanently larger, which is the opposite of what is needed.
- **`--evict-older-than`.** Would work, but needs a duration nobody can pick from evidence yet. `--cleanup` uses the limit already declared beside it.

## Expected effect

The saved entry should fall from ~971 MB toward roughly 400 MB, with the hit rate unchanged. If the next master build shows hits dropping, the trim is too aggressive and this should be reverted rather than tuned blind.