### PR TITLE
Tint the Delete Sense button red to match its destructive role

### DIFF
--- a/app/(home)/Dictionary/entry/sense.tsx
+++ b/app/(home)/Dictionary/entry/sense.tsx
@@ -6,8 +6,10 @@ import {
 	accessibilityLabel,
 	lineLimit,
 	textInputAutocapitalization,
+	tint,
 } from '@expo/ui/swift-ui/modifiers'
 import {Stack, useLocalSearchParams, useRouter} from 'expo-router'
+import * as c from '@frogpond/colors'
 import {NoticeView} from '@frogpond/notice'
 
 import {DEFINITION_LINES} from '../../../../source/features/dictionary/constants'
@@ -124,6 +126,7 @@ export default function DictionarySensePage(): React.ReactNode {
 					<Section>
 						<Button
 							label="Delete Sense"
+							modifiers={[tint(c.red)]}
 							onPress={() => {
 								store.deleteSense(sense.id)
 								dismiss()


### PR DESCRIPTION
## Summary
- SwiftUI colors a destructive Button's label text red but leaves its `systemImage` icon at the default accent tint, so the trash icon on the Dictionary "Delete Sense" button rendered blue next to red text.
- Adds an explicit `tint(c.red)` modifier so both the icon and label match.

Fixes #7960

## Test plan
- [ ] Open a dictionary entry, push into a sense, confirm the Delete Sense trash icon and label are both red

🤖 Generated with [Claude Code](https://claude.com/claude-code)