### PR TITLE
Give every building status a glyph, and a status to services that are not doors

### DIFF
--- a/source/features/building-hours/lib/__tests__/contextual-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/contextual-status.test.ts
@@ -243,4 +243,20 @@ describe('contextualStatus', () => {
 
 		expect(contextualStatus(building, now).short).toBe('Opens at 1 PM')
 	})
+
+	it('names the service when only the service is open', () => {
+		// data/building-hours/7-3-sarn.yaml; the advocate line runs 8pm to 8am.
+		let building = makeBuilding([
+			{title: 'Office', hours: [{days: ['Tu'], from: '7:00pm', to: '8:00pm'}]},
+			{
+				title: 'Phone',
+				isPhysicallyOpen: false,
+				status: {symbol: 'phone.circle', name: 'Phone'},
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'], from: '8:00pm', to: '8:00am'}],
+			},
+		])
+		let now = moment.tz('2026-09-08 22:00', timezone) // Tuesday 10pm
+
+		expect(contextualStatus(building, now).short).toBe('Phone until 8 AM')
+	})
 })

--- a/source/features/building-hours/lib/__tests__/contextual-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/contextual-status.test.ts
@@ -259,4 +259,21 @@ describe('contextualStatus', () => {
 
 		expect(contextualStatus(building, now).short).toBe('Phone until 8 AM')
 	})
+
+	it('prefers a service open now over a door that opens later', () => {
+		// SARN's line runs overnight; its office opens at 10:10am. At 3am the line
+		// is what you can actually reach, so the row must not point at the office.
+		let building = makeBuilding([
+			{title: 'Office', hours: [{days: ['We'], from: '10:10am', to: '10:30am'}]},
+			{
+				title: 'Phone',
+				isPhysicallyOpen: false,
+				status: {symbol: 'phone.circle', name: 'Phone'},
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'], from: '8:00pm', to: '8:00am'}],
+			},
+		])
+		let now = moment.tz('2026-09-09 03:00', timezone) // Wednesday 3am
+
+		expect(contextualStatus(building, now).short).toBe('Phone until 8 AM')
+	})
 })

--- a/source/features/building-hours/lib/__tests__/find-open-service.test.ts
+++ b/source/features/building-hours/lib/__tests__/find-open-service.test.ts
@@ -1,0 +1,68 @@
+import {describe, expect, it} from '@jest/globals'
+import {findOpenService} from '../find-open-service'
+import {plainMoment} from './moment.helper'
+import {BuildingType} from '../../types'
+
+let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
+
+// data/building-hours/7-3-sarn.yaml
+const sarn: BuildingType = {
+	name: 'SARN',
+	category: 'Health and Wellness',
+	schedule: [
+		{
+			title: 'Office',
+			hours: [{days: ['Tu'], from: '7:00pm', to: '8:00pm'}],
+		},
+		{
+			title: 'Phone',
+			isPhysicallyOpen: false,
+			status: {symbol: 'phone.circle', name: 'Phone'},
+			hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'], from: '8:00pm', to: '8:00am'}],
+		},
+	],
+}
+
+// 2026-09-08 is a Tuesday.
+describe('a service that is running', () => {
+	it('returns what it calls itself', () => {
+		expect(findOpenService(sarn, at('2026-09-08', '22:00:00'))).toEqual({
+			symbol: 'phone.circle',
+			name: 'Phone',
+		})
+	})
+
+	it('returns it in the small hours, when the window carried over', () => {
+		expect(findOpenService(sarn, at('2026-09-09', '03:00:00'))?.name).toBe('Phone')
+	})
+})
+
+describe('no service to report', () => {
+	it('returns null when the service window is not running', () => {
+		expect(findOpenService(sarn, at('2026-09-08', '14:00:00'))).toBeNull()
+	})
+
+	it('returns null for a set that is a door', () => {
+		let building: BuildingType = {
+			name: 'B',
+			category: 'C',
+			schedule: [{title: 'Hours', hours: [{days: ['Tu'], from: '8:00am', to: '9:00pm'}]}],
+		}
+		expect(findOpenService(building, at('2026-09-08', '14:00:00'))).toBeNull()
+	})
+
+	it('returns null when a non-door set never said what it is', () => {
+		let building: BuildingType = {
+			name: 'B',
+			category: 'C',
+			schedule: [
+				{
+					title: 'Phone',
+					isPhysicallyOpen: false,
+					hours: [{days: ['Tu'], from: '8:00am', to: '9:00pm'}],
+				},
+			],
+		}
+		expect(findOpenService(building, at('2026-09-08', '14:00:00'))).toBeNull()
+	})
+})

--- a/source/features/building-hours/lib/__tests__/get-schedule-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/get-schedule-status.test.ts
@@ -3,79 +3,32 @@ import {getScheduleStatusAtMoment} from '../get-schedule-status'
 import {dayMoment} from './moment.helper'
 import {SingleBuildingScheduleType} from '../../types'
 
-it('handles if a schedule is open', () => {
-	let m = dayMoment('Fri 3:00pm')
-	let schedule: SingleBuildingScheduleType = {
-		days: ['Fr'],
-		from: '10:30am',
-		to: '12:00am',
-	}
+const allDay: SingleBuildingScheduleType = {days: ['Fr'], from: '10:30am', to: '12:00am'}
 
-	expect(getScheduleStatusAtMoment(schedule, m)).toBe('Open')
+it('reads Open while the window is running', () => {
+	expect(getScheduleStatusAtMoment(allDay, dayMoment('Fri 3:00pm'))).toBe('Open')
 })
 
-it('handles the minute the schedule opens', () => {
-	let m = dayMoment('Fri 10:30am')
-	let schedule: SingleBuildingScheduleType = {
-		days: ['Fr'],
-		from: '10:30am',
-		to: '12:00am',
-	}
-
-	expect(getScheduleStatusAtMoment(schedule, m)).toBe('Open')
+it('reads Open on the minute it opens', () => {
+	expect(getScheduleStatusAtMoment(allDay, dayMoment('Fri 10:30am'))).toBe('Open')
 })
 
-it('returns the time remaining before the schedule opens', () => {
+it('reads Almost Open within half an hour of opening', () => {
 	let m = dayMoment('Fri 10:29:00am', 'ddd h:mm:ssa')
-	let schedule: SingleBuildingScheduleType = {
-		days: ['Fr'],
-		from: '10:30am',
-		to: '12:00am',
-	}
-
-	expect(getScheduleStatusAtMoment(schedule, m)).toBe('Opens in a minute')
+	expect(getScheduleStatusAtMoment(allDay, m)).toBe('Almost Open')
 })
 
-it('returns the time remaining before the schedule closes', () => {
+it('reads Almost Closed within half an hour of closing', () => {
 	let m = dayMoment('Fri 11:55:00pm', 'ddd h:mm:ssa')
-	let schedule: SingleBuildingScheduleType = {
-		days: ['Fr'],
-		from: '10:30am',
-		to: '12:00am',
-	}
-
-	expect(getScheduleStatusAtMoment(schedule, m)).toBe('Closes in 5 minutes')
+	expect(getScheduleStatusAtMoment(allDay, m)).toBe('Almost Closed')
 })
 
-it('handles after the schedule closes', () => {
-	let m = dayMoment('Fri 1:01pm')
-	let schedule: SingleBuildingScheduleType = {
-		days: ['Fr'],
-		from: '10:30am',
-		to: '1:00pm',
-	}
-
-	expect(getScheduleStatusAtMoment(schedule, m)).toBe('Closed')
+it('reads Closed once the window has passed', () => {
+	let schedule: SingleBuildingScheduleType = {days: ['Fr'], from: '10:30am', to: '1:00pm'}
+	expect(getScheduleStatusAtMoment(schedule, dayMoment('Fri 1:01pm'))).toBe('Closed')
 })
 
-it('rounds the second down when calculating times (pre-30s)', () => {
-	let m = dayMoment('Tue 7:43:30am', 'ddd h:mm:ssa')
-	let schedule: SingleBuildingScheduleType = {
-		days: ['Tu'],
-		from: '8:00am',
-		to: '1:00pm',
-	}
-
-	expect(getScheduleStatusAtMoment(schedule, m)).toBe('Opens in 17 minutes')
-})
-
-it('rounds the second down when calculating times (post-30s)', () => {
-	let m = dayMoment('Tue 7:43:31am', 'ddd h:mm:ssa')
-	let schedule: SingleBuildingScheduleType = {
-		days: ['Tu'],
-		from: '8:00am',
-		to: '1:00pm',
-	}
-
-	expect(getScheduleStatusAtMoment(schedule, m)).toBe('Opens in 17 minutes')
+it('reads Closed well before the window opens', () => {
+	let schedule: SingleBuildingScheduleType = {days: ['Tu'], from: '8:00am', to: '1:00pm'}
+	expect(getScheduleStatusAtMoment(schedule, dayMoment('Tue 6:00am'))).toBe('Closed')
 })

--- a/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
@@ -124,7 +124,6 @@ describe('a schedule running past midnight', () => {
 		],
 	}
 
-
 	it('is Open early Sunday, while Saturday night runs on', () => {
 		expect(getShortBuildingStatus(building, at('2026-09-13', '01:00:00'))).toBe('Open')
 	})
@@ -139,7 +138,6 @@ describe('a schedule running past midnight', () => {
 })
 
 describe('the chapel badge', () => {
-
 	// data/building-hours/3-1-post-office.yaml
 	let postOffice: BuildingType = {
 		name: 'Post Office',

--- a/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
@@ -3,6 +3,8 @@ import {getShortBuildingStatus} from '../get-short-status'
 import {dayMoment, plainMoment} from './moment.helper'
 import {BuildingType} from '../../types'
 
+let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
+
 it('checks a list of schedules to see if any are open', () => {
 	let m = dayMoment('Fri 1:00pm')
 	let building: BuildingType = {
@@ -122,7 +124,6 @@ describe('a schedule running past midnight', () => {
 		],
 	}
 
-	let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
 
 	it('is Open early Sunday, while Saturday night runs on', () => {
 		expect(getShortBuildingStatus(building, at('2026-09-13', '01:00:00'))).toBe('Open')
@@ -138,7 +139,6 @@ describe('a schedule running past midnight', () => {
 })
 
 describe('the chapel badge', () => {
-	let at = (date: string, time: string) => plainMoment(`${date}T${time}`, 'YYYY-MM-DD[T]HH:mm:ss')
 
 	// data/building-hours/3-1-post-office.yaml
 	let postOffice: BuildingType = {
@@ -192,5 +192,35 @@ describe('the chapel badge', () => {
 
 	it('reads Open once chapel has let out', () => {
 		expect(getShortBuildingStatus(postOffice, at('2026-09-07', '10:35:00'))).toBe('Open')
+	})
+})
+
+describe('a building reachable by something that is not a door', () => {
+	const sarn: BuildingType = {
+		name: 'SARN',
+		category: 'Health and Wellness',
+		breakSchedule: undefined,
+		schedule: [
+			{title: 'Office', hours: [{days: ['Tu'], from: '7:00pm', to: '8:00pm'}]},
+			{
+				title: 'Phone',
+				isPhysicallyOpen: false,
+				status: {symbol: 'phone.circle', name: 'Phone'},
+				hours: [{days: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'], from: '8:00pm', to: '8:00am'}],
+			},
+		],
+	}
+
+	it('reads Service when only the service is running', () => {
+		// 2026-09-08 is a Tuesday; the office shut at 8pm.
+		expect(getShortBuildingStatus(sarn, at('2026-09-08', '22:00:00'))).toBe('Service')
+	})
+
+	it('prefers the door when both are open', () => {
+		expect(getShortBuildingStatus(sarn, at('2026-09-08', '19:30:00'))).toBe('Almost Closed')
+	})
+
+	it('reads Closed when neither is running', () => {
+		expect(getShortBuildingStatus(sarn, at('2026-09-08', '14:00:00'))).toBe('Closed')
 	})
 })

--- a/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
+++ b/source/features/building-hours/lib/__tests__/get-short-building-status.test.ts
@@ -132,10 +132,8 @@ describe('a schedule running past midnight', () => {
 		expect(getShortBuildingStatus(building, at('2026-09-11', '01:00:00'))).toBe('Closed')
 	})
 
-	it('counts down to the close carried over from last night', () => {
-		expect(getShortBuildingStatus(building, at('2026-09-13', '01:45:00'))).toBe(
-			'Closes in 15 minutes',
-		)
+	it('reads Almost Closed in the last half hour of the carried-over window', () => {
+		expect(getShortBuildingStatus(building, at('2026-09-13', '01:45:00'))).toBe('Almost Closed')
 	})
 })
 

--- a/source/features/building-hours/lib/__tests__/status-glyph.test.ts
+++ b/source/features/building-hours/lib/__tests__/status-glyph.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from '@jest/globals'
+import {statusGlyph} from '../status-glyph'
+
+describe('the glyph a status shows', () => {
+	it('fills the circle when open', () => {
+		expect(statusGlyph('Open').symbol).toBe('circle.fill')
+	})
+
+	it('empties it when closed', () => {
+		expect(statusGlyph('Closed').symbol).toBe('circle')
+	})
+
+	it('fills half of it when a change is near', () => {
+		expect(statusGlyph('Almost Open').symbol).toBe('circle.lefthalf.filled')
+		expect(statusGlyph('Almost Closed').symbol).toBe('circle.righthalf.filled')
+	})
+
+	it('rings a bell for chapel', () => {
+		expect(statusGlyph('Chapel').symbol).toBe('bell.circle')
+	})
+
+	it('takes the service symbol from the data', () => {
+		expect(statusGlyph('Service', {symbol: 'phone.circle', name: 'Phone'}).symbol).toBe(
+			'phone.circle',
+		)
+	})
+
+	it('falls back to a filled circle when a service named no symbol', () => {
+		expect(statusGlyph('Service', {name: 'Phone'}).symbol).toBe('circle.fill')
+	})
+
+	it('falls back to a filled circle when there is no service at all', () => {
+		expect(statusGlyph('Service').symbol).toBe('circle.fill')
+	})
+})

--- a/source/features/building-hours/lib/color-helpers.ts
+++ b/source/features/building-hours/lib/color-helpers.ts
@@ -1,21 +1,15 @@
 import * as c from '@frogpond/colors'
 import {ColorValue} from 'react-native'
+import type {BuildingStatusType} from '../types'
 
-export const BG_COLORS: Record<string, ColorValue> = {
+const BG_COLORS: Record<BuildingStatusType, ColorValue> = {
 	Open: c.systemGreen,
+	'Almost Open': c.systemYellow,
+	'Almost Closed': c.systemYellow,
+	Chapel: c.systemYellow,
+	Service: c.systemGreen,
 	Closed: c.systemRed,
 }
 
-export const FG_COLORS: Record<string, ColorValue> = {
-	Open: c.label,
-	Closed: c.label,
-}
-
-export const getAccentBackgroundColor = (openStatus: string): ColorValue =>
-	BG_COLORS[openStatus] ?? c.systemYellow
-
-// systemYellow (the fallback background for "Opening/Closing Soon") stays
-// bright in dark mode, so the dynamic `label` color -- white in dark mode --
-// is illegible against it. Use a fixed dark color instead of a dynamic one.
-export const getAccentTextColor = (openStatus: string): ColorValue =>
-	FG_COLORS[openStatus] ?? c.black
+export const getAccentBackgroundColor = (status: BuildingStatusType): ColorValue =>
+	BG_COLORS[status]

--- a/source/features/building-hours/lib/contextual-status.ts
+++ b/source/features/building-hours/lib/contextual-status.ts
@@ -5,6 +5,7 @@ import {findOpenWindow, windowOpeningOn} from './find-open-window'
 import {CHAPEL_COUNTDOWN_MINUTES, isChapelTime} from './chapel'
 import {findChapelReopen} from './find-chapel-reopen'
 import {findChapelPause} from './find-chapel-pause'
+import {findOpenService} from './find-open-service'
 
 const ALMOST_THRESHOLD_MINUTES = 30
 
@@ -125,6 +126,19 @@ export function contextualStatus(building: BuildingType, now: Moment): Contextua
 			return plain(`Opens in ${minutesUntilOpen} min`)
 		}
 		return plain(`Opens at ${formatTime(next.open)}`)
+	}
+
+	// A phone line or a delivery service is not a door, so it is only worth naming
+	// once nothing physical is open.
+	let service = findOpenService(building, now)
+	if (service) {
+		let set = (building.schedule || []).find((candidate) => candidate.status === service)
+		let window = set?.hours
+			.map((hours) => findOpenWindow(hours, now))
+			.find((candidate) => candidate !== null)
+		if (window) {
+			return plain(`${service.name} until ${formatTime(window.close)}`)
+		}
 	}
 
 	// Not "Closed today": this is only reached once nothing opens again today, so

--- a/source/features/building-hours/lib/contextual-status.ts
+++ b/source/features/building-hours/lib/contextual-status.ts
@@ -119,17 +119,9 @@ export function contextualStatus(building: BuildingType, now: Moment): Contextua
 		return plain(`Reopens at ${formatTime(chapelReopen)}`)
 	}
 
-	let next = findNextOpenToday(building, now)
-	if (next) {
-		let minutesUntilOpen = next.open.diff(now, 'minutes')
-		if (minutesUntilOpen <= ALMOST_THRESHOLD_MINUTES) {
-			return plain(`Opens in ${minutesUntilOpen} min`)
-		}
-		return plain(`Opens at ${formatTime(next.open)}`)
-	}
-
-	// A phone line or a delivery service is not a door, so it is only worth naming
-	// once nothing physical is open.
+	// A phone line or a delivery service is not a door, so it never outranks one.
+	// It does outrank a door that opens later, though: something reachable now
+	// beats something reachable at ten past ten.
 	let service = findOpenService(building, now)
 	if (service) {
 		let set = (building.schedule || []).find((candidate) => candidate.status === service)
@@ -139,6 +131,15 @@ export function contextualStatus(building: BuildingType, now: Moment): Contextua
 		if (window) {
 			return plain(`${service.name} until ${formatTime(window.close)}`)
 		}
+	}
+
+	let next = findNextOpenToday(building, now)
+	if (next) {
+		let minutesUntilOpen = next.open.diff(now, 'minutes')
+		if (minutesUntilOpen <= ALMOST_THRESHOLD_MINUTES) {
+			return plain(`Opens in ${minutesUntilOpen} min`)
+		}
+		return plain(`Opens at ${formatTime(next.open)}`)
 	}
 
 	// Not "Closed today": this is only reached once nothing opens again today, so

--- a/source/features/building-hours/lib/find-open-service.ts
+++ b/source/features/building-hours/lib/find-open-service.ts
@@ -1,0 +1,25 @@
+import type {Moment} from 'moment-timezone'
+import type {BuildingType, ServiceStatusType} from '../types'
+
+import {findOpenWindow} from './find-open-window'
+
+/**
+ * What a building is reachable by right now that is not a door, or null.
+ *
+ * A set only counts when it says what it is: a set marked not physically open
+ * but carrying no `status` has nothing to call itself on the status line, so it
+ * stays silent rather than guessing.
+ */
+export function findOpenService(building: BuildingType, m: Moment): ServiceStatusType | null {
+	for (let set of building.schedule || []) {
+		if (set.isPhysicallyOpen !== false) continue
+		if (!set.status) continue
+
+		let running = set.hours.some((hours) => findOpenWindow(hours, m) !== null)
+		if (running) {
+			return set.status
+		}
+	}
+
+	return null
+}

--- a/source/features/building-hours/lib/get-schedule-status.ts
+++ b/source/features/building-hours/lib/get-schedule-status.ts
@@ -1,29 +1,32 @@
 import type {Moment} from 'moment-timezone'
-import type {SingleBuildingScheduleType} from '../types'
+import type {BuildingStatusType, SingleBuildingScheduleType} from '../types'
 
 import {parseHours} from './parse-hours'
 
-function in30(start: Moment, end: Moment) {
-	return start.clone().add(30, 'minutes').isSameOrAfter(end)
+const ALMOST_THRESHOLD_MINUTES = 30
+
+function within(minutes: number, start: Moment, end: Moment): boolean {
+	return start.clone().add(minutes, 'minutes').isSameOrAfter(end)
 }
 
-function timeBetween(start: Moment, end: Moment) {
-	return start.clone().seconds(0).to(end)
-}
-
-export function getScheduleStatusAtMoment(schedule: SingleBuildingScheduleType, m: Moment): string {
+/**
+ * How one window reads at `m`: running, about to change, or neither.
+ *
+ * The caller picks the wording. This says only which state the window is in,
+ * so the set of answers stays closed and a glyph can be chosen from it.
+ */
+export function getScheduleStatusAtMoment(
+	schedule: SingleBuildingScheduleType,
+	m: Moment,
+): BuildingStatusType {
 	let {open, close} = parseHours(schedule, m)
 
-	if (m.isBefore(open) && in30(m, open)) {
-		return `Opens ${timeBetween(m, open)}`
+	if (m.isBefore(open)) {
+		return within(ALMOST_THRESHOLD_MINUTES, m, open) ? 'Almost Open' : 'Closed'
 	}
 
 	if (m.isBetween(open, close, 'minute', '[)')) {
-		if (in30(m, close)) {
-			return `Closes ${timeBetween(m, close)}`
-		}
-
-		return 'Open'
+		return within(ALMOST_THRESHOLD_MINUTES, m, close) ? 'Almost Closed' : 'Open'
 	}
 
 	return 'Closed'

--- a/source/features/building-hours/lib/get-short-status.ts
+++ b/source/features/building-hours/lib/get-short-status.ts
@@ -1,5 +1,5 @@
 import type {Moment} from 'moment-timezone'
-import type {BuildingType} from '../types'
+import type {BuildingStatusType, BuildingType} from '../types'
 
 import {isChapelTime} from './chapel'
 import {findChapelReopen} from './find-chapel-reopen'
@@ -7,7 +7,7 @@ import {findChapelPause} from './find-chapel-pause'
 import {schedulesInEffect} from './schedules-in-effect'
 import {getScheduleStatusAtMoment} from './get-schedule-status'
 
-export function getShortBuildingStatus(info: BuildingType, m: Moment): string {
+export function getShortBuildingStatus(info: BuildingType, m: Moment): BuildingStatusType {
 	let schedules = info.schedule || []
 	if (!schedules.length) {
 		return 'Closed'

--- a/source/features/building-hours/lib/get-short-status.ts
+++ b/source/features/building-hours/lib/get-short-status.ts
@@ -4,6 +4,7 @@ import type {BuildingStatusType, BuildingType} from '../types'
 import {isChapelTime} from './chapel'
 import {findChapelReopen} from './find-chapel-reopen'
 import {findChapelPause} from './find-chapel-pause'
+import {findOpenService} from './find-open-service'
 import {schedulesInEffect} from './schedules-in-effect'
 import {getScheduleStatusAtMoment} from './get-schedule-status'
 
@@ -38,5 +39,12 @@ export function getShortBuildingStatus(info: BuildingType, m: Moment): BuildingS
 		return filteredSchedules.map((schedule) => getScheduleStatusAtMoment(schedule, m))
 	})
 
-	return statuses.find((status) => status !== 'Closed') ?? 'Closed'
+	let physical = statuses.find((status) => status !== 'Closed')
+	if (physical) {
+		return physical
+	}
+
+	// Only once no door is open is it worth naming a phone line or a delivery
+	// service; a building you can walk into should say so first.
+	return findOpenService(info, m) ? 'Service' : 'Closed'
 }

--- a/source/features/building-hours/lib/index.ts
+++ b/source/features/building-hours/lib/index.ts
@@ -9,10 +9,7 @@ export {hasDisplayableHours, firstScheduleNote} from './schedule-summary'
 export {getDayOfWeek} from './get-day-of-week'
 export {parseHours} from './parse-hours'
 export {blankSchedule} from './blank-schedule'
-export {
-	BG_COLORS as hoursBackgroundColors,
-	FG_COLORS as hoursForegroundColors,
-	getAccentBackgroundColor,
-	getAccentTextColor,
-} from './color-helpers'
+export {getAccentBackgroundColor} from './color-helpers'
+export {statusGlyph} from './status-glyph'
+export {findOpenService} from './find-open-service'
 export {toPickerDate, fromPickerDate} from './picker-time'

--- a/source/features/building-hours/lib/status-glyph.ts
+++ b/source/features/building-hours/lib/status-glyph.ts
@@ -1,9 +1,15 @@
+import type {ComponentProps} from 'react'
 import type {ColorValue} from 'react-native'
+import type {Image} from '@expo/ui/swift-ui'
 import type {BuildingStatusType, ServiceStatusType} from '../types'
 
 import {getAccentBackgroundColor} from './color-helpers'
 
-const SYMBOLS: Record<BuildingStatusType, string> = {
+/** The SF Symbol names `Image` will accept, taken from its own prop rather than
+ * from a second copy of Apple's catalogue. */
+type SymbolName = NonNullable<ComponentProps<typeof Image>['systemName']>
+
+const SYMBOLS: Record<BuildingStatusType, SymbolName> = {
 	Open: 'circle.fill',
 	'Almost Open': 'circle.lefthalf.filled',
 	'Almost Closed': 'circle.righthalf.filled',
@@ -24,9 +30,14 @@ const SYMBOLS: Record<BuildingStatusType, string> = {
 export function statusGlyph(
 	status: BuildingStatusType,
 	service?: ServiceStatusType,
-): {symbol: string; color: ColorValue} {
+): {symbol: SymbolName; color: ColorValue} {
+	// A symbol out of the data is an unchecked string: the schema can say it is
+	// a string but not that Apple ships it, so a name with a typo in it draws
+	// nothing. Ours are checked, because `SYMBOLS` is typed.
+	let fromData = status === 'Service' ? (service?.symbol as SymbolName | undefined) : undefined
+
 	return {
-		symbol: (status === 'Service' ? service?.symbol : undefined) ?? SYMBOLS[status],
+		symbol: fromData ?? SYMBOLS[status],
 		color: getAccentBackgroundColor(status),
 	}
 }

--- a/source/features/building-hours/lib/status-glyph.ts
+++ b/source/features/building-hours/lib/status-glyph.ts
@@ -1,0 +1,32 @@
+import type {ColorValue} from 'react-native'
+import type {BuildingStatusType, ServiceStatusType} from '../types'
+
+import {getAccentBackgroundColor} from './color-helpers'
+
+const SYMBOLS: Record<BuildingStatusType, string> = {
+	Open: 'circle.fill',
+	'Almost Open': 'circle.lefthalf.filled',
+	'Almost Closed': 'circle.righthalf.filled',
+	Chapel: 'bell.circle',
+	// Replaced by the set's own symbol whenever one reaches us; this is only
+	// what a service falls back to.
+	Service: 'circle.fill',
+	Closed: 'circle',
+}
+
+/**
+ * The SF Symbol and colour a status shows on a row.
+ *
+ * Every symbol shares the circle silhouette, so the column stays aligned and
+ * shape carries what colour could not: yellow alone means three different
+ * things, and means nothing at all to a colourblind reader.
+ */
+export function statusGlyph(
+	status: BuildingStatusType,
+	service?: ServiceStatusType,
+): {symbol: string; color: ColorValue} {
+	return {
+		symbol: (status === 'Service' ? service?.symbol : undefined) ?? SYMBOLS[status],
+		color: getAccentBackgroundColor(status),
+	}
+}

--- a/source/features/building-hours/list/building-list-row.tsx
+++ b/source/features/building-hours/list/building-list-row.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
-import type {ColorValue} from 'react-native'
 import {Button, HStack, Image, Spacer, SwipeActions, Text, VStack} from '@expo/ui/swift-ui'
 import {
 	accessibilityIdentifier,
 	accessibilityLabel,
+	allowsTightening,
 	buttonStyle,
 	contentShape,
 	fixedSize,
@@ -11,6 +11,7 @@ import {
 	foregroundStyle,
 	layoutPriority,
 	lineLimit,
+	minimumScaleFactor,
 	shapes,
 	tint,
 	truncationMode,
@@ -20,7 +21,8 @@ import type {Moment} from 'moment-timezone'
 import type {BuildingType} from '../types'
 import {
 	getShortBuildingStatus,
-	getAccentBackgroundColor,
+	statusGlyph,
+	findOpenService,
 	contextualStatus,
 	hasDisplayableHours,
 	firstScheduleNote,
@@ -36,7 +38,15 @@ export const BUILDING_ROW_PREFIX = 'building-row-'
 export const ADD_TO_FAVORITES = 'Add to Favorites'
 export const REMOVE_FROM_FAVORITES = 'Remove from Favorites'
 
-const SINGLE_LINE = [lineLimit(1), truncationMode('tail')]
+const SINGLE_LINE = [
+	lineLimit(1),
+	truncationMode('tail'),
+	// The status wins this row on layout priority, so without these the name is
+	// what gets an ellipsis. Shrinking a little reads better than losing letters,
+	// and keeps every row the same height.
+	minimumScaleFactor(0.8),
+	allowsTightening(true),
+]
 
 type Props = {
 	building: BuildingType
@@ -58,7 +68,7 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 	onSelect,
 }: Props): React.ReactNode {
 	let status = getShortBuildingStatus(building, now)
-	let accentBg: ColorValue = getAccentBackgroundColor(status)
+	let glyph = statusGlyph(status, findOpenService(building, now) ?? undefined)
 	let statusText = contextualStatus(building, now)
 
 	let subtitle = building.subtitle
@@ -107,8 +117,8 @@ export const BuildingListRow = React.memo(function BuildingListRow({
 								{hasHours ? statusText.short : (firstNote ?? '')}
 							</Text>
 							<Image
-								modifiers={[foregroundStyle(accentBg), font({textStyle: 'caption2'})]}
-								systemName="circle.fill"
+								modifiers={[foregroundStyle(glyph.color), font({textStyle: 'caption2'})]}
+								systemName={glyph.symbol}
 							/>
 							<Image
 								modifiers={[font({textStyle: 'footnote'}), foregroundStyle(c.tertiaryLabel)]}

--- a/source/features/building-hours/types.ts
+++ b/source/features/building-hours/types.ts
@@ -28,11 +28,25 @@ export type SingleBuildingScheduleType = {
 	to: string
 }
 
+/**
+ * What a set that is not a door calls itself.
+ *
+ * `name` is what the status line says and is required: without a word for the
+ * service there is no honest way to word the row, so the set stays closed. The
+ * symbol is decoration, and falls back to a filled circle. `name` is short
+ * because the row is narrow.
+ */
+export type ServiceStatusType = {
+	symbol?: string
+	name: string
+}
+
 export type NamedBuildingScheduleType = {
 	title: string
 	notes?: string
 	isPhysicallyOpen?: boolean
 	closedForChapelTime?: boolean
+	status?: ServiceStatusType
 	hours: SingleBuildingScheduleType[]
 }
 

--- a/source/features/building-hours/types.ts
+++ b/source/features/building-hours/types.ts
@@ -1,4 +1,14 @@
-export type BuildingStatusType = 'Open' | 'Closed' | 'Almost Closed' | 'Almost Open' | 'Chapel'
+/**
+ * What a building's dot says: whether it is open, about to change, shut for
+ * chapel, or reachable by something that is not a door.
+ */
+export type BuildingStatusType =
+	| 'Open'
+	| 'Almost Open'
+	| 'Almost Closed'
+	| 'Chapel'
+	| 'Service'
+	| 'Closed'
 
 export type DayOfWeekEnumType = 'Mo' | 'Tu' | 'We' | 'Th' | 'Fr' | 'Sa' | 'Su'
 

--- a/source/testing/expo-ui-mock.tsx
+++ b/source/testing/expo-ui-mock.tsx
@@ -96,6 +96,7 @@ export const textInputAutocapitalization = named(
 	'autocapitalization',
 )
 export const layoutPriority = named('layoutPriority', 'priority')
+export const allowsTightening = named('allowsTightening', 'value')
 export const textSelection = named('textSelection', 'value')
 export const tint = named('tint', 'color')
 export const truncationMode = named('truncationMode', 'mode')


### PR DESCRIPTION
Two problems, one cause.

**The dot could not say what it needed to.** The row had five statuses and three colours: `color-helpers.ts` mapped Open to green and Closed to red, and everything else fell through to `systemYellow`. Yellow therefore meant Almost Open, Almost Closed and Chapel at once, and the whole signal was lost to a colourblind reader.

**A set that is not a door had no way to say it was open.** SARN's advocate line runs 8pm to 8am, and `contextualStatus` skipped those sets entirely:

| When | Row said | Dot | Actually |
| --- | --- | --- | --- |
| Tue 20:30 | Closed today | red | Line staffed |
| Sat 22:00 | Closed today | red | Line staffed |
| Tue 07:00 | Opens at 11:10 AM | red | Line staffed until 8am |

## What changed

Every status now has a glyph as well as a colour. All of them share the circle silhouette, so the column stays aligned and shape carries what colour could not:

| Status | Glyph | Colour |
| --- | --- | --- |
| Open | `circle.fill` | green |
| Almost Open | `circle.lefthalf.filled` | yellow |
| Almost Closed | `circle.righthalf.filled` | yellow |
| Chapel | `bell.circle` | yellow |
| Service | the set's own symbol | green |
| Closed | `circle` | red |

A schedule set can describe the service behind it, via the `status` block that #7986 adds to the schema and the two data files. This branch is the code that reads it: `name` is what the status line says, and `symbol` is the glyph, falling back to a filled circle when absent.

**Availability first, kind second.** The service glyph appears only when no door is open, so a building open at the door while staffing a phone still reads Open. But a service open *now* outranks a door that opens *later*: at 3am SARN's line is what you can actually reach.

**`BuildingStatusType` is real now.** It was declared and never used, and never matched what the code produced — `getScheduleStatusAtMoment` returned sentences like `"Opens in 17 minutes"` that nothing rendered, formatted for every row on every minute tick and thrown away. It now returns a status, the colour map is keyed by that type, and a missing case is a type error rather than a silent fall-through to yellow. `getAccentTextColor`, `FG_COLORS` and two barrel aliases went with it, all of which had zero consumers.

## Depends on the data landing first

The data half is split out into #7986 so ccc-server can pick the fields up separately. `fetchBuildings` uses this repository's bundled hours only when `isUITesting`; every other run fetches `spaces/hours` over the wire, so a field reaches a device only after the server has it.

Until then this branch is inert for the Service status specifically: a dev build shows SARN as a plain red circle, which is correct given the data it was handed. Everything else here — the glyphs, the typed status, the Almost states — works immediately.

## Test plan

- [x] `npx jest` — 199 suites, 1797 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint` — clean
- [x] `npx oxfmt --check .` — clean
- [x] UITest on a simulator: Open and Closed glyphs render and are distinguishable
- [x] Dev build on a physical iPhone: installs, launches, survives
- [ ] The half-filled, bell and phone glyphs seen on a device

The last box needs either the clock moved or the server updated, and `simctl` has no time command. That gap is what the dev-overrides spec is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAehhCQ3YMSnedwQHnrB1i
