### PR TITLE
Let the specials filter turn itself back on

### DIFF
--- a/modules/food-menu/__tests__/fancy-menu.test.tsx
+++ b/modules/food-menu/__tests__/fancy-menu.test.tsx
@@ -169,6 +169,40 @@ describe('FancyMenu', () => {
 		expect(screen.getByText('Pot Roast')).toBeTruthy()
 	})
 
+	// The mirror of the case above. A meal with no specials must not decide the
+	// toggle for the rest of the visit: moving on to a meal that does have them
+	// should leave the reader the handful worth reading, rather than every
+	// condiment and dressing the cafe stocks.
+	test('applies the specials filter to a meal that has them', async () => {
+		let dinnerMeals: ProcessedMealType[] = MEALS.map((meal) =>
+			meal.label === 'Dinner'
+				? {...meal, stations: [station('Home', ['3', '4'], 'closes at 8pm')]}
+				: meal,
+		)
+
+		await render(
+			<FancyMenu
+				foodItems={{
+					1: item('1', 'Pancakes', 'Grill'),
+					3: item('3', 'Pot Roast', 'Home'),
+					4: {...item('4', 'Prime Rib', 'Home'), special: true},
+				}}
+				meals={dinnerMeals}
+				menuCorIcons={COR_ICONS}
+				name="The Caf"
+				now={moment.tz(BREAKFAST_TIME, TIMEZONE)}
+				onItemPress={jest.fn()}
+			/>,
+		)
+
+		// Breakfast has no specials, so the whole meal is on screen.
+		expect(screen.getByText('Pancakes')).toBeTruthy()
+
+		await fireEvent.press(screen.getByTestId('choose-dinner'))
+		expect(screen.getByText('Prime Rib')).toBeTruthy()
+		expect(screen.queryByText('Pot Roast')).toBeNull()
+	})
+
 	// Which meal the menu starts on is `chooseMeal`'s decision, covered directly
 	// in lib/__tests__. What only shows up at this level is whether the choice
 	// outlives a render of the screen above, which hands down a fresh Moment

--- a/modules/food-menu/fancy-menu.tsx
+++ b/modules/food-menu/fancy-menu.tsx
@@ -126,7 +126,7 @@ export function FancyMenu(props: Props): React.ReactNode {
 	// Moment on each of their renders, so anything tracking it would follow
 	// every one of them and take the user's filters with it.
 	const [filters, setFilters] = useState<FilterType<MenuItemType>[]>(() =>
-		buildFilters(Object.values(foodItems), menuCorIcons, meals, now),
+		buildFilters(menuCorIcons, meals, now),
 	)
 
 	const meal = chooseMeal(meals, filters, now)

--- a/modules/food-menu/lib/build-filters.tsx
+++ b/modules/food-menu/lib/build-filters.tsx
@@ -9,7 +9,6 @@ import {chooseMeal, EMPTY_MEAL} from './choose-meal'
 import {dietaryBadge} from './dietary-badge'
 
 export function buildFilters(
-	foodItems: MenuItemType[],
 	corIcons: MasterCorIconMapType,
 	meals: ProcessedMealType[],
 	now?: Moment,
@@ -39,16 +38,14 @@ export function buildFilters(
 	const mealOptions = meals.map((m) => ({label: m.label}))
 	const selectedMeal = (now == null ? meals[0] : chooseMeal(meals, [], now)) ?? EMPTY_MEAL
 
-	// Check if there is at least one special in order to show the specials-only filter
-	const stationNames = selectedMeal.stations.map((s) => s.label)
-	const shouldShowSpecials =
-		foodItems.filter((item) => item.special && stationNames.includes(item.station)).length >= 1
-
 	return [
 		{
+			// On by default, whatever the starting meal holds. Whether a given
+			// meal has anything special to show is decided per meal, as the
+			// reader moves between them, by `offerSpecials`.
 			type: 'toggle',
 			key: 'specials',
-			enabled: shouldShowSpecials,
+			enabled: true,
 			spec: {
 				title: 'Specials Only',
 				label: 'Only Show Specials',

--- a/modules/food-menu/lib/offer-specials.ts
+++ b/modules/food-menu/lib/offer-specials.ts
@@ -6,16 +6,19 @@ import type {MenuItemType} from '../types'
  * The specials toggle, against the meal actually on screen.
  *
  * Showing only the specials is the useful default — the full list carries every
- * condiment and salad dressing the location stocks. But the toggle is seeded
- * once, from whichever meal was showing when the filters were built, and the
- * meal moves: the clock rolls into the next one, or the user picks another. A
- * meal with no specials of its own — Brunch, most days — would otherwise keep
+ * condiment and salad dressing the location stocks — so the toggle is built on.
+ * But the meal moves: the clock rolls into the next one, or the user picks
+ * another. A meal with no specials of its own — Brunch, most days — would keep
  * the filter applied and render nothing at all.
  *
  * So a meal with nothing special still offers the toggle, drawn but disabled
  * and forced off. Removing it instead takes the control out of the toolbar
  * exactly when the reader most wants to see its state — and if it were somehow
  * left on, there would be nothing left on screen to turn it off with.
+ *
+ * The override is applied over the user's own setting rather than written into
+ * it, so moving on to a meal that does have specials restores whatever the
+ * reader last chose: on unless they turned it off themselves.
  */
 export function offerSpecials(
 	filters: FilterType<MenuItemType>[],

--- a/uitests/ModuleFilterTests.swift
+++ b/uitests/ModuleFilterTests.swift
@@ -120,7 +120,8 @@ class ModuleFilterTests: UITestCase {
 
 		let filters = FilterScreen(app: app)
 
-		// The Pause serves specials, so the toggle is seeded on.
+		// The toggle is built on; a meal with no specials of its own would
+		// force it off and grey it out. The Pause's current meal has them.
 		filters.verifyTrigger(Keys.specials, isSelected: true)
 
 		filters.tapTrigger(Keys.specials)


### PR DESCRIPTION
Closes #741

Fix the age-old issue where the Specials filter might not recompute itself when switching menus. 

Solution logic:

1. The meal has no specials — forced off and greyed out, since there'd be nothing left on screen.
2.	The user set it themselves — that sticks across meals.
3.	Otherwise on.