### PR TITLE
Move Student Orgs and the printer list to @expo/ui

### DIFF
--- a/app/(home)/PrintJobs/[jobId]/printers.tsx
+++ b/app/(home)/PrintJobs/[jobId]/printers.tsx
@@ -34,10 +34,8 @@ type PrinterListViewProps = {
 function PrinterListView({job}: PrinterListViewProps): React.ReactNode {
 	let router = useRouter()
 
-	let {data: username = ''} = useQuery({
-		...credentialsOptions,
-		select: (data) => stoprintUsername(data, isStoprintMocked),
-	})
+	let {data: credentials} = useQuery(credentialsOptions)
+	let username = stoprintUsername(credentials, isStoprintMocked)
 
 	let {
 		data: allPrinters = [],
@@ -179,10 +177,8 @@ function PrinterListView({job}: PrinterListViewProps): React.ReactNode {
 function PrinterListLoader(): React.ReactNode {
 	let {jobId} = useLocalSearchParams<{jobId: string}>()
 
-	let {data: username = '', isLoading: credentialsLoading} = useQuery({
-		...credentialsOptions,
-		select: (data) => stoprintUsername(data, isStoprintMocked),
-	})
+	let {data: credentials, isLoading: credentialsLoading} = useQuery(credentialsOptions)
+	let username = stoprintUsername(credentials, isStoprintMocked)
 
 	let {
 		data: job,
@@ -191,7 +187,7 @@ function PrinterListLoader(): React.ReactNode {
 		refetch: jobRefetch,
 	} = useQuery(jobByIdOptions(username, jobId))
 
-	if (credentialsLoading || jobLoading) {
+	if ((credentialsLoading && !isStoprintMocked) || jobLoading) {
 		return <LoadingView text="Loading…" />
 	}
 

--- a/app/(home)/PrintJobs/[jobId]/printers.tsx
+++ b/app/(home)/PrintJobs/[jobId]/printers.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
-import {SectionList, StyleSheet} from 'react-native'
+import {StyleSheet} from 'react-native'
+import {Host, List, Section} from '@expo/ui/swift-ui'
+import * as c from '@frogpond/colors'
+import {listStyle, refreshable} from '@expo/ui/swift-ui/modifiers'
 import {isStoprintMocked, type Printer, type PrintJob} from '../../../../source/lib/stoprint'
 import {stoprintUsername} from '../../../../source/features/stoprint/lib'
-import {Detail, ListRow, ListSectionHeader, ListSeparator, Title} from '@frogpond/lists'
+import {DisclosureRow} from '../../../../source/components/rows'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 import groupBy from 'lodash/groupBy'
 import {StoPrintErrorView} from '../../../../source/features/stoprint/components/error'
@@ -18,7 +21,10 @@ import {credentialsOptions} from '../../../../source/lib/login'
 import {RecentPopularPrintersResponse} from '../../../../source/lib/stoprint/types'
 
 const styles = StyleSheet.create({
-	list: {},
+	host: {
+		flex: 1,
+		backgroundColor: c.systemGroupedBackground,
+	},
 })
 
 type PrinterListViewProps = {
@@ -58,7 +64,6 @@ function PrinterListView({job}: PrinterListViewProps): React.ReactNode {
 	} = useQuery(colorPrintersOptions)
 
 	let isLoading = allPrintersLoading || recentPrintersLoading || colorPrintersLoading
-	let isRefetching = allPrintersRefetching || recentPrintersRefetching || colorPrintersRefetching
 
 	let openPrintRelease = React.useCallback(
 		(printer: Printer) =>
@@ -69,11 +74,13 @@ function PrinterListView({job}: PrinterListViewProps): React.ReactNode {
 		[router, job],
 	)
 
-	let refetchAll = React.useCallback(() => {
-		allPrintersRefetch()
-		colorPrintersRefetch()
-		recentPrintersRefetch()
-	}, [allPrintersRefetch, colorPrintersRefetch, recentPrintersRefetch])
+	// Returns all three, rather than firing and forgetting them: SwiftUI's
+	// `refreshable` spinner runs until the handler it was given settles, so a
+	// void return would stop it the instant the pull ended.
+	let refetchAll = React.useCallback(
+		() => Promise.all([allPrintersRefetch(), colorPrintersRefetch(), recentPrintersRefetch()]),
+		[allPrintersRefetch, colorPrintersRefetch, recentPrintersRefetch],
+	)
 
 	if (allPrintersError) {
 		return (
@@ -142,22 +149,30 @@ function PrinterListView({job}: PrinterListViewProps): React.ReactNode {
 	let availableGrouped = colorJob ? groupedByBuilding : grouped
 
 	return (
-		<SectionList
-			ItemSeparatorComponent={ListSeparator}
-			contentInsetAdjustmentBehavior="automatic"
-			keyExtractor={(item: Printer) => item.printerName}
-			onRefresh={refetchAll}
-			refreshing={isRefetching}
-			renderItem={({item}: {item: Printer}) => (
-				<ListRow onPress={() => openPrintRelease(item)}>
-					<Title>{item.printerName}</Title>
-					<Detail>{item.location}</Detail>
-				</ListRow>
-			)}
-			renderSectionHeader={({section: {title}}) => <ListSectionHeader title={title} />}
-			sections={availableGrouped}
-			style={styles.list}
-		/>
+		<Host style={styles.host}>
+			<List
+				modifiers={[
+					listStyle('insetGrouped'),
+					refreshable(async () => {
+						await refetchAll()
+					}),
+				]}
+			>
+				{availableGrouped.map((section) => (
+					<Section key={section.title} title={section.title}>
+						{section.data.map((printer) => (
+							<DisclosureRow
+								key={printer.printerName}
+								detail={printer.location}
+								image={{systemName: 'printer'}}
+								onPress={() => openPrintRelease(printer)}
+								title={printer.printerName}
+							/>
+						))}
+					</Section>
+				))}
+			</List>
+		</Host>
 	)
 }
 

--- a/app/(home)/PrintJobs/[jobId]/release.tsx
+++ b/app/(home)/PrintJobs/[jobId]/release.tsx
@@ -80,10 +80,8 @@ type PrintJobReleaseViewProps = {
 function PrintJobReleaseView({job, printer}: PrintJobReleaseViewProps): React.ReactNode {
 	let router = useRouter()
 
-	let {data: username = '', isLoading: loadingUsername} = useQuery({
-		...credentialsOptions,
-		select: (data) => stoprintUsername(data, isStoprintMocked),
-	})
+	let {data: credentials, isLoading: loadingUsername} = useQuery(credentialsOptions)
+	let username = stoprintUsername(credentials, isStoprintMocked)
 
 	let {data: heldJobs = []} = useQuery(heldJobsOptions(username, printer?.printerName))
 	let jobId = job.id.toString()
@@ -151,7 +149,7 @@ function PrintJobReleaseView({job, printer}: PrintJobReleaseViewProps): React.Re
 		},
 	})
 
-	if (loadingUsername) {
+	if (loadingUsername && !isStoprintMocked) {
 		return (
 			<ScrollView contentInsetAdjustmentBehavior="automatic">
 				<LoadingView />
@@ -224,10 +222,8 @@ function PrintJobReleaseLoader(): React.ReactNode {
 		printer?: string
 	}>()
 
-	let {data: username = '', isLoading: credentialsLoading} = useQuery({
-		...credentialsOptions,
-		select: (data) => stoprintUsername(data, isStoprintMocked),
-	})
+	let {data: credentials, isLoading: credentialsLoading} = useQuery(credentialsOptions)
+	let username = stoprintUsername(credentials, isStoprintMocked)
 
 	let {
 		data: job,
@@ -243,7 +239,7 @@ function PrintJobReleaseLoader(): React.ReactNode {
 		refetch: printerRefetch,
 	} = useQuery(printerByNameOptions(username, printerName))
 
-	if (credentialsLoading || jobLoading || printerLoading) {
+	if ((credentialsLoading && !isStoprintMocked) || jobLoading || printerLoading) {
 		return <LoadingView text="Loading…" />
 	}
 

--- a/app/(home)/StudentOrgs/index.tsx
+++ b/app/(home)/StudentOrgs/index.tsx
@@ -1,16 +1,10 @@
 import * as React from 'react'
-import {StyleSheet, SectionList} from 'react-native'
+import {StyleSheet} from 'react-native'
+import {ContentUnavailableView, Host, List, Section} from '@expo/ui/swift-ui'
+import {listStyle, refreshable} from '@expo/ui/swift-ui/modifiers'
 import {NoticeView, LoadingView} from '@frogpond/notice'
-import {Column} from '@frogpond/layout'
-import {
-	ListRow,
-	ListSectionHeader,
-	ListSeparator,
-	Detail,
-	Title,
-	largeListProps,
-	emptyList,
-} from '@frogpond/lists'
+import {emptyList} from '@frogpond/lists'
+import {DisclosureRow} from '../../../source/components/rows'
 import * as c from '@frogpond/colors'
 import groupBy from 'lodash/groupBy'
 import toPairs from 'lodash/toPairs'
@@ -37,12 +31,9 @@ const orgToArray = memoize((term: StudentOrgType) =>
 )
 
 const styles = StyleSheet.create({
-	wrapper: {
+	host: {
 		flex: 1,
-		backgroundColor: c.systemBackground,
-	},
-	contentContainer: {
-		flexGrow: 1,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })
 
@@ -52,14 +43,7 @@ function StudentOrgsView(): React.ReactNode {
 	let [query, setQuery] = React.useState('')
 	let searchQuery = useDebounce(query.toLowerCase(), 200)
 
-	let {
-		data: orgs = [],
-		error,
-		isError,
-		refetch,
-		isRefetching,
-		isLoading,
-	} = useQuery(studentOrgsOptions)
+	let {data: orgs = [], error, isError, refetch, isLoading} = useQuery(studentOrgsOptions)
 
 	let results = React.useMemo(() => {
 		if (!orgs) {
@@ -115,41 +99,52 @@ function StudentOrgsView(): React.ReactNode {
 		)
 	}
 
+	if (isLoading) {
+		return (
+			<>
+				{searchChrome}
+				<LoadingView />
+			</>
+		)
+	}
+
 	return (
 		<>
 			{searchChrome}
 
-			<SectionList
-				ItemSeparatorComponent={ListSeparator}
-				ListEmptyComponent={
-					searchQuery ? (
-						<NoticeView text={`No results found for "${searchQuery}"`} />
-					) : isLoading ? (
-						<LoadingView />
+			<Host style={styles.host}>
+				<List
+					modifiers={[
+						listStyle('insetGrouped'),
+						refreshable(async () => {
+							await refetch()
+						}),
+					]}
+				>
+					{grouped.length === 0 ? (
+						<ContentUnavailableView
+							systemImage="person.3"
+							title={
+								searchQuery ? `No results found for "${searchQuery}"` : 'No organizations found.'
+							}
+						/>
 					) : (
-						<NoticeView text="No organizations found." />
-					)
-				}
-				contentContainerStyle={styles.contentContainer}
-				contentInsetAdjustmentBehavior="automatic"
-				keyExtractor={(item) => item.name + item.category}
-				keyboardDismissMode="on-drag"
-				keyboardShouldPersistTaps="never"
-				onRefresh={refetch}
-				refreshing={isRefetching}
-				renderItem={({item}) => (
-					<ListRow arrowPosition="top" onPress={() => onPressOrg(item)}>
-						<Column flex={1}>
-							<Title lines={1}>{item.name}</Title>
-							<Detail lines={1}>{item.category}</Detail>
-						</Column>
-					</ListRow>
-				)}
-				renderSectionHeader={({section: {title}}) => <ListSectionHeader title={title} />}
-				sections={grouped}
-				style={styles.wrapper}
-				{...largeListProps}
-			/>
+						grouped.map((section) => (
+							<Section key={section.title} title={section.title}>
+								{section.data.map((org) => (
+									<DisclosureRow
+										key={org.name + org.category}
+										detail={org.category}
+										detailLines={1}
+										onPress={() => onPressOrg(org)}
+										title={org.name}
+									/>
+								))}
+							</Section>
+						))
+					)}
+				</List>
+			</Host>
 		</>
 	)
 }

--- a/source/components/__tests__/rows.test.tsx
+++ b/source/components/__tests__/rows.test.tsx
@@ -52,3 +52,83 @@ describe('DisclosureRow', () => {
 		expect(onPress).toHaveBeenCalledTimes(1)
 	})
 })
+
+describe('DisclosureRow detail lines', () => {
+	it('renders each of several detail lines', async () => {
+		await render(
+			<DisclosureRow
+				detail={['Rølvaag Library', '7:00 PM – Fri, Sep. 11']}
+				onPress={jest.fn()}
+				title="Organ Recital"
+			/>,
+		)
+
+		expect(screen.getByText('Rølvaag Library')).toBeOnTheScreen()
+		expect(screen.getByText('7:00 PM – Fri, Sep. 11')).toBeOnTheScreen()
+	})
+
+	/// A row builds its detail lines from optional fields, so an absent one
+	/// arrives as undefined rather than being left out of the array.
+	it('drops the gaps a missing detail line would leave', async () => {
+		await render(
+			<DisclosureRow
+				detail={[undefined, 'Only this one', '']}
+				onPress={jest.fn()}
+				title="Organ Recital"
+			/>,
+		)
+
+		expect(screen.getByText('Only this one')).toBeOnTheScreen()
+		expect(screen.getByLabelText('Organ Recital, Only this one')).toBeOnTheScreen()
+	})
+
+	it('reads every detail line as part of the row label', async () => {
+		await render(
+			<DisclosureRow
+				detail={['Rølvaag Library', '7:00 PM']}
+				onPress={jest.fn()}
+				title="Organ Recital"
+			/>,
+		)
+
+		expect(screen.getByLabelText('Organ Recital, Rølvaag Library, 7:00 PM')).toBeOnTheScreen()
+	})
+
+	it('still takes a single detail string', async () => {
+		await render(
+			<DisclosureRow detail="Runs every 20 minutes" onPress={jest.fn()} title="Shuttle" />,
+		)
+
+		expect(screen.getByLabelText('Shuttle, Runs every 20 minutes')).toBeOnTheScreen()
+	})
+})
+
+describe('DisclosureRow leading image', () => {
+	it('shows a leading symbol', async () => {
+		await render(
+			<DisclosureRow image={{systemName: 'printer'}} onPress={jest.fn()} title="stoPrint-LPR" />,
+		)
+
+		expect(screen.getByLabelText('printer')).toBeOnTheScreen()
+	})
+
+	/// `@expo/ui`'s own Image reads only SF Symbols and local files, so a remote
+	/// thumbnail has to be a React Native image hosted inside the SwiftUI row.
+	it('hosts a remote thumbnail rather than passing the URL to @expo/ui', async () => {
+		await render(
+			<DisclosureRow
+				image={{uri: 'https://example.com/thumb.jpg', width: 70, height: 40}}
+				onPress={jest.fn()}
+				title="KSTO"
+			/>,
+		)
+
+		expect(screen.getByTestId('disclosure-row-thumbnail')).toBeOnTheScreen()
+	})
+
+	it('draws no image slot when there is no image', async () => {
+		await render(<DisclosureRow onPress={jest.fn()} title="KSTO" />)
+
+		expect(screen.queryByTestId('disclosure-row-thumbnail')).not.toBeOnTheScreen()
+	})
+})

--- a/source/components/rows.tsx
+++ b/source/components/rows.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react'
-import {Button, HStack, Image, Spacer, Text, VStack} from '@expo/ui/swift-ui'
+import {Image as RNImage, StyleSheet} from 'react-native'
+import type {ColorValue} from 'react-native'
+import type {SFSymbol} from 'sf-symbols-typescript'
+import {Button, HStack, Image, RNHostView, Spacer, Text, VStack} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
 	buttonStyle,
@@ -8,6 +11,7 @@ import {
 	font,
 	foregroundStyle,
 	lineLimit,
+	frame,
 	shapes,
 	truncationMode,
 } from '@expo/ui/swift-ui/modifiers'
@@ -67,43 +71,113 @@ export function ActionRow(props: RowProps): React.ReactNode {
 	)
 }
 
+/**
+ * A leading symbol, drawn by SwiftUI itself.
+ */
+type SymbolImage = {systemName: SFSymbol; tint?: ColorValue}
+
+/**
+ * A leading thumbnail fetched over the network. `@expo/ui`'s own `Image` reads
+ * only SF Symbols, asset-catalog names and local files, so this is a React
+ * Native image hosted inside the SwiftUI row -- which needs its size stated
+ * up front, since `RNHostView` gives a hosted view no bounds of its own.
+ */
+type ThumbnailImage = {uri: string; width: number; height: number}
+
+export type DisclosureRowImage = SymbolImage | ThumbnailImage
+
+/// Mirrored by `TestIdentifiers.Rows.thumbnail`.
+const THUMBNAIL_ID = 'disclosure-row-thumbnail'
+
+const SYMBOL_SIZE = 20
+
 type DisclosureRowProps = {
 	title: string
-	/** A second, quieter line under the title. Omitted entirely when absent, so
-	 * a row without one is a single line rather than a line and a gap. */
-	detail?: string
+	/**
+	 * One or more quieter lines under the title. Entries that are absent or
+	 * blank are dropped rather than drawn, so a caller can build the array
+	 * straight from optional fields without filtering first.
+	 */
+	detail?: string | (string | undefined | null)[]
 	/** How many lines the title may wrap to before it truncates. */
 	titleLines?: number
+	/** How many lines each detail line may wrap to. Unbounded by default. */
+	detailLines?: number
+	/** A symbol or thumbnail at the leading edge. */
+	image?: DisclosureRowImage
 	onPress: () => void
 }
 
+/** The detail lines actually worth drawing, in order. */
+function detailLinesOf(detail: DisclosureRowProps['detail']): string[] {
+	if (!detail) {
+		return []
+	}
+	let lines = Array.isArray(detail) ? detail : [detail]
+	return lines.filter((line): line is string => Boolean(line && line.trim()))
+}
+
+function LeadingImage({image}: {image: DisclosureRowImage}): React.ReactNode {
+	if ('systemName' in image) {
+		return (
+			<Image
+				color={image.tint ?? c.secondaryLabel}
+				size={SYMBOL_SIZE}
+				systemName={image.systemName}
+			/>
+		)
+	}
+
+	return (
+		<HStack modifiers={[frame({width: image.width, height: image.height})]}>
+			<RNHostView matchContents={false}>
+				<RNImage
+					accessibilityIgnoresInvertColors={true}
+					source={{uri: image.uri}}
+					style={[styles.thumbnail, {width: image.width, height: image.height}]}
+					testID={THUMBNAIL_ID}
+				/>
+			</RNHostView>
+		</HStack>
+	)
+}
+
 /**
- * The list row this app repeats most: a title, an optional detail line, and a
- * disclosure chevron. Shared rather than repeated per screen because the
- * `contentShape` placement below is easy to get wrong and impossible to catch
- * in Jest -- see [[NavigationRow]] for why the chevron is drawn by hand.
+ * The list row this app repeats most: an optional leading image, a title, any
+ * number of quieter detail lines, and a disclosure chevron. Shared rather than
+ * repeated per screen because the `contentShape` placement below is easy to get
+ * wrong and impossible to catch in Jest -- see [[NavigationRow]] for why the
+ * chevron is drawn by hand.
  */
 export function DisclosureRow(props: DisclosureRowProps): React.ReactNode {
-	let {title, detail, titleLines = 1, onPress} = props
+	let {title, detail, titleLines = 1, detailLines, image, onPress} = props
+
+	let details = detailLinesOf(detail)
+	let detailModifiers = [
+		font({textStyle: 'subheadline'}),
+		foregroundStyle(c.secondaryLabel),
+		...(detailLines ? [lineLimit(detailLines), truncationMode('tail')] : []),
+	]
 
 	return (
 		<Button
-			modifiers={[buttonStyle('plain'), accessibilityLabel(detail ? `${title}, ${detail}` : title)]}
+			modifiers={[buttonStyle('plain'), accessibilityLabel([title, ...details].join(', '))]}
 			onPress={onPress}
 		>
 			{/* contentShape on the label, not the Button -- see NavigationRow. */}
-			<HStack modifiers={[contentShape(shapes.rectangle())]} spacing={8}>
+			<HStack modifiers={[contentShape(shapes.rectangle())]} spacing={12}>
+				{image ? <LeadingImage image={image} /> : null}
 				<VStack alignment="leading" spacing={2}>
 					<Text
 						modifiers={[foregroundStyle(c.label), lineLimit(titleLines), truncationMode('tail')]}
 					>
 						{title}
 					</Text>
-					{detail ? (
-						<Text modifiers={[font({textStyle: 'subheadline'}), foregroundStyle(c.secondaryLabel)]}>
-							{detail}
+					{details.map((line) => (
+						<Text key={line} modifiers={detailModifiers}>
+							{line}
 						</Text>
-					) : null}
+					))}
 				</VStack>
 				<Spacer />
 				<Image color={c.tertiaryLabel} size={14} systemName="chevron.right" />
@@ -111,3 +185,9 @@ export function DisclosureRow(props: DisclosureRowProps): React.ReactNode {
 		</Button>
 	)
 }
+
+const styles = StyleSheet.create({
+	thumbnail: {
+		resizeMode: 'cover',
+	},
+})

--- a/source/features/stoprint/__tests__/print-jobs-gate.test.ts
+++ b/source/features/stoprint/__tests__/print-jobs-gate.test.ts
@@ -28,11 +28,12 @@ describe('printJobsGate', () => {
 		).toBe('jobs')
 	})
 
-	/// The mock does not make the credentials read instant; a gate that ignored
-	/// that would flash the job list before the screen knew who it was for.
-	it('still waits for the credentials read even when mocked', () => {
+	/// A mocked run prints as the stand-in account whatever the keychain holds,
+	/// so there is nothing to wait for. Waiting anyway hung the printer screen
+	/// on the simulator, where that read did not always come back.
+	it('does not wait on the credentials read when mocked', () => {
 		expect(printJobsGate({isLoadingCredentials: true, hasCredentials: false, isMocked: true})).toBe(
-			'loading',
+			'jobs',
 		)
 	})
 })
@@ -55,5 +56,13 @@ describe('stoprintUsername', () => {
 
 	it('still prefers a real account over the stand-in', () => {
 		expect(stoprintUsername({username: 'ole'}, true)).toBe('ole')
+	})
+
+	/// A keychain with nothing in it leaves the credentials query with no data
+	/// at all, not a null. React Query skips `select` entirely in that case, so
+	/// this has to be applied to the query's result rather than inside it --
+	/// undefined is the input that actually reaches it on a mocked run.
+	it('stands in an account when the credentials read yielded nothing', () => {
+		expect(stoprintUsername(undefined, true)).toBe(MOCK_STOPRINT_USERNAME)
 	})
 })

--- a/source/features/stoprint/lib.ts
+++ b/source/features/stoprint/lib.ts
@@ -41,7 +41,10 @@ export function printJobsGate(state: {
 }): PrintJobsGate {
 	let {isLoadingCredentials, hasCredentials, isMocked} = state
 
-	if (isLoadingCredentials) {
+	// A mocked run prints as `MOCK_STOPRINT_USERNAME` whatever the keychain
+	// says, so waiting on that read gains nothing -- and on the simulator it
+	// does not always come back, which left the printer screen on its spinner.
+	if (isLoadingCredentials && !isMocked) {
 		return 'loading'
 	}
 

--- a/source/lib/stoprint/__mocks__/api.ts
+++ b/source/lib/stoprint/__mocks__/api.ts
@@ -2,6 +2,7 @@
 /* stoprint and papercut api mock data */
 
 import {mockAllPrinters} from './data/all-printers'
+import {mockColorPrinters} from './data/color-printers'
 import {mockHeldJobs} from './data/held-jobs'
 import {mockJobs} from './data/jobs'
 import {mockRecent} from './data/recent'
@@ -10,6 +11,7 @@ import {mockRelease} from './data/release'
 import {SharedWebCredentials} from 'react-native-keychain'
 import type {
 	AllPrintersResponse,
+	CancelResponse,
 	HeldJobsResponse,
 	PrintJobsResponse,
 	RecentPopularPrintersResponse,
@@ -28,6 +30,13 @@ export function logIn(
 }
 
 export const fetchJobs = (username: string): Promise<PrintJobsResponse> => Promise.resolve(mockJobs)
+
+export const fetchColorPrinters = (): Promise<string[]> => Promise.resolve(mockColorPrinters)
+
+/// `CancelResponse` is an alias for the fetch `Response`, so this hands back a
+/// real one rather than the JSON body the caller actually reads.
+export const cancelPrintJobForUser = (): Promise<CancelResponse> =>
+	Promise.resolve(new Response(JSON.stringify({success: true})))
 
 export const fetchAllPrinters = (username: string): Promise<AllPrintersResponse> =>
 	Promise.resolve(mockAllPrinters)

--- a/source/lib/stoprint/__mocks__/data/all-printers.ts
+++ b/source/lib/stoprint/__mocks__/data/all-printers.ts
@@ -74,7 +74,7 @@ export const mockAllPrinters: AllPrintersResponse = [
 		printerName: 'mfc-dataservices',
 	},
 	{
-		location: 'Dittmann HOM Link',
+		location: 'CAD HOM Link',
 		serverName: 'printers',
 		code: '',
 		printerName: 'mfc-dc204',

--- a/source/lib/stoprint/__mocks__/data/color-printers.ts
+++ b/source/lib/stoprint/__mocks__/data/color-printers.ts
@@ -1,0 +1,5 @@
+/**
+ * The printers a colour job may be sent to, named from `mockAllPrinters` so a
+ * colour job narrows the list rather than emptying it.
+ */
+export const mockColorPrinters: string[] = ['mfc-it', 'mfc-toh101', 'mfc-rns-2nd']

--- a/source/lib/stoprint/__mocks__/data/recent.ts
+++ b/source/lib/stoprint/__mocks__/data/recent.ts
@@ -41,7 +41,7 @@ export const mockRecent: RecentPopularPrintersResponse = {
 			printerName: 'mfc-toh101',
 		},
 		{
-			location: 'Dittmann HOM Link',
+			location: 'CAD HOM Link',
 			serverName: 'printers',
 			code: '',
 			printerName: 'mfc-dc204',

--- a/source/lib/stoprint/api.ts
+++ b/source/lib/stoprint/api.ts
@@ -1,7 +1,9 @@
 import {mobileReleaseApi, papercutApi} from './urls'
 import {encode} from 'base-64'
 import {
+	cancelPrintJobForUser as mockCancelPrintJobForUser,
 	fetchAllPrinters as mockFetchAllPrinters,
+	fetchColorPrinters as mockFetchColorPrinters,
 	fetchJobs as mockFetchJobs,
 	fetchRecentPrinters as mockFetchRecentPrinters,
 	heldJobsAvailableAtPrinterForUser as mockHeldJobsAvailableAtPrinterForUser,
@@ -95,6 +97,10 @@ export function fetchRecentPrinters(
 }
 
 export async function fetchColorPrinters(options: Options): Promise<string[]> {
+	if (isStoprintMocked) {
+		return mockFetchColorPrinters()
+	}
+
 	let response = await client.get<ColorPrintersResponse>('printing/color-printers', options).json()
 	return response.data.colorPrinters
 }
@@ -125,6 +131,10 @@ export function cancelPrintJobForUser(
 	username: string,
 	options: Options,
 ): Promise<CancelResponse> {
+	if (isStoprintMocked) {
+		return mockCancelPrintJobForUser()
+	}
+
 	return mobileReleaseApi
 		.post<CancelResponse>('held-jobs/cancel', {
 			...options,

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -34,6 +34,34 @@ class StageOneListsTests: UITestCase {
 		screen.capture("Print Jobs")
 	}
 
+	func testStudentOrgsList() throws {
+		StudentOrgsScreen(app: app)
+			.navigate()
+			.capture("Student Orgs")
+	}
+
+	/// Reaching the printer list means releasing a job, so this taps a mocked
+	/// job that is Pending Release -- the only status whose row pushes here
+	/// rather than to the release screen.
+	func testPrinterList() throws {
+		let screen = StoPrintScreen(app: app).navigate()
+
+		let job = app.buttons
+			.matching(NSPredicate(format: "label BEGINSWITH %@", "IMG_2259-COLLAGE.jpg"))
+			.firstMatch
+		XCTAssertTrue(job.waitForExistence(timeout: 30), "A pending-release job should be listed")
+		job.tap()
+
+		// Every printer in the fixtures is named mfc-<something>; their location
+		// is blank, so a row is its name alone.
+		let anyPrinter = app.buttons
+			.matching(NSPredicate(format: "label BEGINSWITH %@", "mfc-"))
+			.firstMatch
+		XCTAssertTrue(anyPrinter.waitForExistence(timeout: 30), "The printer list should be shown")
+
+		screen.capture("Printers")
+	}
+
 	func testMoreList() throws {
 		MoreScreen(app: app)
 			.navigate()

--- a/uitests/UITestCase.swift
+++ b/uitests/UITestCase.swift
@@ -54,9 +54,31 @@ class UITestCase: XCTestCase {
 	/// this, a rescued flake skips every test after it and the shard reports
 	/// green having run almost nothing.
 	override func tearDownWithError() throws {
+		if (testRun?.failureCount ?? 0) > 0 {
+			captureFailureScreen()
+		}
+
 		if UITestCase.failedTest == name, testRun?.failureCount == 0 {
 			UITestCase.failedTest = nil
 		}
+	}
+
+	/// Attach a screenshot of wherever the app ended up, for a test that failed.
+	///
+	/// `continueAfterFailure` is false, so a failed test stops at its assertion
+	/// and the screen is still whatever the assertion was unhappy about --
+	/// which is the one picture worth having and the one nobody thinks to take
+	/// in advance. Xcode's own automatic screenshots need a test plan this
+	/// project does not have, and the scheme defaults throw them away.
+	///
+	/// `.keepAlways` rather than `.deleteOnSuccess`: this only runs for a
+	/// failure, so there is no success for the latter to key off, and CI's
+	/// "Extract failure attachments" step reads whatever is in the bundle.
+	private func captureFailureScreen() {
+		let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+		attachment.name = "Failure - \(name)"
+		attachment.lifetime = .keepAlways
+		add(attachment)
 	}
 
 	/// Points the app at a Metro other than the default localhost:8081, when


### PR DESCRIPTION
<!-- Wren: description yours to write. Below is only what is in the branch, and the screenshots. -->

Stage 2 (part one) of #7921. **Stacked on #7924** — review that first; this branch contains its commits.

### Commits

- `84de8fbb7` Let a disclosure row carry several detail lines and a leading image
- `1f4eea6c2` Move Student Orgs and the printer list to @expo/ui
- `67065c7e5` Finish mocking stoPrint, and reach the printer list with it

### Screens on the simulator

| Student Orgs | Select Printer |
| --- | --- |
| ![Student Orgs](https://github.com/user-attachments/assets/aab69b85-d3c7-480d-a4fa-615ff437b69a) | ![Printers](https://github.com/user-attachments/assets/ddeaadab-f9a8-44f8-ad7d-b651a0f12cd1) |

The printer rows with no second line are printers whose `location` is blank in the fixtures — the row drops an empty detail rather than drawing a gap.

### Three stoPrint bugs, found by trying to photograph that second screen

- **`fetchColorPrinters` and `cancelPrintJobForUser` had no mock guard**, so a mocked run still called the live server.
- **The credentials gate hung** the printer screen on its spinner. A mocked run prints as the stand-in account whatever the keychain holds, so it no longer waits on that read. The real path still does.
- **The stand-in account was applied inside a query's `select`**, which React Query skips when a query has no data — exactly the empty-keychain case it existed for. This one is on #7924 and is user-facing: it showed "Could not find this print job."

A failing UI test now attaches a screenshot of wherever it stopped (`UITestCase.tearDownWithError`). All three were invisible in the logs.

### Not fixed here

`GET https://stolaf.api.frogpond.tech/v1/color-printers` answers **404**. That is a server response rather than a network failure, so a colour print job on the real API likely hits the same "Connection Issue" screen. Unrelated to this migration; worth an issue against `ccc-server`.

The new detail-array and thumbnail props have no consumer yet — Streaming Media and Athletics are the next PR. The thumbnail path is Jest-tested but has not been seen on a device.

