### PR TITLE
Percent-encode mailto body and subject instead of form-encoding

### DIFF
--- a/source/components/__tests__/email.test.ts
+++ b/source/components/__tests__/email.test.ts
@@ -35,13 +35,13 @@ describe('formatEmailParts', () => {
 
 	it('should encode the subject', () => {
 		expect(formatEmailParts({subject: 'a thing'})).toMatchInlineSnapshot(
-			'"mailto:?subject=a+thing"',
+			'"mailto:?subject=a%20thing"',
 		)
 	})
 
 	it('should encode to and subject', () => {
 		expect(formatEmailParts({to: ['test@domain.com'], subject: 'a thing'})).toMatchInlineSnapshot(
-			'"mailto:test@domain.com?subject=a+thing"',
+			'"mailto:test@domain.com?subject=a%20thing"',
 		)
 	})
 
@@ -52,7 +52,7 @@ describe('formatEmailParts', () => {
 				subject: 'a thing',
 				body: 'hey there',
 			}),
-		).toMatchInlineSnapshot('"mailto:test@domain.com?subject=a+thing&body=hey+there"')
+		).toMatchInlineSnapshot('"mailto:test@domain.com?subject=a%20thing&body=hey%20there"')
 		expect(
 			formatEmailParts({
 				to: ['test@domain.com', 'test2@domain.com'],
@@ -60,7 +60,7 @@ describe('formatEmailParts', () => {
 				body: 'hey there',
 			}),
 		).toMatchInlineSnapshot(
-			'"mailto:test@domain.com,test2@domain.com?subject=a+thing&body=hey+there"',
+			'"mailto:test@domain.com,test2@domain.com?subject=a%20thing&body=hey%20there"',
 		)
 	})
 
@@ -74,7 +74,20 @@ describe('formatEmailParts', () => {
 				body: 'hey there',
 			}),
 		).toMatchInlineSnapshot(
-			'"mailto:test@domain.com?cc=test2%40domain.com&bcc=test3%40domain.com&subject=a+thing&body=hey+there"',
+			'"mailto:test@domain.com?cc=test2%40domain.com&bcc=test3%40domain.com&subject=a%20thing&body=hey%20there"',
 		)
+	})
+
+	// `mailto:` follows RFC 6068, not the `application/x-www-form-urlencoded`
+	// convention -- `+` is a literal plus sign there, not a decoded space, so a
+	// mail client that percent-decodes per spec would show a literal "+".
+	it('never encodes a space as +', () => {
+		let href = formatEmailParts({
+			to: ['test@domain.com'],
+			subject: 'a thing',
+			body: 'hey there',
+		})
+
+		expect(href).not.toContain('+')
 	})
 })

--- a/source/components/send-email.ts
+++ b/source/components/send-email.ts
@@ -39,23 +39,29 @@ export function sendEmail(args: Args): void {
 export function formatEmailParts(args: Args): string {
 	const {to = [], cc = [], bcc = [], subject = '', body = ''} = args
 
-	let mailto = new URL(`mailto:${to.join(',')}`)
+	// `mailto:` follows RFC 6068, not the `application/x-www-form-urlencoded`
+	// convention: `+` is a literal plus sign there, not a decoded space. So this
+	// builds the query string with `encodeURIComponent`, which percent-encodes
+	// a space as `%20`, instead of `URLSearchParams`, which encodes it as `+`.
+	const params: Array<[string, string]> = []
 
 	if (cc.length) {
-		mailto.searchParams.append('cc', cc.join(','))
+		params.push(['cc', cc.join(',')])
 	}
 
 	if (bcc.length) {
-		mailto.searchParams.append('bcc', bcc.join(','))
+		params.push(['bcc', bcc.join(',')])
 	}
 
 	if (subject) {
-		mailto.searchParams.append('subject', subject)
+		params.push(['subject', subject])
 	}
 
 	if (body) {
-		mailto.searchParams.append('body', body)
+		params.push(['body', body])
 	}
 
-	return mailto.href
+	const query = params.map(([key, value]) => `${key}=${encodeURIComponent(value)}`).join('&')
+
+	return `mailto:${to.join(',')}${query ? `?${query}` : ''}`
 }


### PR DESCRIPTION
Resolves that issue where emails were being sent with plusses in place of every space