### PR TITLE
ask the server for the color printers at the correct URL

### DIFF
--- a/source/lib/stoprint/api.ts
+++ b/source/lib/stoprint/api.ts
@@ -95,7 +95,7 @@ export function fetchRecentPrinters(
 }
 
 export async function fetchColorPrinters(options: Options): Promise<string[]> {
-	let response = await client.get<ColorPrintersResponse>('color-printers', options).json()
+	let response = await client.get<ColorPrintersResponse>('printing/color-printers', options).json()
 	return response.data.colorPrinters
 }
 


### PR DESCRIPTION
<!-- Wren: description yours to write. Below is only the evidence. -->

One line in `source/lib/stoprint/api.ts`. Not part of the @expo/ui migration, so it is off master rather than stacked.

```
GET /v1/color-printers            404
GET /v1/printing/color-printers   200  {"data":{"colorPrinters":["mfc-rml-4-disco","mfc-toh101"]}}
```

The response already matches `ColorPrintersResponse`, so only the path changes.

Sending a **colour** print job hits `fetchColorPrinters` on the printer picker, so that screen has been failing with "Connection Issue" for anyone printing in colour. Greyscale jobs never call it and are unaffected.

Found while making the printer screens reachable to UI tests in #7925 — the screen needs a St. Olaf account to open, which is why this went unseen.
