### PR TITLE
Group the calendar filters into submenus and count their matches

### DIFF
--- a/modules/ccc-calendar/__tests__/calendar-picker.test.tsx
+++ b/modules/ccc-calendar/__tests__/calendar-picker.test.tsx
@@ -52,18 +52,9 @@ test('labels each choice with how many events match it', async () => {
 	expect(screen.getByText('Wellness Center (2)')).toBeTruthy()
 })
 
-test('omits the organisation section when no source names one', async () => {
+test('omits the organisation submenu when no source names one', async () => {
 	await render(picker({organizations: []}))
-	expect(screen.queryByText('ORGANIZATION')).toBeNull()
-})
-
-test('All Events clears whichever axis is filtered', async () => {
-	let onSelectFilter = jest.fn()
-	await render(picker({filter: {axis: 'category', value: 'Athletics'}, onSelectFilter}))
-
-	fireEvent.press(screen.getByText('All Events'))
-
-	expect(onSelectFilter).toHaveBeenCalledWith(null)
+	expect(screen.queryByText('Organization')).toBeNull()
 })
 
 test('choosing an unselected organisation filters on it', async () => {
@@ -91,4 +82,32 @@ test('a category on one axis does not read as selected on the other', async () =
 	fireEvent.press(screen.getByText('Athletics (3)'))
 
 	expect(onSelectFilter).toHaveBeenCalledWith({axis: 'category', value: 'Athletics'})
+})
+
+test('a submenu row names the selection on its own axis', async () => {
+	await render(picker({filter: {axis: 'category', value: 'Athletics'}}))
+
+	expect(screen.getByText('Category: Athletics')).toBeTruthy()
+	expect(screen.getByText('Organization')).toBeTruthy()
+})
+
+test('a submenu row names nothing when the other axis is filtered', async () => {
+	await render(picker({filter: {axis: 'organization', value: 'Wellness Center'}}))
+
+	expect(screen.getByText('Category')).toBeTruthy()
+	expect(screen.getByText('Organization: Wellness Center')).toBeTruthy()
+})
+
+test('Reset Filters is absent while nothing is filtered', async () => {
+	await render(picker())
+	expect(screen.queryByText('Reset Filters')).toBeNull()
+})
+
+test('Reset Filters clears whichever axis is filtered', async () => {
+	let onSelectFilter = jest.fn()
+	await render(picker({filter: {axis: 'organization', value: 'Wellness Center'}, onSelectFilter}))
+
+	fireEvent.press(screen.getByText('Reset Filters'))
+
+	expect(onSelectFilter).toHaveBeenCalledWith(null)
 })

--- a/modules/ccc-calendar/__tests__/calendar-picker.test.tsx
+++ b/modules/ccc-calendar/__tests__/calendar-picker.test.tsx
@@ -25,12 +25,15 @@ const SOURCES: CalendarSource[] = [
 function picker(overrides = {}): React.ReactElement {
 	return (
 		<CalendarPicker
-			categories={['Athletics', 'Chapel']}
+			categories={[
+				{value: 'Athletics', count: 3},
+				{value: 'Chapel', count: 1},
+			]}
 			enabledIds={['stolaf', 'presence']}
 			filter={null}
 			onSelectFilter={jest.fn()}
 			onToggleSource={jest.fn()}
-			organizations={['Wellness Center']}
+			organizations={[{value: 'Wellness Center', count: 2}]}
 			sources={SOURCES}
 			{...overrides}
 		/>
@@ -43,10 +46,10 @@ test('lists every calendar as a toggle', async () => {
 	expect(screen.getByText('Presence')).toBeTruthy()
 })
 
-test('lists the categories and the organisations', async () => {
+test('labels each choice with how many events match it', async () => {
 	await render(picker())
-	expect(screen.getByText('Athletics')).toBeTruthy()
-	expect(screen.getByText('Wellness Center')).toBeTruthy()
+	expect(screen.getByText('Athletics (3)')).toBeTruthy()
+	expect(screen.getByText('Wellness Center (2)')).toBeTruthy()
 })
 
 test('omits the organisation section when no source names one', async () => {
@@ -67,7 +70,7 @@ test('choosing an unselected organisation filters on it', async () => {
 	let onSelectFilter = jest.fn()
 	await render(picker({onSelectFilter}))
 
-	fireEvent.press(screen.getByText('Wellness Center'))
+	fireEvent.press(screen.getByText('Wellness Center (2)'))
 
 	expect(onSelectFilter).toHaveBeenCalledWith({axis: 'organization', value: 'Wellness Center'})
 })
@@ -76,7 +79,7 @@ test('choosing the category already filtered on clears the filter', async () => 
 	let onSelectFilter = jest.fn()
 	await render(picker({filter: {axis: 'category', value: 'Athletics'}, onSelectFilter}))
 
-	fireEvent.press(screen.getByText('Athletics'))
+	fireEvent.press(screen.getByText('Athletics (3)'))
 
 	expect(onSelectFilter).toHaveBeenCalledWith(null)
 })
@@ -85,7 +88,7 @@ test('a category on one axis does not read as selected on the other', async () =
 	let onSelectFilter = jest.fn()
 	await render(picker({filter: {axis: 'organization', value: 'Athletics'}, onSelectFilter}))
 
-	fireEvent.press(screen.getByText('Athletics'))
+	fireEvent.press(screen.getByText('Athletics (3)'))
 
 	expect(onSelectFilter).toHaveBeenCalledWith({axis: 'category', value: 'Athletics'})
 })

--- a/modules/ccc-calendar/calendar-picker.tsx
+++ b/modules/ccc-calendar/calendar-picker.tsx
@@ -16,12 +16,12 @@ import type {CalendarSource} from './sources'
  * what the list is narrowed to. Category and organisation are one selection
  * between them, not one each -- see `CalendarFilter`.
  *
- * The sections are written ORGANIZATION, CATEGORY, CALENDARS and reach the
- * screen in the opposite order -- CALENDARS at the top -- because SwiftUI
- * draws a Menu's contents bottom-to-top. Confirmed against a screenshot from
- * `testPickerMenuShowsItsSections`, which is also why the category list is
- * sorted Z-A to read A-Z. Reordering these to match the rendered order would
- * invert the menu.
+ * The children are written RESET, ORGANIZATION, CATEGORY, CALENDARS and reach
+ * the screen in the opposite order -- CALENDARS at the top, Reset Filters at
+ * the bottom -- because SwiftUI draws a Menu's contents bottom-to-top.
+ * Confirmed against a screenshot from `testPickerMenuShowsItsRows`, which is
+ * also why each axis's choices are sorted Z-A to read A-Z. Reordering these to
+ * match the rendered order would invert the menu.
  */
 type Props = {
 	sources: CalendarSource[]
@@ -39,6 +39,19 @@ const STAYS_OPEN = [menuActionDismissBehavior('disabled')]
 // Mirrored by `TestIdentifiers.Calendar.picker` in the XCUITest target: it is
 // the only handle those tests have on the toolbar menu.
 const LABEL = accessibilityLabel('Calendar filter')
+
+/**
+ * What a collapsed submenu row reads. It names its axis, and names the
+ * selection too when that axis is the one filtered -- otherwise the only way
+ * to see what the list is narrowed to is to open both submenus.
+ */
+function axisLabel(
+	axis: CalendarFilter['axis'],
+	title: string,
+	filter: CalendarFilter | null,
+): string {
+	return filter?.axis === axis ? `${title}: ${filter.value}` : title
+}
 
 export function CalendarPicker({
 	sources,
@@ -73,8 +86,13 @@ export function CalendarPicker({
 			<Stack.Toolbar.View>
 				<Host matchContents={true}>
 					<Menu label={<Image systemName="calendar" />} modifiers={menuModifiers}>
+						{/* Rendered first so it sits at the visual bottom, below both axes */}
+						{filter ? <Button label="Reset Filters" onPress={() => onSelectFilter(null)} /> : null}
 						{organizations.length > 0 ? (
-							<Section modifiers={STAYS_OPEN} title="ORGANIZATION">
+							<Menu
+								label={axisLabel('organization', 'Organization', filter)}
+								modifiers={STAYS_OPEN}
+							>
 								{organizations.map((organization) => (
 									<Toggle
 										isOn={filter?.axis === 'organization' && filter.value === organization.value}
@@ -83,9 +101,9 @@ export function CalendarPicker({
 										onIsOnChange={() => toggleFilter('organization', organization.value)}
 									/>
 								))}
-							</Section>
+							</Menu>
 						) : null}
-						<Section modifiers={STAYS_OPEN} title="CATEGORY">
+						<Menu label={axisLabel('category', 'Category', filter)} modifiers={STAYS_OPEN}>
 							{categories.map((category) => (
 								<Toggle
 									isOn={filter?.axis === 'category' && filter.value === category.value}
@@ -94,14 +112,7 @@ export function CalendarPicker({
 									onIsOnChange={() => toggleFilter('category', category.value)}
 								/>
 							))}
-							{/* Rendered last so it sits at the visual top of the section */}
-							<Toggle
-								isOn={filter === null}
-								key="__all__"
-								label="All Events"
-								onIsOnChange={() => onSelectFilter(null)}
-							/>
-						</Section>
+						</Menu>
 						<Section modifiers={STAYS_OPEN} title="CALENDARS">
 							{onRequestDeviceCalendars ? (
 								<Button label="Add Device Calendars…" onPress={onRequestDeviceCalendars} />

--- a/modules/ccc-calendar/calendar-picker.tsx
+++ b/modules/ccc-calendar/calendar-picker.tsx
@@ -7,6 +7,7 @@ import {
 	menuActionDismissBehavior,
 } from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
+import type {CalendarFilterOption} from '../../source/features/calendar/filter'
 import type {CalendarFilter} from '../../source/features/calendar/store'
 import type {CalendarSource} from './sources'
 
@@ -26,8 +27,8 @@ type Props = {
 	sources: CalendarSource[]
 	enabledIds: string[]
 	onToggleSource: (id: string) => void
-	categories: string[]
-	organizations: string[]
+	categories: CalendarFilterOption[]
+	organizations: CalendarFilterOption[]
 	filter: CalendarFilter | null
 	onSelectFilter: (filter: CalendarFilter | null) => void
 	onTodayPress?: () => void
@@ -76,10 +77,10 @@ export function CalendarPicker({
 							<Section modifiers={STAYS_OPEN} title="ORGANIZATION">
 								{organizations.map((organization) => (
 									<Toggle
-										isOn={filter?.axis === 'organization' && filter.value === organization}
-										key={organization}
-										label={organization}
-										onIsOnChange={() => toggleFilter('organization', organization)}
+										isOn={filter?.axis === 'organization' && filter.value === organization.value}
+										key={organization.value}
+										label={`${organization.value} (${organization.count})`}
+										onIsOnChange={() => toggleFilter('organization', organization.value)}
 									/>
 								))}
 							</Section>
@@ -87,10 +88,10 @@ export function CalendarPicker({
 						<Section modifiers={STAYS_OPEN} title="CATEGORY">
 							{categories.map((category) => (
 								<Toggle
-									isOn={filter?.axis === 'category' && filter.value === category}
-									key={category}
-									label={category}
-									onIsOnChange={() => toggleFilter('category', category)}
+									isOn={filter?.axis === 'category' && filter.value === category.value}
+									key={category.value}
+									label={`${category.value} (${category.count})`}
+									onIsOnChange={() => toggleFilter('category', category.value)}
 								/>
 							))}
 							{/* Rendered last so it sits at the visual top of the section */}

--- a/modules/ccc-calendar/calendar-picker.tsx
+++ b/modules/ccc-calendar/calendar-picker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {Stack} from 'expo-router'
-import {Button, Host, Image, Menu, Section, Toggle} from '@expo/ui/swift-ui'
+import {Button, Divider, Host, Image, Menu, Section, Toggle} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
 	foregroundStyle,
@@ -18,7 +18,9 @@ import type {CalendarSource} from './sources'
  *
  * The children are written RESET, ORGANIZATION, CATEGORY, CALENDARS and reach
  * the screen in the opposite order -- CALENDARS at the top, Reset Filters at
- * the bottom -- because SwiftUI draws a Menu's contents bottom-to-top.
+ * the bottom -- because SwiftUI draws a Menu's contents bottom-to-top. The rule
+ * separating Reset Filters from the axes above it is written after it for the
+ * same reason.
  * Confirmed against a screenshot from `testPickerMenuShowsItsRows`, which is
  * also why each axis's choices are sorted Z-A to read A-Z. Reordering these to
  * match the rendered order would invert the menu.
@@ -87,7 +89,12 @@ export function CalendarPicker({
 				<Host matchContents={true}>
 					<Menu label={<Image systemName="calendar" />} modifiers={menuModifiers}>
 						{/* Rendered first so it sits at the visual bottom, below both axes */}
-						{filter ? <Button label="Reset Filters" onPress={() => onSelectFilter(null)} /> : null}
+						{filter ? (
+							<>
+								<Button label="Reset Filters" onPress={() => onSelectFilter(null)} />
+								<Divider />
+							</>
+						) : null}
 						{organizations.length > 0 ? (
 							<Menu
 								label={axisLabel('organization', 'Organization', filter)}

--- a/modules/filter/__tests__/expo-ui-mock.tsx
+++ b/modules/filter/__tests__/expo-ui-mock.tsx
@@ -76,6 +76,16 @@ export const padding = (params: Record<string, unknown> = {}): Modifier => ({
 	...params,
 })
 
+/**
+ * A `Divider` draws a rule and carries nothing -- no label, no children, no
+ * behaviour. The stand-in is an empty view: it exists so a tree containing one
+ * mounts, not to be asserted on. What a rule looks like is a screenshot's
+ * business.
+ */
+export function Divider({modifiers}: {modifiers?: Modifier[]}): React.ReactNode {
+	return <ViewWithModifiers modifiers={modifiers} />
+}
+
 export function Host({children}: WithChildren & {matchContents?: boolean}): React.ReactNode {
 	return <View>{children}</View>
 }

--- a/source/features/calendar/__tests__/filter.test.ts
+++ b/source/features/calendar/__tests__/filter.test.ts
@@ -27,36 +27,52 @@ function sourced(key: string, categories: string[], organization?: string[]): So
 }
 
 describe('availableCategories', () => {
-	test('deduplicates categories carried by more than one event', () => {
-		let events = [sourced('a', ['Music']), sourced('b', ['Music'])]
-		expect(availableCategories(events)).toStrictEqual(['Music'])
+	test('counts the events carrying each category', () => {
+		let events = [sourced('a', ['Music']), sourced('b', ['Music']), sourced('c', ['Chapel'])]
+		expect(availableCategories(events)).toStrictEqual([
+			{value: 'Music', count: 2},
+			{value: 'Chapel', count: 1},
+		])
+	})
+
+	test('an event listing a category twice still counts once', () => {
+		let events = [sourced('a', ['Music', 'Music'])]
+		expect(availableCategories(events)).toStrictEqual([{value: 'Music', count: 1}])
 	})
 
 	test('sorts Z-A, so SwiftUI renders it A-Z bottom-to-top', () => {
 		let events = [sourced('a', ['Athletics']), sourced('b', ['Music'])]
-		expect(availableCategories(events)).toStrictEqual(['Music', 'Athletics'])
+		expect(availableCategories(events)).toStrictEqual([
+			{value: 'Music', count: 1},
+			{value: 'Athletics', count: 1},
+		])
 	})
 })
 
 describe('availableOrganizations', () => {
 	test('an event with no organisation contributes nothing', () => {
-		let events = [sourced('a', [])]
-		expect(availableOrganizations(events)).toStrictEqual([])
+		expect(availableOrganizations([sourced('a', [])])).toStrictEqual([])
 	})
 
-	test('an event naming two organisations contributes both', () => {
+	test('an event naming two organisations counts toward both', () => {
 		let events = [sourced('a', [], ['Music Department', 'Wellness Center'])]
-		expect(availableOrganizations(events)).toStrictEqual(['Wellness Center', 'Music Department'])
+		expect(availableOrganizations(events)).toStrictEqual([
+			{value: 'Wellness Center', count: 1},
+			{value: 'Music Department', count: 1},
+		])
 	})
 
-	test('deduplicates organisations named by more than one event', () => {
+	test('counts the events naming each organisation', () => {
 		let events = [sourced('a', [], ['Music Department']), sourced('b', [], ['Music Department'])]
-		expect(availableOrganizations(events)).toStrictEqual(['Music Department'])
+		expect(availableOrganizations(events)).toStrictEqual([{value: 'Music Department', count: 2}])
 	})
 
 	test('sorts Z-A, so SwiftUI renders it A-Z bottom-to-top', () => {
 		let events = [sourced('a', [], ['Athletics']), sourced('b', [], ['Music Department'])]
-		expect(availableOrganizations(events)).toStrictEqual(['Music Department', 'Athletics'])
+		expect(availableOrganizations(events)).toStrictEqual([
+			{value: 'Music Department', count: 1},
+			{value: 'Athletics', count: 1},
+		])
 	})
 })
 

--- a/source/features/calendar/__tests__/filter.test.ts
+++ b/source/features/calendar/__tests__/filter.test.ts
@@ -109,3 +109,25 @@ describe('filterEvents', () => {
 		expect(filterEvents(events, filter)).toStrictEqual([])
 	})
 })
+
+describe('a tally and the filter it describes', () => {
+	// The count is a promise about what choosing that value would leave on
+	// screen, so the two have to be counting the same events. They arrive at it
+	// differently -- the tally walks every event once, the filter tests each
+	// event against one value -- and nothing but this ties them together.
+	let events = [
+		sourced('a', ['Music', 'Music'], ['Music Department']),
+		sourced('b', ['Music', 'Chapel'], ['Music Department', 'Wellness Center']),
+		sourced('c', ['Chapel'], []),
+	]
+
+	test.each(availableCategories(events))('$value ($count) categorises $count events', (option) => {
+		let filtered = filterEvents(events, {axis: 'category', value: option.value})
+		expect(filtered).toHaveLength(option.count)
+	})
+
+	test.each(availableOrganizations(events))('$value ($count) sponsors $count events', (option) => {
+		let filtered = filterEvents(events, {axis: 'organization', value: option.value})
+		expect(filtered).toHaveLength(option.count)
+	})
+})

--- a/source/features/calendar/filter.ts
+++ b/source/features/calendar/filter.ts
@@ -2,22 +2,46 @@ import type {SourcedEvent} from '@frogpond/event-list/types'
 
 import type {CalendarFilter} from './store'
 
-/**
- * Every category at least one event carries, sorted Z-A. SwiftUI's Menu
- * renders a section bottom-to-top, so Z-A here reads A-Z on screen.
- */
-export function availableCategories(events: SourcedEvent[]): string[] {
-	let categories = new Set(events.flatMap((e) => e.event.categories ?? []))
-	return [...categories].sort((a, b) => b.localeCompare(a))
+/** A value the calendar can be narrowed to, and how many events carry it. */
+export type CalendarFilterOption = {
+	value: string
+	count: number
 }
 
 /**
- * Every organisation sponsoring at least one event, sorted Z-A. SwiftUI's
- * Menu renders a section bottom-to-top, so Z-A here reads A-Z on screen.
+ * Every value at least one event carries, tallied, sorted Z-A by value.
+ * SwiftUI's Menu renders its contents bottom-to-top, so Z-A here reads A-Z on
+ * screen.
+ *
+ * A value is counted once per event, however many times that event lists it:
+ * the tally answers "how many events would this leave me", so it has to agree
+ * with what `filterEvents` returns.
  */
-export function availableOrganizations(events: SourcedEvent[]): string[] {
-	let organizations = new Set(events.flatMap((e) => e.event.organization ?? []))
-	return [...organizations].sort((a, b) => b.localeCompare(a))
+function tally(
+	events: SourcedEvent[],
+	valuesOf: (entry: SourcedEvent) => readonly string[],
+): CalendarFilterOption[] {
+	let counts = new Map<string, number>()
+
+	for (let entry of events) {
+		for (let value of new Set(valuesOf(entry))) {
+			counts.set(value, (counts.get(value) ?? 0) + 1)
+		}
+	}
+
+	return [...counts]
+		.map(([value, count]) => ({value, count}))
+		.sort((a, b) => b.value.localeCompare(a.value))
+}
+
+/** Every category at least one event carries, with its tally. */
+export function availableCategories(events: SourcedEvent[]): CalendarFilterOption[] {
+	return tally(events, (entry) => entry.event.categories ?? [])
+}
+
+/** Every organisation sponsoring at least one event, with its tally. */
+export function availableOrganizations(events: SourcedEvent[]): CalendarFilterOption[] {
+	return tally(events, (entry) => entry.event.organization ?? [])
 }
 
 /**

--- a/uitests/ModuleCalendarTests.swift
+++ b/uitests/ModuleCalendarTests.swift
@@ -12,7 +12,7 @@ class ModuleCalendarTests: UITestCase {
 			.navigate()
 			.openPicker()
 			.checkCategoriesListed()
-			.capture("33-category-submenu")
+			.capture("35-category-submenu")
 	}
 
 	/// Selecting a category filters the list; selecting it again clears the filter.
@@ -301,6 +301,7 @@ class ModuleCalendarTests: UITestCase {
 
 		screen
 			.openPicker()
+			.capture("36-reset-filters-offered")
 			.tapResetFilters()
 			.capture("32-filter-cleared")
 

--- a/uitests/ModuleCalendarTests.swift
+++ b/uitests/ModuleCalendarTests.swift
@@ -267,6 +267,16 @@ class ModuleCalendarTests: UITestCase {
 		screen
 			.openPicker()
 			.toggleCalendar(TestIdentifiers.Calendar.uitestCalendar)
+
+		// With no calendar enabled there is no category and no organisation, so
+		// each axis draws an empty Menu -- which SwiftUI draws as no row at all.
+		// The picker is still open, and a reading that only knew about the axes
+		// would call it closed and leave it covering the list.
+		XCTAssertTrue(
+			screen.pickerIsPresented(),
+			"The picker should still read as open with every calendar switched off")
+
+		screen
 			.dismissMenu()
 			.capture("31-no-calendars-enabled")
 

--- a/uitests/ModuleCalendarTests.swift
+++ b/uitests/ModuleCalendarTests.swift
@@ -26,7 +26,7 @@ class ModuleCalendarTests: UITestCase {
 
 		screen.selectCategory(TestIdentifiers.Calendar.categories[0])
 
-		let stayedOpen = screen.menuIsPresented()
+		let stayedOpen = screen.pickerIsPresented()
 		XCTContext.runActivity(
 			named: stayedOpen
 				? "Menu stayed presented after selecting category"

--- a/uitests/ModuleCalendarTests.swift
+++ b/uitests/ModuleCalendarTests.swift
@@ -12,6 +12,7 @@ class ModuleCalendarTests: UITestCase {
 			.navigate()
 			.openPicker()
 			.checkCategoriesListed()
+			.capture("33-category-submenu")
 	}
 
 	/// Selecting a category filters the list; selecting it again clears the filter.
@@ -234,17 +235,24 @@ class ModuleCalendarTests: UITestCase {
 	}
 
 	/// The picker is three lists in one: which calendars contribute events, and
-	/// the two axes the list can be narrowed along. SwiftUI renders a Menu's
+	/// a row per axis the list can be narrowed along. SwiftUI renders a Menu's
 	/// contents bottom-to-top, so only a screenshot settles the order they
 	/// actually reach the screen in.
-	func testPickerMenuShowsItsSections() throws {
-		CalendarScreen(app: app)
+	func testPickerMenuShowsItsRows() throws {
+		let screen = CalendarScreen(app: app)
 			.navigate()
 			.openPicker()
 			.verifyMenuSection(TestIdentifiers.Calendar.calendarsSection)
-			.verifyMenuSection(TestIdentifiers.Calendar.categorySection)
-			.verifyMenuSection(TestIdentifiers.Calendar.organizationSection)
-			.capture("30-picker-sections")
+
+		for row in [
+			TestIdentifiers.Calendar.categoryMenu, TestIdentifiers.Calendar.organizationMenu,
+		] {
+			XCTAssertTrue(
+				app.buttons[row].waitForExistence(timeout: 30),
+				"\(row) should be a row of the open picker")
+		}
+
+		screen.capture("30-picker-rows")
 	}
 
 	/// The CALENDARS section is what makes a source controllable. UI test mode
@@ -276,9 +284,9 @@ class ModuleCalendarTests: UITestCase {
 			"Switching the calendar back on should restore its rows")
 	}
 
-	/// "All Events" clears whichever axis is filtered, and is the only way back
-	/// to the whole list without hunting for the selected item to untick.
-	func testAllEventsClearsTheFilter() throws {
+	/// Reset Filters clears whichever axis is filtered, and is the only way back
+	/// to the whole list without hunting for the selected choice to untick.
+	func testResetFiltersClearsTheFilter() throws {
 		let screen = CalendarScreen(app: app).navigate()
 		let unfiltered = screen.visibleRowCount()
 
@@ -293,13 +301,21 @@ class ModuleCalendarTests: UITestCase {
 
 		screen
 			.openPicker()
-			.selectCategory(TestIdentifiers.Calendar.allEvents)
-			.dismissMenu()
+			.tapResetFilters()
 			.capture("32-filter-cleared")
 
 		XCTAssertEqual(
 			screen.visibleRowCount(), unfiltered,
-			"All Events should restore the whole list")
+			"Reset Filters should restore the whole list")
+	}
+
+	/// Reset Filters is an undo, so it has nothing to offer an unfiltered list.
+	func testResetFiltersIsAbsentWhileUnfiltered() throws {
+		CalendarScreen(app: app).navigate().openPicker()
+
+		XCTAssertFalse(
+			app.buttons[TestIdentifiers.Calendar.resetFilters].exists,
+			"Reset Filters should be absent while the list is unfiltered")
 	}
 
 	/// Organisation is the second filter axis, and the only one whose values
@@ -327,12 +343,11 @@ class ModuleCalendarTests: UITestCase {
 
 		screen
 			.openPicker()
-			.selectCategory(TestIdentifiers.Calendar.allEvents)
-			.dismissMenu()
+			.tapResetFilters()
 
 		XCTAssertEqual(
 			screen.visibleRowCount(), unfiltered,
-			"All Events should restore the whole list")
+			"Reset Filters should restore the whole list")
 	}
 
 	/// The list merges several calendars and so credits none of them; the

--- a/uitests/Screens/CalendarScreen.swift
+++ b/uitests/Screens/CalendarScreen.swift
@@ -24,9 +24,10 @@ struct CalendarScreen: Screen {
 		return self
 	}
 
-	/// Every category is a menu item, so a UIMenu action is a button.
+	/// Every category is a submenu item, so a UIMenu action is a button.
 	@discardableResult
 	func checkCategoriesListed() -> Self {
+		openSubmenu(TestIdentifiers.Calendar.categoryMenu)
 		for category in TestIdentifiers.Calendar.categories {
 			XCTContext.runActivity(named: category) { _ in
 				XCTAssertTrue(
@@ -37,9 +38,9 @@ struct CalendarScreen: Screen {
 		return self
 	}
 
-	/// Tap an item in the open menu. A category, an organisation and All Events
-	/// are all Toggles inside a Menu, which reach XCUITest as buttons labelled
-	/// with their titles.
+	/// Tap an item in whichever menu is open. A category and an organisation are
+	/// Toggles inside a Menu and Reset Filters is a Button; all three reach
+	/// XCUITest as buttons labelled with their titles.
 	@discardableResult
 	private func tapMenuItem(_ title: String) -> Self {
 		let item = app.buttons[title]
@@ -50,16 +51,46 @@ struct CalendarScreen: Screen {
 		return self
 	}
 
-	/// Tap a category in the open menu.
+	/// Open one of the picker's two filter submenus. A nested Menu reaches
+	/// XCUITest as a button, and its choices only enter the hierarchy once it
+	/// has been tapped.
+	///
+	/// Matched on the prefix: a row names its selection after a colon once that
+	/// axis is filtered, so the exact label depends on the state of the list.
 	@discardableResult
-	func selectCategory(_ category: String) -> Self {
-		tapMenuItem(category)
+	func openSubmenu(_ title: String) -> Self {
+		let row = app.buttons.matching(
+			NSPredicate(format: "label BEGINSWITH %@", title)
+		).firstMatch
+		XCTAssertTrue(
+			row.waitForExistence(timeout: 30),
+			"\(title) should be a row of the open picker")
+		row.tap()
+		return self
 	}
 
-	/// Tap an organisation in the open menu's ORGANIZATION section.
+	/// Clear the filter from the open picker. The action dismisses the menu, so
+	/// nothing after it needs to.
+	@discardableResult
+	func tapResetFilters() -> Self {
+		tapMenuItem(TestIdentifiers.Calendar.resetFilters)
+		_ = app.staticTexts[TestIdentifiers.Calendar.calendarsSection]
+			.waitForNonExistence(timeout: 10)
+		return self
+	}
+
+	/// Tap a category, opening the Category submenu to reach it.
+	@discardableResult
+	func selectCategory(_ category: String) -> Self {
+		openSubmenu(TestIdentifiers.Calendar.categoryMenu)
+		return tapMenuItem(category)
+	}
+
+	/// Tap an organisation, opening the Organization submenu to reach it.
 	@discardableResult
 	func selectOrganization(_ organization: String) -> Self {
-		tapMenuItem(organization)
+		openSubmenu(TestIdentifiers.Calendar.organizationMenu)
+		return tapMenuItem(organization)
 	}
 
 	/// Assert a category is selected in the open menu.
@@ -88,14 +119,28 @@ struct CalendarScreen: Screen {
 		app.staticTexts[TestIdentifiers.Calendar.calendarsSection].exists
 	}
 
+	/// Whether the picker is up, counting a submenu drawn over its parent.
+	///
+	/// Opening a submenu replaces the parent's contents, taking the CALENDARS
+	/// header with it, so a choice that exists only inside a submenu stands in
+	/// for the header while one is open.
+	func pickerIsPresented() -> Bool {
+		if menuIsPresented() {
+			return true
+		}
+		return app.buttons[TestIdentifiers.Calendar.categories[0]].exists
+	}
+
 	/// Close the menu by tapping well away from it -- the toolbar button is at
 	/// the bottom right and the menu opens upward from it, so the top left is
 	/// clear of both.
 	@discardableResult
 	func dismissMenu() -> Self {
-		if menuIsPresented() {
+		if pickerIsPresented() {
 			app.coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.2)).tap()
 			_ = app.staticTexts[TestIdentifiers.Calendar.calendarsSection]
+				.waitForNonExistence(timeout: 10)
+			_ = app.buttons[TestIdentifiers.Calendar.categories[0]]
 				.waitForNonExistence(timeout: 10)
 		}
 		return self

--- a/uitests/Screens/CalendarScreen.swift
+++ b/uitests/Screens/CalendarScreen.swift
@@ -133,12 +133,15 @@ struct CalendarScreen: Screen {
 
 	/// Whether the picker is up, counting a submenu drawn over its parent.
 	///
-	/// Opening a submenu replaces everything the parent drew, CALENDARS header
-	/// included, so `menuIsPresented` reads an open submenu as no menu at all.
-	/// An axis row survives both states, and unlike a category it is drawn
-	/// whatever the enabled calendars happen to hold.
+	/// Two readings because neither covers both states. Opening a submenu
+	/// replaces everything the parent drew, CALENDARS header included, so
+	/// `menuIsPresented` alone reads an open submenu as no menu at all. An axis
+	/// row alone is worse: an axis with nothing to offer draws an empty Menu,
+	/// which SwiftUI renders as no row, so a picker opened with every calendar
+	/// switched off has neither axis in it -- and that is exactly when
+	/// `testTogglingACalendarOffEmptiesTheList` looks.
 	func pickerIsPresented() -> Bool {
-		axisRow().exists
+		menuIsPresented() || axisRow().exists
 	}
 
 	/// Close the menu by tapping well away from it -- the toolbar button is at
@@ -148,8 +151,11 @@ struct CalendarScreen: Screen {
 	func dismissMenu() -> Self {
 		if pickerIsPresented() {
 			app.coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.2)).tap()
-			XCTAssertTrue(
-				axisRow().waitForNonExistence(timeout: 10),
+			_ = app.staticTexts[TestIdentifiers.Calendar.calendarsSection]
+				.waitForNonExistence(timeout: 10)
+			_ = axisRow().waitForNonExistence(timeout: 10)
+			XCTAssertFalse(
+				pickerIsPresented(),
 				"Tapping away from the picker should close it, submenu and all")
 		}
 		return self

--- a/uitests/Screens/CalendarScreen.swift
+++ b/uitests/Screens/CalendarScreen.swift
@@ -119,16 +119,26 @@ struct CalendarScreen: Screen {
 		app.staticTexts[TestIdentifiers.Calendar.calendarsSection].exists
 	}
 
+	/// Either axis's row, wherever the picker currently is. The parent menu
+	/// draws both as the rows that open its submenus; an open submenu draws its
+	/// own as the title above its choices, with the same label.
+	private func axisRow() -> XCUIElement {
+		app.buttons.matching(
+			NSPredicate(
+				format: "label BEGINSWITH %@ OR label BEGINSWITH %@",
+				TestIdentifiers.Calendar.categoryMenu,
+				TestIdentifiers.Calendar.organizationMenu)
+		).firstMatch
+	}
+
 	/// Whether the picker is up, counting a submenu drawn over its parent.
 	///
-	/// Opening a submenu replaces the parent's contents, taking the CALENDARS
-	/// header with it, so a choice that exists only inside a submenu stands in
-	/// for the header while one is open.
+	/// Opening a submenu replaces everything the parent drew, CALENDARS header
+	/// included, so `menuIsPresented` reads an open submenu as no menu at all.
+	/// An axis row survives both states, and unlike a category it is drawn
+	/// whatever the enabled calendars happen to hold.
 	func pickerIsPresented() -> Bool {
-		if menuIsPresented() {
-			return true
-		}
-		return app.buttons[TestIdentifiers.Calendar.categories[0]].exists
+		axisRow().exists
 	}
 
 	/// Close the menu by tapping well away from it -- the toolbar button is at
@@ -138,10 +148,9 @@ struct CalendarScreen: Screen {
 	func dismissMenu() -> Self {
 		if pickerIsPresented() {
 			app.coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.2)).tap()
-			_ = app.staticTexts[TestIdentifiers.Calendar.calendarsSection]
-				.waitForNonExistence(timeout: 10)
-			_ = app.buttons[TestIdentifiers.Calendar.categories[0]]
-				.waitForNonExistence(timeout: 10)
+			XCTAssertTrue(
+				axisRow().waitForNonExistence(timeout: 10),
+				"Tapping away from the picker should close it, submenu and all")
 		}
 		return self
 	}

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -246,11 +246,18 @@ struct TestIdentifiers {
 		/// `modules/ccc-calendar/fixtures/uitest-events.json` read at the app's
 		/// frozen clock, so they hold for as long as that fixture does.
 		static let categories = ["Music (10)", "Academic Year (6)"]
-		/// The picker menu's section headers. SwiftUI draws a Menu section title
-		/// as static text, uppercased by the caller rather than by the platform.
+		/// The picker menu's one section header. SwiftUI draws a Menu section
+		/// title as static text, uppercased by the caller rather than by the
+		/// platform.
 		static let calendarsSection = "CALENDARS"
-		static let categorySection = "CATEGORY"
-		static let organizationSection = "ORGANIZATION"
+		/// The rows that open each axis's submenu. A row names its selection
+		/// after a colon once that axis is filtered, so a test matching one has
+		/// to match on the prefix.
+		static let categoryMenu = "Category"
+		static let organizationMenu = "Organization"
+		/// Clears whichever axis is filtered, from the bottom of the picker.
+		/// Present only while something is filtered, and it dismisses the menu.
+		static let resetFilters = "Reset Filters"
 		/// A sponsoring organisation named by the fixture calendar's events,
 		/// written as the menu draws it. It sponsors three of them, so filtering
 		/// to it leaves the list narrowed rather than empty.
@@ -262,9 +269,6 @@ struct TestIdentifiers {
 		/// only too long. A name long enough to wrap its row costs half again
 		/// the height of one that does not.
 		static let organization = "Music Organizations (3)"
-		/// Clears whichever axis is filtered. Rendered inside the CATEGORY
-		/// section, at its visual top.
-		static let allEvents = "All Events"
 		/// The one calendar UI test mode enables, from `REMOTE_SOURCES`.
 		static let uitestCalendar = "UI Test Fixtures"
 		/// Every attribution caption opens with this. The list should carry

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -241,18 +241,19 @@ struct TestIdentifiers {
 
 	enum Calendar {
 		static let picker = "Calendar filter"
-		/// Categories from the St. Olaf calendar. Unlike calendar sources, these
-		/// come from the event data itself, so the exact set depends on what the
-		/// calendar is serving. These two appear reliably.
-		static let categories = ["Music", "Academic Year"]
+		/// Categories the picker offers, written as the menu draws them: the
+		/// name, then how many events carry it. The counts come from
+		/// `modules/ccc-calendar/fixtures/uitest-events.json` read at the app's
+		/// frozen clock, so they hold for as long as that fixture does.
+		static let categories = ["Music (10)", "Academic Year (6)"]
 		/// The picker menu's section headers. SwiftUI draws a Menu section title
 		/// as static text, uppercased by the caller rather than by the platform.
 		static let calendarsSection = "CALENDARS"
 		static let categorySection = "CATEGORY"
 		static let organizationSection = "ORGANIZATION"
-		/// A sponsoring organisation named by the fixture calendar's events. It
-		/// sponsors three of them, so filtering to it leaves the list narrowed
-		/// rather than empty.
+		/// A sponsoring organisation named by the fixture calendar's events,
+		/// written as the menu draws it. It sponsors three of them, so filtering
+		/// to it leaves the list narrowed rather than empty.
 		///
 		/// The fixture names two organisations, and short ones. iOS scrolls a
 		/// menu taller than the screen, and a section header scrolled out of the
@@ -260,7 +261,7 @@ struct TestIdentifiers {
 		/// merely offscreen -- so `verifyMenuSection` fails on a menu that is
 		/// only too long. A name long enough to wrap its row costs half again
 		/// the height of one that does not.
-		static let organization = "Music Organizations"
+		static let organization = "Music Organizations (3)"
 		/// Clears whichever axis is filtered. Rendered inside the CATEGORY
 		/// section, at its visual top.
 		static let allEvents = "All Events"


### PR DESCRIPTION
<!-- Description left for Wren to write. -->

## Screenshots

• | •
--- | ---
**The picker, filtered to a category**<br>![menu with reset](https://github.com/user-attachments/assets/92fabe96-4d80-45c3-9b62-29ece3b5453f) | **Category submenu**<br>![category submenu](https://github.com/user-attachments/assets/1d4aaa33-2691-49d1-9d90-350ec8920773)
**Organization submenu**<br>![organization submenu](https://github.com/user-attachments/assets/e10bd39c-a08a-4150-a38f-e9c51ade969c) | **The picker with nothing filtered**<br>![menu unfiltered](https://github.com/user-attachments/assets/0ecf83e3-adfa-4f8f-ab17-9611f6ca4302)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

