### PR TITLE
Keep the iOS build artifacts for three days, not ninety

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -93,7 +93,7 @@ jobs:
             ios/AllAboutOlaf/main.jsbundle
             ios/AllAboutOlaf/main.jsbundle.map
             ios/assets/
-          retention-days: 1
+          retention-days: 3
 
   ios-cache-check:
     name: Check if iOS cache exists
@@ -154,6 +154,7 @@ jobs:
         with:
           name: ios-app
           path: ios-app.tar
+          retention-days: 3
 
   ios-build:
     name: Build for iOS
@@ -310,6 +311,7 @@ jobs:
         with:
           name: ios-app
           path: ios-app.tar
+          retention-days: 3
 
   uitest-plan:
     name: Plan UITest shards


### PR DESCRIPTION
Drop the storage retention time from 90d to 3d for workflow artifacts. I figure we might as well be nice to GitHub's hard drives.  