### PR TITLE
Move the banner builder and component library to @expo/ui

### DIFF
--- a/app/(component-library)/BadgeLibrary.tsx
+++ b/app/(component-library)/BadgeLibrary.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import {Platform, StyleSheet} from 'react-native'
 import * as c from '@frogpond/colors'
 import {OutlineBadge, SolidBadge} from '@frogpond/badge'
-import {Section} from '@frogpond/tableview'
+import {Section} from '@expo/ui/swift-ui'
 import {Stack} from 'expo-router'
 import {
 	LibraryWrapper,
@@ -10,7 +10,7 @@ import {
 } from '../../source/features/settings/screens/overview/component-library/base/library-wrapper'
 
 const OutlineBadgeExamples = (): React.ReactNode => (
-	<Section header="Outline badge">
+	<Section title="Outline badge">
 		<Example title="Default">
 			<OutlineBadge text="Status" />
 		</Example>
@@ -36,7 +36,7 @@ const OutlineBadgeExamples = (): React.ReactNode => (
 )
 
 const SolidBadgeExamples = (): React.ReactNode => (
-	<Section header="Solid badge">
+	<Section title="Solid badge">
 		<Example title="Default">
 			<SolidBadge status="Status" />
 		</Example>

--- a/app/(component-library)/ButtonLibrary.tsx
+++ b/app/(component-library)/ButtonLibrary.tsx
@@ -2,49 +2,12 @@ import * as React from 'react'
 import {Alert} from 'react-native'
 import {Stack} from 'expo-router'
 
-import * as c from '@frogpond/colors'
-import {Section} from '@frogpond/tableview'
+import {Section} from '@expo/ui/swift-ui'
 import {Button} from '@frogpond/button'
-import {ButtonCell} from '@frogpond/tableview/cells'
 import {
 	LibraryWrapper,
 	Example,
 } from '../../source/features/settings/screens/overview/component-library/base/library-wrapper'
-
-const ButtonCellExample = (): React.ReactNode => {
-	return (
-		<>
-			<ButtonCell disabled={false} onPress={() => undefined} title="Enabled" />
-
-			<ButtonCell disabled={true} onPress={() => undefined} title="Disabled" />
-
-			<ButtonCell indeterminate={true} onPress={() => undefined} title="Indeterminate" />
-
-			<ButtonCell accessoryIcon="graduationcap.fill" onPress={() => undefined} title="Accessory" />
-
-			<ButtonCell
-				accessoryIcon="graduationcap.fill"
-				onPress={() => undefined}
-				textStyle={{color: c.red}}
-				title="Accessory, textstyle"
-			/>
-
-			<ButtonCell
-				accessoryIcon="graduationcap.fill"
-				disabled={true}
-				onPress={() => undefined}
-				textStyle={{color: c.red}}
-				title="Disabled, textstyle, accessory"
-			/>
-
-			<ButtonCell
-				disabled={false}
-				onPress={() => Alert.alert('You tapped the button!')}
-				title="Callback"
-			/>
-		</>
-	)
-}
 
 const ButtonExample = (): React.ReactNode => {
 	return (
@@ -82,11 +45,7 @@ export default function ButtonLibraryPage(): React.ReactNode {
 			<Stack.Title>Buttons</Stack.Title>
 			<LibraryWrapper>
 				<>
-					<Section header="@frogpond/tableview/cells">
-						<ButtonCellExample />
-					</Section>
-
-					<Section header="@frogpond/button">
+					<Section title="@frogpond/button">
 						<ButtonExample />
 					</Section>
 				</>

--- a/app/(component-library)/ColorsLibrary.tsx
+++ b/app/(component-library)/ColorsLibrary.tsx
@@ -11,7 +11,7 @@
 
 import * as React from 'react'
 import {DynamicColorIOS, PlatformColor, StyleSheet, Text, View} from 'react-native'
-import {Section} from '@frogpond/tableview'
+import {Section} from '@expo/ui/swift-ui'
 import {Stack} from 'expo-router'
 import {LibraryWrapper} from '../../source/features/settings/screens/overview/component-library/base/library-wrapper'
 
@@ -236,19 +236,19 @@ export default function ColorsLibraryPage(): React.ReactNode {
 			<Stack.Title>Colors</Stack.Title>
 			<LibraryWrapper>
 				<>
-					<Section header="Platform Colors">
+					<Section title="Platform Colors">
 						<PlatformColorsExample />
 					</Section>
 
-					<Section header="Fallback Colors">
+					<Section title="Fallback Colors">
 						<FallbackColorsExample />
 					</Section>
 
-					<Section header="iOS Dynamic Colors">
+					<Section title="iOS Dynamic Colors">
 						<DynamicColorsExample />
 					</Section>
 
-					<Section header="Variant Colors">
+					<Section title="Variant Colors">
 						<VariantColorsExample />
 					</Section>
 				</>

--- a/app/(component-library)/ComponentLibrary.tsx
+++ b/app/(component-library)/ComponentLibrary.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react'
 
-import {TableView, Section} from '@frogpond/tableview'
-import {PushButtonCell} from '@frogpond/tableview/cells'
+import {StyleSheet} from 'react-native'
+import {Host, List, Section} from '@expo/ui/swift-ui'
+import {listStyle} from '@expo/ui/swift-ui/modifiers'
+import * as c from '@frogpond/colors'
 import {Stack, useRouter} from 'expo-router'
+
+import {DisclosureRow} from '../../source/components/rows'
 
 // This file is named ComponentLibrary.tsx (not index.tsx) so it doesn't
 // claim the bare `/` route -- (component-library) is a top-level group,
@@ -10,6 +14,14 @@ import {Stack, useRouter} from 'expo-router'
 // app/(home)/index.tsx for the unqualified `/` path. This screen is
 // reachable at /ComponentLibrary. PR 8's developer.tsx entry point must
 // push to '/ComponentLibrary', not '/(component-library)' or '/'.
+const LIBRARIES = [
+	{title: 'Badges', route: '/(component-library)/BadgeLibrary'},
+	{title: 'Buttons', route: '/(component-library)/ButtonLibrary'},
+	{title: 'Colors', route: '/(component-library)/ColorsLibrary'},
+	{title: 'Context Menus', route: '/(component-library)/ContextMenuLibrary'},
+	{title: 'FAQ Banners', route: '/(component-library)/FaqBannerLibrary'},
+] as const
+
 export default function ComponentLibraryRootPage(): React.ReactNode {
 	const router = useRouter()
 
@@ -24,30 +36,26 @@ export default function ComponentLibraryRootPage(): React.ReactNode {
 				/>
 			</Stack.Toolbar>
 
-			<TableView>
-				<Section>
-					<PushButtonCell
-						onPress={() => router.navigate('/(component-library)/BadgeLibrary')}
-						title="Badges"
-					/>
-					<PushButtonCell
-						onPress={() => router.navigate('/(component-library)/ButtonLibrary')}
-						title="Buttons"
-					/>
-					<PushButtonCell
-						onPress={() => router.navigate('/(component-library)/ColorsLibrary')}
-						title="Colors"
-					/>
-					<PushButtonCell
-						onPress={() => router.navigate('/(component-library)/ContextMenuLibrary')}
-						title="Context Menus"
-					/>
-					<PushButtonCell
-						onPress={() => router.navigate('/(component-library)/FaqBannerLibrary')}
-						title="FAQ Banners"
-					/>
-				</Section>
-			</TableView>
+			<Host style={styles.host}>
+				<List modifiers={[listStyle('insetGrouped')]}>
+					<Section>
+						{LIBRARIES.map((library) => (
+							<DisclosureRow
+								key={library.route}
+								onPress={() => router.navigate(library.route)}
+								title={library.title}
+							/>
+						))}
+					</Section>
+				</List>
+			</Host>
 		</>
 	)
 }
+
+const styles = StyleSheet.create({
+	host: {
+		flex: 1,
+		backgroundColor: c.systemGroupedBackground,
+	},
+})

--- a/app/(component-library)/ContextMenuLibrary.tsx
+++ b/app/(component-library)/ContextMenuLibrary.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import {Button, Host, Menu, Section as SwiftUISection} from '@expo/ui/swift-ui'
+import {Button, Host, Menu, Section, Section as SwiftUISection} from '@expo/ui/swift-ui'
 import {accessibilityIdentifier} from '@expo/ui/swift-ui/modifiers'
-import {Section} from '@frogpond/tableview'
 import {Stack} from 'expo-router'
 import {
 	Example,

--- a/app/(component-library)/FaqBannerLibrary.tsx
+++ b/app/(component-library)/FaqBannerLibrary.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {Alert, StyleSheet} from 'react-native'
-import {Section} from '@frogpond/tableview'
+import {Section} from '@expo/ui/swift-ui'
 import {Stack} from 'expo-router'
 
 import {FaqBannerPresentation} from '../../source/features/faqs/banner'
@@ -126,7 +126,7 @@ const textExamples: Faq[] = [
 const BannerSection = ({header, faqs}: {header: string; faqs: Faq[]}): React.ReactNode => (
 	// Banners are standalone cards with their own corners and borders, so the
 	// section drops the cell chrome that would clip and divide them.
-	<Section header={header} hideSeparator={true} roundedCorners={false}>
+	<Section title={header}>
 		{faqs.map((faq) => (
 			// Both handlers report which banner fired them, so a dismiss tap that
 			// leaks through to the card shows up as the wrong alert. Passing

--- a/app/(settings)/BannerBuilder.tsx
+++ b/app/(settings)/BannerBuilder.tsx
@@ -1,8 +1,20 @@
 import * as React from 'react'
-import {Alert, ScrollView, Share, StyleSheet, Text, View} from 'react-native'
-import {Cell, Section, TableView} from '@frogpond/tableview'
-import {CellTextField, CellToggle, PushButtonCell, ButtonCell} from '@frogpond/tableview/cells'
+import {Alert, Share, StyleSheet} from 'react-native'
+import {
+	Host,
+	LabeledContent,
+	List,
+	Picker,
+	RNHostView,
+	Section,
+	Text,
+	TextField,
+	Toggle,
+	useNativeState,
+} from '@expo/ui/swift-ui'
+import {lineLimit, listStyle, pickerStyle, tag} from '@expo/ui/swift-ui/modifiers'
 import * as c from '@frogpond/colors'
+import {ActionRow} from '../../source/components/rows'
 import {dump} from 'js-yaml'
 import {Stack, useNavigation} from 'expo-router'
 
@@ -128,142 +140,122 @@ export default function BannerBuilderPage(): React.ReactNode {
 				/>
 			</Stack.Toolbar>
 
-			<ScrollView
-				contentInsetAdjustmentBehavior="automatic"
-				keyboardDismissMode="on-drag"
-				keyboardShouldPersistTaps="always"
-				style={styles.container}
-			>
-				<View style={styles.previewSection}>
-					<Text style={styles.previewLabel}>PREVIEW</Text>
-					<BannerPreview faq={currentFaq} />
-				</View>
+			<Host style={styles.host}>
+				<List modifiers={[listStyle('insetGrouped')]}>
+					<Section title="PREVIEW">
+						{/* The banner is a React Native component, so SwiftUI hosts it
+						    -- and it redraws as the fields below are typed into. */}
+						<RNHostView matchContents={true}>
+							<FaqBannerPresentation faq={currentFaq} />
+						</RNHostView>
+					</Section>
 
-				<TableView>
-					<Section header="Content">
-						<CellTextField
-							label="Title"
-							labelWidth={110}
-							onChangeText={setBannerTitle}
-							placeholder="Banner title"
-							value={bannerTitle}
-						/>
-						<CellTextField
+					<Section title="CONTENT">
+						<FormField label="Title" onChangeText={setBannerTitle} placeholder="Banner title" />
+						<FormField
 							label="Text"
-							labelWidth={110}
 							multiline={true}
 							onChangeText={setBannerText}
 							placeholder="Banner description"
-							value={bannerText}
 						/>
-						<CellTextField
-							label="CTA"
-							labelWidth={110}
-							onChangeText={setBannerCta}
-							placeholder="Learn more"
-							value={bannerCta}
-						/>
-						<CellTextField
-							label="Question"
-							labelWidth={110}
-							onChangeText={setQuestion}
-							placeholder="FAQ question"
-							value={question}
-						/>
-						<CellTextField
+						<FormField label="CTA" onChangeText={setBannerCta} placeholder="Learn more" />
+						<FormField label="Question" onChangeText={setQuestion} placeholder="FAQ question" />
+						<FormField
 							label="Answer"
-							labelWidth={110}
 							multiline={true}
 							onChangeText={setAnswer}
 							placeholder="Full FAQ answer (markdown)"
-							value={answer}
 						/>
 					</Section>
 
-					<Section header="Appearance">
-						{SEVERITY_OPTIONS.map((opt) => (
-							<Cell
-								key={opt}
-								accessory={severity === opt ? 'Checkmark' : undefined}
-								onPress={() => setSeverity(opt)}
-								title={opt.charAt(0).toUpperCase() + opt.slice(1)}
-							/>
-						))}
+					<Section title="APPEARANCE">
+						{/* One of three, so a picker rather than rows carrying their own
+						    checkmarks -- the control says it is a single choice. */}
+						<Picker
+							label="Severity"
+							modifiers={[pickerStyle('segmented')]}
+							onSelectionChange={(selection) => setSeverity(selection as FaqSeverity)}
+							selection={severity}
+						>
+							{SEVERITY_OPTIONS.map((option) => (
+								<Text key={option} modifiers={[tag(option)]}>
+									{option.charAt(0).toUpperCase() + option.slice(1)}
+								</Text>
+							))}
+						</Picker>
 					</Section>
 
-					<Section header="Colors & Icon">
-						<CellTextField
+					<Section title="COLORS & ICON">
+						<FormField
 							label="Icon"
-							labelWidth={110}
 							onChangeText={setIcon}
 							placeholder="e.g. alert-circle, help-circle"
-							value={icon}
 						/>
-						<CellTextField
-							label="BG Color"
-							labelWidth={110}
-							onChangeText={setBackgroundColor}
-							placeholder="#fef2f2"
-							value={backgroundColor}
-						/>
-						<CellTextField
-							label="FG Color"
-							labelWidth={110}
-							onChangeText={setForegroundColor}
-							placeholder="#7f1d1d"
-							value={foregroundColor}
-						/>
+						<FormField label="BG Color" onChangeText={setBackgroundColor} placeholder="#fef2f2" />
+						<FormField label="FG Color" onChangeText={setForegroundColor} placeholder="#7f1d1d" />
 					</Section>
 
-					<Section header="Behavior">
-						<CellToggle label="Dismissable" onChange={setDismissable} value={dismissable} />
+					<Section title="BEHAVIOR">
+						<Toggle isOn={dismissable} label="Dismissable" onIsOnChange={setDismissable} />
 					</Section>
 
-					<Section header="Target Screens">
+					{/* Toggles rather than rows with checkmarks: any number of these
+					    can be on at once, which a checkmark does not say and a switch
+					    does. */}
+					<Section title="TARGET SCREENS">
 						{TARGET_OPTIONS.map((target) => (
-							<Cell
+							<Toggle
 								key={target}
-								accessory={selectedTargets.includes(target) ? 'Checkmark' : undefined}
-								onPress={() => toggleTarget(target)}
-								title={target}
+								isOn={selectedTargets.includes(target)}
+								label={target}
+								onIsOnChange={() => toggleTarget(target)}
 							/>
 						))}
 					</Section>
 
-					<Section header="Actions">
-						<ButtonCell onPress={applyToApp} title="Apply Banner to App" />
-						<PushButtonCell onPress={exportYaml} title="Export as YAML" />
+					<Section title="ACTIONS">
+						<ActionRow onPress={applyToApp} title="Apply Banner to App" />
+						<ActionRow onPress={exportYaml} title="Export as YAML" />
 					</Section>
-				</TableView>
-			</ScrollView>
+				</List>
+			</Host>
 		</>
 	)
 }
 
-/** Inline preview that renders the banner directly from local form state */
-function BannerPreview({faq}: {faq: Faq}): React.ReactNode {
+/**
+ * One labelled field. `LabeledContent` puts the name leading and the field
+ * trailing, which is what the old cell's fixed label width was imitating.
+ *
+ * The field owns its own native state: `TextField` writes through an
+ * `ObservableState` rather than a plain string, so re-rendering the form as
+ * each keystroke lands cannot fight what is being typed.
+ */
+function FormField(props: {
+	label: string
+	placeholder: string
+	multiline?: boolean
+	onChangeText: (text: string) => void
+}): React.ReactNode {
+	let {label, placeholder, multiline = false, onChangeText} = props
+	let state = useNativeState('')
+
 	return (
-		<View style={styles.directPreview}>
-			<FaqBannerPresentation faq={faq} />
-		</View>
+		<LabeledContent label={label}>
+			<TextField
+				axis={multiline ? 'vertical' : 'horizontal'}
+				modifiers={multiline ? [lineLimit(4)] : []}
+				onTextChange={onChangeText}
+				placeholder={placeholder}
+				text={state}
+			/>
+		</LabeledContent>
 	)
 }
 
 const styles = StyleSheet.create({
-	container: {
+	host: {
 		flex: 1,
-	},
-	previewSection: {
-		padding: 16,
-		gap: 8,
-	},
-	previewLabel: {
-		color: c.secondaryLabel,
-		fontSize: 12,
-		fontWeight: '600',
-		letterSpacing: 0.5,
-	},
-	directPreview: {
-		marginTop: 8,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })

--- a/source/features/settings/screens/overview/component-library/base/library-wrapper.tsx
+++ b/source/features/settings/screens/overview/component-library/base/library-wrapper.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
-import {ScrollView, StyleProp, StyleSheet, ViewStyle} from 'react-native'
-import {TableView, Cell} from '@frogpond/tableview'
+import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
+import {Host, HStack, List, RNHostView, Spacer, Text} from '@expo/ui/swift-ui'
+import {listStyle} from '@expo/ui/swift-ui/modifiers'
+import * as c from '@frogpond/colors'
 
 interface WrapperProps {
 	children: React.ReactNode
@@ -12,23 +14,37 @@ interface RowProps {
 	contentContainerStyle?: StyleProp<ViewStyle>
 }
 
+/** The grouped list every component-library screen is drawn inside. */
 export const LibraryWrapper = ({children}: WrapperProps): React.ReactNode => (
-	<ScrollView contentContainerStyle={styles.container} contentInsetAdjustmentBehavior="automatic">
-		<TableView>{children}</TableView>
-	</ScrollView>
+	<Host style={styles.host}>
+		<List modifiers={[listStyle('insetGrouped')]}>{children}</List>
+	</Host>
 )
 
+/**
+ * One example: what it is on the left, the component itself on the right.
+ *
+ * Everything these screens demonstrate is a React Native component, so the
+ * example is hosted rather than drawn by SwiftUI. `matchContents` lets each one
+ * report its own size, since a badge, a button and a colour swatch have nothing
+ * in common to state up front.
+ */
 export const Example = ({title, children, contentContainerStyle}: RowProps): React.ReactNode => (
-	<Cell
-		cellAccessoryView={children}
-		cellStyle="Basic"
-		contentContainerStyle={contentContainerStyle}
-		title={title}
-	/>
+	<HStack spacing={12}>
+		<Text>{title}</Text>
+		<Spacer />
+		{/* One View, because RNHostView hosts exactly one element -- and it is
+		    where `contentContainerStyle` lands, since RNHostView takes no style
+		    of its own. */}
+		<RNHostView matchContents={true}>
+			<View style={contentContainerStyle}>{children}</View>
+		</RNHostView>
+	</HStack>
 )
 
 const styles = StyleSheet.create({
-	container: {
-		paddingVertical: 20,
+	host: {
+		flex: 1,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })


### PR DESCRIPTION
<!-- Wren: description yours to write. Below is only what is in the branch. -->

Stage 3 (PR 4 of 5) of #7921 — the banner builder and the component library. **Stacked on #7939.**

### Commits

- `736339f1b` Move the banner builder to @expo/ui
- `22ed22eee` Draw the component library index and wrapper with @expo/ui
- `7668d5901` Draw the component library screens with @expo/ui

**`@frogpond/tableview` is down from 9 files to 2** — `Campus/detail/report` and `BuildingHoursScheduleEditor`, which go together in the next PR and take the module with them.

### The banner builder is the first form here

The controls say more than the cells did:

- **Severity is a segmented picker.** It was three rows each carrying their own checkmark; a picker says "one of these" in the control itself.
- **Target screens are switches.** Also checkmark rows before, but any number can be on at once — which a switch communicates and a checkmark does not.
- **Fields own native state.** A SwiftUI `TextField` writes through an `ObservableState` rather than a string prop, so re-rendering the form on each keystroke cannot fight what is being typed. That matters here because the preview redraws live as you type. Same pattern as `login-credentials.tsx`.
- **The preview is hosted, not rebuilt.** It is the banner component itself, which is the point of looking at it.

### The component library needed every screen touched

All five reached past the shared wrapper for their own `Section`, so converting the wrapper alone was never going to be enough. I had assumed otherwise earlier in #7921 and was wrong.

`ButtonLibrary` loses its `@frogpond/tableview/cells` section rather than porting it: it documented the module this stage deletes, so there is nothing left for it to show.

### Not captured

No screenshots. Both the banner builder and the component library sit behind Settings → enable dev mode → Developer, and all seven screens are `devOnly`. They are converted, type-checked and linted, but nobody has looked at them — worth saying rather than letting the absence read as coverage.

### Follow-up worth having

The library now documents no row components at all, having lost the cells section. `DisclosureRow`, `ActionRow` and `DetailRow` replaced those cells and deserve a screen of their own — new work rather than migration, so not here.
