### PR TITLE
Change news list style from 'plain' to 'insetGrouped'

### DIFF
--- a/source/features/news/news-list.tsx
+++ b/source/features/news/news-list.tsx
@@ -49,7 +49,7 @@ export const NewsList = (props: Props): React.ReactNode => {
 			<VStack spacing={0}>
 				<List
 					modifiers={[
-						listStyle('plain'),
+						listStyle('insetGrouped'),
 						refreshable(async () => {
 							await refetch()
 						}),
@@ -77,6 +77,6 @@ export const NewsList = (props: Props): React.ReactNode => {
 const styles = StyleSheet.create({
 	host: {
 		flex: 1,
-		backgroundColor: c.systemBackground,
+		backgroundColor: c.systemGroupedBackground,
 	},
 })


### PR DESCRIPTION
Part of the audit in #7957.

![News list, insetGrouped](https://github.com/user-attachments/assets/a4f56275-3f3e-4310-9e60-31f229c51fa4)

<!-- description left for Hawken -->