### PR TITLE
Warn before chapel shuts a building

### DIFF
--- a/source/features/building-hours/detail/building-detail.tsx
+++ b/source/features/building-hours/detail/building-detail.tsx
@@ -92,7 +92,7 @@ export function BuildingDetailSwiftUI({building, now, campus}: Props): React.Rea
 						<Text
 							modifiers={[font({textStyle: 'body', weight: 'semibold'}), foregroundStyle(c.label)]}
 						>
-							{statusText}
+							{statusText.long}
 						</Text>
 					</HStack>
 				</Section>

--- a/source/features/building-hours/lib/__tests__/contextual-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/contextual-status.test.ts
@@ -151,6 +151,54 @@ describe('contextualStatus', () => {
 		expect(result.short).toBe('Closed')
 	})
 
+	it('counts down to a chapel closure', () => {
+		// data/building-hours/3-1-post-office.yaml; Monday chapel is 10:10-10:30am.
+		let building = makeBuilding([
+			{
+				title: 'Hours',
+				closedForChapelTime: true,
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '8:00am', to: '5:00pm'}],
+			},
+		])
+		let now = moment.tz('2026-09-07 10:00', timezone) // Monday, ten minutes out
+
+		expect(contextualStatus(building, now)).toEqual({
+			short: 'Chapel in 10 min',
+			long: 'Closes for chapel in 10 minutes',
+		})
+	})
+
+	it('says minute in the singular with one minute left', () => {
+		let building = makeBuilding([
+			{
+				title: 'Hours',
+				closedForChapelTime: true,
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '8:00am', to: '5:00pm'}],
+			},
+		])
+		let now = moment.tz('2026-09-07 10:09', timezone)
+
+		expect(contextualStatus(building, now)).toEqual({
+			short: 'Chapel in 1 min',
+			long: 'Closes for chapel in 1 minute',
+		})
+	})
+
+	it("names the day's real close before the countdown starts", () => {
+		// The whole reason chapel stays an overlay: at 9:55 this building is open
+		// until five, not until chapel.
+		let building = makeBuilding([
+			{
+				title: 'Hours',
+				closedForChapelTime: true,
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '8:00am', to: '5:00pm'}],
+			},
+		])
+		let now = moment.tz('2026-09-07 09:55', timezone)
+
+		expect(contextualStatus(building, now).short).toBe('Open until 5 PM')
+	})
+
 	it('says when a chapel closure lifts', () => {
 		// data/building-hours/3-1-post-office.yaml; Monday chapel is 10:10-10:30am.
 		let building = makeBuilding([

--- a/source/features/building-hours/lib/__tests__/contextual-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/contextual-status.test.ts
@@ -22,7 +22,7 @@ describe('contextualStatus', () => {
 		])
 		let now = moment.tz('2026-09-07 14:00', timezone) // Monday 2pm
 		let result = contextualStatus(building, now)
-		expect(result).toBe('Open until 8 PM')
+		expect(result.short).toBe('Open until 8 PM')
 	})
 
 	it('returns "Closes in X min" when almost closed', () => {
@@ -34,7 +34,7 @@ describe('contextualStatus', () => {
 		])
 		let now = moment.tz('2026-09-07 19:45', timezone) // Monday 7:45pm
 		let result = contextualStatus(building, now)
-		expect(result).toMatch(/Closes in \d+ min/u)
+		expect(result.short).toMatch(/Closes in \d+ min/u)
 	})
 
 	it('returns "Opens at X" when closed but opens later today', () => {
@@ -46,7 +46,7 @@ describe('contextualStatus', () => {
 		])
 		let now = moment.tz('2026-09-07 14:00', timezone) // Monday 2pm
 		let result = contextualStatus(building, now)
-		expect(result).toBe('Opens at 5 PM')
+		expect(result.short).toBe('Opens at 5 PM')
 	})
 
 	it('names the earliest opening today, not the first one listed', () => {
@@ -70,12 +70,12 @@ describe('contextualStatus', () => {
 			},
 		])
 
-		expect(contextualStatus(building, moment.tz('2026-09-07 10:00', timezone))).toBe(
+		expect(contextualStatus(building, moment.tz('2026-09-07 10:00', timezone)).short).toBe(
 			'Opens at 11 AM',
 		)
 		// And again once the first window has passed: the answer moves to the
 		// kitchen's evening window, still not the delivery one.
-		expect(contextualStatus(building, moment.tz('2026-09-07 14:30', timezone))).toBe(
+		expect(contextualStatus(building, moment.tz('2026-09-07 14:30', timezone)).short).toBe(
 			'Opens at 5 PM',
 		)
 	})
@@ -92,7 +92,7 @@ describe('contextualStatus', () => {
 		])
 		let now = moment.tz('2026-09-07 08:00', timezone) // Monday 8am
 
-		expect(contextualStatus(building, now)).toBe('Opens at 9 AM')
+		expect(contextualStatus(building, now).short).toBe('Opens at 9 AM')
 	})
 
 	it('returns "Opens in X min" when almost open', () => {
@@ -104,7 +104,7 @@ describe('contextualStatus', () => {
 		])
 		let now = moment.tz('2026-09-07 16:45', timezone) // Monday 4:45pm
 		let result = contextualStatus(building, now)
-		expect(result).toMatch(/Opens in \d+ min/u)
+		expect(result.short).toMatch(/Opens in \d+ min/u)
 	})
 
 	it('reports the window carried over from last night', () => {
@@ -120,7 +120,7 @@ describe('contextualStatus', () => {
 			},
 		])
 		let now = moment.tz('2026-09-13 00:30', timezone) // Sunday 12:30am
-		expect(contextualStatus(building, now)).toBe('Closes in 30 min')
+		expect(contextualStatus(building, now).short).toBe('Closes in 30 min')
 	})
 
 	it('does not report a window that no night of the week is running', () => {
@@ -136,7 +136,7 @@ describe('contextualStatus', () => {
 			},
 		])
 		let now = moment.tz('2026-09-11 00:30', timezone) // Friday 12:30am
-		expect(contextualStatus(building, now)).toBe('Opens at 7 AM')
+		expect(contextualStatus(building, now).short).toBe('Opens at 7 AM')
 	})
 
 	it('returns "Closed" when nothing opens again today', () => {
@@ -148,7 +148,7 @@ describe('contextualStatus', () => {
 		])
 		let now = moment.tz('2026-09-12 14:00', timezone) // Saturday 2pm
 		let result = contextualStatus(building, now)
-		expect(result).toBe('Closed')
+		expect(result.short).toBe('Closed')
 	})
 
 	it('says when a chapel closure lifts', () => {
@@ -162,7 +162,7 @@ describe('contextualStatus', () => {
 		])
 		let now = moment.tz('2026-09-07 10:15', timezone)
 
-		expect(contextualStatus(building, now)).toBe('Reopens at 10:30 AM')
+		expect(contextualStatus(building, now).short).toBe('Reopens at 10:30 AM')
 	})
 
 	it('counts down the last ten minutes of chapel', () => {
@@ -175,7 +175,7 @@ describe('contextualStatus', () => {
 		])
 		let now = moment.tz('2026-09-07 10:22', timezone)
 
-		expect(contextualStatus(building, now)).toBe('Reopens in 8 min')
+		expect(contextualStatus(building, now).short).toBe('Reopens in 8 min')
 	})
 
 	it('points at the next real opening when the building will not resume', () => {
@@ -193,6 +193,6 @@ describe('contextualStatus', () => {
 		])
 		let now = moment.tz('2026-09-10 11:15', timezone)
 
-		expect(contextualStatus(building, now)).toBe('Opens at 1 PM')
+		expect(contextualStatus(building, now).short).toBe('Opens at 1 PM')
 	})
 })

--- a/source/features/building-hours/lib/__tests__/find-chapel-pause.test.ts
+++ b/source/features/building-hours/lib/__tests__/find-chapel-pause.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, it} from '@jest/globals'
+import {findChapelPause} from '../find-chapel-pause'
+import {plainMoment} from './moment.helper'
+import {NamedBuildingScheduleType} from '../../types'
+
+let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
+
+// data/building-hours/3-1-post-office.yaml
+const postOffice: NamedBuildingScheduleType = {
+	title: 'Hours',
+	closedForChapelTime: true,
+	hours: [
+		{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '8:00am', to: '5:00pm'},
+		{days: ['Sa'], from: '10:00am', to: '1:00pm'},
+	],
+}
+
+// 2026-09-07 is a Monday; chapel runs 10:10-10:30am.
+describe('a set chapel is about to shut', () => {
+	it('names the chapel start inside the countdown', () => {
+		let pause = findChapelPause(postOffice, at('2026-09-07', '10:05:00'))
+
+		expect(pause?.format('HH:mm')).toBe('10:10')
+	})
+
+	it('includes the exact edge of the countdown', () => {
+		let pause = findChapelPause(postOffice, at('2026-09-07', '10:00:00'))
+
+		expect(pause?.format('HH:mm')).toBe('10:10')
+	})
+
+	it('stays quiet before the countdown begins', () => {
+		expect(findChapelPause(postOffice, at('2026-09-07', '09:55:00'))).toBeNull()
+	})
+
+	it('stays quiet once chapel is running', () => {
+		expect(findChapelPause(postOffice, at('2026-09-07', '10:15:00'))).toBeNull()
+	})
+
+	it('stays quiet on a day without chapel', () => {
+		// 2026-09-12 is a Saturday; the Saturday window is open at 10am.
+		expect(findChapelPause(postOffice, at('2026-09-12', '10:00:00'))).toBeNull()
+	})
+})
+
+describe('a set chapel will not shut', () => {
+	it('stays quiet when the set does not observe chapel', () => {
+		let set: NamedBuildingScheduleType = {
+			title: 'Hours',
+			hours: [{days: ['Mo'], from: '8:00am', to: '5:00pm'}],
+		}
+
+		expect(findChapelPause(set, at('2026-09-07', '10:05:00'))).toBeNull()
+	})
+
+	it('stays quiet when the window closes before chapel starts', () => {
+		// Closing at 10:05 is this window's own business, not chapel's.
+		let set: NamedBuildingScheduleType = {
+			title: 'Hours',
+			closedForChapelTime: true,
+			hours: [{days: ['Mo'], from: '8:00am', to: '10:05am'}],
+		}
+
+		expect(findChapelPause(set, at('2026-09-07', '10:00:00'))).toBeNull()
+	})
+
+	it('stays quiet when the set is not open yet', () => {
+		let set: NamedBuildingScheduleType = {
+			title: 'Hours',
+			closedForChapelTime: true,
+			hours: [{days: ['Mo'], from: '10:30am', to: '5:00pm'}],
+		}
+
+		expect(findChapelPause(set, at('2026-09-07', '10:05:00'))).toBeNull()
+	})
+})

--- a/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
@@ -173,6 +173,12 @@ describe('the chapel badge', () => {
 		],
 	}
 
+	it('reads Chapel in the minutes before chapel shuts the building', () => {
+		// The dot has to turn with the text, or the row reads "Chapel in 5 min"
+		// beside a green Open dot.
+		expect(getShortBuildingStatus(postOffice, at('2026-09-07', '10:05:00'))).toBe('Chapel')
+	})
+
 	it('reads Chapel when the building resumes as chapel ends', () => {
 		expect(getShortBuildingStatus(postOffice, at('2026-09-07', '10:15:00'))).toBe('Chapel')
 	})

--- a/source/features/building-hours/lib/__tests__/is-chapel-time.test.ts
+++ b/source/features/building-hours/lib/__tests__/is-chapel-time.test.ts
@@ -1,6 +1,9 @@
 import {describe, expect, it} from '@jest/globals'
-import {findChapelWindow, isChapelTime} from '../chapel'
+import {findChapelWindow, findNextChapelWindow, isChapelTime} from '../chapel'
 import {dayMoment, plainMoment} from './moment.helper'
+
+// 2026-09-07 is a Monday; chapel runs 10:10-10:30am.
+let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
 
 it('checks if a moment is during chapel time', () => {
 	let m = isChapelTime(dayMoment('Mon 10:10am'))
@@ -18,9 +21,6 @@ it('returns false if chapel is over', () => {
 })
 
 describe('findChapelWindow', () => {
-	// 2026-09-07 is a Monday; chapel runs 10:10-10:30am.
-	let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
-
 	it('returns the window running right now', () => {
 		let window = findChapelWindow(at('2026-09-07', '10:15:00'))
 
@@ -35,5 +35,27 @@ describe('findChapelWindow', () => {
 	it('returns null on a day with no chapel', () => {
 		// 2026-09-12 is a Saturday.
 		expect(findChapelWindow(at('2026-09-12', '10:15:00'))).toBeNull()
+	})
+})
+
+describe('findNextChapelWindow', () => {
+	it("returns today's window before chapel starts", () => {
+		let window = findNextChapelWindow(at('2026-09-07', '10:05:00'))
+
+		expect(window?.open.format('HH:mm')).toBe('10:10')
+		expect(window?.close.format('HH:mm')).toBe('10:30')
+	})
+
+	it('returns null once chapel is running', () => {
+		expect(findNextChapelWindow(at('2026-09-07', '10:15:00'))).toBeNull()
+	})
+
+	it('returns null once chapel is over', () => {
+		expect(findNextChapelWindow(at('2026-09-07', '11:00:00'))).toBeNull()
+	})
+
+	it('returns null on a day with no chapel', () => {
+		// 2026-09-12 is a Saturday.
+		expect(findNextChapelWindow(at('2026-09-12', '09:00:00'))).toBeNull()
 	})
 })

--- a/source/features/building-hours/lib/chapel.ts
+++ b/source/features/building-hours/lib/chapel.ts
@@ -4,7 +4,7 @@ import type {SingleBuildingScheduleType} from '../types'
 import {getDayOfWeek} from './get-day-of-week'
 import {formatBuildingTimes} from './format-times'
 import {parseHours} from './parse-hours'
-import {findOpenWindow} from './find-open-window'
+import {findOpenWindow, windowOpeningOn} from './find-open-window'
 import type {HourPairType} from './find-open-window'
 
 // TODO: fetch this over the network
@@ -14,6 +14,13 @@ const chapelSchedule: SingleBuildingScheduleType[] = [
 	{days: ['Th'], from: '11:00am', to: '12:35pm'},
 ]
 
+/**
+ * How long before chapel starts, or after it ends, a countdown is worth showing.
+ * Chapel windows run 20 to 95 minutes, so the 30-minute threshold the rest of the
+ * status line uses would spend most of one counting down.
+ */
+export const CHAPEL_COUNTDOWN_MINUTES = 10
+
 /** The chapel window running at `m`, or null when chapel is not in session. */
 export function findChapelWindow(
 	m: Moment,
@@ -22,6 +29,25 @@ export function findChapelWindow(
 	for (let schedule of schedules) {
 		let window = findOpenWindow(schedule, m)
 		if (window) {
+			return window
+		}
+	}
+
+	return null
+}
+
+/** Today's chapel window, when it has not started yet at `m`; null otherwise. */
+export function findNextChapelWindow(
+	m: Moment,
+	schedules: SingleBuildingScheduleType[] = chapelSchedule,
+): HourPairType | null {
+	let dayOfWeek = getDayOfWeek(m)
+
+	for (let schedule of schedules) {
+		if (!schedule.days.includes(dayOfWeek)) continue
+
+		let window = windowOpeningOn(schedule, m)
+		if (m.isBefore(window.open)) {
 			return window
 		}
 	}

--- a/source/features/building-hours/lib/contextual-status.ts
+++ b/source/features/building-hours/lib/contextual-status.ts
@@ -2,14 +2,10 @@ import type {Moment} from 'moment-timezone'
 import type {BuildingType, NamedBuildingScheduleType} from '../types'
 import {getDayOfWeek} from './get-day-of-week'
 import {findOpenWindow, windowOpeningOn} from './find-open-window'
-import {isChapelTime} from './chapel'
+import {CHAPEL_COUNTDOWN_MINUTES, isChapelTime} from './chapel'
 import {findChapelReopen} from './find-chapel-reopen'
 
 const ALMOST_THRESHOLD_MINUTES = 30
-
-// Chapel windows run 20 to 95 minutes, so the 30-minute threshold above would
-// spend most of one counting down. Ten minutes keeps the countdown meaningful.
-const CHAPEL_COUNTDOWN_MINUTES = 10
 
 /** Formats a time as "8 PM", or "8:15 PM" when it isn't on the hour. */
 function formatTime(m: Moment): string {
@@ -79,42 +75,51 @@ function findNextOpenToday(building: BuildingType, now: Moment): OpenWindow | nu
 	return earliest
 }
 
+/** The status line's two spellings: the list row is cramped, the detail screen is not. */
+export type ContextualStatus = {short: string; long: string}
+
+/** A status that reads the same either way, which is every one but the chapel warning. */
+function plain(text: string): ContextualStatus {
+	return {short: text, long: text}
+}
+
 /**
  * Human-readable status for a building right now, e.g. "Open until 8 PM",
  * "Closes in 15 min", "Reopens at 10:30 AM", "Reopens in 8 min",
- * "Opens at 5 PM", "Opens in 10 min", or "Closed".
+ * "Opens at 5 PM", "Opens in 10 min", or "Closed". The two forms differ only
+ * for the chapel warning, which the list row has no room to spell out.
  */
-export function contextualStatus(building: BuildingType, now: Moment): string {
+export function contextualStatus(building: BuildingType, now: Moment): ContextualStatus {
 	let current = findCurrentOpen(building, now)
 	if (current) {
 		let minutesLeft = current.close.diff(now, 'minutes')
 		if (minutesLeft <= ALMOST_THRESHOLD_MINUTES) {
-			return `Closes in ${minutesLeft} min`
+			return plain(`Closes in ${minutesLeft} min`)
 		}
-		return `Open until ${formatTime(current.close)}`
+		return plain(`Open until ${formatTime(current.close)}`)
 	}
 
 	let chapelReopen = findChapelReopenForBuilding(building, now)
 	if (chapelReopen) {
 		let minutesLeft = chapelReopen.diff(now, 'minutes')
 		if (minutesLeft <= CHAPEL_COUNTDOWN_MINUTES) {
-			return `Reopens in ${minutesLeft} min`
+			return plain(`Reopens in ${minutesLeft} min`)
 		}
-		return `Reopens at ${formatTime(chapelReopen)}`
+		return plain(`Reopens at ${formatTime(chapelReopen)}`)
 	}
 
 	let next = findNextOpenToday(building, now)
 	if (next) {
 		let minutesUntilOpen = next.open.diff(now, 'minutes')
 		if (minutesUntilOpen <= ALMOST_THRESHOLD_MINUTES) {
-			return `Opens in ${minutesUntilOpen} min`
+			return plain(`Opens in ${minutesUntilOpen} min`)
 		}
-		return `Opens at ${formatTime(next.open)}`
+		return plain(`Opens at ${formatTime(next.open)}`)
 	}
 
 	// Not "Closed today": this is only reached once nothing opens again today, so
 	// both readings are true, but "Closed today" also reads as "has no hours
 	// today" -- a claim about the whole day that a building open this morning
 	// would contradict. The detail sheet carries the real hours.
-	return 'Closed'
+	return plain('Closed')
 }

--- a/source/features/building-hours/lib/contextual-status.ts
+++ b/source/features/building-hours/lib/contextual-status.ts
@@ -4,6 +4,7 @@ import {getDayOfWeek} from './get-day-of-week'
 import {findOpenWindow, windowOpeningOn} from './find-open-window'
 import {CHAPEL_COUNTDOWN_MINUTES, isChapelTime} from './chapel'
 import {findChapelReopen} from './find-chapel-reopen'
+import {findChapelPause} from './find-chapel-pause'
 
 const ALMOST_THRESHOLD_MINUTES = 30
 
@@ -92,6 +93,15 @@ function plain(text: string): ContextualStatus {
 export function contextualStatus(building: BuildingType, now: Moment): ContextualStatus {
 	let current = findCurrentOpen(building, now)
 	if (current) {
+		let chapelPause = findChapelPause(current.set, now)
+		if (chapelPause) {
+			let minutes = chapelPause.diff(now, 'minutes')
+			return {
+				short: `Chapel in ${minutes} min`,
+				long: `Closes for chapel in ${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`,
+			}
+		}
+
 		let minutesLeft = current.close.diff(now, 'minutes')
 		if (minutesLeft <= ALMOST_THRESHOLD_MINUTES) {
 			return plain(`Closes in ${minutesLeft} min`)

--- a/source/features/building-hours/lib/contextual-status.ts
+++ b/source/features/building-hours/lib/contextual-status.ts
@@ -1,5 +1,5 @@
 import type {Moment} from 'moment-timezone'
-import type {BuildingType} from '../types'
+import type {BuildingType, NamedBuildingScheduleType} from '../types'
 import {getDayOfWeek} from './get-day-of-week'
 import {findOpenWindow, windowOpeningOn} from './find-open-window'
 import {isChapelTime} from './chapel'
@@ -18,7 +18,10 @@ function formatTime(m: Moment): string {
 
 type OpenWindow = {open: Moment; close: Moment}
 
-function findCurrentOpen(building: BuildingType, now: Moment): OpenWindow | null {
+/** The window a building is open under, and the set that posted it. */
+type CurrentOpen = OpenWindow & {set: NamedBuildingScheduleType}
+
+function findCurrentOpen(building: BuildingType, now: Moment): CurrentOpen | null {
 	for (let set of building.schedule || []) {
 		if (set.isPhysicallyOpen === false) continue
 		if (set.closedForChapelTime && isChapelTime(now)) continue
@@ -29,7 +32,7 @@ function findCurrentOpen(building: BuildingType, now: Moment): OpenWindow | null
 			// discard exactly those.
 			let window = findOpenWindow(hours, now)
 			if (window) {
-				return window
+				return {...window, set}
 			}
 		}
 	}

--- a/source/features/building-hours/lib/find-chapel-pause.ts
+++ b/source/features/building-hours/lib/find-chapel-pause.ts
@@ -1,0 +1,36 @@
+import type {Moment} from 'moment-timezone'
+import type {NamedBuildingScheduleType} from '../types'
+
+import {CHAPEL_COUNTDOWN_MINUTES, findNextChapelWindow} from './chapel'
+import {findOpenWindow} from './find-open-window'
+
+/**
+ * When chapel is about to shut `set`, the moment chapel starts; null otherwise.
+ *
+ * The mirror of `findChapelReopen`, which speaks once chapel already has the
+ * doors shut. A set earns the warning only while it is open, opting into chapel
+ * closure, and running a window chapel will interrupt: a window closing before
+ * chapel starts is closing on its own terms, and blaming chapel for an ordinary
+ * closing time would misread the schedule.
+ */
+export function findChapelPause(set: NamedBuildingScheduleType, m: Moment): Moment | null {
+	if (!set.closedForChapelTime) {
+		return null
+	}
+
+	let chapel = findNextChapelWindow(m)
+	if (!chapel) {
+		return null
+	}
+
+	if (chapel.open.diff(m, 'minutes') > CHAPEL_COUNTDOWN_MINUTES) {
+		return null
+	}
+
+	let interrupted = set.hours.some((schedule) => {
+		let window = findOpenWindow(schedule, m)
+		return window !== null && window.close.isAfter(chapel.open)
+	})
+
+	return interrupted ? chapel.open : null
+}

--- a/source/features/building-hours/lib/get-short-status.ts
+++ b/source/features/building-hours/lib/get-short-status.ts
@@ -3,6 +3,7 @@ import type {BuildingType} from '../types'
 
 import {isChapelTime} from './chapel'
 import {findChapelReopen} from './find-chapel-reopen'
+import {findChapelPause} from './find-chapel-pause'
 import {schedulesInEffect} from './schedules-in-effect'
 import {getScheduleStatusAtMoment} from './get-schedule-status'
 
@@ -21,6 +22,12 @@ export function getShortBuildingStatus(info: BuildingType, m: Moment): string {
 			// Chapel has the doors shut either way; it is only worth naming when
 			// the building opens again the minute chapel lets out.
 			return findChapelReopen(set, m) ? 'Chapel' : 'Closed'
+		}
+
+		// The branch above needs chapel already running, this one needs it still
+		// ahead, so the two never both fire.
+		if (findChapelPause(set, m)) {
+			return 'Chapel'
 		}
 
 		let filteredSchedules = schedulesInEffect(set.hours, m)

--- a/source/features/building-hours/list/building-list-row.tsx
+++ b/source/features/building-hours/list/building-list-row.tsx
@@ -77,7 +77,7 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 				modifiers={[
 					buttonStyle('plain'),
 					accessibilityIdentifier(`${BUILDING_ROW_PREFIX}${building.name}`),
-					accessibilityLabel(`${building.name}, ${statusText}`),
+					accessibilityLabel(`${building.name}, ${statusText.long}`),
 				]}
 				onPress={() => onSelect(building)}
 			>
@@ -104,7 +104,7 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 									layoutPriority(1),
 								]}
 							>
-								{hasHours ? statusText : (firstNote ?? '')}
+								{hasHours ? statusText.short : (firstNote ?? '')}
 							</Text>
 							<Image
 								modifiers={[foregroundStyle(accentBg), font({textStyle: 'caption2'})]}


### PR DESCRIPTION
A building that observes chapel closure gave no warning before chapel shut it. The status flipped straight from one state to the other:

```
MON 10:09 -> Open until 5 PM
MON 10:10 -> Reopens at 10:30 AM
```

That is the post office with its committed hours against Monday chapel. The print center behaves the same way.

## What changed

A new `findChapelPause` mirrors the existing `findChapelReopen`. It names the chapel start only when the set observes chapel, is open now, has chapel starting within the countdown, and is running a window chapel will actually interrupt. 

That last condition matters: a window closing at 10:05 with chapel at 10:10 is closing on its own terms, and blaming chapel for an ordinary closing time would misread the schedule.

`contextualStatus` now returns a `{short, long}` pair. The list row is cramped and has an accessibility label of its own; the detail screen has a line to itself and speaks whatever it shows. For every status but the chapel warning the two forms are identical.

| | Row | Detail |
| --- | --- | --- |
| Visible | `short` | `long` |
| Spoken | name plus `long` | `long` |

Resulting sequence for a building open 8:00am to 5:00pm:

| Time | Dot | Row text |
| --- | --- | --- |
| before 10:00 | Open | Open until 5 PM |
| 10:00 to 10:09 | Chapel | Chapel in 10 min, down to Chapel in 1 min |
| 10:10 to 10:19 | Chapel | Reopens at 10:30 AM |
| 10:20 to 10:29 | Chapel | Reopens in 10 min, down to Reopens in 1 min |
| 10:30 onward | Open | Open until 5 PM |

The countdown threshold is the existing ten minute chapel constant, not the thirty minute one the rest of the status line uses. Chapel windows run twenty to ninety-five minutes, so thirty would spend most of one counting down. That constant moved from `contextual-status.ts` into `chapel.ts`, since two modules now read it and a chapel fact belongs with the chapel schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqRYTaSDg6zZBECHvCiQRd