### PR TITLE
Tick the timer when the app returns to the foreground

### DIFF
--- a/modules/timer/__tests__/index.test.ts
+++ b/modules/timer/__tests__/index.test.ts
@@ -1,3 +1,4 @@
+import {AppState, type AppStateStatus} from 'react-native'
 import {act, renderHook} from '@testing-library/react-native'
 
 // Override the global mock - timer tests need real time behavior
@@ -16,12 +17,41 @@ const advanceBy = async (ms: number) => {
 }
 
 describe('useMomentTimer', () => {
+	// AppState events come from the native side, so the only way to drive the
+	// hook's foregrounding behaviour is to keep the handlers it registers and
+	// call them.
+	let appStateHandlers: ((status: AppStateStatus) => void)[] = []
+
+	const sendAppState = async (status: AppStateStatus) => {
+		await act(() => {
+			for (let handler of appStateHandlers) handler(status)
+		})
+	}
+
+	/** Suspends the JS clock the way iOS does: time passes, timers do not fire. */
+	const backgroundFor = async (ms: number) => {
+		await sendAppState('background')
+		jest.setSystemTime(Date.now() + ms)
+		await sendAppState('active')
+	}
+
 	beforeEach(() => {
 		jest.useFakeTimers()
+		appStateHandlers = []
+		jest.spyOn(AppState, 'addEventListener').mockImplementation((type, handler) => {
+			let changeHandler = handler as (status: AppStateStatus) => void
+			if (type === 'change') appStateHandlers.push(changeHandler)
+			return {
+				remove: () => {
+					appStateHandlers = appStateHandlers.filter((each) => each !== changeHandler)
+				},
+			}
+		})
 	})
 
 	afterEach(() => {
 		jest.useRealTimers()
+		jest.restoreAllMocks()
 	})
 
 	it('applies the timezone to the value it starts with', async () => {
@@ -71,5 +101,41 @@ describe('useMomentTimer', () => {
 		await advanceBy(ONE_MINUTE * 5)
 
 		expect(result.current.now.format('h:mma')).toBe('6:02pm')
+	})
+
+	it('catches up to the real time when the app returns to the foreground', async () => {
+		jest.setSystemTime(new Date('2019-12-18T18:02:50Z'))
+
+		let {result} = await renderHook(() => useMomentTimer({intervalMs: ONE_MINUTE, timezone: 'UTC'}))
+
+		await backgroundFor(ONE_MINUTE * 20)
+
+		expect(result.current.now.format('h:mma')).toBe('6:22pm')
+	})
+
+	it('ignores transitions that are not to the foreground', async () => {
+		jest.setSystemTime(new Date('2019-12-18T18:02:50Z'))
+
+		let {result} = await renderHook(() => useMomentTimer({intervalMs: ONE_MINUTE, timezone: 'UTC'}))
+
+		await sendAppState('background')
+		jest.setSystemTime(Date.now() + ONE_MINUTE * 20)
+		await sendAppState('inactive')
+
+		expect(result.current.now.format('h:mma')).toBe('6:02pm')
+	})
+
+	it('stops listening for the foreground once unmounted', async () => {
+		// A listener left behind outlives the screen that registered it, and keeps
+		// ticking a hook nobody is rendering.
+		jest.setSystemTime(new Date('2019-12-18T18:02:50Z'))
+
+		let {unmount} = await renderHook(() =>
+			useMomentTimer({intervalMs: ONE_MINUTE, timezone: 'UTC'}),
+		)
+
+		await unmount()
+
+		expect(appStateHandlers).toHaveLength(0)
 	})
 })

--- a/modules/timer/index.ts
+++ b/modules/timer/index.ts
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useRef, useState} from 'react'
+import {AppState} from 'react-native'
 import {default as moment, unitOfTime, type Moment} from 'moment-timezone'
 
 import {isUITesting} from '@frogpond/launch-arguments'
@@ -33,6 +34,11 @@ interface MomentProps extends BasicProps {
  *
  * Boundaries are measured against the epoch, which lines up with local time
  * because every timezone offset is a whole number of minutes.
+ *
+ * Timers do not run while the app is in the background, so `onTick` also runs
+ * on the way back to the foreground — otherwise the screen keeps whatever time
+ * it showed when the user left, for as long as it takes the next boundary to
+ * come around.
  */
 function useBoundaryInterval(onTick: () => void, intervalMs: number): void {
 	let savedTick = useRef(onTick)
@@ -56,7 +62,14 @@ function useBoundaryInterval(onTick: () => void, intervalMs: number): void {
 
 		scheduleTick()
 
-		return () => clearTimeout(timeout)
+		let subscription = AppState.addEventListener('change', (status) => {
+			if (status === 'active') savedTick.current()
+		})
+
+		return () => {
+			clearTimeout(timeout)
+			subscription.remove()
+		}
 	}, [intervalMs])
 }
 

--- a/modules/timer/package.json
+++ b/modules/timer/package.json
@@ -13,6 +13,7 @@
   },
   "peerDependencies": {
     "moment-timezone": "^0.6.3",
-    "react": "catalog:"
+    "react": "catalog:",
+    "react-native": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -935,6 +935,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.2.3
+      react-native:
+        specifier: 'catalog:'
+        version: 0.86.3(patch_hash=6ca2e1225f38672b073b92b9d13f24feebbe9e37ba67708a3f1569275ce99191)(@babel/core@7.29.7)(@react-native/jest-preset@0.86.3)(@types/react@19.2.18)(react@19.2.3)(supports-color@8.1.1)
 
   modules/toolbar:
     dependencies:


### PR DESCRIPTION
Closes #3659, open since 2019.

`useBoundaryInterval` schedules a `setTimeout` to the next wall-clock boundary and re-aims it after every tick. Timers don't run while the app is backgrounded, so a screen watching the clock keeps whatever time it had when you left. Switch to another app for twenty minutes, come back to the Bus view, and the departure it calls "next" is twenty minutes stale until the timer catches up.

So the effect also listens for the return to the foreground, and ticks once on the way in:

```ts
let subscription = AppState.addEventListener('change', (status) => {
	if (status === 'active') savedTick.current()
})
```

Seven screens run on `useMomentTimer` and get this for free — Bus, Calendar, Campus hours, the building detail, Print Jobs.

## One tick is enough

#3659 proposed storing the time at background and working out how many ticks were missed. Not needed: every tick callback reads the clock fresh (`new Date()`, `moment()`), so a single tick lands on the right time no matter how long we were away. The pending timeout doesn't need clearing either — its delay is computed from `Date.now()` each time it re-arms, so it self-corrects to the next real boundary.

The `status === 'active'` guard matters more than it looks. iOS sends `inactive` for a swipe up, a notification pulled down, an incoming call — none of which mean the screen is back.

## What the tests do and don't prove

`AppState` events come from the native side, so the test holds onto the handlers the hook registers and calls them, then moves the system clock without running timers — which is what backgrounding does to the JS thread. That covers the hook's own decisions: it catches up on `active`, ignores `inactive`, and unsubscribes on unmount.

It does not prove the real `AppState` fires on a device. An XCUITest can't cover that either — `isUITesting` freezes the clock at `UITEST_FROZEN_DATE`, so no timer ticks under UI testing at all. The remaining check is by hand: open Bus, press Home, wait past a minute, come back.
