### PR TITLE
Frame the building a venue sits in when the venue is only a point

### DIFF
--- a/source/features/building-hours/detail/building-detail.tsx
+++ b/source/features/building-hours/detail/building-detail.tsx
@@ -18,8 +18,7 @@ import {useQuery} from '@tanstack/react-query'
 import * as c from '@frogpond/colors'
 import type {Moment} from 'moment-timezone'
 import {BuildingCutout} from './building-cutout'
-import {hasFootprint} from '../../map/lib/building-footprints'
-import {findBuildingFeature} from '../lib/find-building-feature'
+import {resolveCutoutFeature} from '../lib/find-building-feature'
 import type {BuildingType} from '../types'
 import type {Campus} from '../query'
 import {mapDataOptions} from '../../map/query'
@@ -74,11 +73,12 @@ export function BuildingDetailSwiftUI({building, now, campus}: Props): React.Rea
 		...mapDataOptions(campus),
 		enabled: Boolean(building.building),
 	})
-	let joined = mapFeatures ? findBuildingFeature(mapFeatures, building) : undefined
 	// A venue can join to a record with no outline -- a point of interest rather
-	// than a building. There is nothing to frame, so the section goes too: an
-	// empty row reads as a broken image, not as an absent one.
-	let feature = joined && hasFootprint(joined) ? joined : undefined
+	// than a building -- in which case this follows its `parent` to the building
+	// it sits in. Undefined when nothing in that chain has an outline, and the
+	// section goes with it: an empty row reads as a broken image, not an absent
+	// one.
+	let feature = mapFeatures ? resolveCutoutFeature(mapFeatures, building) : undefined
 
 	return (
 		// A Host doesn't need a React Native scroll view under it: the hosting

--- a/source/features/building-hours/lib/__tests__/find-building-feature.test.ts
+++ b/source/features/building-hours/lib/__tests__/find-building-feature.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from '@jest/globals'
 import {makeBuilding} from '../../../map/__tests__/fixtures'
-import {findBuildingFeature} from '../find-building-feature'
+import {findBuildingFeature, resolveCutoutFeature} from '../find-building-feature'
 import type {BuildingType} from '../../types'
 
 function makeVenue(overrides: Partial<BuildingType> & {name: string}): BuildingType {
@@ -41,5 +41,81 @@ describe('findBuildingFeature', () => {
 		expect(findBuildingFeature(features, registrar)).toBe(toh)
 		expect(findBuildingFeature(features, financialAid)).toBe(toh)
 		expect(findBuildingFeature(features, healthServices)).toBe(toh)
+	})
+})
+
+/** A feature with an outline, which is what a cutout needs to frame. */
+function makeFootprint(id: string, parent?: string) {
+	let feature = makeBuilding(parent === undefined ? {id} : {id, parent})
+	feature.geometry.geometries.push({
+		type: 'Polygon',
+		coordinates: [
+			[
+				[-93.18, 44.46],
+				[-93.17, 44.46],
+				[-93.17, 44.47],
+				[-93.18, 44.47],
+				[-93.18, 44.46],
+			],
+		],
+	})
+	return feature
+}
+
+describe('resolveCutoutFeature', () => {
+	test("frames the venue's own feature when it has a footprint", () => {
+		let toh = makeFootprint('toh')
+		let venue = makeVenue({name: 'Registrar', building: 'toh'})
+
+		expect(resolveCutoutFeature([toh], venue)).toBe(toh)
+	})
+
+	test('frames the parent when the venue sits on a point', () => {
+		let bc = makeFootprint('bc')
+		let cage = makeBuilding({id: 'thecage', parent: 'bc'})
+		let venue = makeVenue({name: 'The Cage', building: 'thecage'})
+
+		expect(resolveCutoutFeature([cage, bc], venue)).toBe(bc)
+	})
+
+	test('walks more than one link to reach a footprint', () => {
+		let bc = makeFootprint('bc')
+		let desk = makeBuilding({id: 'desk', parent: 'kiosk'})
+		let kiosk = makeBuilding({id: 'kiosk', parent: 'bc'})
+		let venue = makeVenue({name: 'A Desk', building: 'desk'})
+
+		expect(resolveCutoutFeature([desk, kiosk, bc], venue)).toBe(bc)
+	})
+
+	test('gives up when nothing in the chain has a footprint', () => {
+		let windmill = makeBuilding({id: 'windmill'})
+		let venue = makeVenue({name: 'Windmill', building: 'windmill'})
+
+		expect(resolveCutoutFeature([windmill], venue)).toBeUndefined()
+	})
+
+	test('gives up when a parent names a feature that is not in the feed', () => {
+		let orphan = makeBuilding({id: 'orphan', parent: 'nosuchbuilding'})
+		let venue = makeVenue({name: 'Orphan', building: 'orphan'})
+
+		expect(resolveCutoutFeature([orphan], venue)).toBeUndefined()
+	})
+
+	// A cycle cannot be reached through the published data -- verify.py in
+	// campus-map-data rejects a parent that names its own place -- but the app
+	// reads whatever the server sends, and a loop here would hang the render.
+	test('stops rather than looping when parents form a cycle', () => {
+		let a = makeBuilding({id: 'a', parent: 'b'})
+		let b = makeBuilding({id: 'b', parent: 'a'})
+		let venue = makeVenue({name: 'A', building: 'a'})
+
+		expect(resolveCutoutFeature([a, b], venue)).toBeUndefined()
+	})
+
+	test('returns undefined for a venue with no key at all', () => {
+		let bc = makeFootprint('bc')
+		let venue = makeVenue({name: 'A Carleton Venue'})
+
+		expect(resolveCutoutFeature([bc], venue)).toBeUndefined()
 	})
 })

--- a/source/features/building-hours/lib/find-building-feature.ts
+++ b/source/features/building-hours/lib/find-building-feature.ts
@@ -1,3 +1,4 @@
+import {hasFootprint} from '../../map/lib/building-footprints'
 import type {Building, Feature} from '../../map/types'
 import type {BuildingType} from '../types'
 
@@ -20,4 +21,47 @@ export function findBuildingFeature(
 	}
 
 	return features.find((feature) => feature.id === venue.building)
+}
+
+/**
+ * The feature a venue's cutout should frame: its own, or the nearest thing it
+ * sits inside that has an outline to draw.
+ *
+ * Six St. Olaf venues key to a point rather than a footprint -- the dining
+ * rooms, the bookstore, the visitor desk, the admissions office -- because the
+ * college publishes them in the points-of-interest layer. A point has no area,
+ * so framing one gave a bounding box of zero size and a blank tile at maximum
+ * zoom. Those records carry a `parent` naming the building they are in, which
+ * is what this follows.
+ *
+ * Returns `undefined` when nothing in the chain has an outline, which is the
+ * answer for the windmill and the wind chime memorial: they are in no building
+ * and there is nothing to draw.
+ */
+export function resolveCutoutFeature(
+	features: Array<Feature<Building>>,
+	venue: BuildingType,
+): Feature<Building> | undefined {
+	let feature = findBuildingFeature(features, venue)
+
+	// A `parent` that names its own place, or two that name each other, would
+	// walk forever. verify.py in campus-map-data rejects both, but this reads
+	// whatever the server sends and a hung render is worse than no cutout.
+	let visited = new Set<string>()
+
+	while (feature) {
+		if (hasFootprint(feature)) {
+			return feature
+		}
+
+		let parent = feature.properties.parent
+		if (!parent || visited.has(feature.id)) {
+			return undefined
+		}
+		visited.add(feature.id)
+
+		feature = features.find((candidate) => candidate.id === parent)
+	}
+
+	return undefined
 }

--- a/source/features/map/types.ts
+++ b/source/features/map/types.ts
@@ -59,6 +59,16 @@ export type Building = {
 	links?: Array<LabelLink>
 	/** St. Olaf-only: a human-readable category summary, e.g. "Administrative & Academic". */
 	type?: string | null
+	/**
+	 * The building this place sits inside, as a feature id.
+	 *
+	 * St. Olaf publishes its dining rooms, its bookstore, its visitor desk and
+	 * its admissions office as points in the points-of-interest layer rather
+	 * than as footprints, so there is nothing to frame or highlight for them;
+	 * this names something there is. Null for anything that is a building
+	 * itself, or is in none. Carleton's feed carries no parents at all.
+	 */
+	parent?: string | null
 }
 
 export type Longitude = number


### PR DESCRIPTION
Stacked on #7899. Completes the cutout for the venues #7898 had to give up on.

Six St. Olaf venues key to a record with **no outline** — The Cage, The Lion's Pause, Stav Hall, The Kings' Dining Room, the Visitor Information Desk, the Bookstore, and the Admissions Office — because the college publishes them in the points-of-interest layer rather than as footprints. Framing a point gives a bounding box of zero size, which clamps to maximum zoom and draws a blank tan tile. #7898 dropped the cutout for them rather than ship that.

StoDevX/campus-map-data#10 added a `parent` naming the building each sits in, and the deployed feed now serves it:

```
$ curl -s https://stolaf.api.frogpond.tech/v1/map/geojson | …
admissionsoffice        -> toh
stavhall                -> bc
stolafcollegebookstore  -> bc
thecage                 -> bc
thekingsdiningroom      -> bc
thelionspause           -> bc
visitorinformationdesk  -> bc
```

`resolveCutoutFeature` follows it: the venue's own feature if it has an outline, otherwise the nearest thing it sits inside that does. So The Cage now frames Buntrock Commons, and the Admissions Office frames Tomson Hall.

## The walk keeps the ids it has seen

A `parent` naming its own place, or two naming each other, would loop forever. `verify.py` in campus-map-data rejects both — it was written alongside the field for exactly this reason — but the app reads whatever the server sends, and a hung render is worse than an absent cutout.

## Still undefined when nothing in the chain has an outline

The Windmill, the Wind Chime Memorial and the Electric Vehicle Charger are in no building. There is genuinely nothing to draw, and the section stays gone rather than showing an empty row.

## Tests

Seven new cases against `resolveCutoutFeature`, written before the implementation and confirmed failing first:

- the venue's own footprint wins when it has one
- a point resolves to its parent
- more than one link is walked
- nothing in the chain has a footprint → undefined
- a parent naming a feature absent from the feed → undefined
- **a cycle stops rather than hanging**
- no key at all → undefined

`Building.parent` is declared as `string | null` on the map type, documented as St. Olaf-only — Carleton's feed carries none.