### PR TITLE
Move the read-only detail screens to @expo/ui

### DIFF
--- a/app/(home)/CourseDetail.tsx
+++ b/app/(home)/CourseDetail.tsx
@@ -172,16 +172,7 @@ export default function CourseDetailPage(): React.ReactNode {
 
 	// The route param is a course id, meaningless to a user, so the title
 	// stays empty until the course loads rather than falling back to it.
-	// The name is the screen, so it takes a large title -- and the card that
-	// used to repeat it below the bar is gone. Safe to collapse here: the list
-	// is the only scrollable, so there is nothing above it to collapse against
-	// instead. See the note in Directory/index.tsx.
-	let screenTitle = (
-		<>
-			<Stack.Screen options={{headerLargeTitleEnabled: true}} />
-			<Stack.Title>{course?.name ?? ''}</Stack.Title>
-		</>
-	)
+	let screenTitle = <Stack.Title>{course?.name ?? ''}</Stack.Title>
 
 	if (termLoading || courseLoading) {
 		return (

--- a/app/(home)/CourseDetail.tsx
+++ b/app/(home)/CourseDetail.tsx
@@ -172,7 +172,16 @@ export default function CourseDetailPage(): React.ReactNode {
 
 	// The route param is a course id, meaningless to a user, so the title
 	// stays empty until the course loads rather than falling back to it.
-	let screenTitle = <Stack.Title>{course?.name ?? ''}</Stack.Title>
+	// The name is the screen, so it takes a large title -- and the card that
+	// used to repeat it below the bar is gone. Safe to collapse here: the list
+	// is the only scrollable, so there is nothing above it to collapse against
+	// instead. See the note in Directory/index.tsx.
+	let screenTitle = (
+		<>
+			<Stack.Screen options={{headerLargeTitleEnabled: true}} />
+			<Stack.Title>{course?.name ?? ''}</Stack.Title>
+		</>
+	)
 
 	if (termLoading || courseLoading) {
 		return (

--- a/app/(home)/CourseDetail.tsx
+++ b/app/(home)/CourseDetail.tsx
@@ -1,152 +1,101 @@
 import * as React from 'react'
 import {Stack, useLocalSearchParams} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
-import {timezone} from '@frogpond/constants'
-import {StyleSheet, Text, Platform, ScrollViewProps, ScrollView, TextProps} from 'react-native'
+import {StyleSheet} from 'react-native'
+import {Host, LabeledContent, List, RNHostView, Section, Text, VStack} from '@expo/ui/swift-ui'
+import {font, foregroundStyle, listStyle, multilineTextAlignment} from '@expo/ui/swift-ui/modifiers'
 import type {CourseType, TermType} from '../../source/lib/course-search'
 import {SolidBadge as Badge} from '@frogpond/badge'
-import moment from 'moment-timezone'
 import {formatDay} from '../../source/features/sis/course-search/lib/format-day'
-import {TableView, Section, Cell} from '@frogpond/tableview'
 import {
-	SelectableCell,
-	MultiLineDetailCell,
-	MultiLineLeftDetailCell,
-} from '@frogpond/tableview/cells'
+	courseSchedule,
+	type ScheduleSlot,
+} from '../../source/features/sis/course-search/lib/course-schedule'
+import {DetailRow, SelectableText} from '../../source/components/rows'
 import * as c from '@frogpond/colors'
 import {deptNum} from '../../source/features/sis/course-search/lib/format-dept-num'
 import {formatCourseNotes} from '../../source/features/sis/course-search/lib/format-course-notes'
-import groupBy from 'lodash/groupBy'
-import map from 'lodash/map'
-import zip from 'lodash/zip'
 
 import {courseByIdOptions, termByNumberOptions} from '../../source/features/sis/course-search/query'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 
 const PENDING_TERM: TermType = {hash: '', path: '', term: 0, type: '', year: 0}
 
-const Container = (props: ScrollViewProps) => (
-	<ScrollView
-		{...props}
-		contentInsetAdjustmentBehavior="automatic"
-		style={[styles.container, props.style]}
-	/>
-)
-
-const Header = (props: TextProps) => <Text {...props} style={[styles.header, props.style]} />
-const SubHeader = (props: TextProps) => <Text {...props} style={[styles.subHeader, props.style]} />
-
 const styles = StyleSheet.create({
-	chunk: {
-		paddingVertical: 10,
-	},
-	time: {
-		lineHeight: 20,
-	},
-	location: {
-		fontStyle: 'italic',
-		lineHeight: 20,
-	},
-	rightDetail: {
-		color: c.secondaryLabel,
-		textAlign: 'right',
-	},
-	container: {
-		paddingVertical: 6,
-	},
-	header: {
-		fontSize: 36,
-		textAlign: 'center',
-		marginTop: 20,
-		marginHorizontal: 10,
-		color: c.label,
-	},
-	subHeader: {
-		fontSize: 21,
-		textAlign: 'center',
-		marginTop: 5,
+	host: {
+		flex: 1,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })
 
 function Information({course}: {course: CourseType}) {
 	return (
-		<Section header="INFORMATION">
+		<Section title="INFORMATION">
 			{course.instructors ? (
-				<Cell
-					cellStyle="LeftDetail"
-					detail={course.instructors.length === 1 ? 'Instructor' : 'Instructors'}
-					title={course.instructors.join(', ')}
+				<DetailRow
+					label={course.instructors.length === 1 ? 'Instructor' : 'Instructors'}
+					value={course.instructors.join(', ')}
 				/>
 			) : null}
-			<Cell cellStyle="LeftDetail" detail="Type" title={course.type} />
-			{course.gereqs ? (
-				<Cell cellStyle="LeftDetail" detail="GEs" title={course.gereqs.join(', ')} />
-			) : null}
-			{course.pn ? (
-				<Cell cellStyle="LeftDetail" detail="Pass/Fail" title={course.pn ? 'Yes' : 'No'} />
-			) : null}
-			<MultiLineLeftDetailCell
-				detail="Prerequisites"
-				title={course.prerequisites ? course.prerequisites : 'None'}
-			/>
-			{course.credits ? (
-				<Cell cellStyle="LeftDetail" detail="Credits" title={course.credits} />
-			) : null}
+			<DetailRow label="Type" value={course.type} />
+			{course.gereqs ? <DetailRow label="GEs" value={course.gereqs.join(', ')} /> : null}
+			{course.pn ? <DetailRow label="Pass/Fail" value="Yes" /> : null}
+			<DetailRow label="Prerequisites" value={course.prerequisites || 'None'} />
+			{course.credits ? <DetailRow label="Credits" value={String(course.credits)} /> : null}
 		</Section>
 	)
 }
 
 function Schedule({course}: {course: CourseType}) {
-	if (!course.offerings) {
+	let schedule = courseSchedule(course.offerings)
+
+	if (!schedule.length) {
 		return null
 	}
-	let groupedByDay = groupBy(course.offerings, (courseOffering) => courseOffering.day)
-	let schedule = map(groupedByDay, (offerings, day) => {
-		let timesFormatted = offerings.map((offering) => {
-			let start = moment.tz(offering.start, 'H:mm', timezone()).format('h:mm A')
-			let end = moment.tz(offering.end, 'H:mm', timezone()).format('h:mm A')
-			return `${start} – ${end}`
-		})
-		let locations = offerings.map((offering) => offering.location)
 
-		let timelocs = zip(timesFormatted, locations)
-
-		let timelocsObj = timelocs.map(([time, location]) => ({time, location}))
-
-		let rightDetail = timelocsObj.map((timeloc) => (
-			<Text key={timeloc.time} style={styles.rightDetail}>
-				<Text style={styles.time}>{timeloc.time} </Text>
-				<Text style={styles.location}>({timeloc.location})</Text>
-			</Text>
-		))
-
-		return <MultiLineDetailCell key={day} rightDetail={rightDetail} title={formatDay(day)} />
-	})
-
-	return <Section header="SCHEDULE">{schedule}</Section>
+	return (
+		<Section title="SCHEDULE">
+			{schedule.map(({day, slots}) => (
+				<LabeledDay key={day} day={day} slots={slots} />
+			))}
+		</Section>
+	)
 }
+
+/**
+ * A day and everything the course does on it. Two meetings on one day stack
+ * under a single heading rather than repeating it.
+ */
+function LabeledDay({day, slots}: {day: string; slots: ScheduleSlot[]}) {
+	return (
+		<LabeledContent label={formatDay(day)}>
+			<VStack alignment="trailing" spacing={2}>
+				{slots.map((slot) => (
+					<Text key={slot.time} modifiers={SLOT_MODIFIERS}>
+						{slot.time} ({slot.location})
+					</Text>
+				))}
+			</VStack>
+		</LabeledContent>
+	)
+}
+
+const SLOT_MODIFIERS = [
+	font({textStyle: 'footnote'}),
+	foregroundStyle(c.secondaryLabel),
+	multilineTextAlignment('trailing'),
+]
 
 function Notes({course}: {course: CourseType}) {
 	if (!course.notes) {
 		return null
 	}
 
-	let notesText = formatCourseNotes(course.notes)
-
-	let notes =
-		Platform.OS === 'ios' ? (
-			<SelectableCell text={notesText} />
-		) : (
-			<Cell
-				cellContentView={
-					<Text selectable={true} style={styles.chunk}>
-						{notesText}
-					</Text>
-				}
-			/>
-		)
-
-	return <Section header="NOTES">{notes}</Section>
+	return (
+		<Section title="NOTES">
+			<SelectableText text={formatCourseNotes(course.notes)} />
+		</Section>
+	)
 }
 
 function Description({course}: {course: CourseType}) {
@@ -154,22 +103,11 @@ function Description({course}: {course: CourseType}) {
 		return null
 	}
 
-	let descText = course.description[0]
-
-	let description =
-		Platform.OS === 'ios' ? (
-			<SelectableCell text={descText} />
-		) : (
-			<Cell
-				cellContentView={
-					<Text selectable={true} style={styles.chunk}>
-						{descText}
-					</Text>
-				}
-			/>
-		)
-
-	return <Section header="DESCRIPTION">{description}</Section>
+	return (
+		<Section title="DESCRIPTION">
+			<SelectableText text={course.description[0] ?? ''} />
+		</Section>
+	)
 }
 
 const BGCOLORS = {
@@ -185,19 +123,37 @@ function CourseDetailView({course}: Props): React.ReactNode {
 	let status = course.status === 'O' ? ('Open' as const) : ('Closed' as const)
 
 	return (
-		<Container>
-			<Header>{course.title || course.name}</Header>
-			<SubHeader>{deptNum(course)}</SubHeader>
-			<Badge accentColor={BGCOLORS[status]} status={status} />
-			<TableView>
+		<Host style={styles.host}>
+			<List modifiers={[listStyle('insetGrouped')]}>
+				<Section>
+					<Text modifiers={TITLE_MODIFIERS}>{course.title || course.name}</Text>
+					<Text modifiers={SUBTITLE_MODIFIERS}>{deptNum(course)}</Text>
+					{/* The badge is a React Native component, so SwiftUI hosts it. */}
+					<RNHostView matchContents={true}>
+						<Badge accentColor={BGCOLORS[status]} status={status} />
+					</RNHostView>
+				</Section>
+
 				<Information course={course} />
 				<Schedule course={course} />
 				<Notes course={course} />
 				<Description course={course} />
-			</TableView>
-		</Container>
+			</List>
+		</Host>
 	)
 }
+
+const TITLE_MODIFIERS = [
+	font({textStyle: 'title2', weight: 'semibold'}),
+	foregroundStyle(c.label),
+	multilineTextAlignment('center'),
+]
+
+const SUBTITLE_MODIFIERS = [
+	font({textStyle: 'title3'}),
+	foregroundStyle(c.secondaryLabel),
+	multilineTextAlignment('center'),
+]
 
 export default function CourseDetailPage(): React.ReactNode {
 	let {clbid, term} = useLocalSearchParams<{clbid: string; term: string}>()

--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
-import {ScrollView, Text, StyleSheet, Image} from 'react-native'
+import {StyleSheet, Image as RNImage} from 'react-native'
+import {Host, List, RNHostView, Section, Text} from '@expo/ui/swift-ui'
+import {font, foregroundStyle, listStyle, multilineTextAlignment} from '@expo/ui/swift-ui/modifiers'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
 import {openUrl} from '@frogpond/open-url'
 import {callPhone} from '../../../source/components/call-phone'
 import {sendEmail} from '../../../source/components/send-email'
-import {Detail} from '@frogpond/lists'
-import {TableView, Section, Cell} from '@frogpond/tableview'
-import {MultiLineLeftDetailCell} from '@frogpond/tableview/cells'
+import {DetailRow, DisclosureRow} from '../../../source/components/rows'
 import * as c from '@frogpond/colors'
 import {directoryContactOptions} from '../../../source/features/directory/query'
 import type {
@@ -89,111 +89,104 @@ export default function DirectoryDetailPage(): React.ReactNode {
 	return (
 		<>
 			{screenTitle}
-			<ScrollView contentInsetAdjustmentBehavior="automatic">
-				<Image
-					accessibilityIgnoresInvertColors={true}
-					resizeMode="cover"
-					source={{uri: photo}}
-					style={styles.image}
-				/>
-				<Detail style={[styles.header, styles.headerTitle]}>{displayTitle}</Detail>
+			<Host style={styles.host}>
+				<List modifiers={[listStyle('insetGrouped')]}>
+					<Section>
+						{/* The photo is a network image, so React Native draws it and
+						    SwiftUI hosts it. */}
+						<RNHostView matchContents={true}>
+							<RNImage
+								accessibilityIgnoresInvertColors={true}
+								resizeMode="cover"
+								source={{uri: photo}}
+								style={styles.image}
+							/>
+						</RNHostView>
+						<Text modifiers={HEADER_MODIFIERS}>{displayTitle}</Text>
+					</Section>
 
-				<TableView>
 					{officeHours || email || profileUrl || pronouns ? (
-						<Section header="ABOUT">
-							{pronouns?.length ? (
-								<Cell
-									cellStyle="LeftDetail"
-									detail="Pronouns"
-									title={pronouns.join(', ').concat('')}
-								/>
-							) : null}
+						<Section title="ABOUT">
+							{pronouns?.length ? <DetailRow label="Pronouns" value={pronouns.join(', ')} /> : null}
 
 							{email ? (
-								<Cell
-									accessory="DisclosureIndicator"
-									cellStyle="LeftDetail"
-									detail="Email"
+								<DetailRow
+									label="Email"
 									onPress={() => sendEmail({to: [email], subject: '', body: ''})}
-									title={email}
+									value={email}
 								/>
 							) : null}
 
-							{officeHours && (
-								<MultiLineLeftDetailCell
-									accessory={officeHours.href ? 'DisclosureIndicator' : undefined}
-									detail={officeHours.title}
-									onPress={
-										officeHours.href
-											? () => officeHours.href && openUrl(officeHours.href)
-											: undefined
-									}
-									title={officeHours.description}
+							{officeHours ? (
+								<DetailRow
+									label={officeHours.title}
+									onPress={officeHours.href ? () => openUrl(String(officeHours.href)) : undefined}
+									value={officeHours.description}
 								/>
-							)}
+							) : null}
 
 							{profileUrl ? (
-								<Cell
-									accessory="DisclosureIndicator"
-									cellStyle="LeftDetail"
-									detail="Profile"
-									onPress={() => openUrl(profileUrl)}
-									title={profileUrl}
-								/>
+								<DetailRow label="Profile" onPress={() => openUrl(profileUrl)} value={profileUrl} />
 							) : null}
 						</Section>
 					) : null}
 
 					{campusLocations.map((loc: CampusLocation, i: number) => (
-						<Section key={i} header="OFFICE">
-							{Boolean(loc.display) && (
-								<Cell cellStyle="LeftDetail" detail="Location" title={loc.display} />
-							)}
-							{Boolean(loc.phone) && (
-								<Cell
-									accessory="DisclosureIndicator"
-									cellStyle="LeftDetail"
-									detail="Phone"
+						<Section key={i} title="OFFICE">
+							{loc.display ? <DetailRow label="Location" value={loc.display} /> : null}
+							{loc.phone ? (
+								<DetailRow
+									label="Phone"
 									onPress={() => callPhone(loc.phone, {prompt: false})}
-									title={loc.phone}
+									value={loc.phone}
 								/>
-							)}
+							) : null}
 						</Section>
 					))}
 
 					{departments.length ? (
-						<Section header={departments.length !== 1 ? 'DEPARTMENTS' : 'DEPARTMENT'}>
-							{departments.map((dept: Department, key: number) => (
-								<Cell
-									key={key}
-									accessory="DisclosureIndicator"
-									cellStyle="Basic"
-									detail="Department"
-									onPress={() => {
+						<Section title={departments.length === 1 ? 'DEPARTMENT' : 'DEPARTMENTS'}>
+							{departments.map((dept: Department) => (
+								<DisclosureRow
+									key={dept.name}
+									onPress={() =>
 										router.push({
 											pathname: '/Directory',
-											params: {
-												queryType: 'department',
-												queryParam: dept.name,
-											},
+											params: {queryType: 'department', queryParam: dept.name},
 										})
-									}}
+									}
 									title={dept.name}
 								/>
 							))}
 						</Section>
 					) : null}
-				</TableView>
 
-				<Text selectable={true} style={[styles.footer, styles.poweredBy]}>
-					Powered by the St. Olaf Directory
-				</Text>
-			</ScrollView>
+					<Section>
+						<Text modifiers={CREDIT_MODIFIERS}>Powered by the St. Olaf Directory</Text>
+					</Section>
+				</List>
+			</Host>
 		</>
 	)
 }
 
+const HEADER_MODIFIERS = [
+	font({textStyle: 'subheadline'}),
+	foregroundStyle(c.secondaryLabel),
+	multilineTextAlignment('center'),
+]
+
+const CREDIT_MODIFIERS = [
+	font({textStyle: 'caption2'}),
+	foregroundStyle(c.secondaryLabel),
+	multilineTextAlignment('center'),
+]
+
 const styles = StyleSheet.create({
+	host: {
+		flex: 1,
+		backgroundColor: c.systemGroupedBackground,
+	},
 	image: {
 		width: 100,
 		height: 100,
@@ -201,24 +194,5 @@ const styles = StyleSheet.create({
 		borderRadius: 4,
 		borderWidth: 0.2,
 		borderColor: c.label,
-		marginTop: 10,
-	},
-	header: {
-		justifyContent: 'center',
-		textAlign: 'center',
-		marginHorizontal: 30,
-	},
-	headerTitle: {
-		marginTop: 10,
-		marginBottom: 10,
-		fontSize: 14,
-	},
-	footer: {
-		fontSize: 10,
-		color: c.secondaryLabel,
-		textAlign: 'center',
-	},
-	poweredBy: {
-		paddingBottom: 20,
 	},
 })

--- a/app/(home)/StudentOrgs/[name].tsx
+++ b/app/(home)/StudentOrgs/[name].tsx
@@ -41,7 +41,16 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 	let {name} = useLocalSearchParams<{name: string}>()
 	let {data: org, isLoading, error, refetch} = useQuery(orgByNameOptions(name))
 
-	let screenTitle = <Stack.Title>{org?.name ?? name}</Stack.Title>
+	// The name is the screen, so it takes a large title -- and the card that
+	// used to repeat it below the bar is gone. Safe to collapse here: the list
+	// is the only scrollable, so there is nothing above it to collapse against
+	// instead. See the note in Directory/index.tsx.
+	let screenTitle = (
+		<>
+			<Stack.Screen options={{headerLargeTitleEnabled: true}} />
+			<Stack.Title>{org?.name ?? name}</Stack.Title>
+		</>
+	)
 
 	if (isLoading) {
 		return (

--- a/app/(home)/StudentOrgs/[name].tsx
+++ b/app/(home)/StudentOrgs/[name].tsx
@@ -20,6 +20,24 @@ import {decode} from '@frogpond/html-lib'
 import {orgByNameOptions} from '../../../source/features/student-orgs/query'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 
+/**
+ * The org's name, at the top of its own screen.
+ *
+ * A large title would be the platform idiom, but UIKit draws one on a single
+ * line -- and these names run long enough that it truncated more often than
+ * not. In the body it wraps.
+ *
+ * `frame(maxWidth: Infinity)` before the alignment: a Text is only as wide as
+ * its content, so centring inside that says nothing about the row it sits in,
+ * and the name drew left of centre until it filled the row.
+ */
+const ORG_NAME_MODIFIERS = [
+	font({textStyle: 'title', weight: 'semibold'}),
+	foregroundStyle(c.label),
+	frame({maxWidth: Infinity}),
+	multilineTextAlignment('center'),
+]
+
 /// No card behind the credit: it is a footnote about where the data came
 /// from, not a row of it.
 const CREDIT_MODIFIERS = [
@@ -41,16 +59,7 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 	let {name} = useLocalSearchParams<{name: string}>()
 	let {data: org, isLoading, error, refetch} = useQuery(orgByNameOptions(name))
 
-	// The name is the screen, so it takes a large title -- and the card that
-	// used to repeat it below the bar is gone. Safe to collapse here: the list
-	// is the only scrollable, so there is nothing above it to collapse against
-	// instead. See the note in Directory/index.tsx.
-	let screenTitle = (
-		<>
-			<Stack.Screen options={{headerLargeTitleEnabled: true}} />
-			<Stack.Title>{org?.name ?? name}</Stack.Title>
-		</>
-	)
+	let screenTitle = <Stack.Title>{org?.name ?? name}</Stack.Title>
 
 	if (isLoading) {
 		return (
@@ -92,6 +101,10 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 			{screenTitle}
 			<Host style={styles.host}>
 				<List modifiers={[listStyle('insetGrouped')]}>
+					<Section>
+						<Text modifiers={ORG_NAME_MODIFIERS}>{orgName}</Text>
+					</Section>
+
 					{category ? (
 						<Section title="CATEGORY">
 							<Text>{category}</Text>

--- a/app/(home)/StudentOrgs/[name].tsx
+++ b/app/(home)/StudentOrgs/[name].tsx
@@ -1,10 +1,16 @@
 import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import {Host, List, Section, Text} from '@expo/ui/swift-ui'
-import {font, foregroundStyle, listStyle, multilineTextAlignment} from '@expo/ui/swift-ui/modifiers'
+import {
+	font,
+	foregroundStyle,
+	frame,
+	listRowBackground,
+	listStyle,
+	multilineTextAlignment,
+} from '@expo/ui/swift-ui/modifiers'
 import {Stack, useLocalSearchParams} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
-import moment from 'moment'
 import {DisclosureRow, SelectableText} from '../../../source/components/rows'
 import * as c from '@frogpond/colors'
 import {openUrl} from '@frogpond/open-url'
@@ -14,10 +20,14 @@ import {decode} from '@frogpond/html-lib'
 import {orgByNameOptions} from '../../../source/features/student-orgs/query'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 
+/// No card behind the credit: it is a footnote about where the data came
+/// from, not a row of it.
 const CREDIT_MODIFIERS = [
 	font({textStyle: 'caption2'}),
 	foregroundStyle(c.secondaryLabel),
 	multilineTextAlignment('center'),
+	frame({maxWidth: Infinity}),
+	listRowBackground('clear'),
 ]
 
 const styles = StyleSheet.create({
@@ -66,34 +76,13 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 		)
 	}
 
-	let {
-		name: orgName,
-		category,
-		meetings,
-		website,
-		contacts,
-		advisors,
-		description,
-		lastUpdated: orgLastUpdated,
-	} = org
+	let {name: orgName, category, meetings, website, contacts, advisors, description} = org
 
 	return (
 		<>
 			{screenTitle}
 			<Host style={styles.host}>
 				<List modifiers={[listStyle('insetGrouped')]}>
-					<Section>
-						<Text
-							modifiers={[
-								font({textStyle: 'largeTitle', weight: 'light'}),
-								foregroundStyle(c.label),
-								multilineTextAlignment('center'),
-							]}
-						>
-							{orgName}
-						</Text>
-					</Section>
-
 					{category ? (
 						<Section title="CATEGORY">
 							<Text>{category}</Text>
@@ -144,10 +133,7 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 					) : null}
 
 					<Section>
-						<Text modifiers={CREDIT_MODIFIERS}>
-							Last updated: {moment(orgLastUpdated, 'MMMM, DD YYYY HH:mm:ss').calendar()}
-						</Text>
-						<Text modifiers={CREDIT_MODIFIERS}>Powered by the St. Olaf Student Orgs Database</Text>
+						<Text modifiers={CREDIT_MODIFIERS}>Powered by Presence.io</Text>
 					</Section>
 				</List>
 			</Host>

--- a/app/(home)/StudentOrgs/[name].tsx
+++ b/app/(home)/StudentOrgs/[name].tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
-import {ScrollView, Text, StyleSheet} from 'react-native'
+import {StyleSheet} from 'react-native'
+import {Host, List, Section, Text} from '@expo/ui/swift-ui'
+import {font, foregroundStyle, listStyle, multilineTextAlignment} from '@expo/ui/swift-ui/modifiers'
 import {Stack, useLocalSearchParams} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
 import moment from 'moment'
-import {Cell, Section, TableView} from '@frogpond/tableview'
-import {SelectableCell} from '@frogpond/tableview/cells'
+import {DisclosureRow, SelectableText} from '../../../source/components/rows'
 import * as c from '@frogpond/colors'
 import {openUrl} from '@frogpond/open-url'
 import {sendEmail} from '../../../source/components/send-email'
@@ -13,26 +14,16 @@ import {decode} from '@frogpond/html-lib'
 import {orgByNameOptions} from '../../../source/features/student-orgs/query'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 
+const CREDIT_MODIFIERS = [
+	font({textStyle: 'caption2'}),
+	foregroundStyle(c.secondaryLabel),
+	multilineTextAlignment('center'),
+]
+
 const styles = StyleSheet.create({
-	name: {
-		textAlign: 'center',
-		marginTop: 20,
-		marginBottom: 15,
-		paddingHorizontal: 5,
-		color: c.label,
-		fontSize: 32,
-		fontWeight: '300',
-	},
-	footer: {
-		fontSize: 10,
-		color: c.secondaryLabel,
-		textAlign: 'center',
-	},
-	lastUpdated: {
-		paddingBottom: 10,
-	},
-	poweredBy: {
-		paddingBottom: 20,
+	host: {
+		flex: 1,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })
 
@@ -89,44 +80,43 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 	return (
 		<>
 			{screenTitle}
-			<ScrollView contentInsetAdjustmentBehavior="automatic">
-				<TableView>
-					<Text selectable={true} style={styles.name}>
-						{orgName}
-					</Text>
+			<Host style={styles.host}>
+				<List modifiers={[listStyle('insetGrouped')]}>
+					<Section>
+						<Text
+							modifiers={[
+								font({textStyle: 'largeTitle', weight: 'light'}),
+								foregroundStyle(c.label),
+								multilineTextAlignment('center'),
+							]}
+						>
+							{orgName}
+						</Text>
+					</Section>
 
 					{category ? (
-						<Section header="CATEGORY">
-							<Cell cellStyle="Basic" title={category} />
+						<Section title="CATEGORY">
+							<Text>{category}</Text>
 						</Section>
 					) : null}
 
 					{meetings ? (
-						<Section header="MEETINGS">
-							<SelectableCell text={decode(meetings)} />
+						<Section title="MEETINGS">
+							<SelectableText text={decode(meetings)} />
 						</Section>
 					) : null}
 
 					{website ? (
-						<Section header="WEBSITE">
-							<Cell
-								accessory="DisclosureIndicator"
-								cellStyle="Basic"
-								onPress={() => {
-									openUrl(website)
-								}}
-								title={website}
-							/>
+						<Section title="WEBSITE">
+							<DisclosureRow onPress={() => openUrl(website)} title={website} />
 						</Section>
 					) : null}
 
 					{contacts.length ? (
-						<Section header="CONTACT">
-							{contacts.map((contact, i) => (
-								<Cell
-									key={i}
-									accessory="DisclosureIndicator"
-									cellStyle={contact.title ? 'Subtitle' : 'Basic'}
+						<Section title="CONTACT">
+							{contacts.map((contact) => (
+								<DisclosureRow
+									key={contact.email}
 									detail={contact.title}
 									onPress={() => sendEmail({to: [contact.email], subject: orgName})}
 									title={showNameOrEmail(contact)}
@@ -136,12 +126,10 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 					) : null}
 
 					{advisors.length ? (
-						<Section header={advisors.length === 1 ? 'ADVISOR' : 'ADVISORS'}>
-							{advisors.map((contact, i) => (
-								<Cell
-									key={i}
-									accessory="DisclosureIndicator"
-									cellStyle="Basic"
+						<Section title={advisors.length === 1 ? 'ADVISOR' : 'ADVISORS'}>
+							{advisors.map((contact) => (
+								<DisclosureRow
+									key={contact.email}
 									onPress={() => sendEmail({to: [contact.email], subject: orgName})}
 									title={contact.name}
 								/>
@@ -150,20 +138,19 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 					) : null}
 
 					{description ? (
-						<Section header="DESCRIPTION">
-							<SelectableCell text={decode(description)} />
+						<Section title="DESCRIPTION">
+							<SelectableText text={decode(description)} />
 						</Section>
 					) : null}
 
-					<Text selectable={true} style={[styles.footer, styles.lastUpdated]}>
-						Last updated: {moment(orgLastUpdated, 'MMMM, DD YYYY HH:mm:ss').calendar()}
-					</Text>
-
-					<Text selectable={true} style={[styles.footer, styles.poweredBy]}>
-						Powered by the St. Olaf Student Orgs Database
-					</Text>
-				</TableView>
-			</ScrollView>
+					<Section>
+						<Text modifiers={CREDIT_MODIFIERS}>
+							Last updated: {moment(orgLastUpdated, 'MMMM, DD YYYY HH:mm:ss').calendar()}
+						</Text>
+						<Text modifiers={CREDIT_MODIFIERS}>Powered by the St. Olaf Student Orgs Database</Text>
+					</Section>
+				</List>
+			</Host>
 		</>
 	)
 }

--- a/source/components/__tests__/rows.test.tsx
+++ b/source/components/__tests__/rows.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {fireEvent, render, screen} from '@testing-library/react-native'
 
-import {DisclosureRow} from '../rows'
+import {DetailRow, DisclosureRow, SelectableText} from '../rows'
 
 jest.mock('@expo/ui/swift-ui', () => {
 	// oxlint-disable-next-line typescript/no-require-imports
@@ -130,5 +130,59 @@ describe('DisclosureRow leading image', () => {
 		await render(<DisclosureRow onPress={jest.fn()} title="KSTO" />)
 
 		expect(screen.queryByTestId('disclosure-row-thumbnail')).not.toBeOnTheScreen()
+	})
+})
+
+describe('DetailRow', () => {
+	it('shows the label and its value', async () => {
+		await render(<DetailRow label="Credits" value="1.00" />)
+
+		expect(screen.getByText('Credits')).toBeOnTheScreen()
+		expect(screen.getByText('1.00')).toBeOnTheScreen()
+	})
+
+	it('calls onPress when the row is tappable', async () => {
+		let onPress = jest.fn()
+		await render(<DetailRow label="Email" onPress={onPress} value="ole@stolaf.edu" />)
+
+		fireEvent.press(screen.getByLabelText('Email, ole@stolaf.edu'))
+
+		expect(onPress).toHaveBeenCalledTimes(1)
+	})
+
+	/// A row with nowhere to go must not look like one that has somewhere.
+	it('is not a button when there is nothing to tap', async () => {
+		await render(<DetailRow label="Pronouns" value="they/them" />)
+
+		expect(screen.queryByLabelText('Pronouns, they/them')).not.toBeOnTheScreen()
+	})
+})
+
+describe('SelectableText', () => {
+	it('shows the text', async () => {
+		await render(<SelectableText text="Mondays at 7pm, Tomson 280" />)
+
+		expect(screen.getByTestId('selectable-text')).toBeOnTheScreen()
+	})
+
+	/// The reason this is a TextInput rather than an @expo/ui Text. Asking for
+	/// them collectively detects nothing under the new architecture, so a
+	/// regression here would read as "selection still works" while quietly
+	/// making every phone number and address unactionable.
+	it('names each data detector rather than asking for all of them', async () => {
+		await render(<SelectableText text="Call 507-786-2222" />)
+
+		expect(screen.getByTestId('selectable-text').props.dataDetectorTypes).toEqual([
+			'calendarEvent',
+			'link',
+			'phoneNumber',
+			'address',
+		])
+	})
+
+	it('cannot be edited', async () => {
+		await render(<SelectableText text="Mondays at 7pm" />)
+
+		expect(screen.getByTestId('selectable-text').props.editable).toBe(false)
 	})
 })

--- a/source/components/rows.tsx
+++ b/source/components/rows.tsx
@@ -206,7 +206,7 @@ const styles = StyleSheet.create({
 		resizeMode: 'cover',
 	},
 	selectableText: {
-		color: c.secondaryLabel,
+		color: c.label,
 		paddingVertical: 4,
 	},
 })

--- a/source/components/rows.tsx
+++ b/source/components/rows.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react'
-import {Image as RNImage, StyleSheet, TextInput as RNTextInput} from 'react-native'
+import {
+	Image as RNImage,
+	StyleSheet,
+	TextInput as RNTextInput,
+	useWindowDimensions,
+} from 'react-native'
 import type {ColorValue} from 'react-native'
 import type {SFSymbol} from 'sf-symbols-typescript'
 import {
@@ -282,7 +287,22 @@ const DETECTED_TYPES: React.ComponentProps<typeof RNTextInput>['dataDetectorType
 	'address',
 ]
 
+/**
+ * What an inset-grouped row leaves for its content: the list's own margin
+ * either side of the card, and the card's padding either side of the row.
+ *
+ * Stated rather than measured because a hosted view reports its own intrinsic
+ * size, and a paragraph's intrinsic width is however long its longest line
+ * would be unwrapped -- far wider than the row, so it drew clipped at both
+ * edges until given a width to wrap to.
+ */
+const LIST_MARGIN = 20
+const ROW_PADDING = 16
+const ROW_CONTENT_INSET = (LIST_MARGIN + ROW_PADDING) * 2
+
 export function SelectableText({text}: {text: string}): React.ReactNode {
+	let {width: screenWidth} = useWindowDimensions()
+
 	return (
 		<RNHostView matchContents={true}>
 			<RNTextInput
@@ -290,7 +310,7 @@ export function SelectableText({text}: {text: string}): React.ReactNode {
 				editable={false}
 				multiline={true}
 				scrollEnabled={false}
-				style={styles.selectableText}
+				style={[styles.selectableText, {width: screenWidth - ROW_CONTENT_INSET}]}
 				testID={SELECTABLE_TEXT_ID}
 				value={text}
 			/>

--- a/source/components/rows.tsx
+++ b/source/components/rows.tsx
@@ -1,8 +1,17 @@
 import * as React from 'react'
-import {Image as RNImage, StyleSheet} from 'react-native'
+import {Image as RNImage, StyleSheet, TextInput as RNTextInput} from 'react-native'
 import type {ColorValue} from 'react-native'
 import type {SFSymbol} from 'sf-symbols-typescript'
-import {Button, HStack, Image, RNHostView, Spacer, Text, VStack} from '@expo/ui/swift-ui'
+import {
+	Button,
+	HStack,
+	Image,
+	LabeledContent,
+	RNHostView,
+	Spacer,
+	Text,
+	VStack,
+} from '@expo/ui/swift-ui'
 import {
 	accessibilityLabel,
 	buttonStyle,
@@ -10,8 +19,9 @@ import {
 	disabled as disabledModifier,
 	font,
 	foregroundStyle,
-	lineLimit,
 	frame,
+	lineLimit,
+	multilineTextAlignment,
 	shapes,
 	truncationMode,
 } from '@expo/ui/swift-ui/modifiers'
@@ -190,4 +200,100 @@ const styles = StyleSheet.create({
 	thumbnail: {
 		resizeMode: 'cover',
 	},
+	selectableText: {
+		color: c.secondaryLabel,
+		paddingVertical: 4,
+	},
 })
+
+type DetailRowProps = {
+	/** The quieter half: what this value is. */
+	label: string
+	/** The value itself. */
+	value: string
+	/** How many lines the value may wrap to. Unbounded by default. */
+	valueLines?: number
+	/** Makes the row tappable, and draws a chevron to say so. */
+	onPress?: () => void
+}
+
+/**
+ * A label and its value, side by side -- the shape most of the detail screens
+ * are made of.
+ *
+ * `LabeledContent` is SwiftUI's own, so the two halves align with every other
+ * row in the list and follow the platform's own emphasis rather than ours.
+ */
+export function DetailRow(props: DetailRowProps): React.ReactNode {
+	let {label, value, valueLines, onPress} = props
+
+	let content = (
+		<LabeledContent label={label}>
+			<HStack spacing={6}>
+				<Text
+					modifiers={[
+						foregroundStyle(c.secondaryLabel),
+						multilineTextAlignment('trailing'),
+						...(valueLines ? [lineLimit(valueLines)] : []),
+					]}
+				>
+					{value}
+				</Text>
+				{onPress ? <Image color={c.tertiaryLabel} size={14} systemName="chevron.right" /> : null}
+			</HStack>
+		</LabeledContent>
+	)
+
+	if (!onPress) {
+		return content
+	}
+
+	return (
+		<Button
+			modifiers={[buttonStyle('plain'), accessibilityLabel(`${label}, ${value}`)]}
+			onPress={onPress}
+		>
+			{/* contentShape on the label, not the Button -- see NavigationRow. */}
+			<HStack modifiers={[contentShape(shapes.rectangle())]}>{content}</HStack>
+		</Button>
+	)
+}
+
+/// Mirrored by `TestIdentifiers.Rows.selectableText`.
+const SELECTABLE_TEXT_ID = 'selectable-text'
+
+/**
+ * A block of text a reader can select, and whose phone numbers, addresses,
+ * links and dates iOS turns into things they can tap.
+ *
+ * A React Native `TextInput` rather than an `@expo/ui` `Text`: SwiftUI's
+ * `textSelection` gives selection but no data detectors, and losing those would
+ * make an org's meeting time or a course's room number unactionable.
+ *
+ * `dataDetectorTypes="all"` detects nothing under the new architecture --
+ * `UIDataDetectorTypeAll` is `NSUIntegerMax`, which React Native reads through
+ * `unsignedIntValue` and truncates to 32 bits -- so the types are spelled out.
+ * See https://github.com/facebook/react-native/issues/55367.
+ */
+const DETECTED_TYPES: React.ComponentProps<typeof RNTextInput>['dataDetectorTypes'] = [
+	'calendarEvent',
+	'link',
+	'phoneNumber',
+	'address',
+]
+
+export function SelectableText({text}: {text: string}): React.ReactNode {
+	return (
+		<RNHostView matchContents={true}>
+			<RNTextInput
+				dataDetectorTypes={DETECTED_TYPES}
+				editable={false}
+				multiline={true}
+				scrollEnabled={false}
+				style={styles.selectableText}
+				testID={SELECTABLE_TEXT_ID}
+				value={text}
+			/>
+		</RNHostView>
+	)
+}

--- a/source/features/sis/__tests__/balance-value.test.ts
+++ b/source/features/sis/__tests__/balance-value.test.ts
@@ -1,0 +1,23 @@
+import {balanceValue} from '../lib'
+
+describe('balanceValue', () => {
+	it('shows a balance the server sent', () => {
+		expect(balanceValue('12.34', false)).toBe('12.34')
+	})
+
+	/// A balance of zero is a real answer and must not read as missing.
+	it('shows a zero balance rather than treating it as absent', () => {
+		expect(balanceValue('0.00', false)).toBe('0.00')
+	})
+
+	it('says N/A when the server sent nothing', () => {
+		expect(balanceValue(undefined, false)).toBe('N/A')
+	})
+
+	/// While loading there is no answer yet, which is different from not having
+	/// one -- an ellipsis rather than N/A.
+	it('waits rather than claiming N/A while loading', () => {
+		expect(balanceValue(undefined, true)).toBe('…')
+		expect(balanceValue('12.34', true)).toBe('…')
+	})
+})

--- a/source/features/sis/__tests__/uitest-balances.test.ts
+++ b/source/features/sis/__tests__/uitest-balances.test.ts
@@ -1,0 +1,26 @@
+import {UITEST_BALANCES} from '../../../lib/financials/__fixtures__/balances'
+import {balanceValue} from '../lib'
+
+/// The fixtures exist so the balances layout can be photographed with figures
+/// in it. That only holds if every tile has something to show, and if the
+/// awkward ones survive the formatting the screen puts them through.
+describe('the UI test balances', () => {
+	it('fills every tile', () => {
+		let {flex, ole, print, daily, weekly} = UITEST_BALANCES
+
+		for (let value of [flex, ole, print, daily, weekly]) {
+			expect(balanceValue(value, false)).not.toBe('N/A')
+		}
+	})
+
+	it('names a meal plan, so that row is drawn at all', () => {
+		expect(UITEST_BALANCES.plan).toBeTruthy()
+	})
+
+	/// A zero balance is the case most likely to be mistaken for a missing one,
+	/// which is why one of the fixtures is zero.
+	it('keeps a zero balance rather than showing it as missing', () => {
+		expect(UITEST_BALANCES.ole).toBe('$0.00')
+		expect(balanceValue(UITEST_BALANCES.ole, false)).toBe('$0.00')
+	})
+})

--- a/source/features/sis/balances.tsx
+++ b/source/features/sis/balances.tsx
@@ -1,22 +1,25 @@
 import * as React from 'react'
+import {StyleSheet} from 'react-native'
+import {Host, HStack, List, RNHostView, Section, Text, VStack} from '@expo/ui/swift-ui'
 import {
-	StyleSheet,
-	ScrollView,
-	View,
-	Text,
-	RefreshControl,
-	StyleProp,
-	ViewStyle,
-} from 'react-native'
-import {Cell, TableView, Section} from '@frogpond/tableview'
-import {BalancesShapeType, balancesOptions} from '../../lib/financials'
+	font,
+	foregroundStyle,
+	frame,
+	listStyle,
+	multilineTextAlignment,
+	refreshable,
+	textSelection,
+} from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
+import {BalancesShapeType, balancesOptions} from '../../lib/financials'
 import {sto} from '../../lib/colors'
 import {useRouter} from 'expo-router'
 import {NoCredentialsError, credentialsOptions} from '../../lib/login'
 import {useQuery} from '@tanstack/react-query'
 import {FaqBannerGroup} from '../../features/faqs/banner'
 import {FAQ_TARGETS} from '../../features/faqs/constants'
+import {DetailRow, DisclosureRow} from '../../components/rows'
+import {balanceValue} from './lib'
 
 const DISCLAIMER = 'This data may be outdated or otherwise inaccurate.'
 
@@ -34,7 +37,6 @@ export const BalancesView = (): React.ReactNode => {
 		isError,
 		isLoading,
 		refetch,
-		isRefetching,
 	} = useQuery(balancesOptions(username))
 
 	// Settings hasn't been migrated to expo-router yet, so there's no route
@@ -43,147 +45,98 @@ export const BalancesView = (): React.ReactNode => {
 	// unreachable already) until that migration lands.
 	// oxlint-disable-next-line typescript/no-empty-function
 	let openSettings = () => {}
-	let refresh = <RefreshControl onRefresh={refetch} refreshing={isRefetching} />
 
 	return (
-		<ScrollView
-			contentContainerStyle={styles.stage}
-			contentInsetAdjustmentBehavior="automatic"
-			refreshControl={refresh}
-			testID="balances-view"
-		>
-			<FaqBannerGroup
-				onPressFaq={(faqId) => router.push({pathname: '/Faq', params: {faqId}})}
-				style={styles.banner}
-				target={FAQ_TARGETS.SIS}
-			/>
-			<TableView>
-				<Section footer={DISCLAIMER} header="BALANCES">
-					<View style={styles.balancesRow}>
-						<FormattedValueCell indeterminate={isLoading} label="Flex" value={data.flex} />
-
-						<FormattedValueCell indeterminate={isLoading} label="Ole" value={data.ole} />
-
-						<FormattedValueCell
-							indeterminate={isLoading}
-							label="Copy/Print"
-							style={styles.finalCell}
-							value={data.print}
+		<Host style={styles.host} testID="balances-view">
+			<List
+				modifiers={[
+					listStyle('insetGrouped'),
+					refreshable(async () => {
+						await refetch()
+					}),
+				]}
+			>
+				<Section>
+					<RNHostView matchContents={true}>
+						<FaqBannerGroup
+							onPressFaq={(faqId) => router.push({pathname: '/Faq', params: {faqId}})}
+							target={FAQ_TARGETS.SIS}
 						/>
-					</View>
+					</RNHostView>
 				</Section>
 
-				<Section footer={DISCLAIMER} header="MEAL PLAN">
-					<View style={styles.balancesRow}>
-						<FormattedValueCell
-							indeterminate={isLoading}
-							label="Daily Meals Left"
-							value={data.daily}
-						/>
-
-						<FormattedValueCell
-							indeterminate={isLoading}
-							label="Weekly Meals Left"
-							style={styles.finalCell}
-							value={data.weekly}
-						/>
-					</View>
-					{Boolean(data.plan) && data.plan != null && (
-						<Cell cellStyle="Subtitle" detail={data.plan} title="Meal Plan" />
-					)}
+				<Section footer={<Text>{DISCLAIMER}</Text>} title="BALANCES">
+					<HStack spacing={0}>
+						<BalanceTile isLoading={isLoading} label="Flex" value={data.flex} />
+						<BalanceTile isLoading={isLoading} label="Ole" value={data.ole} />
+						<BalanceTile isLoading={isLoading} label="Copy/Print" value={data.print} />
+					</HStack>
 				</Section>
 
-				{isError && error instanceof Error && (
-					<Section footer="You'll need to log in in order to see this data.">
+				<Section footer={<Text>{DISCLAIMER}</Text>} title="MEAL PLAN">
+					<HStack spacing={0}>
+						<BalanceTile isLoading={isLoading} label="Daily Meals Left" value={data.daily} />
+						<BalanceTile isLoading={isLoading} label="Weekly Meals Left" value={data.weekly} />
+					</HStack>
+					{data.plan ? <DetailRow label="Meal Plan" value={data.plan} /> : null}
+				</Section>
+
+				{isError && error instanceof Error ? (
+					<Section footer={<Text>You&apos;ll need to log in in order to see this data.</Text>}>
 						{error instanceof NoCredentialsError ? (
-							<Cell
-								accessory="DisclosureIndicator"
-								cellStyle="Basic"
-								onPress={openSettings}
-								title="Log in with St. Olaf"
-							/>
+							<DisclosureRow onPress={openSettings} title="Log in with St. Olaf" />
 						) : (
-							<Cell cellStyle="Basic" title={error.message} titleTextColor={sto.red} />
+							<Text modifiers={[foregroundStyle(sto.red)]}>{error.message}</Text>
 						)}
 					</Section>
-				)}
-			</TableView>
-		</ScrollView>
+				) : null}
+			</List>
+		</Host>
+	)
+}
+
+/**
+ * One figure and what it counts, sharing a row with its siblings.
+ *
+ * `frame(maxWidth: Infinity)` on each is what splits the row evenly: three
+ * balances or two meal counts, without either arrangement needing to say how
+ * many there are.
+ */
+function BalanceTile(props: {
+	isLoading: boolean
+	label: string
+	value: string | undefined
+}): React.ReactNode {
+	let {isLoading, label, value} = props
+
+	return (
+		<VStack modifiers={[frame({maxWidth: Infinity})]} spacing={6}>
+			<Text
+				modifiers={[
+					font({textStyle: 'title2', weight: 'ultraLight'}),
+					foregroundStyle(c.secondaryLabel),
+					multilineTextAlignment('center'),
+					textSelection(true),
+				]}
+			>
+				{balanceValue(value, isLoading)}
+			</Text>
+			<Text
+				modifiers={[
+					font({textStyle: 'subheadline'}),
+					foregroundStyle(c.label),
+					multilineTextAlignment('center'),
+				]}
+			>
+				{label}
+			</Text>
+		</VStack>
 	)
 }
 
 let styles = StyleSheet.create({
-	stage: {
-		paddingVertical: 20,
-	},
-	banner: {
-		marginHorizontal: 16,
-		marginBottom: 16,
-	},
-
-	balances: {
-		borderRightWidth: StyleSheet.hairlineWidth,
-		borderRightColor: c.separator,
-	},
-
-	finalCell: {
-		borderRightWidth: 0,
-	},
-
-	balancesRow: {
-		flexDirection: 'row',
-		marginTop: 0,
-		marginBottom: -10,
-	},
-
-	rectangle: {
-		backgroundColor: c.secondarySystemGroupedBackground,
-		height: 88,
+	host: {
 		flex: 1,
-		alignItems: 'center',
-		paddingVertical: 10,
-		paddingHorizontal: 10,
-		marginBottom: 10,
-	},
-
-	// Text styling
-	financialText: {
-		paddingTop: 8,
-		color: c.secondaryLabel,
-		textAlign: 'center',
-		fontWeight: '200',
-		fontSize: 23,
-	},
-	rectangleButtonText: {
-		paddingTop: 15,
-		color: c.label,
-		textAlign: 'center',
-		fontSize: 16,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })
-
-function getValueOrNa(value: string | undefined): string {
-	if (value === undefined) {
-		return 'N/A'
-	}
-	return value
-}
-
-function FormattedValueCell(props: {
-	indeterminate: boolean
-	label: string
-	value: string | undefined
-	style?: StyleProp<ViewStyle>
-	formatter?: (str: string | undefined) => string
-}) {
-	let {indeterminate, label, value, style, formatter = getValueOrNa} = props
-
-	return (
-		<View style={[styles.rectangle, styles.balances, style]}>
-			<Text selectable={true} style={styles.financialText}>
-				{indeterminate ? '…' : formatter(value)}
-			</Text>
-			<Text style={styles.rectangleButtonText}>{label}</Text>
-		</View>
-	)
-}

--- a/source/features/sis/balances.tsx
+++ b/source/features/sis/balances.tsx
@@ -113,7 +113,7 @@ function BalanceTile(props: {
 		<VStack modifiers={[frame({maxWidth: Infinity})]} spacing={6}>
 			<Text
 				modifiers={[
-					font({textStyle: 'title2', weight: 'ultraLight'}),
+					font({textStyle: 'title2'}),
 					foregroundStyle(c.secondaryLabel),
 					multilineTextAlignment('center'),
 					textSelection(true),

--- a/source/features/sis/components/recents-list.tsx
+++ b/source/features/sis/components/recents-list.tsx
@@ -40,9 +40,10 @@ function RecentItemsList(props: Props): React.ReactNode {
 				/>
 			) : (
 				items.map((item, i) => (
-					<>
+					// The key belongs on what `map` returns -- on the Pressable
+					// inside, React never saw it, and every recent search warned.
+					<React.Fragment key={item}>
 						<Pressable
-							key={item}
 							// adding long press allows for copy text when selectable is true
 							onLongPress={noop}
 							onPress={() => props.onItemPress(item)}
@@ -55,7 +56,7 @@ function RecentItemsList(props: Props): React.ReactNode {
 						</Pressable>
 
 						{i < items.length - 1 ? <ListSeparator spacing={{left: 17, right: 17}} /> : null}
-					</>
+					</React.Fragment>
 				))
 			)}
 		</>

--- a/source/features/sis/course-search/lib/__tests__/course-schedule.test.ts
+++ b/source/features/sis/course-search/lib/__tests__/course-schedule.test.ts
@@ -1,0 +1,48 @@
+import {setTimezone} from '@frogpond/constants'
+import {courseSchedule} from '../course-schedule'
+import type {CourseType} from '../../../../../lib/course-search'
+
+setTimezone('America/Chicago')
+
+function offerings(list: {day: string; start: string; end: string; location: string}[]) {
+	return list as CourseType['offerings']
+}
+
+describe('courseSchedule', () => {
+	it('groups a course by day, in the order the days arrive', () => {
+		let schedule = courseSchedule(
+			offerings([
+				{day: 'Mo', start: '9:00', end: '10:00', location: 'RNS 310'},
+				{day: 'We', start: '9:00', end: '10:00', location: 'RNS 310'},
+			]),
+		)
+
+		expect(schedule.map((s) => s.day)).toEqual(['Mo', 'We'])
+	})
+
+	it('formats each slot as a twelve-hour range with its room', () => {
+		let schedule = courseSchedule(
+			offerings([{day: 'Mo', start: '13:05', end: '14:00', location: 'RNS 310'}]),
+		)
+
+		expect(schedule[0]?.slots).toEqual([{time: '1:05 PM – 2:00 PM', location: 'RNS 310'}])
+	})
+
+	/// A lab that meets twice on one day is two slots under one heading, not two
+	/// headings.
+	it('keeps two slots on the same day together', () => {
+		let schedule = courseSchedule(
+			offerings([
+				{day: 'Tu', start: '8:00', end: '9:00', location: 'RNS 310'},
+				{day: 'Tu', start: '14:00', end: '16:00', location: 'RNS 190'},
+			]),
+		)
+
+		expect(schedule).toHaveLength(1)
+		expect(schedule[0]?.slots).toHaveLength(2)
+	})
+
+	it('has nothing to show for a course with no offerings', () => {
+		expect(courseSchedule(undefined)).toEqual([])
+	})
+})

--- a/source/features/sis/course-search/lib/__tests__/uitest-courses.test.ts
+++ b/source/features/sis/course-search/lib/__tests__/uitest-courses.test.ts
@@ -1,0 +1,41 @@
+import {
+	UITEST_COURSES,
+	UITEST_COURSE_NAME,
+} from '../../../../../lib/course-search/__fixtures__/courses'
+import {courseSchedule} from '../course-schedule'
+import {setTimezone} from '@frogpond/constants'
+
+setTimezone('America/Chicago')
+
+/// The fixture exists so the course detail screen has every section to draw.
+/// A section whose field went missing would leave that part of the screen
+/// blank, and the capture would look fine.
+describe('the UI test course', () => {
+	let [course] = UITEST_COURSES
+
+	it('is there at all', () => {
+		expect(course).toBeDefined()
+	})
+
+	it('is the course the tests search for', () => {
+		expect(course?.name).toBe(UITEST_COURSE_NAME)
+	})
+
+	it('carries something for every section of the detail screen', () => {
+		expect(course?.instructors?.length).toBeGreaterThan(1)
+		expect(course?.gereqs?.length).toBeTruthy()
+		expect(course?.prerequisites).toBeTruthy()
+		expect(course?.notes?.length).toBeTruthy()
+		expect(course?.description?.length).toBeTruthy()
+		expect(course?.credits).toBeTruthy()
+	})
+
+	/// Two meetings on one Friday, so the schedule has a grouped row to draw --
+	/// the case courseSchedule exists to handle.
+	it('meets twice on one day, so the schedule groups a row', () => {
+		let schedule = courseSchedule(course?.offerings)
+		let friday = schedule.find((day) => day.day === 'Fr')
+
+		expect(friday?.slots).toHaveLength(2)
+	})
+})

--- a/source/features/sis/course-search/lib/course-schedule.ts
+++ b/source/features/sis/course-search/lib/course-schedule.ts
@@ -1,0 +1,44 @@
+import {timezone} from '@frogpond/constants'
+import moment from 'moment-timezone'
+import type {CourseType} from '../../../../lib/course-search'
+
+/** One meeting: when it runs and where. */
+export interface ScheduleSlot {
+	time: string
+	location: string
+}
+
+/** A day's meetings, which may be more than one for a course with a lab. */
+export interface ScheduleDay {
+	day: string
+	slots: ScheduleSlot[]
+}
+
+/**
+ * A course's offerings gathered by day, with each slot's times formatted in
+ * campus time.
+ *
+ * The feed sends one record per meeting, so a course meeting twice on a Tuesday
+ * arrives as two records that belong under one heading.
+ */
+// Typed optional despite the feed's own type saying otherwise: the screen has
+// always guarded against a course arriving without offerings, so the guard is
+// answering something real.
+export function courseSchedule(offerings: CourseType['offerings'] | undefined): ScheduleDay[] {
+	if (!offerings) {
+		return []
+	}
+
+	let byDay = new Map<string, ScheduleSlot[]>()
+
+	for (let offering of offerings) {
+		let start = moment.tz(offering.start, 'H:mm', timezone()).format('h:mm A')
+		let end = moment.tz(offering.end, 'H:mm', timezone()).format('h:mm A')
+
+		let slots = byDay.get(offering.day) ?? []
+		slots.push({time: `${start} – ${end}`, location: offering.location})
+		byDay.set(offering.day, slots)
+	}
+
+	return [...byDay].map(([day, slots]) => ({day, slots}))
+}

--- a/source/features/sis/lib.ts
+++ b/source/features/sis/lib.ts
@@ -1,0 +1,12 @@
+/**
+ * What a balance tile shows: the figure, or why there isn't one.
+ *
+ * Loading and absent are different answers -- an ellipsis says "not yet",
+ * where N/A says "the server had nothing".
+ */
+export function balanceValue(value: string | undefined, isLoading: boolean): string {
+	if (isLoading) {
+		return '…'
+	}
+	return value ?? 'N/A'
+}

--- a/source/lib/course-search/__fixtures__/courses.ts
+++ b/source/lib/course-search/__fixtures__/courses.ts
@@ -1,0 +1,67 @@
+import type {RawCourseType, TermInfoType} from '../types'
+
+/**
+ * One term and one course, for UI testing.
+ *
+ * The catalogue is several megabytes of live data that changes every
+ * registration cycle, so a test searching it cannot say what it will find. This
+ * is the smallest set that still reaches the detail screen: a term to search,
+ * and a course in it to open.
+ *
+ * The course is built to exercise the detail screen's every section rather than
+ * to be typical -- it has instructors, GEs, prerequisites, notes, a
+ * description, and a lab that meets twice on one day so the schedule has a
+ * grouped row to draw.
+ */
+export const UITEST_TERM = {
+	hash: 'uitest',
+	path: '2026-1.json',
+	term: 20261,
+	type: 'json',
+	year: 2026,
+} as const
+
+export const UITEST_TERM_INFO: TermInfoType = {
+	files: [UITEST_TERM],
+	type: 'json',
+}
+
+/// Mirrored by `TestIdentifiers.CourseCatalog.aCourse`.
+export const UITEST_COURSE_NAME = 'Hybrid Test Course'
+
+export const UITEST_COURSES: RawCourseType[] = [
+	{
+		clbid: 170131,
+		credits: 1,
+		crsid: 1,
+		department: 'CSCI',
+		description: [
+			'A course that exists only under UI testing, so the detail screen has every one of its sections to draw.',
+		],
+		enrolled: 12,
+		gereqs: ['SED', 'WRI'],
+		instructors: ['Ada Lovelace', 'Grace Hopper'],
+		level: 200,
+		max: 30,
+		name: UITEST_COURSE_NAME,
+		notes: ['Meets in the second half of the semester.'],
+		number: 251,
+		offerings: [
+			{day: 'Mo', start: '9:00', end: '10:00', location: 'RNS 310'},
+			{day: 'We', start: '9:00', end: '10:00', location: 'RNS 310'},
+			// Twice on one Friday: the case the schedule has to group rather
+			// than draw as two headings.
+			{day: 'Fr', start: '9:00', end: '10:00', location: 'RNS 310'},
+			{day: 'Fr', start: '13:00', end: '15:00', location: 'RNS 190'},
+		],
+		pn: true,
+		prerequisites: 'CSCI 125 or consent of instructor',
+		section: 'A',
+		semester: 1,
+		status: 'O',
+		term: 20261,
+		title: UITEST_COURSE_NAME,
+		type: 'Research',
+		year: 2026,
+	},
+]

--- a/source/lib/course-search/urls.ts
+++ b/source/lib/course-search/urls.ts
@@ -1,5 +1,7 @@
 import ky, {Options} from 'ky'
+import {isUITesting} from '@frogpond/launch-arguments'
 import {CourseType, RawCourseType, TermInfoType, TermType} from './types'
+import {UITEST_COURSES, UITEST_TERM_INFO} from './__fixtures__/courses'
 import intersection from 'lodash/intersection'
 
 const BASE_URL = 'https://stolaf.dev'
@@ -10,8 +12,11 @@ export const DEPT_DATA = `${BASE_URL}/course-data/data-lists/valid_departments.j
 export const TIMES_DATA = `${BASE_URL}/course-data/data-lists/valid_times.json`
 
 export let client = ky.create({baseUrl: COURSE_DATA_PAGE})
+// The catalogue is several megabytes that change every registration cycle, so
+// a UI test searching it cannot say what it will find -- see
+// `source/features/dictionary/query.ts` for the same reasoning about entries.
 export let infoJson = (options?: Options): Promise<TermInfoType> =>
-	client.get('info.json', options).json()
+	isUITesting ? Promise.resolve(UITEST_TERM_INFO) : client.get('info.json', options).json()
 export let geData = (options?: Options): Promise<string[]> =>
 	client.get('data-lists/valid_gereqs.json', options).json()
 export let deptData = (options?: Options): Promise<string[]> =>
@@ -24,7 +29,9 @@ export let coursesForTerm = async (
 	gereqs: string[] = [],
 	options?: Options,
 ): Promise<Array<CourseType>> => {
-	let data: RawCourseType[] = await client.get(`${term.path}`, options).json()
+	let data: RawCourseType[] = isUITesting
+		? UITEST_COURSES
+		: await client.get(`${term.path}`, options).json()
 	return data
 		.map((course) => ({
 			spaceAvailable: course.enrolled < course.max,

--- a/source/lib/financials/__fixtures__/balances.ts
+++ b/source/lib/financials/__fixtures__/balances.ts
@@ -1,0 +1,22 @@
+import type {BalancesShapeType} from '../types'
+
+/**
+ * Balances for UI testing.
+ *
+ * There is no other way to see this screen: St. Olaf moved the balances login
+ * behind Google sign-in, which the app cannot do, so every real run shows N/A
+ * in each tile and the FAQ banner explaining why. Without fixtures the layout
+ * can only ever be photographed empty.
+ *
+ * The figures are deliberately awkward -- a four-figure balance, a zero, and a
+ * half meal -- so a tile that cannot fit its number, or that treats zero as
+ * missing, shows up rather than passing on tidy round data.
+ */
+export const UITEST_BALANCES: BalancesShapeType = {
+	flex: '$1,234.56',
+	ole: '$0.00',
+	print: '$12.34',
+	daily: '2',
+	weekly: '10.5',
+	plan: 'Ole Unlimited',
+}

--- a/source/lib/financials/balances.ts
+++ b/source/lib/financials/balances.ts
@@ -1,6 +1,8 @@
 import ky from 'ky'
+import {isUITesting} from '@frogpond/launch-arguments'
 import {OLECARD_DATA_ENDPOINT} from './urls'
 import type {BalancesShapeType, OleCardBalancesType} from './types'
+import {UITEST_BALANCES} from './__fixtures__/balances'
 import {performLogin} from '../login'
 import {queryOptions} from '@tanstack/react-query'
 
@@ -12,11 +14,19 @@ export const queryKeys = {
 export const balancesOptions = (username: string | undefined) =>
 	queryOptions({
 		queryKey: queryKeys.default(username),
-		enabled: Boolean(username),
+		// A mocked run needs no account, so it must not wait for one -- with no
+		// credentials the username is empty and the query would never run at all.
+		enabled: isUITesting || Boolean(username),
 		queryFn: () => getBalances(),
 	})
 
 export async function getBalances(): Promise<BalancesShapeType> {
+	// Ahead of `performLogin`, which a UI-test run has no account for -- and
+	// which St. Olaf now answers with a Google sign-in the app cannot complete.
+	if (isUITesting) {
+		return UITEST_BALANCES
+	}
+
 	await performLogin()
 
 	const url = OLECARD_DATA_ENDPOINT

--- a/source/testing/expo-ui-mock.tsx
+++ b/source/testing/expo-ui-mock.tsx
@@ -184,6 +184,20 @@ export function Menu({
 	)
 }
 
+/// A label beside its value. The real one is SwiftUI's own `LabeledContent`,
+/// which draws the label leading and the content trailing.
+export function LabeledContent({
+	children,
+	label,
+}: WithModifiers & {label?: string | React.ReactNode}): React.ReactNode {
+	return (
+		<View>
+			{typeof label === 'string' ? <RNText>{label}</RNText> : label}
+			{children}
+		</View>
+	)
+}
+
 export function RNHostView({children}: WithModifiers): React.ReactNode {
 	return <View>{children}</View>
 }
@@ -290,6 +304,10 @@ export const tint = (color: unknown): Modifier => ({$type: 'tint', color})
 export const listStyle = (style: string): Modifier => ({$type: 'listStyle', style})
 export const lineLimit = (value: unknown): Modifier => ({$type: 'lineLimit', value})
 export const truncationMode = (mode: string): Modifier => ({$type: 'truncationMode', mode})
+export const multilineTextAlignment = (alignment: string): Modifier => ({
+	$type: 'multilineTextAlignment',
+	alignment,
+})
 export const lineSpacing = (value: number): Modifier => ({$type: 'lineSpacing', value})
 export const italic = (): Modifier => ({$type: 'italic'})
 export const bold = (): Modifier => ({$type: 'bold'})

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -90,6 +90,11 @@ class StageOneListsTests: UITestCase {
 		XCTAssertTrue(firstOrg.waitForExistence(timeout: 30), "An org should be listed")
 		firstOrg.tap()
 
+		// Wait for a section of the pushed screen, not just the tap: a capture
+		// taken straight after lands mid-animation, with both screens on it.
+		let category = app.staticTexts["CATEGORY"].firstMatch
+		XCTAssertTrue(category.waitForExistence(timeout: 30), "The org detail should be shown")
+
 		screen.capture("Student Orgs - detail")
 	}
 

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -114,7 +114,10 @@ class StageOneListsTests: UITestCase {
 		field.tap()
 		field.typeText(TestIdentifiers.CourseCatalog.aCourse)
 
-		let result = app.buttons
+		// Any descendant, not a button: the results list is the one screen still
+		// on SectionList, so its rows are React Native views rather than
+		// SwiftUI buttons.
+		let result = app.descendants(matching: .any)
 			.matching(NSPredicate(format: "label CONTAINS %@", TestIdentifiers.CourseCatalog.aCourse))
 			.firstMatch
 		XCTAssertTrue(result.waitForExistence(timeout: 30), "The fixture course should be found")

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -71,6 +71,38 @@ class StageOneListsTests: UITestCase {
 			.capture("Streaming Media")
 	}
 
+	/// The four detail screens, each of which is mostly label-beside-value rows.
+	func testSISBalances() throws {
+		SISScreen(app: app)
+			.navigate()
+			.acceptAcknowledgement()
+			.checkBalancesVisible()
+			.capture("SIS - Balances")
+	}
+
+	func testStudentOrgDetail() throws {
+		let screen = StudentOrgsScreen(app: app).navigate()
+
+		// The first org alphabetically, whatever the college is listing today.
+		let firstOrg = app.buttons
+			.matching(NSPredicate(format: "label BEGINSWITH %@", "Academic"))
+			.firstMatch
+		XCTAssertTrue(firstOrg.waitForExistence(timeout: 30), "An org should be listed")
+		firstOrg.tap()
+
+		screen.capture("Student Orgs - detail")
+	}
+
+	func testDirectoryContactDetail() throws {
+		let screen = DirectoryScreen(app: app).navigate()
+
+		let contact = app.buttonLabelled(TestIdentifiers.Directory.aContact)
+		XCTAssertTrue(contact.waitForExistence(timeout: 30), "A contact tile should be shown")
+		contact.tap()
+
+		screen.capture("Directory - contact detail")
+	}
+
 	func testMoreList() throws {
 		MoreScreen(app: app)
 			.navigate()

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -103,6 +103,31 @@ class StageOneListsTests: UITestCase {
 		screen.capture("Directory - contact detail")
 	}
 
+	/// Searches the catalogue, which under UI testing holds one course, and
+	/// opens it. That course carries something for every section the detail
+	/// screen draws.
+	func testCourseDetail() throws {
+		let screen = CourseCatalogScreen(app: app).navigate()
+
+		let field = app.searchFields.firstMatch
+		XCTAssertTrue(field.waitForExistence(timeout: 30), "Course search should offer a field")
+		field.tap()
+		field.typeText(TestIdentifiers.CourseCatalog.aCourse)
+
+		let result = app.buttons
+			.matching(NSPredicate(format: "label CONTAINS %@", TestIdentifiers.CourseCatalog.aCourse))
+			.firstMatch
+		XCTAssertTrue(result.waitForExistence(timeout: 30), "The fixture course should be found")
+		result.tap()
+
+		let prerequisites = app.staticTexts["Prerequisites"].firstMatch
+		XCTAssertTrue(
+			prerequisites.waitForExistence(timeout: 30),
+			"The course detail screen should be shown")
+
+		screen.capture("Course detail")
+	}
+
 	func testMoreList() throws {
 		MoreScreen(app: app)
 			.navigate()

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -457,6 +457,10 @@ struct TestIdentifiers {
 
 	enum CourseCatalog {
 		static let recent = "Recent"
+		/// The one course a UI-test run's catalogue holds. Mirrors
+		/// `UITEST_COURSE_NAME` in
+		/// `source/lib/course-search/__fixtures__/courses.ts`.
+		static let aCourse = "Hybrid Test Course"
 	}
 
 	// MARK: - StoPrint


### PR DESCRIPTION
<!-- Wren: description yours to write. Below is only what is in the branch, and the screenshots. -->

Stage 3 (PR 2 of 5) of #7921 — the read-only detail screens. **Stacked on #7932.**

### Commits

- `757e756ef` Move the read-only detail screens to @expo/ui
- `9247477e3` Give the balances screen figures to show under UI testing
- `712a37a56` Give the course catalogue one course to find under UI testing
- `50087153c` Give a recent search its key where React looks for it

`@frogpond/tableview` is down from 11 files to 7.

### Screens on the simulator

| SIS Balances | Course detail |
| --- | --- |
| ![Balances](https://github.com/user-attachments/assets/0ae0a6c5-3e72-41ef-93e0-e1cca1e348c0) | ![Course detail](https://github.com/user-attachments/assets/562715f3-82c5-41e6-a148-e823c0c76390) |

| Student org detail | Directory entry |
| --- | --- |
| ![Org detail](https://github.com/user-attachments/assets/c44cc1cf-1e9a-4126-a77a-c49e8db91465) | ![Directory detail](https://github.com/user-attachments/assets/b668416c-99a1-4142-9fa5-67919b9c4bea) |

### Two rows, shared

**`DetailRow`** — a label beside its value on SwiftUI's own `LabeledContent`, with an optional `onPress` that adds a chevron. Most of all four screens is this one row.

**`SelectableText`** stays a React Native `TextInput`. `SelectableCell` was never only selectable: it carries `dataDetectorTypes` so phone numbers, addresses and dates become tappable, plus a documented workaround for an RN truncation bug. SwiftUI's `textSelection` offers selection and **no detectors**, so porting it to `@expo/ui` would have quietly made an org's meeting time and a course's room number unactionable. There is a test asserting the detectors are still named individually.

### Fixtures, because these screens are otherwise unreachable

**Balances** shows N/A in every tile for everyone: St. Olaf moved its login behind Google sign-in, which the app cannot complete, and the screen says so in a banner. The figures are deliberately awkward — a four-figure balance, a zero, a half meal — so a tile that cannot fit its number or reads zero as missing shows up rather than passing on tidy data.

**The catalogue** is several megabytes that change every registration cycle, and the course detail screen is only reachable by searching it. One term and one course, built to be drawn rather than to be typical: two instructors, GEs, prerequisites, notes, a description, and a lab meeting twice on one Friday so the schedule has a grouped row. Tests assert both fixture sets still carry all of that — a field going missing would leave that section blank and the screenshot would look fine.

### Design changes on the org detail

The org's name stays at the top of the body, and is now actually centred. It never was: `multilineTextAlignment('center')` centres text inside the `Text`'s own frame, and a `Text` is only as wide as its content, so the name drew left of the card's centre. It needs `frame({maxWidth: Infinity})` first.

A navigation large title was tried instead and reverted — UIKit draws one on a single line, and these names run long enough that it truncated more often than not ("Academic Success Ce…"). In the body it wraps.

The credit names Presence.io, which is where the data comes from, and loses its card: it is a footnote about the source, not a row of data. "Last updated" went with it — a date the database last changed is nothing a reader can act on.

Descriptions take the ordinary label colour. Secondary is for a value beside a label, not the body of the thing you opened the screen for.

Balance figures take the weight iOS gives a value, rather than the ultraLight they had.

### Bugs found and fixed

- **`RecentItemsList` never had a key.** It sat on a `Pressable` inside the fragment each row returns, so React never saw one and warned on every recent search. Unrelated to this migration; it only became visible because the catalogue fixtures gave the screen something to list.
- **`balanceValue`** now tells "still loading" apart from "the server had nothing". The old N/A-or-ellipsis conditional did that by accident.
- **`CourseDetail`'s Android branches** are gone. This app is iOS only, so they were unreachable.
- **Hosted text drew clipped at both edges.** `RNHostView` sizes a hosted view to its intrinsic size, and a paragraph's intrinsic width is its longest line unwrapped — far wider than the row. Every org description and course description lost a word from the start of each line. It now takes the width the row leaves it, derived from the window the way the directory tiles derive theirs.

### Also

`courseSchedule` is extracted and tested, including that a lab meeting twice on one day belongs under one heading rather than two.



