### PR TITLE
Report a chapel closure only when chapel is what ends it

### DIFF
--- a/source/features/building-hours/lib/__tests__/contextual-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/contextual-status.test.ts
@@ -104,4 +104,49 @@ describe('contextualStatus', () => {
 		let result = contextualStatus(building, now)
 		expect(result).toBe('Closed today')
 	})
+
+	it('says when a chapel closure lifts', () => {
+		// data/building-hours/3-1-post-office.yaml; Monday chapel is 10:10-10:30am.
+		let building = makeBuilding([
+			{
+				title: 'Hours',
+				closedForChapelTime: true,
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '8:00am', to: '5:00pm'}],
+			},
+		])
+		let now = moment.tz('2026-09-07 10:15', timezone)
+
+		expect(contextualStatus(building, now)).toBe('Reopens at 10:30 AM')
+	})
+
+	it('counts down the last ten minutes of chapel', () => {
+		let building = makeBuilding([
+			{
+				title: 'Hours',
+				closedForChapelTime: true,
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '8:00am', to: '5:00pm'}],
+			},
+		])
+		let now = moment.tz('2026-09-07 10:22', timezone)
+
+		expect(contextualStatus(building, now)).toBe('Reopens in 8 min')
+	})
+
+	it('points at the next real opening when the building will not resume', () => {
+		// data/building-hours/7-2-health-services.yaml; Thursday chapel runs to
+		// 12:35pm, but the 9:00-11:30am window is over by then.
+		let building = makeBuilding([
+			{
+				title: 'Hours',
+				closedForChapelTime: true,
+				hours: [
+					{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '9:00am', to: '11:30am'},
+					{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '1:00pm', to: '4:00pm'},
+				],
+			},
+		])
+		let now = moment.tz('2026-09-10 11:15', timezone)
+
+		expect(contextualStatus(building, now)).toBe('Opens at 1 PM')
+	})
 })

--- a/source/features/building-hours/lib/__tests__/find-chapel-reopen.test.ts
+++ b/source/features/building-hours/lib/__tests__/find-chapel-reopen.test.ts
@@ -1,0 +1,80 @@
+import {describe, expect, it} from '@jest/globals'
+import {findChapelReopen} from '../find-chapel-reopen'
+import {plainMoment} from './moment.helper'
+import {NamedBuildingScheduleType} from '../../types'
+
+let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
+
+// data/building-hours/3-1-post-office.yaml
+const postOffice: NamedBuildingScheduleType = {
+	title: 'Hours',
+	closedForChapelTime: true,
+	hours: [
+		{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '8:00am', to: '5:00pm'},
+		{days: ['Sa'], from: '10:00am', to: '1:00pm'},
+	],
+}
+
+// data/building-hours/7-2-health-services.yaml
+const healthServices: NamedBuildingScheduleType = {
+	title: 'Hours',
+	closedForChapelTime: true,
+	hours: [
+		{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '9:00am', to: '11:30am'},
+		{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '1:00pm', to: '4:00pm'},
+	],
+}
+
+describe('a window that outlasts chapel', () => {
+	it('reopens when chapel ends', () => {
+		// Monday chapel is 10:10-10:30am; the post office runs 8-5.
+		let reopen = findChapelReopen(postOffice, at('2026-09-07', '10:15:00'))
+
+		expect(reopen?.format('HH:mm')).toBe('10:30')
+	})
+})
+
+describe('a window that does not outlast chapel', () => {
+	it('is null when the window dies mid-chapel', () => {
+		// Thursday chapel is 11:00am-12:35pm; health services closes at 11:30am
+		// and does not reopen until 1pm.
+		expect(findChapelReopen(healthServices, at('2026-09-10', '11:15:00'))).toBeNull()
+	})
+
+	it('is null when the window closes exactly as chapel ends', () => {
+		// Tuesday chapel is 11:10-11:30am and health services closes at 11:30am,
+		// so it never resumes. This is why the comparison is strict.
+		expect(findChapelReopen(healthServices, at('2026-09-08', '11:15:00'))).toBeNull()
+	})
+})
+
+describe('chapel that is not what closed the building', () => {
+	it('is null when no window is running', () => {
+		// Thursday noon: chapel runs to 12:35 but health services is in its own
+		// 11:30-1:00 gap.
+		expect(findChapelReopen(healthServices, at('2026-09-10', '12:00:00'))).toBeNull()
+	})
+
+	it('is null outside chapel', () => {
+		expect(findChapelReopen(postOffice, at('2026-09-07', '14:00:00'))).toBeNull()
+	})
+
+	it('is null when the set does not close for chapel', () => {
+		let alwaysOpen: NamedBuildingScheduleType = {...postOffice, closedForChapelTime: undefined}
+
+		expect(findChapelReopen(alwaysOpen, at('2026-09-07', '10:15:00'))).toBeNull()
+	})
+
+	it('is null for a building that has not opened yet', () => {
+		// Opening at 10:30am, exactly when Monday chapel ends. Chapel is not
+		// what is keeping it shut at 10:15 -- it simply has not opened -- so
+		// this is an ordinary "opens in 15 min", not a chapel closure.
+		let opensAsChapelEnds: NamedBuildingScheduleType = {
+			title: 'Hours',
+			closedForChapelTime: true,
+			hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '10:30am', to: '5:00pm'}],
+		}
+
+		expect(findChapelReopen(opensAsChapelEnds, at('2026-09-07', '10:15:00'))).toBeNull()
+	})
+})

--- a/source/features/building-hours/lib/__tests__/get-detailed-building-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/get-detailed-building-status.test.ts
@@ -195,3 +195,40 @@ describe('a window still running from last night', () => {
 		expect(actual.map((row) => row.status)).toEqual(['7:00 AM — Midnight'])
 	})
 })
+
+describe('the chapel row', () => {
+	let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
+
+	let healthServices: BuildingType = {
+		name: 'Health Services',
+		category: '???',
+		breakSchedule: undefined,
+		schedule: [
+			{
+				title: 'Hours',
+				closedForChapelTime: true,
+				hours: [
+					{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '9:00am', to: '11:30am'},
+					{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '1:00pm', to: '4:00pm'},
+				],
+			},
+		],
+	}
+
+	it('replaces the hours when the building resumes as chapel ends', () => {
+		// Monday chapel is 10:10-10:30am, inside the 9:00-11:30am window.
+		let actual = getDetailedBuildingStatus(healthServices, at('2026-09-07', '10:15:00'))
+
+		expect(actual).toHaveLength(1)
+		expect(actual[0].status).toBe('Closed for chapel: 10:10 AM — 10:30 AM')
+		expect(actual[0].isActive).toBe(false)
+	})
+
+	it('shows the real hours when the building will not resume', () => {
+		// Thursday chapel runs to 12:35pm, long after the 11:30am close.
+		let actual = getDetailedBuildingStatus(healthServices, at('2026-09-10', '11:15:00'))
+
+		expect(actual.map((row) => row.status)).toEqual(['9:00 AM — 11:30 AM', '1:00 PM — 4:00 PM'])
+		expect(actual.every((row) => !row.isActive)).toBe(true)
+	})
+})

--- a/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
@@ -138,3 +138,55 @@ describe('a schedule running past midnight', () => {
 		)
 	})
 })
+
+describe('the chapel badge', () => {
+	let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
+
+	// data/building-hours/3-1-post-office.yaml
+	let postOffice: BuildingType = {
+		name: 'Post Office',
+		category: '???',
+		breakSchedule: undefined,
+		schedule: [
+			{
+				title: 'Hours',
+				closedForChapelTime: true,
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '8:00am', to: '5:00pm'}],
+			},
+		],
+	}
+
+	// data/building-hours/7-2-health-services.yaml
+	let healthServices: BuildingType = {
+		name: 'Health Services',
+		category: '???',
+		breakSchedule: undefined,
+		schedule: [
+			{
+				title: 'Hours',
+				closedForChapelTime: true,
+				hours: [
+					{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '9:00am', to: '11:30am'},
+					{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '1:00pm', to: '4:00pm'},
+				],
+			},
+		],
+	}
+
+	it('reads Chapel when the building resumes as chapel ends', () => {
+		expect(getShortBuildingStatus(postOffice, at('2026-09-07', '10:15:00'))).toBe('Chapel')
+	})
+
+	it('reads Closed when the window dies mid-chapel', () => {
+		// Not "Closes in 15 minutes": the building is shut, not closing soon.
+		expect(getShortBuildingStatus(healthServices, at('2026-09-10', '11:15:00'))).toBe('Closed')
+	})
+
+	it('reads Closed when the building is in its own gap during chapel', () => {
+		expect(getShortBuildingStatus(healthServices, at('2026-09-10', '12:00:00'))).toBe('Closed')
+	})
+
+	it('reads Open once chapel has let out', () => {
+		expect(getShortBuildingStatus(postOffice, at('2026-09-07', '10:35:00'))).toBe('Open')
+	})
+})

--- a/source/features/building-hours/lib/__tests__/is-chapel-time.test.ts
+++ b/source/features/building-hours/lib/__tests__/is-chapel-time.test.ts
@@ -1,6 +1,6 @@
-import {expect, it} from '@jest/globals'
-import {isChapelTime} from '../chapel'
-import {dayMoment} from './moment.helper'
+import {describe, expect, it} from '@jest/globals'
+import {findChapelWindow, isChapelTime} from '../chapel'
+import {dayMoment, plainMoment} from './moment.helper'
 
 it('checks if a moment is during chapel time', () => {
 	let m = isChapelTime(dayMoment('Mon 10:10am'))
@@ -15,4 +15,25 @@ it('returns false if there is no chapel that day', () => {
 it('returns false if chapel is over', () => {
 	let m = isChapelTime(dayMoment('Fri 1:00pm'))
 	expect(m).toBe(false)
+})
+
+describe('findChapelWindow', () => {
+	// 2026-09-07 is a Monday; chapel runs 10:10-10:30am.
+	let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
+
+	it('returns the window running right now', () => {
+		let window = findChapelWindow(at('2026-09-07', '10:15:00'))
+
+		expect(window?.open.format('HH:mm')).toBe('10:10')
+		expect(window?.close.format('HH:mm')).toBe('10:30')
+	})
+
+	it('returns null outside chapel', () => {
+		expect(findChapelWindow(at('2026-09-07', '10:35:00'))).toBeNull()
+	})
+
+	it('returns null on a day with no chapel', () => {
+		// 2026-09-12 is a Saturday.
+		expect(findChapelWindow(at('2026-09-12', '10:15:00'))).toBeNull()
+	})
 })

--- a/source/features/building-hours/lib/chapel.ts
+++ b/source/features/building-hours/lib/chapel.ts
@@ -2,9 +2,10 @@ import type {Moment} from 'moment-timezone'
 import type {SingleBuildingScheduleType} from '../types'
 
 import {getDayOfWeek} from './get-day-of-week'
-import {isScheduleReallyOpenAtMoment} from './is-schedule-really-open'
 import {formatBuildingTimes} from './format-times'
 import {parseHours} from './parse-hours'
+import {findOpenWindow} from './find-open-window'
+import type {HourPairType} from './find-open-window'
 
 // TODO: fetch this over the network
 const chapelSchedule: SingleBuildingScheduleType[] = [
@@ -13,18 +14,26 @@ const chapelSchedule: SingleBuildingScheduleType[] = [
 	{days: ['Th'], from: '11:00am', to: '12:35pm'},
 ]
 
+/** The chapel window running at `m`, or null when chapel is not in session. */
+export function findChapelWindow(
+	m: Moment,
+	schedules: SingleBuildingScheduleType[] = chapelSchedule,
+): HourPairType | null {
+	for (let schedule of schedules) {
+		let window = findOpenWindow(schedule, m)
+		if (window) {
+			return window
+		}
+	}
+
+	return null
+}
+
 export function isChapelTime(
 	m: Moment,
 	schedules: SingleBuildingScheduleType[] = chapelSchedule,
 ): boolean {
-	let dayOfWeek = getDayOfWeek(m)
-	let sched = schedules.find((schedule) => schedule.days.includes(dayOfWeek))
-
-	if (!sched) {
-		return false
-	}
-
-	return isScheduleReallyOpenAtMoment(sched, m)
+	return findChapelWindow(m, schedules) !== null
 }
 
 export function formatChapelTime(

--- a/source/features/building-hours/lib/contextual-status.ts
+++ b/source/features/building-hours/lib/contextual-status.ts
@@ -3,8 +3,13 @@ import type {BuildingType} from '../types'
 import {getDayOfWeek} from './get-day-of-week'
 import {findOpenWindow, windowOpeningOn} from './find-open-window'
 import {isChapelTime} from './chapel'
+import {findChapelReopen} from './find-chapel-reopen'
 
 const ALMOST_THRESHOLD_MINUTES = 30
+
+// Chapel windows run 20 to 95 minutes, so the 30-minute threshold above would
+// spend most of one counting down. Ten minutes keeps the countdown meaningful.
+const CHAPEL_COUNTDOWN_MINUTES = 10
 
 /** Formats a time as "8 PM", or "8:15 PM" when it isn't on the hour. */
 function formatTime(m: Moment): string {
@@ -31,6 +36,18 @@ function findCurrentOpen(building: BuildingType, now: Moment): OpenWindow | null
 	return null
 }
 
+function findChapelReopenForBuilding(building: BuildingType, now: Moment): Moment | null {
+	for (let set of building.schedule || []) {
+		if (set.isPhysicallyOpen === false) continue
+
+		let reopen = findChapelReopen(set, now)
+		if (reopen) {
+			return reopen
+		}
+	}
+	return null
+}
+
 function findNextOpenToday(building: BuildingType, now: Moment): OpenWindow | null {
 	let dayOfWeek = getDayOfWeek(now)
 
@@ -51,7 +68,8 @@ function findNextOpenToday(building: BuildingType, now: Moment): OpenWindow | nu
 
 /**
  * Human-readable status for a building right now, e.g. "Open until 8 PM",
- * "Closes in 15 min", "Opens at 5 PM", "Opens in 10 min", or "Closed today".
+ * "Closes in 15 min", "Reopens at 10:30 AM", "Reopens in 8 min",
+ * "Opens at 5 PM", "Opens in 10 min", or "Closed today".
  */
 export function contextualStatus(building: BuildingType, now: Moment): string {
 	let current = findCurrentOpen(building, now)
@@ -61,6 +79,15 @@ export function contextualStatus(building: BuildingType, now: Moment): string {
 			return `Closes in ${minutesLeft} min`
 		}
 		return `Open until ${formatTime(current.close)}`
+	}
+
+	let chapelReopen = findChapelReopenForBuilding(building, now)
+	if (chapelReopen) {
+		let minutesLeft = chapelReopen.diff(now, 'minutes')
+		if (minutesLeft <= CHAPEL_COUNTDOWN_MINUTES) {
+			return `Reopens in ${minutesLeft} min`
+		}
+		return `Reopens at ${formatTime(chapelReopen)}`
 	}
 
 	let next = findNextOpenToday(building, now)

--- a/source/features/building-hours/lib/find-chapel-reopen.ts
+++ b/source/features/building-hours/lib/find-chapel-reopen.ts
@@ -1,0 +1,35 @@
+import type {Moment} from 'moment-timezone'
+import type {NamedBuildingScheduleType} from '../types'
+
+import {findChapelWindow} from './chapel'
+import {findOpenWindow} from './find-open-window'
+
+/**
+ * When `set` resumes the instant chapel ends, the moment it does; null
+ * otherwise.
+ *
+ * Chapel shuts a building whenever the set opts in and chapel is in session,
+ * but that is only worth *calling* a chapel closure when chapel is the sole
+ * thing holding the doors shut -- when a window is running and outlasts chapel,
+ * so the building opens again the minute chapel lets out. A window that dies
+ * mid-chapel, or one that closes exactly as chapel ends, leaves the reader
+ * waiting for a reopening that never comes; those are ordinary closures whose
+ * own hours tell the true story.
+ */
+export function findChapelReopen(set: NamedBuildingScheduleType, m: Moment): Moment | null {
+	if (!set.closedForChapelTime) {
+		return null
+	}
+
+	let chapel = findChapelWindow(m)
+	if (!chapel) {
+		return null
+	}
+
+	let resumes = set.hours.some((schedule) => {
+		let window = findOpenWindow(schedule, m)
+		return window !== null && window.close.isAfter(chapel.close)
+	})
+
+	return resumes ? chapel.close : null
+}

--- a/source/features/building-hours/lib/get-detailed-status.ts
+++ b/source/features/building-hours/lib/get-detailed-status.ts
@@ -3,7 +3,8 @@ import flatten from 'lodash/flatten'
 import type {BuildingType} from '../types'
 
 import {schedulesInEffect} from './schedules-in-effect'
-import {isChapelTime, formatChapelTime} from './chapel'
+import {formatChapelTime} from './chapel'
+import {findChapelReopen} from './find-chapel-reopen'
 import {isScheduleOpenAtMoment} from './is-schedule-open'
 import {formatBuildingTimes} from './format-times'
 
@@ -31,7 +32,10 @@ export function getDetailedBuildingStatus(info: BuildingType, m: Moment): Buildi
 
 	let results = schedules.map((set) => {
 		let label = set.title
-		if (set.closedForChapelTime && isChapelTime(m)) {
+		// Standing in for the day's hours is only honest when chapel is the one
+		// thing holding the doors shut. Otherwise the real rows say more, and
+		// the per-schedule chapel guard below still marks them inactive.
+		if (findChapelReopen(set, m)) {
 			return [
 				{
 					isActive: false,

--- a/source/features/building-hours/lib/get-short-status.ts
+++ b/source/features/building-hours/lib/get-short-status.ts
@@ -2,6 +2,7 @@ import type {Moment} from 'moment-timezone'
 import type {BuildingType} from '../types'
 
 import {isChapelTime} from './chapel'
+import {findChapelReopen} from './find-chapel-reopen'
 import {schedulesInEffect} from './schedules-in-effect'
 import {getScheduleStatusAtMoment} from './get-schedule-status'
 
@@ -17,7 +18,9 @@ export function getShortBuildingStatus(info: BuildingType, m: Moment): string {
 		}
 
 		if (set.closedForChapelTime && isChapelTime(m)) {
-			return 'Chapel'
+			// Chapel has the doors shut either way; it is only worth naming when
+			// the building opens again the minute chapel lets out.
+			return findChapelReopen(set, m) ? 'Chapel' : 'Closed'
 		}
 
 		let filteredSchedules = schedulesInEffect(set.hours, m)


### PR DESCRIPTION
Update the "is chapel time" helpers such that

- if a building is closed, and marked as closedForChapelTime, it will remain in Closed state and not switch to "closed for chapel" since it hasn't opened yet
- if a building is open, switch to "closed for chapel" and "reopens in 10min" (for times up to 15min away)