### PR TITLE
Move Streaming Media and the athletics scores to @expo/ui

### DIFF
--- a/app/(home)/Athletics.tsx
+++ b/app/(home)/Athletics.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
-import {SectionList, StyleSheet, View} from 'react-native'
+import {StyleSheet, View} from 'react-native'
+import {Host, List, Section} from '@expo/ui/swift-ui'
+import {listStyle, refreshable} from '@expo/ui/swift-ui/modifiers'
 import {Stack} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
 
-import {ListSectionHeader} from '@frogpond/lists'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 import * as c from '@frogpond/colors'
 
@@ -37,14 +38,7 @@ function AthleticsView(): React.ReactNode {
 	const selectedSports = useFilterStore((s) => s.selectedSports)
 	const setAvailableSports = useFilterStore((s) => s.setAvailableSports)
 
-	const {
-		data = NO_SCORES,
-		error,
-		refetch,
-		isLoading,
-		isError,
-		isRefetching,
-	} = useQuery(athleticsOptions)
+	const {data = NO_SCORES, error, refetch, isLoading, isError} = useQuery(athleticsOptions)
 
 	// The day the buckets are measured from. Held steady between renders so the
 	// grouping below doesn't re-run against a clock that has moved on.
@@ -120,20 +114,27 @@ function AthleticsView(): React.ReactNode {
 				<TabBar onSelectSection={setSelectedSection} selectedSection={selectedSection} />
 				{selectedSection === Constants.FILTER ? (
 					<AthleticsFilters sports={sports} />
+				) : sections.length === 0 ? (
+					<EmptyListNotice selectedSection={selectedSection} />
 				) : (
-					<SectionList
-						ListEmptyComponent={<EmptyListNotice selectedSection={selectedSection} />}
-						contentContainerStyle={styles.sectionListContent}
-						contentInsetAdjustmentBehavior="automatic"
-						keyExtractor={(item) => item.id}
-						onRefresh={refetch}
-						refreshing={isRefetching}
-						renderItem={({item}) => <AthleticsRow score={item} />}
-						renderSectionHeader={({section: {title}}) =>
-							title ? <ListSectionHeader title={title} /> : null
-						}
-						sections={sections}
-					/>
+					<Host style={styles.host}>
+						<List
+							modifiers={[
+								listStyle('insetGrouped'),
+								refreshable(async () => {
+									await refetch()
+								}),
+							]}
+						>
+							{sections.map((section, index) => (
+								<Section key={section.title || `section-${index}`} title={section.title}>
+									{section.data.map((score) => (
+										<AthleticsRow key={score.id} score={score} />
+									))}
+								</Section>
+							))}
+						</List>
+					</Host>
 				)}
 			</View>
 		</>
@@ -145,9 +146,9 @@ const styles = StyleSheet.create({
 		backgroundColor: c.secondarySystemBackground,
 		flex: 1,
 	},
-	sectionListContent: {
-		flexGrow: 1,
-		padding: 10,
+	host: {
+		flex: 1,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })
 

--- a/app/(home)/Athletics.tsx
+++ b/app/(home)/Athletics.tsx
@@ -6,6 +6,7 @@ import {Stack} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
 
 import {LoadingView, NoticeView} from '@frogpond/notice'
+import {now} from '@frogpond/timer'
 import * as c from '@frogpond/colors'
 
 import {Constants} from '../../source/features/athletics/constants'
@@ -42,7 +43,10 @@ function AthleticsView(): React.ReactNode {
 
 	// The day the buckets are measured from. Held steady between renders so the
 	// grouping below doesn't re-run against a clock that has moved on.
-	const today = React.useMemo(() => debugDate ?? new Date(), [debugDate])
+	// `now()` rather than `new Date()`: under UI testing it answers the frozen
+	// date the fixtures are written around, so which games count as today does
+	// not depend on the day the suite happens to run.
+	const today = React.useMemo(() => debugDate ?? now().toDate(), [debugDate])
 
 	// Derive the Women's/Men's/Other sport groups for the filter screen.
 	const sports = React.useMemo(() => sportFilterSections(data), [data])

--- a/app/(home)/Streaming Media/index.tsx
+++ b/app/(home)/Streaming Media/index.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
-import {StyleSheet, SectionList} from 'react-native'
+import {StyleSheet} from 'react-native'
+import {ContentUnavailableView, Host, List, Section} from '@expo/ui/swift-ui'
+import {listStyle, refreshable} from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
-import {ListSeparator, ListSectionHeader} from '@frogpond/lists'
 import {NoticeView, LoadingView} from '@frogpond/notice'
 import {FilterToolbar, ListType, selectedOptions} from '@frogpond/filter'
 import {StreamRow} from '../../../source/features/streaming/streams/row'
@@ -15,11 +16,9 @@ import {streamsOptionsFor} from '../../../source/features/streaming/streams/quer
 import {useQuery} from '@tanstack/react-query'
 
 const styles = StyleSheet.create({
-	listContainer: {
-		backgroundColor: c.systemBackground,
-	},
-	contentContainer: {
-		flexGrow: 1,
+	host: {
+		flex: 1,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })
 
@@ -61,7 +60,7 @@ const filterStreams = <T extends object>(streams: StreamType[], filters: ListTyp
 }
 
 export default function StreamingPage(): React.ReactNode {
-	let {data = [], error, refetch, isLoading, isRefetching, isError} = useQuery(streamsOptionsFor())
+	let {data = [], error, refetch, isLoading, isError} = useQuery(streamsOptionsFor())
 
 	// Only the narrowing the user asked for is state; the categories on offer
 	// come from the streams. Keeping the whole filter in state instead would tie
@@ -128,29 +127,48 @@ export default function StreamingPage(): React.ReactNode {
 		/>
 	)
 
+	if (isLoading) {
+		return (
+			<>
+				{header}
+				<LoadingView />
+			</>
+		)
+	}
+
+	let sections = groupStreams(filterStreams(entries, filters))
+	let hasActiveFilter = filters.some((f) => f.spec.selected.length)
+
 	return (
-		<SectionList
-			ItemSeparatorComponent={ListSeparator}
-			ListEmptyComponent={
-				isLoading ? (
-					<LoadingView />
-				) : filters.some((f) => f.spec.selected.length) ? (
-					<NoticeView text="No streams to show. Try changing the filters." />
-				) : (
-					<NoticeView text="No streams." />
-				)
-			}
-			ListHeaderComponent={header}
-			contentContainerStyle={styles.contentContainer}
-			contentInsetAdjustmentBehavior="automatic"
-			keyExtractor={(item: StreamType) => item.eid}
-			onRefresh={refetch}
-			refreshing={isRefetching}
-			renderItem={({item}) => <StreamRow stream={item} />}
-			renderSectionHeader={({section: {title}}) => <ListSectionHeader title={title} />}
-			sections={groupStreams(filterStreams(entries, filters))}
-			style={styles.listContainer}
-			testID="stream-list"
-		/>
+		<>
+			{header}
+
+			<Host style={styles.host} testID="stream-list">
+				<List
+					modifiers={[
+						listStyle('insetGrouped'),
+						refreshable(async () => {
+							await refetch()
+						}),
+					]}
+				>
+					{sections.length === 0 ? (
+						<ContentUnavailableView
+							description={hasActiveFilter ? 'Try changing the filters.' : undefined}
+							systemImage="play.tv"
+							title="No streams."
+						/>
+					) : (
+						sections.map((section) => (
+							<Section key={section.title} title={section.title}>
+								{section.data.map((stream) => (
+									<StreamRow key={stream.eid} stream={stream} />
+								))}
+							</Section>
+						))
+					)}
+				</List>
+			</Host>
+		</>
 	)
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -52,6 +52,7 @@ const config = {
 	// among them Hermes' own Jest snapshots -- which jest counts as obsolete
 	// snapshot files belonging to suites that do not exist, and fails on.
 	modulePathIgnorePatterns: ['<rootDir>/.claude/worktrees/', '<rootDir>/ios/'],
+	globalSetup: './scripts/jest-global-setup.js',
 	setupFiles: ['./scripts/jest-setup.js'],
 	transform: {
 		'^.+\\.mjs$': 'babel-jest',

--- a/scripts/jest-global-setup.js
+++ b/scripts/jest-global-setup.js
@@ -1,0 +1,16 @@
+// Pin the timezone for the whole run.
+//
+// Several features bucket by calendar day in the device's own zone -- the
+// athletics tabs, the calendar's day strip -- so a test asserting which day a
+// fixture lands on depends on where the runner is. CI runs in UTC and
+// developers do not, which is how a green suite locally went red there.
+//
+// America/Chicago is St. Olaf's zone, so the fixtures read as the times a
+// reader on campus would see.
+//
+// Set here rather than in `setupFiles`: this runs once before the workers are
+// forked, and they inherit it. Node caches the zone at first use, so a later
+// assignment can arrive after some other file has already read the old one.
+module.exports = () => {
+	process.env.TZ = 'America/Chicago'
+}

--- a/source/features/athletics/__fixtures__/scores.ts
+++ b/source/features/athletics/__fixtures__/scores.ts
@@ -11,10 +11,13 @@ import type {Score} from '../types'
  * reasoning about entries.
  */
 
-/// A 1x1 transparent PNG. The crests only need to prove the row hosts a remote
-/// image at all, and an inline one cannot fail for want of a network.
+/// A 1x1 grey PNG, stretched to fill the crest's frame.
+///
+/// Visible on purpose: a crest that drew nothing would look exactly like one
+/// that failed to load, so a plain square is what shows the row really did host
+/// the image. Inline rather than a URL so it cannot fail for want of a network.
 const LOGO =
-	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGM4fvwMAASzAlv//YG7AAAAAElFTkSuQmCC'
 
 function score(props: Partial<Score> & Pick<Score, 'id' | 'sport' | 'date_utc'>): Score {
 	return {

--- a/source/features/athletics/__fixtures__/scores.ts
+++ b/source/features/athletics/__fixtures__/scores.ts
@@ -1,0 +1,96 @@
+import type {Score} from '../types'
+
+/**
+ * Scores for UI testing, anchored to `UITEST_FROZEN_DATE` -- the Saturday the
+ * app's clock is frozen to under `--uitesting`. Between them they fill every
+ * bucket the tabs can show: yesterday, today's ongoing/finalized/upcoming, and
+ * a later fixture, so no tab is empty for want of a real game that day.
+ *
+ * Live scores are whatever St. Olaf played this week, which is nothing to
+ * assert against -- see `source/features/dictionary/query.ts` for the same
+ * reasoning about entries.
+ */
+
+/// A 1x1 transparent PNG. The crests only need to prove the row hosts a remote
+/// image at all, and an inline one cannot fail for want of a network.
+const LOGO =
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+
+function score(props: Partial<Score> & Pick<Score, 'id' | 'sport' | 'date_utc'>): Score {
+	return {
+		sport_abbrev: '',
+		date: '',
+		dateFormatted: '',
+		date_end_utc: '',
+		time: '',
+		timestamp: 0,
+		location: {location: 'Northfield, Minn.', facility: 'Manitou Field', homeAway: 'H'},
+		status: {indicator: 'A', value: ''},
+		hometeam: 'St. Olaf',
+		hometeam_logo: LOGO,
+		opponent: 'Carleton',
+		opponent_logo: LOGO,
+		team_score: '',
+		opponent_score: '',
+		result: '',
+		ip_time: '',
+		prescore_info: '',
+		postscore_info: '',
+		links: {},
+		coverage: {},
+		...props,
+	}
+}
+
+export const UITEST_SCORES: Score[] = [
+	score({
+		id: 'uitest-yesterday',
+		sport: "Women's Soccer",
+		date_utc: '2026-09-04T19:00:00-05:00',
+		time: '7:00 PM',
+		result: 'L',
+		team_score: '1',
+		opponent_score: '2',
+	}),
+	score({
+		id: 'uitest-today-ongoing',
+		sport: "Men's Soccer",
+		date_utc: '2026-09-05T14:00:00-05:00',
+		time: '2:00 PM',
+		status: {indicator: 'O', value: 'In Progress'},
+		team_score: '2',
+		opponent_score: '0',
+	}),
+	score({
+		id: 'uitest-today-finalized',
+		sport: 'Volleyball',
+		date_utc: '2026-09-05T11:00:00-05:00',
+		time: '11:00 AM',
+		result: 'W',
+		team_score: '3',
+		opponent_score: '1',
+		opponent: 'Gustavus Adolphus',
+	}),
+	score({
+		id: 'uitest-today-upcoming',
+		sport: 'Football',
+		date_utc: '2026-09-05T19:00:00-05:00',
+		time: '7:00 PM',
+		opponent: 'Bethel',
+	}),
+	/// No `time` at all, which is how the feed sends an all-day fixture -- the
+	/// row reads "All day" for it rather than an empty gap.
+	score({
+		id: 'uitest-upcoming-allday',
+		sport: "Women's Golf",
+		date_utc: '2026-09-07T00:00:00-05:00',
+		opponent: 'Invitational',
+	}),
+	score({
+		id: 'uitest-upcoming',
+		sport: 'Cross Country',
+		date_utc: '2026-09-12T10:00:00-05:00',
+		time: '10:00 AM',
+		opponent: 'St. Thomas',
+	}),
+]

--- a/source/features/athletics/__tests__/game-summary.test.ts
+++ b/source/features/athletics/__tests__/game-summary.test.ts
@@ -1,0 +1,77 @@
+import {gameSummary} from '../utils'
+import type {ProcessedScore} from '../types'
+
+function makeScore(props: Partial<ProcessedScore>): ProcessedScore {
+	return {
+		id: '1',
+		sport: "Women's Soccer",
+		sport_abbrev: 'WSOC',
+		date: '',
+		dateFormatted: '',
+		date_utc: '',
+		date_end_utc: '',
+		time: '7:00 PM',
+		timestamp: 0,
+		location: {} as ProcessedScore['location'],
+		status: {indicator: 'A'} as ProcessedScore['status'],
+		hometeam: 'St. Olaf ',
+		hometeam_logo: '',
+		opponent: ' Carleton',
+		opponent_logo: '',
+		team_score: '',
+		opponent_score: '',
+		result: '' as ProcessedScore['result'],
+		ip_time: '',
+		prescore_info: '',
+		postscore_info: '',
+		links: {} as ProcessedScore['links'],
+		coverage: {} as ProcessedScore['coverage'],
+		parsedDate: new Date('2026-09-11T19:00:00Z'),
+		...props,
+	}
+}
+
+describe('gameSummary', () => {
+	it('shows the kickoff time for a game that has not started', () => {
+		let summary = gameSummary(makeScore({}))
+
+		expect(summary.showsTime).toBe(true)
+		expect(summary.label).toBe('7:00 PM')
+	})
+
+	/// All-day and multi-day fixtures carry no time string at all.
+	it('says All day for a fixture with no time', () => {
+		let summary = gameSummary(makeScore({time: ''}))
+
+		expect(summary.label).toBe('All day')
+	})
+
+	it('shows the score once a game has a result', () => {
+		let summary = gameSummary(
+			makeScore({result: 'W' as ProcessedScore['result'], team_score: '3', opponent_score: '1'}),
+		)
+
+		expect(summary.showsTime).toBe(false)
+		expect(summary.label).toBe('W 3-1')
+	})
+
+	/// An in-progress game has a score but no result letter yet.
+	it('shows the score with no result letter while a game is ongoing', () => {
+		let summary = gameSummary(
+			makeScore({
+				status: {indicator: 'O'} as ProcessedScore['status'],
+				team_score: '1',
+				opponent_score: '0',
+			}),
+		)
+
+		expect(summary.showsTime).toBe(false)
+		expect(summary.label).toBe('1-0')
+	})
+
+	it('reads out the sport, both teams and the state of play', () => {
+		let summary = gameSummary(makeScore({}))
+
+		expect(summary.accessibilityLabel).toBe("Women's Soccer: St. Olaf vs Carleton, 7:00 PM")
+	})
+})

--- a/source/features/athletics/__tests__/uitest-scores.test.ts
+++ b/source/features/athletics/__tests__/uitest-scores.test.ts
@@ -1,0 +1,29 @@
+import {UITEST_FROZEN_DATE} from '@frogpond/timer'
+import {UITEST_SCORES} from '../__fixtures__/scores'
+import {Constants} from '../constants'
+import {groupScoresByDate, sectionsForTab, toProcessedScores} from '../utils'
+
+/// The fixtures exist so no tab is empty for want of a real game. That is only
+/// true if they land in the buckets they were written for, which depends on the
+/// frozen clock -- so this asserts the pairing rather than trusting it.
+const grouped = groupScoresByDate(toProcessedScores(UITEST_SCORES), new Date(UITEST_FROZEN_DATE))
+
+describe('the UI test scores', () => {
+	it('survive parsing, every one of them', () => {
+		expect(toProcessedScores(UITEST_SCORES)).toHaveLength(UITEST_SCORES.length)
+	})
+
+	it('fill the Yesterday tab', () => {
+		expect(sectionsForTab(Constants.YESTERDAY, grouped)).not.toHaveLength(0)
+	})
+
+	it("fill all three of Today's sections", () => {
+		let titles = sectionsForTab(Constants.TODAY, grouped).map((s) => s.title)
+
+		expect(titles).toEqual([Constants.ONGOING, Constants.FINALIZED, Constants.UPCOMING])
+	})
+
+	it('fill the Upcoming tab', () => {
+		expect(sectionsForTab(Constants.UPCOMING, grouped)).not.toHaveLength(0)
+	})
+})

--- a/source/features/athletics/query.ts
+++ b/source/features/athletics/query.ts
@@ -1,5 +1,7 @@
 import {client} from '@frogpond/api'
+import {isUITesting} from '@frogpond/launch-arguments'
 import {queryOptions} from '@tanstack/react-query'
+import {UITEST_SCORES} from './__fixtures__/scores'
 import {Score} from './types'
 import {toProcessedScores} from './utils'
 
@@ -9,6 +11,12 @@ export const keys = {
 
 export const athleticsOptions = queryOptions({
 	queryKey: keys.all,
-	queryFn: ({signal}): Promise<Score[]> => client.get('athletics/scores', {signal}).json<Score[]>(),
+	// UI tests assert against what the tabs do with a week of fixtures, so they
+	// need the same week every run. What St. Olaf actually played changes daily,
+	// and an empty Today is a legitimate result that proves nothing.
+	queryFn: ({signal}): Promise<Score[]> =>
+		isUITesting
+			? Promise.resolve(UITEST_SCORES)
+			: client.get('athletics/scores', {signal}).json<Score[]>(),
 	select: toProcessedScores,
 })

--- a/source/features/athletics/row.tsx
+++ b/source/features/athletics/row.tsx
@@ -1,153 +1,106 @@
 import * as React from 'react'
-import {Image, PixelRatio, StyleSheet, Text, View} from 'react-native'
+import {Image as RNImage, StyleSheet} from 'react-native'
+import {HStack, RNHostView, Text, VStack} from '@expo/ui/swift-ui'
+import {
+	accessibilityElement,
+	accessibilityLabel,
+	font,
+	foregroundStyle,
+	frame,
+	lineLimit,
+	multilineTextAlignment,
+} from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
-import {ProcessedScore} from './types'
+import {gameSummary} from './utils'
+import type {ProcessedScore} from './types'
+
+const LOGO_SIZE = 30
+/// Wide enough for a two-digit score either side of the dash without the
+/// teams' names shifting as a game goes on.
+const SCORE_WIDTH = 96
+
+const TEAM_MODIFIERS = [
+	font({textStyle: 'caption'}),
+	foregroundStyle(c.label),
+	multilineTextAlignment('center'),
+	lineLimit(2),
+]
 
 type Props = {
 	score: ProcessedScore
 }
 
-export const AthleticsRow = React.memo(({score}: Props): React.ReactNode => {
-	// Show time only for games that haven't started yet (status A, no result).
-	// For ongoing (O) and finalized (result is W/L/N) games, show the score panel.
-	const showTime = score.status.indicator === 'A' && score.result === ''
-	// All-day and multi-day fixtures carry no `time` string.
-	const timeText = score.time || 'All day'
-	const gameInfoLabel = showTime
-		? timeText
-		: [score.result, `${score.team_score}-${score.opponent_score}`].filter(Boolean).join(' ')
-	const accessibilityLabel = `${score.sport}: ${score.hometeam.trim()} vs ${score.opponent.trim()}, ${gameInfoLabel}`
+function TeamLogo({uri}: {uri: string}): React.ReactNode {
+	if (!uri) {
+		return null
+	}
+
+	// `@expo/ui`'s Image reads only SF Symbols and local files, so a team's
+	// crest is a React Native image hosted in the row -- and RNHostView gives a
+	// hosted view no bounds of its own, hence the frame.
+	return (
+		<HStack modifiers={[frame({width: LOGO_SIZE, height: LOGO_SIZE})]}>
+			<RNHostView matchContents={false}>
+				<RNImage accessibilityIgnoresInvertColors={true} source={{uri}} style={styles.logo} />
+			</RNHostView>
+		</HStack>
+	)
+}
+
+/**
+ * One fixture: the sport it is, the two teams with their crests, and either a
+ * kickoff time or the score between them.
+ *
+ * The whole row is one accessibility element. Read field by field a scoreboard
+ * announces six fragments and says very little; `gameSummary` builds the
+ * sentence a reader actually wants.
+ */
+export const AthleticsRow = React.memo(function AthleticsRow({score}: Props): React.ReactNode {
+	let summary = gameSummary(score)
 
 	return (
-		<View
-			accessibilityLabel={accessibilityLabel}
-			accessibilityRole="text"
-			accessible={true}
-			style={styles.rowContainer}
+		<VStack
+			modifiers={[accessibilityElement('combine'), accessibilityLabel(summary.accessibilityLabel)]}
+			spacing={4}
 		>
-			<Text style={styles.sportName}>{score.sport}</Text>
-			<View style={styles.container}>
-				<View style={styles.teamLeft}>
-					{score.hometeam_logo ? (
-						<Image
-							accessibilityIgnoresInvertColors={true}
-							source={{uri: score.hometeam_logo}}
-							style={styles.teamLogo}
-						/>
-					) : null}
-					<Text style={styles.teamName}>{score.hometeam.trim()}</Text>
-				</View>
+			<Text modifiers={[font({textStyle: 'caption2', weight: 'bold'}), foregroundStyle(c.label)]}>
+				{score.sport}
+			</Text>
 
-				<View style={styles.gameInfo}>
-					{showTime ? (
-						<Text style={styles.infoTime}>{timeText}</Text>
-					) : (
-						<>
-							{score.result !== '' && <Text style={styles.infoProcess}>{score.result}</Text>}
-							<View style={styles.infoScorePanel}>
-								<Text style={styles.infoScore}>{score.team_score}</Text>
-								<View style={styles.infoDivider} />
-								<Text style={styles.infoScore}>{score.opponent_score}</Text>
-							</View>
-						</>
-					)}
-				</View>
+			<HStack spacing={8}>
+				<VStack modifiers={[frame({maxWidth: Infinity})]} spacing={4}>
+					<TeamLogo uri={score.hometeam_logo} />
+					<Text modifiers={TEAM_MODIFIERS}>{score.hometeam.trim()}</Text>
+				</VStack>
 
-				<View style={styles.teamRight}>
-					{score.opponent_logo ? (
-						<Image
-							accessibilityIgnoresInvertColors={true}
-							source={{uri: score.opponent_logo}}
-							style={styles.teamLogo}
-						/>
-					) : null}
-					<Text style={styles.teamName}>{score.opponent.trim()}</Text>
-				</View>
-			</View>
-		</View>
+				<VStack modifiers={[frame({width: SCORE_WIDTH})]} spacing={2}>
+					<Text
+						modifiers={[
+							font({
+								textStyle: summary.showsTime ? 'body' : 'title2',
+								weight: summary.showsTime ? 'regular' : 'medium',
+							}),
+							foregroundStyle(c.label),
+							multilineTextAlignment('center'),
+						]}
+					>
+						{summary.label}
+					</Text>
+				</VStack>
+
+				<VStack modifiers={[frame({maxWidth: Infinity})]} spacing={4}>
+					<TeamLogo uri={score.opponent_logo} />
+					<Text modifiers={TEAM_MODIFIERS}>{score.opponent.trim()}</Text>
+				</VStack>
+			</HStack>
+		</VStack>
 	)
 })
-AthleticsRow.displayName = 'AthleticsRow'
 
 const styles = StyleSheet.create({
-	rowContainer: {
-		backgroundColor: c.systemBackground,
-		borderRadius: 10,
-		elevation: 3,
-		marginHorizontal: 3,
-		marginVertical: 5,
-		padding: 3,
-		shadowColor: '#000',
-		shadowOffset: {width: 0, height: 2},
-		shadowOpacity: 0.1,
-		shadowRadius: 5,
-	},
-	container: {
-		alignItems: 'center',
-		backgroundColor: c.systemBackground,
-		borderRadius: 5,
-		flex: 1,
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-		padding: 5,
-	},
-	teamLeft: {
-		alignItems: 'center',
-		flex: 1,
-	},
-	teamRight: {
-		alignItems: 'center',
-		flex: 1,
-	},
-	teamLogo: {
-		height: 30,
-		marginVertical: 4,
-		width: 30,
-	},
-	sportName: {
-		color: c.label,
-		fontSize: 11,
-		fontWeight: 'bold',
-		padding: 2,
-		textAlign: 'center',
-	},
-	teamName: {
-		color: c.label,
-		fontSize: 12,
-		textAlign: 'center',
-	},
-	gameInfo: {
-		alignItems: 'center',
-		flex: 1,
-		justifyContent: 'center',
-	},
-	infoProcess: {
-		color: c.label,
-		fontSize: 8,
-		marginVertical: 2,
-	},
-	infoTime: {
-		color: c.label,
-		fontSize: 14,
-		textAlign: 'center',
-	},
-	infoScorePanel: {
-		alignItems: 'center',
-		flexDirection: 'row',
-		height: '100%',
-		justifyContent: 'center',
-	},
-	infoScore: {
-		color: c.label,
-		fontSize: 20,
-		fontWeight: '500',
-		textAlign: 'center',
-		width: 40,
-	},
-	infoDivider: {
-		backgroundColor: c.systemGray,
-		height: 20,
-		marginHorizontal: 8,
-		width: 2 / PixelRatio.get(),
+	logo: {
+		height: LOGO_SIZE,
+		width: LOGO_SIZE,
+		resizeMode: 'contain',
 	},
 })

--- a/source/features/athletics/utils.ts
+++ b/source/features/athletics/utils.ts
@@ -238,3 +238,35 @@ export function toggleSectionSelection(
 export function shortSportName(sport: string): string {
 	return sport.replace(/^(Men's|Women's)\s/u, '')
 }
+
+/** What a score row says about a game, and how it says it. */
+export interface GameSummary {
+	/** True before a game starts, when there is a kickoff time but no score. */
+	showsTime: boolean
+	/** The kickoff time, or the result and score once there is one. */
+	label: string
+	/** The whole row as one sentence, since a scoreboard read field by field
+	 * tells a VoiceOver reader very little. */
+	accessibilityLabel: string
+}
+
+/**
+ * Decides whether a score row shows a kickoff time or a scoreline.
+ *
+ * A game that has not started (status `A`) and carries no result shows its
+ * time; anything ongoing or finished shows the score, with the result letter
+ * in front of it once there is one.
+ */
+export function gameSummary(score: ProcessedScore): GameSummary {
+	let showsTime = score.status.indicator === 'A' && score.result === ''
+	// All-day and multi-day fixtures carry no `time` string.
+	let label = showsTime
+		? score.time || 'All day'
+		: [score.result, `${score.team_score}-${score.opponent_score}`].filter(Boolean).join(' ')
+
+	return {
+		showsTime,
+		label,
+		accessibilityLabel: `${score.sport}: ${score.hometeam.trim()} vs ${score.opponent.trim()}, ${label}`,
+	}
+}

--- a/source/features/streaming/streams/__tests__/row-detail.test.ts
+++ b/source/features/streaming/streams/__tests__/row-detail.test.ts
@@ -1,0 +1,54 @@
+import moment from 'moment-timezone'
+import {streamDetailLines} from '../lib'
+import type {StreamType} from '../types'
+
+function makeStream(props: Partial<StreamType>): StreamType {
+	return {
+		category: 'Music',
+		eid: '1',
+		iframesrc: '',
+		lastmod: '',
+		player: '',
+		poster: '',
+		starttime: '',
+		status: 'upcoming',
+		thumb: '',
+		title: 'Organ Recital',
+		date: moment.tz('2026-09-11T19:00:00', 'America/Winnipeg'),
+		...props,
+	}
+}
+
+describe('streamDetailLines', () => {
+	it('puts the subtitle above the showing time', () => {
+		let lines = streamDetailLines(makeStream({subtitle: 'Boe Memorial Chapel'}))
+
+		expect(lines).toEqual(['Boe Memorial Chapel', '7:00 PM – Fri, Sep. 11th, 2026'])
+	})
+
+	it('falls back to the performer when there is no subtitle', () => {
+		let lines = streamDetailLines(makeStream({performer: 'St. Olaf Choir'}))
+
+		expect(lines[0]).toBe('St. Olaf Choir')
+	})
+
+	/// An archived stream has already happened, so its start time says nothing
+	/// useful -- the old row hid it, and so does this.
+	it('omits the time for an archived stream', () => {
+		let lines = streamDetailLines(makeStream({subtitle: 'Boe', status: 'archived'}))
+
+		expect(lines).toEqual(['Boe'])
+	})
+
+	it('decodes the HTML entities these titles arrive with', () => {
+		let lines = streamDetailLines(makeStream({subtitle: 'Bach &amp; Handel', status: 'archived'}))
+
+		expect(lines).toEqual(['Bach & Handel'])
+	})
+
+	it('yields nothing when a stream has neither subtitle nor performer', () => {
+		let lines = streamDetailLines(makeStream({status: 'archived'}))
+
+		expect(lines).toEqual([])
+	})
+})

--- a/source/features/streaming/streams/lib.ts
+++ b/source/features/streaming/streams/lib.ts
@@ -1,0 +1,37 @@
+import {innerTextWithSpaces, parseHtml} from '@frogpond/html-lib'
+import type {StreamType} from './types'
+
+/**
+ * The quieter lines under a stream's title: where it is, and when it starts.
+ *
+ * An archived stream has already happened, so its start time says nothing
+ * worth reading and is left out.
+ *
+ * The date is still a `Moment`, which is what the streams query builds. The
+ * project prefers `date-fns` for new date handling, but moving this one off
+ * Moment means changing that query's parsing too, which is its own change.
+ */
+export function streamDetailLines(stream: StreamType): string[] {
+	let lines: string[] = []
+
+	let where = decode(stream.subtitle || stream.performer || '')
+	if (where) {
+		lines.push(where)
+	}
+
+	if (stream.status !== 'archived') {
+		lines.push(stream.date.format('h:mm A – ddd, MMM. Do, YYYY'))
+	}
+
+	return lines
+}
+
+/** These titles arrive as HTML, entities and all. */
+function decode(html: string): string {
+	return html ? innerTextWithSpaces(parseHtml(html)) : ''
+}
+
+/** A stream's title, decoded the same way its detail lines are. */
+export function streamTitle(stream: StreamType): string {
+	return decode(stream.title)
+}

--- a/source/features/streaming/streams/row.tsx
+++ b/source/features/streaming/streams/row.tsx
@@ -1,68 +1,27 @@
 import * as React from 'react'
-import {StyleSheet, Image} from 'react-native'
 
-import {ListRow, Detail, Title} from '@frogpond/lists'
-import {Column, Row} from '@frogpond/layout'
-import {innerTextWithSpaces, parseHtml} from '@frogpond/html-lib'
 import {trackedOpenUrl} from '@frogpond/open-url'
-import moment from 'moment'
+import {DisclosureRow} from '../../../components/rows'
+import {streamDetailLines, streamTitle} from './lib'
 import type {StreamType} from './types'
 
-const styles = StyleSheet.create({
-	image: {
-		marginRight: 12,
-		height: 40,
-		width: 70,
-	},
-})
-
-function Name({item}: {item: StreamType}) {
-	let title = innerTextWithSpaces(parseHtml(item.title))
-	return title ? <Title>{title}</Title> : null
-}
-
-function Info({item}: {item: StreamType}) {
-	let detail = innerTextWithSpaces(parseHtml(item.subtitle || item.performer || ''))
-	return detail ? <Detail>{detail}</Detail> : null
-}
-
-function Time({item}: {item: StreamType}) {
-	let showTime = item.status !== 'archived'
-	return showTime ? (
-		<Detail>{moment(item.date).format('h:mm A – ddd, MMM. Do, YYYY')}</Detail>
-	) : null
-}
-
-function Thumbnail({item}: {item: StreamType}) {
-	return item.thumb ? (
-		<Image
-			accessibilityIgnoresInvertColors={true}
-			source={{uri: item.thumb}}
-			style={styles.image}
-		/>
-	) : null
-}
+/// The thumbnails these feeds serve are 16:9-ish; this is the size the row
+/// drew them at before, kept so the list's rhythm is unchanged.
+const THUMBNAIL_WIDTH = 70
+const THUMBNAIL_HEIGHT = 40
 
 type Props = {stream: StreamType}
 
-export const StreamRow = (props: Props): React.ReactNode => {
-	let onPressStream = () => {
-		let {stream} = props
-		trackedOpenUrl({url: stream.player, id: 'StreamingMedia_StreamView'})
-	}
-
-	let {stream} = props
-
-	return (
-		<ListRow arrowPosition="center" onPress={onPressStream}>
-			<Row alignItems="center">
-				<Thumbnail item={stream} />
-				<Column flex={1}>
-					<Name item={stream} />
-					<Info item={stream} />
-					<Time item={stream} />
-				</Column>
-			</Row>
-		</ListRow>
-	)
-}
+export const StreamRow = ({stream}: Props): React.ReactNode => (
+	<DisclosureRow
+		detail={streamDetailLines(stream)}
+		image={
+			stream.thumb
+				? {uri: stream.thumb, width: THUMBNAIL_WIDTH, height: THUMBNAIL_HEIGHT}
+				: undefined
+		}
+		onPress={() => trackedOpenUrl({url: stream.player, id: 'StreamingMedia_StreamView'})}
+		title={streamTitle(stream)}
+		titleLines={2}
+	/>
+)

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -62,6 +62,15 @@ class StageOneListsTests: UITestCase {
 		screen.capture("Printers")
 	}
 
+	/// The first screen to draw a thumbnail through the shared row, so this is
+	/// where a remote image hosted inside a SwiftUI list gets looked at.
+	func testStreamingMediaList() throws {
+		StreamingMediaScreen(app: app)
+			.navigate()
+			.checkStreamListExists()
+			.capture("Streaming Media")
+	}
+
 	func testMoreList() throws {
 		MoreScreen(app: app)
 			.navigate()

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -117,4 +117,14 @@ class StageOneListsTests: UITestCase {
 		filterTab.tap()
 		screen.capture("Athletics - Filter")
 	}
+
+	/// The scores tab, which draws two remote crests per row through
+	/// `RNHostView`. Athletics opens on Today, which may legitimately have no
+	/// games -- the capture is taken either way, since an empty state is worth
+	/// seeing too.
+	func testAthleticsScoresList() throws {
+		AthleticsScreen(app: app)
+			.navigate()
+			.capture("Athletics - Scores")
+	}
 }


### PR DESCRIPTION
<!-- Wren: description yours to write. Below is only what is in the branch, and the screenshots. -->

Stage 2 (part two) of #7921, and the last of the stage-2 screens. **Stacked on #7925**, which is stacked on #7924.

### Commits

- `add6d5617` Move Streaming Media to @expo/ui
- `f67cb8d30` Move the athletics scores to @expo/ui
- `b4e132fd7` Give the athletics tabs a week of fixtures to show
- `338144afc` Read the athletics clock the way the fixtures are written

### Screens on the simulator

| Streaming Media | Athletics — Today |
| --- | --- |
| ![Streaming Media](https://github.com/user-attachments/assets/5286dc05-7761-459b-b904-3aac31b7ec22) | ![Athletics](https://github.com/user-attachments/assets/6fd61ca0-4cfd-43b4-abe1-4f5ca0461401) |

Streaming Media is the first screen to draw a **remote** thumbnail through the shared row — those posters are real network images hosted inside a SwiftUI list, which is what the `RNHostView` path in #7925 was added for and could not be proven in Jest.

The athletics crests are a grey square on purpose: the fixtures inline a 1×1 PNG, and something visible is what distinguishes a hosted image from one that failed to load.

### Two bugs found by looking

- **Athletics measured "today" from `new Date()`**, so under UI testing it ignored the frozen clock and its Today tab followed the wall clock. It reads `now()` now, as the calendar does.
- The screen previously drew a **card inside a card** — its own rounded, shadowed row inside what is now an `insetGrouped` list.

### Athletics fixtures

Live scores are whatever St. Olaf played that day, so a UI test could open Today and find nothing — an empty tab proves nothing about the screen. Under `isUITesting` the scores now come from a fixed week filling every bucket the tabs show, the way the dictionary and building hours already work. A test asserts that pairing, since fixtures drifting out of their buckets would quietly empty the tabs again.

### Known, and not introduced here

- A row with no thumbnail does not align with rows that have one — visible on the two Streaming Media entries without posters. The old `ListRow` behaved the same way; it just reads more obviously in a grouped list.
- The `@expo/ui` `List`-under-`NativeTabs` bottom inset, as described on #7924.

Streaming Media still uses Moment: its `StreamType.date` is built as one by the query, so moving to `date-fns` means changing that parsing and belongs in its own change.
