### PR TITLE
Stop pizza delivery from standing in for the Pause Kitchen opening

### DIFF
--- a/data/building-hours/1-2-pause-kitchen.yaml
+++ b/data/building-hours/1-2-pause-kitchen.yaml
@@ -7,6 +7,7 @@ links:
 
 schedule:
   - title: On Campus Pizza Delivery
+    isPhysicallyOpen: false
     hours:
       - {days: [Mo, Tu, We, Th, Fr, Sa, Su], from: '7:00pm', to: '12:00am'}
 


### PR DESCRIPTION
The Pause Kitchen row read "Opens at 7 PM" all morning, every morning, when the kitchen actually opens at 11:00am on weekdays and noon at weekends.

Its schedule lists two sets, and the delivery one comes first because it is the notable one, not the early one:

```yaml
schedule:
  - title: On Campus Pizza Delivery
    hours:
      - {days: [Mo, …, Su], from: '7:00pm', to: '12:00am'}

  - title: Hours
    hours:
      - {days: [Mo, …, Fr], from: '11:00am', to: '2:00pm'}
      - {days: [Mo, …, Fr], from: '5:00pm', to: '12:00am'}
```

The next-opening search walks sets in file order and returns the first future window it finds, so it reached 7:00pm before it ever saw 11:00am, and stopped.

## What changed

One line: the delivery set is now marked `isPhysicallyOpen: false`.

Delivery is a service rather than a door, which is exactly what that flag marks elsewhere. The phone-only set at SARN uses it for the same reason. Those hours still appear on the detail sheet, and the kitchen's own 5:00pm window already covers the whole delivery window, so nothing is lost from the open status. Every day of the week has its own hours, so there is no day where delivery was the only thing keeping the building open.

## Effect

Measured by loading the real YAML file, not a hand-built fixture:

| Time | Before | After |
| --- | --- | --- |
| Mon 10:00 | Opens at 7 PM | Opens at 11 AM |
| Mon 14:30 | Opens at 7 PM | Opens at 5 PM |
| Mon 16:45 | Opens at 7 PM | Opens in 15 min |
| Sat 10:00 | Opens at 7 PM | Opens at 12 PM |

Unchanged, as a check that nothing was lost: Monday 19:30 and Saturday 20:00 both still read "Open until 12 AM", Saturday 13:30 still reads "Open until 3 PM", and Monday 23:30 still counts down to close.

## What this does not fix

The underlying behaviour. The next-opening search still returns the first future window in file order rather than the earliest one, so the next building whose sets are written out of chronological order will read the same way. That wants a separate change; this one makes the data honest about what the delivery set is, which is worth doing on its own merits.

## Test plan

- [x] `node scripts/validate-data.mjs` — this file validates
- [x] `npx jest` — 196 suites, 1763 passing, 44 snapshots
- [x] `npx oxfmt --check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqRYTaSDg6zZBECHvCiQRd

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqRYTaSDg6zZBECHvCiQRd)_