### PR TITLE
Name the earliest opening today, not the first one listed

### DIFF
--- a/source/features/building-hours/lib/__tests__/contextual-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/contextual-status.test.ts
@@ -49,6 +49,52 @@ describe('contextualStatus', () => {
 		expect(result).toBe('Opens at 5 PM')
 	})
 
+	it('names the earliest opening today, not the first one listed', () => {
+		// The shape of data/building-hours/1-2-pause-kitchen.yaml: a delivery set
+		// written before the kitchen's own hours, because it is the notable one
+		// rather than the early one. Reading the row in file order put "Opens at
+		// 7 PM" on screen all morning. Kept as a fixture rather than read from
+		// the file, since marking that set not physically open is a separate
+		// change and would stop the real file exercising this.
+		let building = makeBuilding([
+			{
+				title: 'On Campus Pizza Delivery',
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '7:00pm', to: '12:00am'}],
+			},
+			{
+				title: 'Hours',
+				hours: [
+					{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '11:00am', to: '2:00pm'},
+					{days: ['Mo', 'Tu', 'We', 'Th', 'Fr'], from: '5:00pm', to: '12:00am'},
+				],
+			},
+		])
+
+		expect(contextualStatus(building, moment.tz('2026-09-07 10:00', timezone))).toBe(
+			'Opens at 11 AM',
+		)
+		// And again once the first window has passed: the answer moves to the
+		// kitchen's evening window, still not the delivery one.
+		expect(contextualStatus(building, moment.tz('2026-09-07 14:30', timezone))).toBe(
+			'Opens at 5 PM',
+		)
+	})
+
+	it('names the earliest opening when one set lists its rows out of order', () => {
+		let building = makeBuilding([
+			{
+				title: 'Hours',
+				hours: [
+					{days: ['Mo'], from: '5:00pm', to: '8:00pm'},
+					{days: ['Mo'], from: '9:00am', to: '12:00pm'},
+				],
+			},
+		])
+		let now = moment.tz('2026-09-07 08:00', timezone) // Monday 8am
+
+		expect(contextualStatus(building, now)).toBe('Opens at 9 AM')
+	})
+
 	it('returns "Opens in X min" when almost open', () => {
 		let building = makeBuilding([
 			{

--- a/source/features/building-hours/lib/contextual-status.ts
+++ b/source/features/building-hours/lib/contextual-status.ts
@@ -48,8 +48,17 @@ function findChapelReopenForBuilding(building: BuildingType, now: Moment): Momen
 	return null
 }
 
+/**
+ * The soonest window today that has not opened yet at `now`, or null when
+ * nothing opens again today.
+ *
+ * Every window is weighed rather than returning at the first future one, because
+ * sets are grouped by what they describe and not by time -- a set written later
+ * can hold the earlier window, and its rows need not run in order either.
+ */
 function findNextOpenToday(building: BuildingType, now: Moment): OpenWindow | null {
 	let dayOfWeek = getDayOfWeek(now)
+	let earliest: OpenWindow | null = null
 
 	for (let set of building.schedule || []) {
 		if (set.isPhysicallyOpen === false) continue
@@ -57,13 +66,14 @@ function findNextOpenToday(building: BuildingType, now: Moment): OpenWindow | nu
 		for (let hours of set.hours) {
 			if (!hours.days.includes(dayOfWeek)) continue
 
-			let {open, close} = windowOpeningOn(hours, now)
-			if (now.isBefore(open)) {
-				return {open, close}
+			let window = windowOpeningOn(hours, now)
+			if (now.isBefore(window.open) && (!earliest || window.open.isBefore(earliest.open))) {
+				earliest = window
 			}
 		}
 	}
-	return null
+
+	return earliest
 }
 
 /**


### PR DESCRIPTION
The next-opening search returned at the first future window it met, walking sets in file order and rows within each set. Sets are grouped by what they describe rather than by time, so a set written later can hold the earlier window, and rows within one set need not run in order either. When that happened the row named a later opening while an earlier one was still ahead.

The Pause Kitchen showed it. Its delivery set is listed before the kitchen's own hours, so the row read "Opens at 7 PM" all morning:

| Time | Before | After |
| --- | --- | --- |
| Mon 10:00 | Opens at 7 PM | Opens at 11 AM |
| Mon 14:30 | Opens at 7 PM | Opens at 5 PM |
| Mon 16:45 | Opens at 7 PM | Opens in 15 min |
| Sat 10:00 | Opens at 7 PM | Opens at 12 PM |

Those are measured by loading the real YAML file on this branch, where it still has its original shape.

## What changed

Every candidate window is weighed instead of returning at the first future one. A few comparisons over at most a handful of rows per building.

Two tests, both of which fail on master:

- The Pause Kitchen shape, two sets with delivery first, checked at Monday 10:00 and again at 14:30 so it also pins that the answer advances once the first window has passed.
- A single set with its rows written out of order, which the across-sets case would not have caught.

Both are fixtures rather than reads of the real file, and the comment says why: pull request 7983 marks that delivery set not physically open, which will stop the real file exercising this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqRYTaSDg6zZBECHvCiQRd)_