### PR TITLE
Move the print release screen to @expo/ui

### DIFF
--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {StyleSheet, Image as RNImage} from 'react-native'
-import {Host, HStack, List, RNHostView, Section, Spacer, Text} from '@expo/ui/swift-ui'
+import {Host, HStack, List, RNHostView, Section, Text, VStack} from '@expo/ui/swift-ui'
 import {
 	font,
 	foregroundStyle,
@@ -84,6 +84,7 @@ export default function DirectoryDetailPage(): React.ReactNode {
 
 	const {
 		campusLocations,
+		displayName,
 		displayTitle,
 		photo,
 		officeHours,
@@ -99,23 +100,36 @@ export default function DirectoryDetailPage(): React.ReactNode {
 			<Host style={styles.host}>
 				<List modifiers={[listStyle('insetGrouped')]}>
 					<Section>
-						{/* The photo is a network image, so React Native draws it and
-						    SwiftUI hosts it. Spacers either side rather than the RN
-						    `alignSelf`, which a hosted view sizing to its own contents
-						    has nothing to align within. */}
-						<HStack modifiers={[frame({maxWidth: Infinity})]}>
-							<Spacer />
-							<RNHostView matchContents={true}>
-								<RNImage
-									accessibilityIgnoresInvertColors={true}
-									resizeMode="cover"
-									source={{uri: photo}}
-									style={styles.image}
-								/>
-							</RNHostView>
-							<Spacer />
+						{/* Name leading, photo trailing, both hung from the top -- so a
+						    long name wraps down the left of the photo rather than
+						    pushing it about. The VStack fills what the photo leaves,
+						    which is what gives the name somewhere to wrap within. */}
+						<HStack alignment="top" spacing={12}>
+							<VStack
+								alignment="leading"
+								modifiers={[frame({maxWidth: Infinity, alignment: 'leading'})]}
+								spacing={2}
+							>
+								<Text modifiers={NAME_MODIFIERS}>{displayName}</Text>
+								{displayTitle ? <Text modifiers={HEADER_MODIFIERS}>{displayTitle}</Text> : null}
+							</VStack>
+
+							{photo ? (
+								/* A network image, so React Native draws it and SwiftUI
+								   hosts it -- at a stated size, since a hosted view has no
+								   bounds of its own. */
+								<HStack modifiers={[frame({width: PHOTO_WIDTH, height: PHOTO_HEIGHT})]}>
+									<RNHostView matchContents={false}>
+										<RNImage
+											accessibilityIgnoresInvertColors={true}
+											resizeMode="cover"
+											source={{uri: photo}}
+											style={styles.image}
+										/>
+									</RNHostView>
+								</HStack>
+							) : null}
 						</HStack>
-						<Text modifiers={HEADER_MODIFIERS}>{displayTitle}</Text>
 					</Section>
 
 					{/* An empty array of pronouns is still an array, so asking whether
@@ -186,11 +200,14 @@ export default function DirectoryDetailPage(): React.ReactNode {
 	)
 }
 
-const HEADER_MODIFIERS = [
-	font({textStyle: 'subheadline'}),
-	foregroundStyle(c.secondaryLabel),
-	multilineTextAlignment('center'),
-]
+/// Portrait rather than square: a directory photo is a head-and-shoulders
+/// shot, and a square crops it to the chin.
+const PHOTO_WIDTH = 80
+const PHOTO_HEIGHT = 104
+
+const NAME_MODIFIERS = [font({textStyle: 'title2', weight: 'semibold'}), foregroundStyle(c.label)]
+
+const HEADER_MODIFIERS = [font({textStyle: 'subheadline'}), foregroundStyle(c.secondaryLabel)]
 
 /// No card behind the credit: it names where the data came from, and is not a
 /// row of it. Matches the org detail.
@@ -208,11 +225,8 @@ const styles = StyleSheet.create({
 		backgroundColor: c.systemGroupedBackground,
 	},
 	image: {
-		width: 100,
-		height: 100,
-		alignSelf: 'center',
-		borderRadius: 4,
-		borderWidth: 0.2,
-		borderColor: c.label,
+		width: PHOTO_WIDTH,
+		height: PHOTO_HEIGHT,
+		borderRadius: 6,
 	},
 })

--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -8,7 +8,6 @@ import {
 	listRowBackground,
 	listRowInsets,
 	listStyle,
-	padding,
 	multilineTextAlignment,
 } from '@expo/ui/swift-ui/modifiers'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
@@ -210,14 +209,11 @@ const NAME_MODIFIERS = [font({textStyle: 'title2', weight: 'semibold'}), foregro
 ///
 /// The padding is ours rather than the list's. Zeroing the insets alone left
 /// the content hard against the screen edge, where the name clipped.
-/// Matches what an inset-grouped row leaves its content, so the name lines up
-/// with the section headings below it.
-const HEADER_PADDING = 20
-
+/// No background, and none of the insetting or rounding a section gives its
+/// rows: the heading runs edge to edge.
 const HEADER_ROW_MODIFIERS = [
 	listRowBackground('clear'),
 	listRowInsets({bottom: 0, leading: 0, top: 0, trailing: 0}),
-	padding({horizontal: HEADER_PADDING}),
 ]
 
 const HEADER_MODIFIERS = [font({textStyle: 'subheadline'}), foregroundStyle(c.secondaryLabel)]

--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -6,7 +6,6 @@ import {
 	foregroundStyle,
 	frame,
 	listRowBackground,
-	listRowInsets,
 	listStyle,
 	multilineTextAlignment,
 } from '@expo/ui/swift-ui/modifiers'
@@ -209,7 +208,11 @@ const NAME_MODIFIERS = [font({textStyle: 'title2', weight: 'semibold'}), foregro
 
 /// No card behind the heading: a name and a face are what the screen is about,
 /// not a row of its data.
-const HEADER_ROW_MODIFIERS = [listRowBackground('clear'), listRowInsets({leading: 0, trailing: 0})]
+///
+/// The row keeps its ordinary insets. Zeroing them clipped the name against
+/// the list's own margin and pushed the photo past the edge the cards below
+/// line up with.
+const HEADER_ROW_MODIFIERS = [listRowBackground('clear')]
 
 const HEADER_MODIFIERS = [font({textStyle: 'subheadline'}), foregroundStyle(c.secondaryLabel)]
 

--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -6,6 +6,7 @@ import {
 	foregroundStyle,
 	frame,
 	listRowBackground,
+	listRowInsets,
 	listStyle,
 	multilineTextAlignment,
 } from '@expo/ui/swift-ui/modifiers'
@@ -44,7 +45,6 @@ export default function DirectoryDetailPage(): React.ReactNode {
 	// scroll, rather than a static heading repeated in the body.
 	let screenTitle = (
 		<>
-			<Stack.Screen options={{headerLargeTitleEnabled: true}} />
 			<Stack.Title>{contact?.displayName ?? 'Contact'}</Stack.Title>
 		</>
 	)
@@ -104,7 +104,7 @@ export default function DirectoryDetailPage(): React.ReactNode {
 						    long name wraps down the left of the photo rather than
 						    pushing it about. The VStack fills what the photo leaves,
 						    which is what gives the name somewhere to wrap within. */}
-						<HStack alignment="top" spacing={12}>
+						<HStack alignment="top" modifiers={HEADER_ROW_MODIFIERS} spacing={12}>
 							<VStack
 								alignment="leading"
 								modifiers={[frame({maxWidth: Infinity, alignment: 'leading'})]}
@@ -206,6 +206,10 @@ const PHOTO_WIDTH = 80
 const PHOTO_HEIGHT = 104
 
 const NAME_MODIFIERS = [font({textStyle: 'title2', weight: 'semibold'}), foregroundStyle(c.label)]
+
+/// No card behind the heading: a name and a face are what the screen is about,
+/// not a row of its data.
+const HEADER_ROW_MODIFIERS = [listRowBackground('clear'), listRowInsets({leading: 0, trailing: 0})]
 
 const HEADER_MODIFIERS = [font({textStyle: 'subheadline'}), foregroundStyle(c.secondaryLabel)]
 

--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -6,7 +6,9 @@ import {
 	foregroundStyle,
 	frame,
 	listRowBackground,
+	listRowInsets,
 	listStyle,
+	padding,
 	multilineTextAlignment,
 } from '@expo/ui/swift-ui/modifiers'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
@@ -40,13 +42,9 @@ export default function DirectoryDetailPage(): React.ReactNode {
 		refetch,
 	} = useQuery(directoryContactOptions(query, type as DirectorySearchTypeEnum, Number(index)))
 
-	// The screen's only copy of the name: a large title that collapses on
-	// scroll, rather than a static heading repeated in the body.
-	let screenTitle = (
-		<>
-			<Stack.Title>{contact?.displayName ?? 'Contact'}</Stack.Title>
-		</>
-	)
+	// No title in the bar: the heading below carries the name, and the bar
+	// repeating it said the same thing twice.
+	let screenTitle = <Stack.Screen options={{title: ''}} />
 
 	if (isLoading) {
 		return (
@@ -206,13 +204,21 @@ const PHOTO_HEIGHT = 104
 
 const NAME_MODIFIERS = [font({textStyle: 'title2', weight: 'semibold'}), foregroundStyle(c.label)]
 
-/// No card behind the heading: a name and a face are what the screen is about,
-/// not a row of its data.
+/// No card behind the heading, and none of the insetting or rounding a section
+/// gives its rows: a name and a face are what the screen is about, not a row of
+/// its data.
 ///
-/// The row keeps its ordinary insets. Zeroing them clipped the name against
-/// the list's own margin and pushed the photo past the edge the cards below
-/// line up with.
-const HEADER_ROW_MODIFIERS = [listRowBackground('clear')]
+/// The padding is ours rather than the list's. Zeroing the insets alone left
+/// the content hard against the screen edge, where the name clipped.
+/// Matches what an inset-grouped row leaves its content, so the name lines up
+/// with the section headings below it.
+const HEADER_PADDING = 20
+
+const HEADER_ROW_MODIFIERS = [
+	listRowBackground('clear'),
+	listRowInsets({bottom: 0, leading: 0, top: 0, trailing: 0}),
+	padding({horizontal: HEADER_PADDING}),
+]
 
 const HEADER_MODIFIERS = [font({textStyle: 'subheadline'}), foregroundStyle(c.secondaryLabel)]
 

--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -1,7 +1,14 @@
 import * as React from 'react'
 import {StyleSheet, Image as RNImage} from 'react-native'
-import {Host, List, RNHostView, Section, Text} from '@expo/ui/swift-ui'
-import {font, foregroundStyle, listStyle, multilineTextAlignment} from '@expo/ui/swift-ui/modifiers'
+import {Host, HStack, List, RNHostView, Section, Spacer, Text} from '@expo/ui/swift-ui'
+import {
+	font,
+	foregroundStyle,
+	frame,
+	listRowBackground,
+	listStyle,
+	multilineTextAlignment,
+} from '@expo/ui/swift-ui/modifiers'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
 import {useQuery} from '@tanstack/react-query'
 import {openUrl} from '@frogpond/open-url'
@@ -93,19 +100,28 @@ export default function DirectoryDetailPage(): React.ReactNode {
 				<List modifiers={[listStyle('insetGrouped')]}>
 					<Section>
 						{/* The photo is a network image, so React Native draws it and
-						    SwiftUI hosts it. */}
-						<RNHostView matchContents={true}>
-							<RNImage
-								accessibilityIgnoresInvertColors={true}
-								resizeMode="cover"
-								source={{uri: photo}}
-								style={styles.image}
-							/>
-						</RNHostView>
+						    SwiftUI hosts it. Spacers either side rather than the RN
+						    `alignSelf`, which a hosted view sizing to its own contents
+						    has nothing to align within. */}
+						<HStack modifiers={[frame({maxWidth: Infinity})]}>
+							<Spacer />
+							<RNHostView matchContents={true}>
+								<RNImage
+									accessibilityIgnoresInvertColors={true}
+									resizeMode="cover"
+									source={{uri: photo}}
+									style={styles.image}
+								/>
+							</RNHostView>
+							<Spacer />
+						</HStack>
 						<Text modifiers={HEADER_MODIFIERS}>{displayTitle}</Text>
 					</Section>
 
-					{officeHours || email || profileUrl || pronouns ? (
+					{/* An empty array of pronouns is still an array, so asking whether
+					    the entry *has* pronouns is the question -- otherwise ABOUT
+					    drew its header over nothing. */}
+					{pronouns?.length || email || officeHours || profileUrl ? (
 						<Section title="ABOUT">
 							{pronouns?.length ? <DetailRow label="Pronouns" value={pronouns.join(', ')} /> : null}
 
@@ -176,10 +192,14 @@ const HEADER_MODIFIERS = [
 	multilineTextAlignment('center'),
 ]
 
+/// No card behind the credit: it names where the data came from, and is not a
+/// row of it. Matches the org detail.
 const CREDIT_MODIFIERS = [
 	font({textStyle: 'caption2'}),
 	foregroundStyle(c.secondaryLabel),
 	multilineTextAlignment('center'),
+	frame({maxWidth: Infinity}),
+	listRowBackground('clear'),
 ]
 
 const styles = StyleSheet.create({

--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -2,11 +2,11 @@ import * as React from 'react'
 import {StyleSheet, Image as RNImage} from 'react-native'
 import {Host, HStack, List, RNHostView, Section, Text, VStack} from '@expo/ui/swift-ui'
 import {
+	clipShape,
 	font,
 	foregroundStyle,
 	frame,
 	listRowBackground,
-	listRowInsets,
 	listStyle,
 	multilineTextAlignment,
 } from '@expo/ui/swift-ui/modifiers'
@@ -95,7 +95,7 @@ export default function DirectoryDetailPage(): React.ReactNode {
 			{screenTitle}
 			<Host style={styles.host}>
 				<List modifiers={[listStyle('insetGrouped')]}>
-					<Section>
+					<Section modifiers={HEADER_SECTION_MODIFIERS}>
 						{/* Name leading, photo trailing, both hung from the top -- so a
 						    long name wraps down the left of the photo rather than
 						    pushing it about. The VStack fills what the photo leaves,
@@ -209,12 +209,14 @@ const NAME_MODIFIERS = [font({textStyle: 'title2', weight: 'semibold'}), foregro
 ///
 /// The padding is ours rather than the list's. Zeroing the insets alone left
 /// the content hard against the screen edge, where the name clipped.
-/// No background, and none of the insetting or rounding a section gives its
-/// rows: the heading runs edge to edge.
-const HEADER_ROW_MODIFIERS = [
-	listRowBackground('clear'),
-	listRowInsets({bottom: 0, leading: 0, top: 0, trailing: 0}),
-]
+/// A section clips its rows to a rounded rectangle, and that corner was cutting
+/// the first glyph of the name. Squaring the clip keeps the heading's own
+/// margins while letting the text reach the edge of them.
+const HEADER_SECTION_MODIFIERS = [clipShape('rectangle')]
+
+/// No card behind the heading: a name and a face are what the screen is about,
+/// not a row of its data.
+const HEADER_ROW_MODIFIERS = [listRowBackground('clear')]
 
 const HEADER_MODIFIERS = [font({textStyle: 'subheadline'}), foregroundStyle(c.secondaryLabel)]
 

--- a/app/(home)/Directory/[index].tsx
+++ b/app/(home)/Directory/[index].tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import {StyleSheet, Image as RNImage} from 'react-native'
 import {Host, HStack, List, RNHostView, Section, Text, VStack} from '@expo/ui/swift-ui'
 import {
-	clipShape,
 	font,
 	foregroundStyle,
 	frame,
@@ -95,12 +94,12 @@ export default function DirectoryDetailPage(): React.ReactNode {
 			{screenTitle}
 			<Host style={styles.host}>
 				<List modifiers={[listStyle('insetGrouped')]}>
-					<Section modifiers={HEADER_SECTION_MODIFIERS}>
+					<Section>
 						{/* Name leading, photo trailing, both hung from the top -- so a
 						    long name wraps down the left of the photo rather than
 						    pushing it about. The VStack fills what the photo leaves,
 						    which is what gives the name somewhere to wrap within. */}
-						<HStack alignment="top" modifiers={HEADER_ROW_MODIFIERS} spacing={12}>
+						<HStack alignment="top" spacing={12}>
 							<VStack
 								alignment="leading"
 								modifiers={[frame({maxWidth: Infinity, alignment: 'leading'})]}
@@ -202,21 +201,6 @@ const PHOTO_WIDTH = 80
 const PHOTO_HEIGHT = 104
 
 const NAME_MODIFIERS = [font({textStyle: 'title2', weight: 'semibold'}), foregroundStyle(c.label)]
-
-/// No card behind the heading, and none of the insetting or rounding a section
-/// gives its rows: a name and a face are what the screen is about, not a row of
-/// its data.
-///
-/// The padding is ours rather than the list's. Zeroing the insets alone left
-/// the content hard against the screen edge, where the name clipped.
-/// A section clips its rows to a rounded rectangle, and that corner was cutting
-/// the first glyph of the name. Squaring the clip keeps the heading's own
-/// margins while letting the text reach the edge of them.
-const HEADER_SECTION_MODIFIERS = [clipShape('rectangle')]
-
-/// No card behind the heading: a name and a face are what the screen is about,
-/// not a row of its data.
-const HEADER_ROW_MODIFIERS = [listRowBackground('clear')]
 
 const HEADER_MODIFIERS = [font({textStyle: 'subheadline'}), foregroundStyle(c.secondaryLabel)]
 

--- a/app/(home)/PrintJobs/[jobId]/release.tsx
+++ b/app/(home)/PrintJobs/[jobId]/release.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
 import {useMutation, useQuery} from '@tanstack/react-query'
-import {Alert, StyleSheet, ScrollView, Text, TextProps} from 'react-native'
-import {TableView, Section, Cell} from '@frogpond/tableview'
-import {ButtonCell} from '@frogpond/tableview/cells'
+import {Alert, StyleSheet} from 'react-native'
+import {Host, List, Section, Text} from '@expo/ui/swift-ui'
+import {
+	font,
+	foregroundStyle,
+	frame,
+	listStyle,
+	multilineTextAlignment,
+} from '@expo/ui/swift-ui/modifiers'
+import {ActionRow, DetailRow} from '../../../../source/components/rows'
 import * as c from '@frogpond/colors'
 import {
 	cancelPrintJobForUser,
@@ -25,49 +32,41 @@ import {credentialsOptions} from '../../../../source/lib/login'
 import {LoadingView, NoticeView} from '@frogpond/notice'
 
 const styles = StyleSheet.create({
-	cancelButton: {
-		color: c.red,
-	},
-	buttonCell: {
-		textAlign: 'center',
-	},
-	header: {
-		fontSize: 30,
-		textAlign: 'center',
-		marginTop: 20,
-		marginHorizontal: 10,
-		color: c.label,
+	host: {
+		flex: 1,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })
 
-const Header = (props: TextProps) => <Text {...props} style={[styles.header, props.style]} />
-
-function LeftDetailCell({detail, title}: {detail: string; title: string}) {
-	return <Cell cellStyle="LeftDetail" detail={detail} title={title} />
-}
+/// `frame(maxWidth: Infinity)` before the alignment: a Text is only as wide as
+/// its content, so centring inside that says nothing about the row it sits in.
+const DOCUMENT_NAME_MODIFIERS = [
+	font({textStyle: 'title', weight: 'semibold'}),
+	foregroundStyle(c.label),
+	frame({maxWidth: Infinity}),
+	multilineTextAlignment('center'),
+]
 
 function JobInformation({job}: {job: PrintJob}) {
 	let wasPrintedAlready = job.statusFormatted === 'Sent to Printer'
 	return (
-		<Section header="JOB INFO">
-			<LeftDetailCell detail="Status" title={job.statusFormatted} />
-			<LeftDetailCell detail="Time" title={job.usageTimeFormatted} />
-			<LeftDetailCell detail="Pages" title={job.totalPages.toString()} />
-			<LeftDetailCell detail="Cost" title={job.usageCostFormatted} />
-			<LeftDetailCell detail="Grayscale" title={job.grayscaleFormatted} />
-			<LeftDetailCell detail="Paper Size" title={job.paperSizeFormatted} />
-			{wasPrintedAlready && <LeftDetailCell detail="Printer" title={job.printerName} />}
+		<Section title="JOB INFO">
+			<DetailRow label="Status" value={job.statusFormatted} />
+			<DetailRow label="Time" value={job.usageTimeFormatted} />
+			<DetailRow label="Pages" value={job.totalPages.toString()} />
+			<DetailRow label="Cost" value={job.usageCostFormatted} />
+			<DetailRow label="Grayscale" value={job.grayscaleFormatted} />
+			<DetailRow label="Paper Size" value={job.paperSizeFormatted} />
+			{wasPrintedAlready ? <DetailRow label="Printer" value={job.printerName} /> : null}
 		</Section>
 	)
 }
 
 function PrinterInformation({printer}: {printer: Printer}) {
 	return (
-		<Section header="PRINTER INFO">
-			<LeftDetailCell detail="Name" title={printer.printerName} />
-			{Boolean(printer.location) && (
-				<LeftDetailCell detail="Location" title={printer.location ?? ''} />
-			)}
+		<Section title="PRINTER INFO">
+			<DetailRow label="Name" value={printer.printerName} />
+			{Boolean(printer.location) && <DetailRow label="Location" value={printer.location ?? ''} />}
 		</Section>
 	)
 }
@@ -150,11 +149,7 @@ function PrintJobReleaseView({job, printer}: PrintJobReleaseViewProps): React.Re
 	})
 
 	if (loadingUsername && !isStoprintMocked) {
-		return (
-			<ScrollView contentInsetAdjustmentBehavior="automatic">
-				<LoadingView />
-			</ScrollView>
-		)
+		return <LoadingView />
 	}
 
 	const requestCancel = () => {
@@ -188,31 +183,36 @@ function PrintJobReleaseView({job, printer}: PrintJobReleaseViewProps): React.Re
 	let actionAvailable = status !== 'complete' && printer
 
 	return (
-		<ScrollView contentInsetAdjustmentBehavior="automatic">
-			<Header>{job.documentName}</Header>
-			<TableView>
+		<Host style={styles.host}>
+			<List modifiers={[listStyle('insetGrouped')]}>
+				<Section>
+					<Text modifiers={DOCUMENT_NAME_MODIFIERS}>{job.documentName}</Text>
+				</Section>
+
 				<JobInformation job={job} />
-				{actionAvailable && (
-					<React.Fragment>
-						{printer && <PrinterInformation printer={printer} />}
-						<Section sectionPaddingBottom={0}>
-							<ButtonCell
+
+				{actionAvailable ? (
+					<>
+						{printer ? <PrinterInformation printer={printer} /> : null}
+						<Section>
+							<ActionRow
+								disabled={status !== 'pending'}
 								onPress={requestRelease}
-								textStyle={styles.buttonCell}
 								title={status === 'printing' ? 'Printing…' : 'Print'}
 							/>
-						</Section>
-						<Section>
-							<ButtonCell
+							{/* Destructive, and last: cancelling a job cannot be undone,
+							    so it sits apart from the action a reader came here for. */}
+							<ActionRow
+								destructive={true}
+								disabled={status !== 'pending'}
 								onPress={requestCancel}
-								textStyle={[styles.buttonCell, styles.cancelButton]}
 								title={status === 'cancelling' ? 'Cancelling…' : 'Cancel'}
 							/>
 						</Section>
-					</React.Fragment>
-				)}
-			</TableView>
-		</ScrollView>
+					</>
+				) : null}
+			</List>
+		</Host>
 	)
 }
 

--- a/app/(home)/StudentOrgs/[name].tsx
+++ b/app/(home)/StudentOrgs/[name].tsx
@@ -155,7 +155,7 @@ export default function StudentOrgsDetailPage(): React.ReactNode {
 					) : null}
 
 					<Section>
-						<Text modifiers={CREDIT_MODIFIERS}>Powered by Presence.io</Text>
+						<Text modifiers={CREDIT_MODIFIERS}>Powered by Presence</Text>
 					</Section>
 				</List>
 			</Host>

--- a/source/components/__tests__/rows.test.tsx
+++ b/source/components/__tests__/rows.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {fireEvent, render, screen} from '@testing-library/react-native'
 
-import {DetailRow, DisclosureRow, SelectableText} from '../rows'
+import {ActionRow, DetailRow, DisclosureRow, SelectableText} from '../rows'
 
 jest.mock('@expo/ui/swift-ui', () => {
 	// oxlint-disable-next-line typescript/no-require-imports
@@ -184,5 +184,37 @@ describe('SelectableText', () => {
 		await render(<SelectableText text="Mondays at 7pm" />)
 
 		expect(screen.getByTestId('selectable-text').props.editable).toBe(false)
+	})
+})
+
+describe('ActionRow', () => {
+	it('calls onPress when tapped', async () => {
+		let onPress = jest.fn()
+		await render(<ActionRow onPress={onPress} title="Print" />)
+
+		fireEvent.press(screen.getByLabelText('Print'))
+
+		expect(onPress).toHaveBeenCalledTimes(1)
+	})
+
+	/// Whether a destructive action is drawn in red is a question for a
+	/// screenshot; Jest has no colour to look at, and asserting the modifier we
+	/// passed would only restate our own input.
+	it('still calls onPress when the action is destructive', async () => {
+		let onPress = jest.fn()
+		await render(<ActionRow destructive={true} onPress={onPress} title="Cancel" />)
+
+		fireEvent.press(screen.getByLabelText('Cancel'))
+
+		expect(onPress).toHaveBeenCalledTimes(1)
+	})
+
+	it('is disabled when it says it is', async () => {
+		let onPress = jest.fn()
+		await render(<ActionRow disabled={true} onPress={onPress} title="Print" />)
+
+		fireEvent.press(screen.getByLabelText('Print'))
+
+		expect(onPress).not.toHaveBeenCalled()
 	})
 })

--- a/source/components/rows.tsx
+++ b/source/components/rows.tsx
@@ -38,6 +38,11 @@ type RowProps = {
 	disabled?: boolean
 }
 
+type ActionRowProps = RowProps & {
+	/** Draws the action in red, for one that destroys something. */
+	destructive?: boolean
+}
+
 /**
  * A row that pushes another screen via React Navigation. `@expo/ui` has no
  * `NavigationLink` (it mounts its destination as a SwiftUI view inside a
@@ -70,8 +75,8 @@ export function NavigationRow(props: RowProps): React.ReactNode {
  * A row that fires an action (open a URL, show an alert, mutate) rather than
  * pushing a screen. Tinted text and no chevron, since there is nowhere to go.
  */
-export function ActionRow(props: RowProps): React.ReactNode {
-	let {title, onPress, disabled = false} = props
+export function ActionRow(props: ActionRowProps): React.ReactNode {
+	let {title, onPress, disabled = false, destructive = false} = props
 
 	return (
 		<Button
@@ -79,7 +84,7 @@ export function ActionRow(props: RowProps): React.ReactNode {
 			onPress={onPress}
 		>
 			<HStack modifiers={[contentShape(shapes.rectangle())]}>
-				<Text modifiers={[foregroundStyle(c.systemBlue)]}>{title}</Text>
+				<Text modifiers={[foregroundStyle(destructive ? c.systemRed : c.systemBlue)]}>{title}</Text>
 				<Spacer />
 			</HStack>
 		</Button>

--- a/source/features/directory/__fixtures__/entries.ts
+++ b/source/features/directory/__fixtures__/entries.ts
@@ -18,6 +18,12 @@ import type {DirectoryItem, SearchResults} from '../types'
 export const UITEST_ENTRY_NAME = 'Kari Testerson'
 export const UITEST_ENTRY_DEPARTMENT = 'Computer Science'
 
+/// A 40x52 gradient, at the photo's own aspect. Inline so it cannot fail for
+/// want of a network, and visible rather than blank: a photo that drew nothing
+/// would look exactly like one that failed to load.
+const PHOTO =
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAA0CAIAAAB3iO3aAAAA6klEQVR4nMXCBVICAAAAwXu7PQqoSHd3dysqqGM+yWfcznISiCk5DcaVnIUSSs5vk0ou7lJKLu/TSq7CGSXXkZySm2heSSBWUBKMF5WEEiUlt8mykvt0VUk4U1PykK0rieQaSqL5ppJYoaUkXmwrSZa7SlKVnpJ0ta8kUxsoydaHSnKNkZJCa6Kk2J4qKXVmSsrduZJKb6Gk2l8qqQ1WShqjjZLmeKukNdkpaU8flXRmT0q6872S/vJFyWD1qmS4PigZbY5Kxts3JZPdu5Lp44eS+f5TyeL5S8ny5VvJ6vVHyfrwq2Rz/FP+A/OrF2HR73bXAAAAAElFTkSuQmCC'
+
 const ENTRY: DirectoryItem = {
 	campusLocations: [
 		{
@@ -51,11 +57,11 @@ const ENTRY: DirectoryItem = {
 		title: 'Office Hours',
 	},
 	onLeave: null,
-	photo: '',
+	photo: PHOTO,
 	profileUrl: 'https://wp.stolaf.edu/profile/testerson',
 	pronouns: ['she', 'her', 'hers'],
 	suffixName: null,
-	thumbnail: '',
+	thumbnail: PHOTO,
 	title: 'Associate Professor',
 	username: 'testerson',
 	description: null,

--- a/source/features/directory/__fixtures__/entries.ts
+++ b/source/features/directory/__fixtures__/entries.ts
@@ -1,0 +1,67 @@
+import type {DirectoryItem, SearchResults} from '../types'
+
+/**
+ * One directory entry, for UI testing.
+ *
+ * The live directory is whoever works at St. Olaf this week, which is nothing
+ * to assert against: a test naming a real person breaks when they leave, and
+ * the desk that was named instead to avoid that carries almost no fields, so
+ * the screen it draws is mostly empty.
+ *
+ * This entry carries every field the detail screen draws -- pronouns, email,
+ * office hours with a link, a profile, a room with a phone, and more than one
+ * department -- so a section that stops rendering shows up rather than looking
+ * like an entry that happened to lack it.
+ */
+
+/// Mirrored by `TestIdentifiers.Directory.fixtureEntry`.
+export const UITEST_ENTRY_NAME = 'Kari Testerson'
+export const UITEST_ENTRY_DEPARTMENT = 'Computer Science'
+
+const ENTRY: DirectoryItem = {
+	campusLocations: [
+		{
+			display: 'Regents Hall 310',
+			buildingabbr: 'RNS',
+			building: 'Regents Hall of Natural Sciences',
+			phone: '507-786-3000',
+			room: 310,
+			shortLocation: 'RNS 310',
+		},
+	],
+	classYear: null,
+	departments: [
+		{href: 'https://wp.stolaf.edu/cs/', name: UITEST_ENTRY_DEPARTMENT},
+		{href: 'https://wp.stolaf.edu/mathematics/', name: 'Mathematics'},
+	],
+	displayName: UITEST_ENTRY_NAME,
+	displayTitle: 'Associate Professor of Computer Science and Mathematics',
+	email: 'testerson@stolaf.edu',
+	firstName: 'Kari',
+	homeAddress: {zip: '', city: '', country: '', state: '', street: []},
+	homePhone: null,
+	lastName: 'Testerson',
+	officeHours: {
+		display: 'M-W-F 10:00 a.m. to noon',
+		prefix: 'Office Hours',
+		hrefLabel: 'Book a time',
+		href: 'https://wp.stolaf.edu/cs/office-hours/',
+		content: 'M-W-F 10:00 a.m. to noon',
+		description: 'M-W-F 10:00 a.m. to noon',
+		title: 'Office Hours',
+	},
+	onLeave: null,
+	photo: '',
+	profileUrl: 'https://wp.stolaf.edu/profile/testerson',
+	pronouns: ['she', 'her', 'hers'],
+	suffixName: null,
+	thumbnail: '',
+	title: 'Associate Professor',
+	username: 'testerson',
+	description: null,
+}
+
+export const UITEST_DIRECTORY_RESULTS: SearchResults = {
+	meta: {count: 1, fullCount: 1},
+	results: [ENTRY],
+}

--- a/source/features/directory/__tests__/uitest-entry.test.ts
+++ b/source/features/directory/__tests__/uitest-entry.test.ts
@@ -1,0 +1,34 @@
+import {UITEST_DIRECTORY_RESULTS, UITEST_ENTRY_NAME} from '../__fixtures__/entries'
+import {formatResults} from '../helpers'
+
+/// The fixture exists so the detail screen has every section to draw. A field
+/// going missing would leave that section blank, and the screenshot would look
+/// like an entry that simply lacked it.
+describe('the UI test directory entry', () => {
+	let [entry] = formatResults(UITEST_DIRECTORY_RESULTS.results)
+
+	it('is the entry the tests search for', () => {
+		expect(entry?.displayName).toBe(UITEST_ENTRY_NAME)
+	})
+
+	it('carries something for every section of the detail screen', () => {
+		expect(entry?.pronouns?.length).toBeTruthy()
+		expect(entry?.email).toBeTruthy()
+		expect(entry?.officeHours).toBeTruthy()
+		expect(entry?.profileUrl).toBeTruthy()
+		expect(entry?.displayTitle).toBeTruthy()
+	})
+
+	/// More than one, so the heading reads DEPARTMENTS and the plural branch is
+	/// the one being drawn.
+	it('belongs to more than one department', () => {
+		expect(entry?.departments.length).toBeGreaterThan(1)
+	})
+
+	it('has a room with a phone in it', () => {
+		let [location] = entry?.campusLocations ?? []
+
+		expect(location?.display).toBeTruthy()
+		expect(location?.phone).toBeTruthy()
+	})
+})

--- a/source/features/directory/query.ts
+++ b/source/features/directory/query.ts
@@ -1,5 +1,7 @@
 import ky from 'ky'
+import {isUITesting} from '@frogpond/launch-arguments'
 import {queryOptions} from '@tanstack/react-query'
+import {UITEST_DIRECTORY_RESULTS} from './__fixtures__/entries'
 import {DirectorySearchTypeEnum, SearchResults} from './types'
 import {formatResults} from './helpers'
 
@@ -45,6 +47,14 @@ async function fetchDirectoryEntries(
 	searchQuery: ReturnType<typeof getDirectoryQuery>,
 	signal?: AbortSignal,
 ): Promise<SearchResults> {
+	// The live directory is whoever works at St. Olaf this week, so a test
+	// searching it cannot say what it will find -- see
+	// `source/features/dictionary/query.ts` for the same reasoning about
+	// entries.
+	if (isUITesting) {
+		return UITEST_DIRECTORY_RESULTS
+	}
+
 	let response = await directory.get('search', {searchParams: searchQuery, signal}).json()
 	return response as SearchResults
 }

--- a/source/testing/expo-ui-mock.tsx
+++ b/source/testing/expo-ui-mock.tsx
@@ -209,6 +209,12 @@ export function Image({
 	return <View accessibilityLabel={labelOf(modifiers) ?? systemName} />
 }
 
+/// Whether a `disabled(…)` modifier asked for the control to be off.
+function isDisabled(modifiers?: Modifier[]): boolean {
+	let found = modifiers?.find((m) => m.$type === 'disabled')
+	return found ? found.isDisabled !== false : false
+}
+
 export function Button({
 	children,
 	label,
@@ -219,7 +225,11 @@ export function Button({
 	// custom `children`, never both -- mirror that so a row's text lands the
 	// same way a query would find it on device.
 	return (
-		<Pressable accessibilityLabel={labelOf(modifiers)} onPress={onPress}>
+		<Pressable
+			accessibilityLabel={labelOf(modifiers)}
+			disabled={isDisabled(modifiers)}
+			onPress={onPress}
+		>
 			{label ? <RNText>{label}</RNText> : children}
 		</Pressable>
 	)

--- a/uitests/ModuleDirectoryTests.swift
+++ b/uitests/ModuleDirectoryTests.swift
@@ -67,13 +67,13 @@ class ModuleDirectoryTests: UITestCase {
 	/// leave both alone -- otherwise the list empties while the title goes on
 	/// naming a department, and the only way back is to navigate in again.
 	func testCancellingSearchKeepsTheLinkedDepartment() throws {
-		let department = TestIdentifiers.Directory.department
+		let department = TestIdentifiers.Directory.fixtureEntryDepartment
 
 		DirectoryScreen(app: app)
 			.navigate()
-			.search(for: "registrar")
+			.search(for: "testerson")
 			.openDepartment(
-				of: TestIdentifiers.Directory.departmentalEntry, named: department)
+				of: TestIdentifiers.Directory.fixtureEntry, named: department)
 			.verifyDepartmentHeading(department)
 			.verifyResultsShown()
 			.cancelSearch()
@@ -86,13 +86,13 @@ class ModuleDirectoryTests: UITestCase {
 	/// department has to name itself above its own results -- otherwise nothing
 	/// on screen says whose names these are.
 	func testDepartmentLinkIsNamedAboveTheResults() throws {
-		let department = TestIdentifiers.Directory.department
+		let department = TestIdentifiers.Directory.fixtureEntryDepartment
 
 		DirectoryScreen(app: app)
 			.navigate()
-			.search(for: "registrar")
+			.search(for: "testerson")
 			.openDepartment(
-				of: TestIdentifiers.Directory.departmentalEntry, named: department)
+				of: TestIdentifiers.Directory.fixtureEntry, named: department)
 			.capture("Directory opened from a department link")
 			.verifyDirectoryTitle()
 			.verifyDepartmentHeading(department)

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -106,13 +106,15 @@ class StageOneListsTests: UITestCase {
 			.navigate()
 			.search(for: TestIdentifiers.Directory.departmentalEntry)
 
-		let row = app.descendants(matching: .any)
+		// The tile gallery is the default view, so a result is a tile rather
+		// than a row -- both open the same entry detail.
+		let result = app.descendants(matching: .any)
 			.matching(
 				NSPredicate(
-					format: "identifier BEGINSWITH %@", TestIdentifiers.Directory.rowPrefix))
+					format: "identifier BEGINSWITH %@", TestIdentifiers.Directory.tilePrefix))
 			.firstMatch
-		XCTAssertTrue(row.waitForExistence(timeout: 30), "A directory result should be listed")
-		row.tap()
+		XCTAssertTrue(result.waitForExistence(timeout: 30), "A directory result should be shown")
+		result.tap()
 
 		// Wait for something only the pushed screen has: a capture taken
 		// straight after the tap lands mid-animation, with both screens in it.
@@ -167,6 +169,30 @@ class StageOneListsTests: UITestCase {
 		XCTAssertTrue(jobInfo.waitForExistence(timeout: 30), "The release screen should be shown")
 
 		screen.capture("Print release")
+	}
+
+	/// The release screen with its actions available, which is a different
+	/// state: a job already sent has nothing left to print or cancel, so those
+	/// rows are drawn only when one is pending and a printer has been chosen.
+	func testPrintReleaseActions() throws {
+		let screen = StoPrintScreen(app: app).navigate()
+
+		let job = app.buttons
+			.matching(NSPredicate(format: "label BEGINSWITH %@", "IMG_2259-COLLAGE.jpg"))
+			.firstMatch
+		XCTAssertTrue(job.waitForExistence(timeout: 30), "A pending job should be listed")
+		job.tap()
+
+		let printer = app.buttons
+			.matching(NSPredicate(format: "label BEGINSWITH %@", "mfc-"))
+			.firstMatch
+		XCTAssertTrue(printer.waitForExistence(timeout: 30), "A printer should be listed")
+		printer.tap()
+
+		let print = app.buttons["Print"].firstMatch
+		XCTAssertTrue(print.waitForExistence(timeout: 30), "Print should be offered")
+
+		screen.capture("Print release - actions")
 	}
 
 	func testMoreList() throws {

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -104,7 +104,7 @@ class StageOneListsTests: UITestCase {
 	func testDirectoryEntryDetail() throws {
 		let screen = DirectoryScreen(app: app)
 			.navigate()
-			.search(for: TestIdentifiers.Directory.departmentalEntry)
+			.search(for: TestIdentifiers.Directory.fixtureEntry)
 
 		// The tile gallery is the default view, so a result is a tile rather
 		// than a row -- both open the same entry detail.
@@ -118,7 +118,11 @@ class StageOneListsTests: UITestCase {
 
 		// Wait for something only the pushed screen has: a capture taken
 		// straight after the tap lands mid-animation, with both screens in it.
-		let department = app.staticTexts[TestIdentifiers.Directory.department].firstMatch
+		let department = app.descendants(matching: .any)
+			.matching(
+				NSPredicate(
+					format: "label CONTAINS %@", TestIdentifiers.Directory.fixtureEntryDepartment))
+			.firstMatch
 		XCTAssertTrue(department.waitForExistence(timeout: 30), "The entry detail should be shown")
 
 		screen.capture("Directory - entry detail")

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -98,19 +98,28 @@ class StageOneListsTests: UITestCase {
 		screen.capture("Student Orgs - detail")
 	}
 
-	func testDirectoryContactDetail() throws {
-		let screen = DirectoryScreen(app: app).navigate()
+	/// A directory *entry*, reached by searching -- not an Important Contact
+	/// tile, which pushes `Directory/named/[title]`, a different screen this
+	/// migration has not touched.
+	func testDirectoryEntryDetail() throws {
+		let screen = DirectoryScreen(app: app)
+			.navigate()
+			.search(for: TestIdentifiers.Directory.departmentalEntry)
 
-		let contact = app.buttonLabelled(TestIdentifiers.Directory.aContact)
-		XCTAssertTrue(contact.waitForExistence(timeout: 30), "A contact tile should be shown")
-		contact.tap()
+		let row = app.descendants(matching: .any)
+			.matching(
+				NSPredicate(
+					format: "identifier BEGINSWITH %@", TestIdentifiers.Directory.rowPrefix))
+			.firstMatch
+		XCTAssertTrue(row.waitForExistence(timeout: 30), "A directory result should be listed")
+		row.tap()
 
 		// Wait for something only the pushed screen has: a capture taken
 		// straight after the tap lands mid-animation, with both screens in it.
-		let action = app.staticTexts[TestIdentifiers.Directory.aContactAction].firstMatch
-		XCTAssertTrue(action.waitForExistence(timeout: 30), "The contact detail should be shown")
+		let department = app.staticTexts[TestIdentifiers.Directory.department].firstMatch
+		XCTAssertTrue(department.waitForExistence(timeout: 30), "The entry detail should be shown")
 
-		screen.capture("Directory - contact detail")
+		screen.capture("Directory - entry detail")
 	}
 
 	/// Searches the catalogue, which under UI testing holds one course, and

--- a/uitests/StageOneListsTests.swift
+++ b/uitests/StageOneListsTests.swift
@@ -105,6 +105,11 @@ class StageOneListsTests: UITestCase {
 		XCTAssertTrue(contact.waitForExistence(timeout: 30), "A contact tile should be shown")
 		contact.tap()
 
+		// Wait for something only the pushed screen has: a capture taken
+		// straight after the tap lands mid-animation, with both screens in it.
+		let action = app.staticTexts[TestIdentifiers.Directory.aContactAction].firstMatch
+		XCTAssertTrue(action.waitForExistence(timeout: 30), "The contact detail should be shown")
+
 		screen.capture("Directory - contact detail")
 	}
 
@@ -136,6 +141,25 @@ class StageOneListsTests: UITestCase {
 		screen.capture("Course detail")
 	}
 
+	/// A job that is not pending release goes to the release screen rather than
+	/// the printer picker, which is the screen this reaches.
+	func testPrintReleaseScreen() throws {
+		let screen = StoPrintScreen(app: app).navigate()
+
+		// "test.pdf" is Sent to Printer in the fixtures, so tapping it opens the
+		// release screen; a Pending Release job would open the printer list.
+		let job = app.buttons
+			.matching(NSPredicate(format: "label BEGINSWITH %@", "test.pdf"))
+			.firstMatch
+		XCTAssertTrue(job.waitForExistence(timeout: 30), "A sent job should be listed")
+		job.tap()
+
+		let jobInfo = app.staticTexts["JOB INFO"].firstMatch
+		XCTAssertTrue(jobInfo.waitForExistence(timeout: 30), "The release screen should be shown")
+
+		screen.capture("Print release")
+	}
+
 	func testMoreList() throws {
 		MoreScreen(app: app)
 			.navigate()
@@ -151,6 +175,9 @@ class StageOneListsTests: UITestCase {
 			otherTab.waitForExistence(timeout: 30),
 			"Other tab should be visible on Transportation")
 		otherTab.tap()
+
+		let section = app.staticTexts["Bus"].firstMatch
+		XCTAssertTrue(section.waitForExistence(timeout: 30), "The Other tab should be showing")
 
 		screen.capture("Transportation - Other Modes")
 	}
@@ -180,6 +207,10 @@ class StageOneListsTests: UITestCase {
 		XCTAssertTrue(found, "Filter tab should be visible on Athletics")
 
 		filterTab.tap()
+
+		let sports = app.staticTexts["Women's Sports"].firstMatch
+		XCTAssertTrue(sports.waitForExistence(timeout: 30), "The Filter tab should be showing")
+
 		screen.capture("Athletics - Filter")
 	}
 

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -368,6 +368,12 @@ struct TestIdentifiers {
 		/// rename it out from under this test.
 		static let departmentalEntry = "Registrar Fax"
 		static let department = "Registrar\u{2019}s Office"
+
+		/// The one entry a UI-test run's directory holds, carrying every field
+		/// the detail screen draws. Mirrors `UITEST_ENTRY_NAME` in
+		/// `source/features/directory/__fixtures__/entries.ts`.
+		static let fixtureEntry = "Kari Testerson"
+		static let fixtureEntryDepartment = "Computer Science"
 	}
 
 	// MARK: - Campus

--- a/uitests/TestIdentifiers.swift
+++ b/uitests/TestIdentifiers.swift
@@ -362,13 +362,6 @@ struct TestIdentifiers {
 		static let showAsList = "Show as list"
 		static let showAsTiles = "Show as tiles"
 
-		/// A directory entry with no title, email or profile, so its detail
-		/// screen carries exactly one element labelled with its department --
-		/// and it is a desk rather than a person, so the college is unlikely to
-		/// rename it out from under this test.
-		static let departmentalEntry = "Registrar Fax"
-		static let department = "Registrar\u{2019}s Office"
-
 		/// The one entry a UI-test run's directory holds, carrying every field
 		/// the detail screen draws. Mirrors `UITEST_ENTRY_NAME` in
 		/// `source/features/directory/__fixtures__/entries.ts`.


### PR DESCRIPTION
<!-- Wren: description yours to write. Below is only what is in the branch, and the screenshots. -->

Stage 3 (PR 3 of 5) of #7921 — the print release screen. **Stacked on #7935.**

### Commits

- `acd385637` Move the print release screen to @expo/ui
- `a998e60aa` Wait for a screen before photographing it
- `f32ed8276` Stop the directory entry drawing a heading over nothing
- Photograph the release screen with something to release
- Photograph the directory entry this migration converted

`@frogpond/tableview` is down from 10 files to 9. The rest are the two building-hours forms, `BannerBuilder`, and the component library.

### The screen, in both its states

| A job already sent | A job pending release |
| --- | --- |
| ![Sent](https://github.com/user-attachments/assets/648340f7-4503-49e3-81e4-ea3808f5ba36) | ![Actions](https://github.com/user-attachments/assets/6defaefb-6c4b-46d6-9847-6543f0436c0a) |

Two captures because they are genuinely different screens: a sent job has nothing left to print or cancel, so the action rows are not drawn at all. The first capture alone would have shown none of what this PR changes.

### Print and Cancel

`ActionRow` grows a `destructive` variant. Cancelling a print job cannot be undone, and a reader should see that in the colour before they tap rather than in the alert afterwards.

Both rows are also **disabled unless the job is actually pending**. The old `ButtonCell`s stayed tappable while a release was already in flight, so Print could be tapped twice.

The `@expo/ui` stand-in now honours a `disabled` modifier, so that is a test rather than an assumption.

### The directory entry's heading

The name and title lead, the photo trails, both hung from the top so a long name wraps down the left of the photo rather than pushing it about. The photo is portrait: a directory photo is head-and-shoulders, and the square it was in cropped it to the chin.

**Directory search now has a fixture.** It searched the live directory, and the entry chosen to keep that stable was a fax machine — carrying so little that half the detail screen drew empty, which is how the empty `ABOUT` heading below went unnoticed. The fixture entry carries every field the screen draws, including a photo, so a section that stops rendering shows up.

### Bugs found

- **The directory entry drew ABOUT over nothing.** The section was rendered whenever the entry had a `pronouns` array, and an empty array is still an array — so an entry with no pronouns, email, office hours or profile got a heading and no rows. Pre-existing; `@frogpond/tableview` hid the empty section where SwiftUI draws its header.
- **A hosted photo lost its centring.** `alignSelf` has nothing to align within once a view is hosted and sizing to its own contents.
- **Three captures photographed the wrong moment.** They fired straight after a tap and landed mid-animation, with two screens in frame.
- **One captured the wrong screen entirely.** The "Directory contact detail" shot on #7935 was `Directory/named/[title]` — an Important Contact, which this migration has not touched — standing in as evidence for `Directory/[index]`, which it did. Now it searches for an entry and opens that.

