### PR TITLE
Describe the services behind the two non-door schedule sets

### DIFF
--- a/data/_schemas/building-hours.yaml
+++ b/data/_schemas/building-hours.yaml
@@ -45,6 +45,13 @@ definitions:
       notes: {type: string}
       closedForChapelTime: {type: boolean}
       isPhysicallyOpen: {type: boolean}
+      status:
+        type: object
+        additionalProperties: false
+        required: [name]
+        properties:
+          symbol: {type: string}
+          name: {type: string, maxLength: 12}
       hours:
         type: array
         items: {$ref: '_defs.json#/definitions/day'}

--- a/data/building-hours/1-2-pause-kitchen.yaml
+++ b/data/building-hours/1-2-pause-kitchen.yaml
@@ -8,6 +8,7 @@ links:
 schedule:
   - title: On Campus Pizza Delivery
     isPhysicallyOpen: false
+    status: {symbol: figure.walk.circle, name: Delivery}
     hours:
       - {days: [Mo, Tu, We, Th, Fr, Sa, Su], from: '7:00pm', to: '12:00am'}
 

--- a/data/building-hours/7-3-sarn.yaml
+++ b/data/building-hours/7-3-sarn.yaml
@@ -13,6 +13,7 @@ schedule:
 
   - title: Phone
     isPhysicallyOpen: false
+    status: {symbol: phone.circle, name: Phone}
     hours:
       - {days: [Mo, Tu, We, Th, Fr, Sa, Su], from: '8:00pm', to: '8:00am'}
     notes: Call 507-786-3777 to connect with a SARN Advocate


### PR DESCRIPTION
Data only, so ccc-server can pick these fields up ahead of the code that reads them. Nothing in the app looks at them yet.

A schedule set marked `isPhysicallyOpen: false` is something you cannot walk into — SARN's advocate line, the Pause Kitchen's delivery. Today both read as plain closures, which is wrong in SARN's case at exactly the hours its line is staffed.

## The field

```yaml
- title: Phone
  isPhysicallyOpen: false
  status: {symbol: phone.circle, name: Phone}
  hours: [...]
```

`name` is required and capped at 12 characters. It is what a status line will say, so without one there is nothing honest to write and the set stays closed. The cap exists because the row it lands in is narrow and no automated test can see truncation.

`symbol` is optional and names an SF Symbol. The schema can say it is a string but not that Apple ships it, so a typo draws nothing rather than failing.

The two sets that get one:

| Building | Set | `status` |
| --- | --- | --- |
| SARN | Phone | `{symbol: phone.circle, name: Phone}` |
| Pause Kitchen | On Campus Pizza Delivery | `{symbol: figure.walk.circle, name: Delivery}` |

The walking figure is the person carrying it, rather than a vehicle the kitchen does not own.

## Test plan

- [x] `node scripts/validate-data.mjs` — both files valid
- [x] Confirmed the schema rejects a `status` with no `name`
- [x] `npx jest` — unaffected, nothing reads the field yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAehhCQ3YMSnedwQHnrB1i
